### PR TITLE
feat(a11y): add comprehensive ARIA accessibility to dashboard

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -55,3 +55,21 @@ Total suite: 132 passing tests (74 new + 58 existing). Zero new dependencies.
 **Files changed:** apps/api/src/__tests__/security.mining.test.ts (new)
 **Lines:** +369 / -0
 **PR:** https://github.com/bokiko/bloxos/pull/8
+
+## 2026-03-18 — Accessibility: ARIA markup across core dashboard components
+
+The dashboard had essentially zero accessibility support — one aria-* attribute across 50+ component files. Added comprehensive WCAG-compliant ARIA markup across the five most impactful files.
+
+layout.tsx: skip-to-main-content link, role=banner on mobile header, aria-label on hamburger/close buttons, role=navigation + aria-label on nav, aria-current=page on active links, aria-label on alert/update count badges, aria-label on command palette + logout buttons, id=main-content + tabIndex=-1 on main, role=complementary + aria-label on aside, role=presentation + aria-hidden on mobile overlay, role=status + aria-label on loading spinner.
+
+Toast.tsx: role=alert/status per toast severity, aria-live=assertive for errors and polite for info/success.
+
+CommandPalette.tsx: role=dialog + aria-modal + aria-label on modal, role=combobox + aria-autocomplete + aria-activedescendant on search input, role=listbox on results list, role=option + aria-selected on each result item.
+
+login/page.tsx: role=alert + id on error div, aria-describedby linking inputs to the error element.
+
+Skeleton.tsx: role=status + aria-label + aria-busy=true on all 10 skeleton components.
+
+**Files changed:** apps/dashboard/src/app/layout.tsx, apps/dashboard/src/app/login/page.tsx, apps/dashboard/src/components/CommandPalette.tsx, apps/dashboard/src/components/Skeleton.tsx, apps/dashboard/src/components/Toast.tsx
+**Lines:** +44 / -20
+**PR:** https://github.com/bokiko/bloxos/pull/6

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -44,7 +44,6 @@ Removed `getUserFarm()` from profit.ts, `getUserId()` from settings.ts, and the 
 **Lines:** +40 / -106 (net -66)
 **PR:** https://github.com/bokiko/bloxos/pull/5
 
-
 ## 2026-03-19 — Testing: Comprehensive tests for mining security validators
 
 The mining-specific security utility functions in apps/api/src/utils/security.ts had zero test coverage despite being critical guards against shell injection, invalid OC values, and malformed miner configuration. Added 74 new unit tests covering all eight untested functions.

--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -205,7 +205,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blox-500"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blox-500" role="status" aria-label="Loading"></div>
       </div>
     );
   }
@@ -229,6 +229,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
           <button
             onClick={() => setSidebarOpen(false)}
             className="lg:hidden p-2 -mr-2 text-slate-400 hover:text-white"
+            aria-label="Close navigation menu"
           >
             <CloseIcon />
           </button>
@@ -236,7 +237,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 p-3 lg:p-4 overflow-y-auto">
+      <nav className="flex-1 p-3 lg:p-4 overflow-y-auto" role="navigation" aria-label="Main navigation">
         <ul className="space-y-1">
           {navItems.map((item) => {
             // Skip admin-only items for non-admins
@@ -252,6 +253,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
                 <Link
                   href={item.href}
                   onClick={() => setSidebarOpen(false)}
+                  aria-current={active ? 'page' : undefined}
                   className={`flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-200 ${
                     active
                       ? 'bg-blox-600/20 text-blox-400 border border-blox-500/30'
@@ -261,12 +263,12 @@ function AppContent({ children }: { children: React.ReactNode }) {
                   <Icon />
                   <span className="font-medium flex-1 text-sm lg:text-base">{item.label}</span>
                   {showAlertBadge && (
-                    <span className="px-2 py-0.5 text-xs font-bold bg-red-500 text-white rounded-full min-w-[20px] text-center">
+                    <span className="px-2 py-0.5 text-xs font-bold bg-red-500 text-white rounded-full min-w-[20px] text-center" aria-label={`${alertCount} unread alerts`}>
                       {alertCount > 99 ? '99+' : alertCount}
                     </span>
                   )}
                   {showUpdateBadge && (
-                    <span className="px-2 py-0.5 text-xs font-bold bg-yellow-500 text-black rounded-full min-w-[20px] text-center" title="Miner updates available">
+                    <span className="px-2 py-0.5 text-xs font-bold bg-yellow-500 text-black rounded-full min-w-[20px] text-center" title="Miner updates available" aria-label={`${updateCount} miner updates available`}>
                       {updateCount}
                     </span>
                   )}
@@ -282,6 +284,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
         <button
           onClick={() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))}
           className="w-full flex items-center gap-2 px-3 py-2 text-sm text-slate-400 hover:text-white hover:bg-slate-700/50 rounded-lg border border-slate-700/50 transition-colors"
+          aria-label="Search or open command palette"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -305,6 +308,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
             onClick={logout}
             className="p-2 text-slate-400 hover:text-red-400 hover:bg-slate-700/50 rounded-lg transition-colors flex-shrink-0"
             title="Logout"
+            aria-label="Logout"
           >
             <LogoutIcon />
           </button>
@@ -316,12 +320,16 @@ function AppContent({ children }: { children: React.ReactNode }) {
   // Protected routes - render with sidebar
   return (
     <div className="min-h-screen">
+      {/* Skip to main content */}
+      <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-blox-600 focus:text-white focus:rounded-lg focus:font-medium">Skip to main content</a>
+
       {/* Mobile Header */}
-      <header className="lg:hidden fixed top-0 left-0 right-0 z-40 bg-slate-800/95 backdrop-blur-sm border-b border-slate-700/50">
+      <header className="lg:hidden fixed top-0 left-0 right-0 z-40 bg-slate-800/95 backdrop-blur-sm border-b border-slate-700/50" role="banner">
         <div className="flex items-center justify-between px-4 py-3">
           <button
             onClick={() => setSidebarOpen(true)}
             className="p-2 -ml-2 text-slate-400 hover:text-white"
+            aria-label="Open navigation menu"
           >
             <MenuIcon />
           </button>
@@ -340,6 +348,8 @@ function AppContent({ children }: { children: React.ReactNode }) {
         <div
           className="lg:hidden fixed inset-0 z-50 bg-black/60 backdrop-blur-sm"
           onClick={() => setSidebarOpen(false)}
+          role="presentation"
+          aria-hidden="true"
         />
       )}
 
@@ -351,6 +361,8 @@ function AppContent({ children }: { children: React.ReactNode }) {
           lg:transform-none lg:z-30
           ${sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
         `}
+        role="complementary"
+        aria-label="Sidebar navigation"
       >
         <SidebarContent />
       </aside>
@@ -362,7 +374,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
       <ToastContainer />
 
       {/* Main content */}
-      <main className="lg:ml-64 pt-16 lg:pt-0 min-h-screen">
+      <main id="main-content" tabIndex={-1} className="lg:ml-64 pt-16 lg:pt-0 min-h-screen">
         <div className="p-4 lg:p-6 max-w-7xl mx-auto">
           {children}
         </div>

--- a/apps/dashboard/src/app/login/page.tsx
+++ b/apps/dashboard/src/app/login/page.tsx
@@ -50,7 +50,7 @@ export default function LoginPage() {
         <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-xl p-6">
           <form onSubmit={handleSubmit} className="space-y-4">
             {error && (
-              <div className="bg-red-500/10 border border-red-500/50 text-red-400 px-4 py-3 rounded-lg text-sm">
+              <div id="login-error" role="alert" className="bg-red-500/10 border border-red-500/50 text-red-400 px-4 py-3 rounded-lg text-sm">
                 {error}
               </div>
             )}
@@ -68,6 +68,7 @@ export default function LoginPage() {
                 placeholder="admin@example.com"
                 required
                 autoComplete="email"
+                aria-describedby={error ? 'login-error' : undefined}
               />
             </div>
 
@@ -84,6 +85,7 @@ export default function LoginPage() {
                 placeholder="Enter your password"
                 required
                 autoComplete="current-password"
+                aria-describedby={error ? 'login-error' : undefined}
               />
             </div>
 

--- a/apps/dashboard/src/components/CommandPalette.tsx
+++ b/apps/dashboard/src/components/CommandPalette.tsx
@@ -191,7 +191,7 @@ export default function CommandPalette() {
       />
 
       {/* Palette */}
-      <div className="relative w-full max-w-lg bg-slate-800 rounded-xl border border-slate-600/50 shadow-2xl shadow-black/50 overflow-hidden">
+      <div className="relative w-full max-w-lg bg-slate-800 rounded-xl border border-slate-600/50 shadow-2xl shadow-black/50 overflow-hidden" role="dialog" aria-modal="true" aria-label="Command palette">
         {/* Search input */}
         <div className="flex items-center px-4 border-b border-slate-700/50">
           <svg className="w-5 h-5 text-slate-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -205,6 +205,11 @@ export default function CommandPalette() {
             onKeyDown={handleKeyDown}
             placeholder="Type a command or search..."
             className="w-full px-3 py-4 bg-transparent text-white placeholder-slate-400 outline-none text-sm"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-expanded={true}
+            aria-controls="command-palette-list"
+            aria-activedescendant={filtered[selectedIndex] ? `command-${filtered[selectedIndex].id}` : undefined}
           />
           <kbd className="hidden sm:inline-flex items-center px-2 py-1 text-xs text-slate-400 bg-slate-700/50 rounded border border-slate-600/50">
             ESC
@@ -212,7 +217,7 @@ export default function CommandPalette() {
         </div>
 
         {/* Results */}
-        <div ref={listRef} className="max-h-72 overflow-y-auto py-2">
+        <div ref={listRef} id="command-palette-list" role="listbox" className="max-h-72 overflow-y-auto py-2">
           {filtered.length === 0 ? (
             <div className="px-4 py-8 text-center text-slate-400 text-sm">
               No results found
@@ -221,6 +226,9 @@ export default function CommandPalette() {
             filtered.map((cmd, i) => (
               <button
                 key={cmd.id}
+                id={`command-${cmd.id}`}
+                role="option"
+                aria-selected={i === selectedIndex}
                 onClick={() => execute(cmd)}
                 onMouseEnter={() => setSelectedIndex(i)}
                 className={`w-full flex items-center gap-3 px-4 py-3 text-left transition-colors ${

--- a/apps/dashboard/src/components/Skeleton.tsx
+++ b/apps/dashboard/src/components/Skeleton.tsx
@@ -1,5 +1,5 @@
 export function SkeletonText({ width = 'w-32', className = '' }: { width?: string; className?: string }) {
-  return <div className={`h-4 bg-slate-700/50 rounded ${width} animate-pulse ${className}`} />;
+  return <div role="status" aria-label="Loading..." aria-busy="true" className={`h-4 bg-slate-700/50 rounded ${width} animate-pulse ${className}`} />;
 }
 
 export function SkeletonBox({
@@ -11,12 +11,12 @@ export function SkeletonBox({
   height?: string;
   className?: string;
 }) {
-  return <div className={`bg-slate-700/50 rounded-xl ${width} ${height} animate-pulse ${className}`} />;
+  return <div role="status" aria-label="Loading..." aria-busy="true" className={`bg-slate-700/50 rounded-xl ${width} ${height} animate-pulse ${className}`} />;
 }
 
 export function SkeletonCard({ className = '' }: { className?: string }) {
   return (
-    <div className={`bg-slate-800/50 rounded-xl border border-slate-700/50 p-5 animate-pulse ${className}`}>
+    <div role="status" aria-label="Loading..." aria-busy="true" className={`bg-slate-800/50 rounded-xl border border-slate-700/50 p-5 animate-pulse ${className}`}>
       <div className="flex items-start justify-between mb-4">
         <div className="space-y-2">
           <div className="h-5 w-40 bg-slate-700/50 rounded" />
@@ -34,7 +34,7 @@ export function SkeletonCard({ className = '' }: { className?: string }) {
 
 export function SkeletonTable({ rows = 5, cols = 4 }: { rows?: number; cols?: number }) {
   return (
-    <div className="bg-slate-800/50 rounded-xl border border-slate-700/50 overflow-hidden animate-pulse">
+    <div role="status" aria-label="Loading..." aria-busy="true" className="bg-slate-800/50 rounded-xl border border-slate-700/50 overflow-hidden animate-pulse">
       <div className="grid gap-px bg-slate-700/30">
         {Array.from({ length: rows }).map((_, i) => (
           <div key={i} className="bg-slate-800/80 px-5 py-4 flex items-center gap-4">
@@ -55,7 +55,7 @@ export function SkeletonTable({ rows = 5, cols = 4 }: { rows?: number; cols?: nu
 
 export function SkeletonRigCard() {
   return (
-    <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-5 animate-pulse">
+    <div role="status" aria-label="Loading..." aria-busy="true" className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-5 animate-pulse">
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
           <div className="w-4 h-4 bg-slate-700/50 rounded" />
@@ -86,7 +86,7 @@ export function SkeletonRigCard() {
 
 export function SkeletonStatCard() {
   return (
-    <div className="bg-slate-800 rounded-xl p-6 border border-slate-700 animate-pulse">
+    <div role="status" aria-label="Loading..." aria-busy="true" className="bg-slate-800 rounded-xl p-6 border border-slate-700 animate-pulse">
       <div className="flex items-center justify-between">
         <div className="space-y-2">
           <div className="h-3 w-20 bg-slate-700/50 rounded" />
@@ -100,7 +100,7 @@ export function SkeletonStatCard() {
 
 export function SkeletonAlertItem() {
   return (
-    <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-4 animate-pulse">
+    <div role="status" aria-label="Loading..." aria-busy="true" className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-4 animate-pulse">
       <div className="flex items-start gap-4">
         <div className="w-10 h-10 bg-slate-700/50 rounded-lg shrink-0" />
         <div className="flex-1 space-y-2">
@@ -119,7 +119,7 @@ export function SkeletonAlertItem() {
 
 export function SkeletonProfileCard() {
   return (
-    <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-5 animate-pulse">
+    <div role="status" aria-label="Loading..." aria-busy="true" className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-5 animate-pulse">
       <div className="flex items-start justify-between mb-4">
         <div className="space-y-2">
           <div className="h-5 w-32 bg-slate-700/50 rounded" />
@@ -144,7 +144,7 @@ export function SkeletonProfileCard() {
 
 export function SkeletonPoolRow() {
   return (
-    <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-5 animate-pulse">
+    <div role="status" aria-label="Loading..." aria-busy="true" className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-5 animate-pulse">
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-4">
           <div className="w-12 h-12 bg-slate-700/50 rounded-xl" />
@@ -167,7 +167,7 @@ export function SkeletonPoolRow() {
 
 export function SkeletonWalletRow() {
   return (
-    <div className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-5 animate-pulse">
+    <div role="status" aria-label="Loading..." aria-busy="true" className="bg-slate-800/50 backdrop-blur-sm rounded-xl border border-slate-700/50 p-5 animate-pulse">
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-4">
           <div className="w-12 h-12 bg-slate-700/50 rounded-xl" />

--- a/apps/dashboard/src/components/Toast.tsx
+++ b/apps/dashboard/src/components/Toast.tsx
@@ -21,6 +21,8 @@ function ToastItem({ toast }: { toast: Toast }) {
 
   return (
     <div
+      role={toast.type === 'error' ? 'alert' : 'status'}
+      aria-live={toast.type === 'error' ? 'assertive' : 'polite'}
       className={`flex items-start gap-3 px-4 py-3 bg-slate-800/95 backdrop-blur-sm border border-slate-700/50 border-l-4 ${borderColor[toast.type]} rounded-lg shadow-xl w-80 max-w-full`}
     >
       <p className={`flex-1 text-sm font-medium leading-snug ${iconColor[toast.type]}`}>
@@ -45,7 +47,7 @@ export default function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 items-end pointer-events-none">
+    <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 items-end pointer-events-none" aria-live="polite">
       {toasts.map((toast) => (
         <div key={toast.id} className="pointer-events-auto animate-slide-in-right">
           <ToastItem toast={toast} />


### PR DESCRIPTION
## Summary

Adds WCAG-compliant accessibility markup across the five core UI files that previously had essentially zero ARIA support.

## What changed

**layout.tsx**
- Skip-to-main-content link (screen-reader only, visible on focus)
- `role="banner"` on mobile header
- `aria-label` on hamburger open / close buttons
- `role="navigation"` + `aria-label="Main navigation"` on nav
- `aria-current="page"` on active nav links
- `aria-label` on alert count and update count badges
- `aria-label` on command palette button and logout button
- `id="main-content"` + `tabIndex={-1}` on main content area
- `role="complementary"` + `aria-label="Sidebar navigation"` on aside
- `role="presentation"` + `aria-hidden="true"` on mobile overlay
- `role="status"` + `aria-label="Loading"` on loading spinner

**Toast.tsx**
- `role="alert"` for error toasts, `role="status"` for info/success
- `aria-live="assertive"` for errors, `aria-live="polite"` for others
- `aria-live="polite"` on the toast container

**CommandPalette.tsx**
- `role="dialog"` + `aria-modal="true"` + `aria-label` on modal
- `role="combobox"` + `aria-autocomplete="list"` + `aria-activedescendant` on search input
- `role="listbox"` on results list
- `role="option"` + `aria-selected` on each result item

**login/page.tsx**
- `role="alert"` + `id` on error message div
- `aria-describedby` on email/password inputs linking to the error element

**Skeleton.tsx**
- `role="status"` + `aria-label="Loading..."` + `aria-busy="true"` on all 10 skeleton components

## Notes
- No visual changes whatsoever
- No new dependencies
- Build passes cleanly