### PR TITLE
feat(ui): add skeleton loading states across dashboard pages

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,16 @@
+# BloxOS Improvement Log
+
+## 2026-03-17 — UI/UX: Skeleton loading states across dashboard pages
+
+Replaced all basic spinner/text loading states with proper skeleton UI across the six main dashboard pages. The skeleton components match the rough shape of actual content (rig cards, stat cards, table rows, profile cards) using animated pulse effects, making the app feel more polished and reducing perceived load time.
+
+**Files changed:**
+- `apps/dashboard/src/components/Skeleton.tsx` (new — 10 reusable skeleton variants)
+- `apps/dashboard/src/app/rigs/page.tsx`
+- `apps/dashboard/src/app/profit/page.tsx`
+- `apps/dashboard/src/app/alerts/page.tsx`
+- `apps/dashboard/src/app/oc-profiles/page.tsx`
+- `apps/dashboard/src/app/pools/page.tsx`
+- `apps/dashboard/src/app/wallets/page.tsx`
+
+**PR:** https://github.com/bokiko/bloxos/pull/1

--- a/apps/dashboard/src/app/alerts/page.tsx
+++ b/apps/dashboard/src/app/alerts/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
+import { SkeletonAlertItem } from '../../components/Skeleton';
 
 const getApiUrl = () => {
   if (typeof window === 'undefined') return 'http://localhost:3001';
@@ -188,9 +189,19 @@ export default function AlertsPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-20">
-        <div className="inline-block w-8 h-8 border-2 border-slate-600 border-t-blox-400 rounded-full animate-spin"></div>
-        <p className="text-slate-400 ml-3">Loading alerts...</p>
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <div className="w-12 h-12 bg-slate-700/50 rounded-xl animate-pulse" />
+          <div className="space-y-2">
+            <div className="h-7 w-24 bg-slate-700/50 rounded animate-pulse" />
+            <div className="h-4 w-36 bg-slate-700/50 rounded animate-pulse" />
+          </div>
+        </div>
+        <div className="space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <SkeletonAlertItem key={i} />
+          ))}
+        </div>
       </div>
     );
   }

--- a/apps/dashboard/src/app/oc-profiles/page.tsx
+++ b/apps/dashboard/src/app/oc-profiles/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { SkeletonProfileCard } from '../../components/Skeleton';
 
 const getApiUrl = () => {
   if (typeof window === 'undefined') return 'http://localhost:3001';
@@ -199,9 +200,19 @@ export default function OCProfilesPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-20">
-        <div className="inline-block w-8 h-8 border-2 border-slate-600 border-t-blox-400 rounded-full animate-spin"></div>
-        <p className="text-slate-400 ml-3">Loading OC profiles...</p>
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <div className="w-12 h-12 bg-slate-700/50 rounded-xl animate-pulse" />
+          <div className="space-y-2">
+            <div className="h-7 w-32 bg-slate-700/50 rounded animate-pulse" />
+            <div className="h-4 w-44 bg-slate-700/50 rounded animate-pulse" />
+          </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <SkeletonProfileCard key={i} />
+          ))}
+        </div>
       </div>
     );
   }

--- a/apps/dashboard/src/app/pools/page.tsx
+++ b/apps/dashboard/src/app/pools/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import Image from 'next/image';
+import { SkeletonPoolRow } from '../../components/Skeleton';
 
 const getApiUrl = () => {
   if (typeof window === 'undefined') return 'http://localhost:3001';
@@ -409,9 +410,10 @@ export default function PoolsPage() {
 
       {/* Pools List */}
       {loading ? (
-        <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-12 text-center">
-          <div className="inline-block w-8 h-8 border-2 border-slate-600 border-t-blox-400 rounded-full animate-spin"></div>
-          <p className="text-slate-400 mt-3">Loading pools...</p>
+        <div className="grid gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <SkeletonPoolRow key={i} />
+          ))}
         </div>
       ) : filteredPools.length === 0 ? (
         <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-12 text-center">

--- a/apps/dashboard/src/app/profit/page.tsx
+++ b/apps/dashboard/src/app/profit/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
+import { SkeletonStatCard, SkeletonTable } from '../../components/Skeleton';
 
 const getApiUrl = () => {
   if (typeof window === 'undefined') return 'http://localhost:3001';
@@ -182,8 +183,19 @@ export default function ProfitPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
+      <div className="space-y-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="space-y-2">
+            <div className="h-7 w-44 bg-slate-700/50 rounded animate-pulse" />
+            <div className="h-4 w-64 bg-slate-700/50 rounded animate-pulse" />
+          </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <SkeletonStatCard key={i} />
+          ))}
+        </div>
+        <SkeletonTable rows={5} cols={4} />
       </div>
     );
   }

--- a/apps/dashboard/src/app/rigs/page.tsx
+++ b/apps/dashboard/src/app/rigs/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
 import { useWebSocket } from '../../hooks/useWebSocket';
+import { SkeletonRigCard } from '../../components/Skeleton';
 
 const getApiUrl = () => {
   if (typeof window === 'undefined') return 'http://localhost:3001';
@@ -854,9 +855,10 @@ export default function RigsPage() {
       </div>
 
       {loading ? (
-        <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-12 text-center">
-          <div className="inline-block w-8 h-8 border-2 border-slate-600 border-t-blox-400 rounded-full animate-spin"></div>
-          <p className="text-slate-400 mt-3">Loading rigs...</p>
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <SkeletonRigCard key={i} />
+          ))}
         </div>
       ) : sortedRigs.length === 0 ? (
         <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-12 text-center">

--- a/apps/dashboard/src/app/wallets/page.tsx
+++ b/apps/dashboard/src/app/wallets/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import Image from 'next/image';
+import { SkeletonWalletRow } from '../../components/Skeleton';
 
 const getApiUrl = () => {
   if (typeof window === 'undefined') return 'http://localhost:3001';
@@ -296,9 +297,10 @@ export default function WalletsPage() {
 
       {/* Wallets List */}
       {loading ? (
-        <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-12 text-center">
-          <div className="inline-block w-8 h-8 border-2 border-slate-600 border-t-blox-400 rounded-full animate-spin"></div>
-          <p className="text-slate-400 mt-3">Loading wallets...</p>
+        <div className="grid gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <SkeletonWalletRow key={i} />
+          ))}
         </div>
       ) : wallets.length === 0 ? (
         <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-12 text-center">

--- a/apps/dashboard/src/components/Skeleton.tsx
+++ b/apps/dashboard/src/components/Skeleton.tsx
@@ -1,0 +1,189 @@
+export function SkeletonText({ width = 'w-32', className = '' }: { width?: string; className?: string }) {
+  return <div className={`h-4 bg-slate-700/50 rounded ${width} animate-pulse ${className}`} />;
+}
+
+export function SkeletonBox({
+  width = 'w-full',
+  height = 'h-24',
+  className = '',
+}: {
+  width?: string;
+  height?: string;
+  className?: string;
+}) {
+  return <div className={`bg-slate-700/50 rounded-xl ${width} ${height} animate-pulse ${className}`} />;
+}
+
+export function SkeletonCard({ className = '' }: { className?: string }) {
+  return (
+    <div className={`bg-slate-800/50 rounded-xl border border-slate-700/50 p-5 animate-pulse ${className}`}>
+      <div className="flex items-start justify-between mb-4">
+        <div className="space-y-2">
+          <div className="h-5 w-40 bg-slate-700/50 rounded" />
+          <div className="h-3 w-24 bg-slate-700/50 rounded" />
+        </div>
+        <div className="h-8 w-20 bg-slate-700/50 rounded-lg" />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="bg-slate-900/50 rounded-lg p-3 h-16" />
+        <div className="bg-slate-900/50 rounded-lg p-3 h-16" />
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonTable({ rows = 5, cols = 4 }: { rows?: number; cols?: number }) {
+  return (
+    <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 overflow-hidden animate-pulse">
+      <div className="grid gap-px bg-slate-700/30">
+        {Array.from({ length: rows }).map((_, i) => (
+          <div key={i} className="bg-slate-800/80 px-5 py-4 flex items-center gap-4">
+            {Array.from({ length: cols }).map((_, j) => (
+              <div
+                key={j}
+                className={`h-4 bg-slate-700/50 rounded ${j === 0 ? 'w-40' : 'w-24'}`}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Page-specific skeletons
+
+export function SkeletonRigCard() {
+  return (
+    <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-5 animate-pulse">
+      <div className="flex items-start justify-between mb-4">
+        <div className="flex items-center gap-3">
+          <div className="w-4 h-4 bg-slate-700/50 rounded" />
+          <div className="w-3 h-3 bg-slate-700/50 rounded-full" />
+          <div className="space-y-2">
+            <div className="h-5 w-36 bg-slate-700/50 rounded" />
+            <div className="h-3 w-48 bg-slate-700/50 rounded" />
+          </div>
+        </div>
+        <div className="h-6 w-16 bg-slate-700/50 rounded-lg" />
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="bg-slate-900/50 rounded-lg p-3">
+            <div className="h-3 w-12 bg-slate-700/50 rounded mb-2" />
+            <div className="h-5 w-16 bg-slate-700/50 rounded" />
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2 pt-3 border-t border-slate-700/50">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-7 w-28 bg-slate-700/50 rounded-lg" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonStatCard() {
+  return (
+    <div className="bg-slate-800 rounded-xl p-6 border border-slate-700 animate-pulse">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <div className="h-3 w-20 bg-slate-700/50 rounded" />
+          <div className="h-7 w-28 bg-slate-700/50 rounded" />
+        </div>
+        <div className="w-12 h-12 bg-slate-700/50 rounded-lg" />
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonAlertItem() {
+  return (
+    <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-4 animate-pulse">
+      <div className="flex items-start gap-4">
+        <div className="w-10 h-10 bg-slate-700/50 rounded-lg shrink-0" />
+        <div className="flex-1 space-y-2">
+          <div className="h-4 w-48 bg-slate-700/50 rounded" />
+          <div className="h-3 w-full bg-slate-700/50 rounded" />
+          <div className="flex gap-3">
+            <div className="h-3 w-20 bg-slate-700/50 rounded" />
+            <div className="h-3 w-16 bg-slate-700/50 rounded" />
+          </div>
+        </div>
+        <div className="h-6 w-16 bg-slate-700/50 rounded-lg" />
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonProfileCard() {
+  return (
+    <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-5 animate-pulse">
+      <div className="flex items-start justify-between mb-4">
+        <div className="space-y-2">
+          <div className="h-5 w-32 bg-slate-700/50 rounded" />
+          <div className="h-4 w-16 bg-slate-700/50 rounded" />
+        </div>
+        <div className="flex gap-1">
+          <div className="w-8 h-8 bg-slate-700/50 rounded-lg" />
+          <div className="w-8 h-8 bg-slate-700/50 rounded-lg" />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="bg-slate-900/50 rounded-lg p-2">
+            <div className="h-3 w-16 bg-slate-700/50 rounded mb-1" />
+            <div className="h-4 w-12 bg-slate-700/50 rounded" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonPoolRow() {
+  return (
+    <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-5 animate-pulse">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-4">
+          <div className="w-12 h-12 bg-slate-700/50 rounded-xl" />
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <div className="h-5 w-32 bg-slate-700/50 rounded" />
+              <div className="h-4 w-12 bg-slate-700/50 rounded" />
+            </div>
+            <div className="h-3 w-64 bg-slate-700/50 rounded" />
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <div className="w-8 h-8 bg-slate-700/50 rounded-lg" />
+          <div className="w-8 h-8 bg-slate-700/50 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonWalletRow() {
+  return (
+    <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-5 animate-pulse">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-4">
+          <div className="w-12 h-12 bg-slate-700/50 rounded-xl" />
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <div className="h-5 w-28 bg-slate-700/50 rounded" />
+              <div className="h-4 w-12 bg-slate-700/50 rounded" />
+            </div>
+            <div className="h-3 w-72 bg-slate-700/50 rounded" />
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <div className="w-8 h-8 bg-slate-700/50 rounded-lg" />
+          <div className="w-8 h-8 bg-slate-700/50 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Added reusable `Skeleton` component system (`SkeletonText`, `SkeletonBox`, `SkeletonTable`, `SkeletonCard`, and page-specific variants)
- Replaced spinner loading states with skeleton UIs on rigs, profit, alerts, oc-profiles, pools, and wallets pages
- Skeletons match the shape of actual page content (rig cards with GPU tags, stat cards, alert items, etc.)
- Uses `animate-pulse` + `bg-slate-700/50` to match the existing dark theme

## Changes

| Page | Before | After |
|------|--------|-------|
| Rigs | Centered spinner in card | 3 skeleton rig cards with stats grid + GPU tag placeholders |
| Profit | Full-page spinner | Header + 4 stat cards + table skeleton |
| Alerts | Full-page spinner | Header + 5 skeleton alert items |
| OC Profiles | Full-page spinner | Header + 6 skeleton profile cards (3-col grid) |
| Pools | Centered spinner in card | 4 skeleton pool rows |
| Wallets | Centered spinner in card | 4 skeleton wallet rows |

## Category
UI/UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)