### PR TITLE
fix: harden agent auth and stabilize dashboard deploy

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -7,8 +7,8 @@
   - [x] Codex Security Audit: 3 rounds, 6/8 fixed, 2 accepted
   - [x] Hardening Do Now: creds rotated, DB 0600, token logging stopped, single-use tokens, Caddy TLS, config model, rate limiting
   - [x] Hardening Do Next Sprint (all 6 items, 2026-04-22):
-    - [x] #8 Migration versioning (hub/migrations.go, schema_version table, 4 migrations)
-    - [x] #9 Smoke tests (33 tests in hub/main_test.go)
+    - [x] #8 Migration versioning (hub/migrations.go, schema_version table, 5 migrations)
+    - [x] #9 Smoke tests (41 tests in hub/main_test.go)
     - [x] #10 Backend-enforce password/PIN rotation (credentialRotationMiddleware)
     - [x] #11 First-boot setup flow (POST /api/setup, bootstrap token, no default creds)
     - [x] #12 Enrollment redesign (durable agent secrets, SHA-256 hashed, revocable)
@@ -31,12 +31,10 @@ To activate on the hub VM:
 1. SSH to hub (creds in memory/credentials.md)
 2. Stop services: `sudo systemctl stop bloxos-hub bloxos-agent`
 3. Rebuild hub: `cd ~/bloxos/hub && /usr/local/go/bin/go build -o bloxos-hub .`
-4. Copy hub binary: `sudo cp ~/bloxos/hub/bloxos-hub /usr/local/bin/bloxos-hub`
-5. Rebuild agent: `cd ~/bloxos/agent && /usr/local/go/bin/go build -o bloxos-agent .`
-6. Copy agent binary: `sudo cp ~/bloxos/agent/bloxos-agent /usr/local/bin/bloxos-agent`
-7. Restart: `sudo systemctl start bloxos-hub bloxos-agent`
-8. On first start: schema migrations run automatically (version 0 to 4)
-9. Existing admin user will hit rotation enforcement -- change password and PIN via API
+4. Rebuild agent: `cd ~/bloxos/agent && /usr/local/go/bin/go build -o bloxos-agent .`
+5. Restart: `sudo systemctl start bloxos-hub bloxos-agent`
+6. On first start: schema migrations run automatically (version 0 to 5)
+7. Existing admin user will hit rotation enforcement -- change password and PIN via API
 
 ### First-boot setup (new deployments only)
 - Hub writes setup token to `~/.bloxos/setup-token` (0600) if no users exist
@@ -46,12 +44,11 @@ To activate on the hub VM:
 - Dashboard needs a setup page (not built yet -- API-only for now)
 
 ### Agent enrollment (existing agents)
-- Existing agents continue working via machine_id recognition (backward compatible)
+- Existing agents must reconnect with a durable secret, or enroll once with a valid install token to mint one
 - New agents receive a durable secret on enrollment (stored at /etc/bloxos/agent-secret)
 - To re-enroll: delete machine from DB, generate new install token, re-run install script
 
 ## Known Issues
-- After rebuilding agent, MUST copy binary to /usr/local/bin/bloxos-agent on hub
 - Self-signed TLS: agents need InsecureSkipVerify for Caddy's cert
 - Dashboard setup page not built yet -- first-boot setup is API-only
 - Credentials were previously committed to HANDOFF.md and must be rotated

--- a/README.md
+++ b/README.md
@@ -73,20 +73,19 @@ cd dashboard && npx next start -H 0.0.0.0 &   # Dashboard on :3000
 
 ```bash
 # One-line install (generate token from dashboard)
-curl -sL http://<hub>:4000/install.sh | BLOXOS_HUB=ws://<hub>:4000 BLOXOS_TOKEN=<token> bash
+curl -sL https://<hub>/install.sh | BLOXOS_HUB=wss://<hub> BLOXOS_TOKEN=<token> bash
 
 # Or manual
 cd agent && go build -o bloxos-agent .
-./bloxos-agent --hub ws://<hub>:4000/ws/agent --token <token>
+./bloxos-agent --hub wss://<hub>/ws/agent --token <token>
 ```
 
-### Default Login
+### First Boot Setup
 
-| | |
-|---|---|
-| **Username** | `admin` |
-| **Password** | `bloxos` |
-| **Terminal PIN** | `1234` |
+1. Start the hub.
+2. Read the one-time setup token from `~/.bloxos/setup-token`, or set `BLOXOS_SETUP_TOKEN`.
+3. `POST /api/setup` with your setup token, admin username, password, and terminal PIN.
+4. Log in with the credentials you just created.
 
 ---
 
@@ -106,7 +105,7 @@ nvidia-smi integration reporting temperature, utilization, VRAM, power draw, and
 Discover and display systemd services and Docker containers. Restart, stop, or start any service or container with one click from the detail view.
 
 ### Built-in Web Terminal
-xterm.js terminal embedded in the dashboard. PTY relay via WebSocket through the hub. PIN-gated access. Full I/O audit logging. No SSH client needed.
+xterm.js terminal embedded in the dashboard. PTY relay via WebSocket through the hub. PIN-gated access with session audit metadata. No SSH client needed.
 
 </td>
 <td width="50%">
@@ -122,6 +121,9 @@ Multi-select machines in list view. Restart a service or reboot across the entir
 
 ### One-Line Agent Install
 Generate a time-limited token from the dashboard. Run one curl command on the target machine. Agent downloads, installs as systemd service, and starts reporting.
+
+### Supported Deploy Path
+The supported checked-in deployment path is `Caddy + systemd` on a single host. The Docker Compose files are not currently maintained as a supported runtime path.
 
 </td>
 </tr>

--- a/dashboard/src/app/machine/[id]/page.tsx
+++ b/dashboard/src/app/machine/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback, useRef, use } from "react";
+import { useEffect, useState, useCallback, useRef, use, useMemo } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
@@ -24,18 +24,15 @@ import {
   Activity, Zap, Monitor, Terminal as TerminalIcon, RotateCcw,
   Lock, Unlock, X, Maximize2, Minimize2, Wifi, BarChart3, Trash2,
 } from "lucide-react";
+import { HUB_URL, getAuthHeaders } from "@/lib/session";
 
 const TerminalComponent = dynamic(
   () => import("@/components/Terminal").then((m) => ({ default: m.Terminal })),
   { ssr: false }
 );
 
-const HUB_URL = process.env.NEXT_PUBLIC_HUB_URL || "http://localhost:4000";
-const HUB_WS_URL = HUB_URL.replace(/^http/, "ws");
-
 function authHeaders(): Record<string, string> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("bloxos_token") : null;
-  return token ? { Authorization: `Bearer ${token}` } : {};
+  return getAuthHeaders();
 }
 
 interface GPUData {
@@ -111,7 +108,7 @@ function getStatus(data: MachineData): MachineStatus {
 export default function MachineDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const { getMachine, connected } = useSSE();
-  const [data, setData] = useState<MachineData | null>(null);
+  const [baseData, setBaseData] = useState<MachineData | null>(null);
   const [services, setServices] = useState<Service[]>([]);
   const [containers, setContainers] = useState<Container[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -125,70 +122,87 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
 
   const [termState, setTermState] = useState<TerminalState>("locked");
   const [termSessionId, setTermSessionId] = useState<string | null>(null);
+  const [termBrowserToken, setTermBrowserToken] = useState<string | null>(null);
   const [pinInput, setPinInput] = useState("");
   const [pinError, setPinError] = useState(false);
   const [termExpanded, setTermExpanded] = useState(false);
   const pinInputRef = useRef<HTMLInputElement>(null);
 
-  const fetchData = useCallback(async () => {
-    try {
-      const hdrs = authHeaders();
-      const [machineRes, servicesRes, containersRes] = await Promise.all([
-        fetch(`${HUB_URL}/api/machines/${id}`, { headers: hdrs }),
-        fetch(`${HUB_URL}/api/machines/${id}/services`, { headers: hdrs }),
-        fetch(`${HUB_URL}/api/machines/${id}/containers`, { headers: hdrs }),
-      ]);
+  useEffect(() => {
+    let cancelled = false;
 
-      if (!machineRes.ok) {
-        setError(machineRes.status === 404 ? "Machine not found" : "Failed to load");
-        return;
+    async function load() {
+      try {
+        const hdrs = authHeaders();
+        const [machineRes, servicesRes, containersRes] = await Promise.all([
+          fetch(`${HUB_URL}/api/machines/${id}`, { headers: hdrs }),
+          fetch(`${HUB_URL}/api/machines/${id}/services`, { headers: hdrs }),
+          fetch(`${HUB_URL}/api/machines/${id}/containers`, { headers: hdrs }),
+        ]);
+
+        if (!machineRes.ok) {
+          if (!cancelled) {
+            setError(machineRes.status === 404 ? "Machine not found" : "Failed to load");
+          }
+          return;
+        }
+
+        const machineJson = await machineRes.json();
+        if (cancelled) return;
+
+        setBaseData(machineJson);
+        setLastUpdated(new Date().toISOString());
+        setError(null);
+
+        if (servicesRes.ok) setServices(await servicesRes.json());
+        if (containersRes.ok) setContainers(await containersRes.json());
+      } catch {
+        if (!cancelled) {
+          setError("Cannot reach hub");
+        }
       }
-
-      const machineJson = await machineRes.json();
-      setData(machineJson);
-      setLastUpdated(new Date().toISOString());
-      setError(null);
-
-      if (servicesRes.ok) setServices(await servicesRes.json());
-      if (containersRes.ok) setContainers(await containersRes.json());
-    } catch {
-      setError("Cannot reach hub");
     }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+  const sseData = getMachine(id);
+  const data = useMemo<MachineData | null>(() => {
+    if (!baseData || !sseData) return baseData;
 
-  useEffect(() => {
-    const sseData = getMachine(id);
-    if (!sseData) return;
+    return {
+      ...baseData,
+      metrics: {
+        cpu_percent: sseData.cpu_percent ?? baseData.metrics.cpu_percent,
+        ram_used_bytes: sseData.ram_used_bytes ?? baseData.metrics.ram_used_bytes,
+        ram_total_bytes: sseData.ram_total_bytes ?? baseData.metrics.ram_total_bytes,
+        disk_used_bytes: sseData.disk_used_bytes ?? baseData.metrics.disk_used_bytes,
+        disk_total_bytes: sseData.disk_total_bytes ?? baseData.metrics.disk_total_bytes,
+        gpu_temp: sseData.gpu_temp ?? baseData.metrics.gpu_temp,
+        gpu_util_percent: sseData.gpu_util_percent ?? baseData.metrics.gpu_util_percent,
+        gpu_vram_used_bytes: sseData.gpu_vram_used_bytes ?? baseData.metrics.gpu_vram_used_bytes,
+        gpu_vram_total_bytes: sseData.gpu_vram_total_bytes ?? baseData.metrics.gpu_vram_total_bytes,
+      },
+      machine: { ...baseData.machine, status: "online" },
+      latency_ms: sseData.latency_ms ?? baseData.latency_ms,
+    };
+  }, [baseData, sseData]);
 
-    setData((prev) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        metrics: {
-          cpu_percent: sseData.cpu_percent ?? prev.metrics.cpu_percent,
-          ram_used_bytes: sseData.ram_used_bytes ?? prev.metrics.ram_used_bytes,
-          ram_total_bytes: sseData.ram_total_bytes ?? prev.metrics.ram_total_bytes,
-          disk_used_bytes: sseData.disk_used_bytes ?? prev.metrics.disk_used_bytes,
-          disk_total_bytes: sseData.disk_total_bytes ?? prev.metrics.disk_total_bytes,
-          gpu_temp: sseData.gpu_temp ?? prev.metrics.gpu_temp,
-          gpu_util_percent: sseData.gpu_util_percent ?? prev.metrics.gpu_util_percent,
-          gpu_vram_used_bytes: sseData.gpu_vram_used_bytes ?? prev.metrics.gpu_vram_used_bytes,
-          gpu_vram_total_bytes: sseData.gpu_vram_total_bytes ?? prev.metrics.gpu_vram_total_bytes,
-        },
-        machine: { ...prev.machine, status: "online" },
-        latency_ms: sseData.latency_ms ?? prev.latency_ms,
-      };
-    });
-    setLastUpdated(new Date().toISOString());
-
-    const raw = sseData as unknown as Record<string, unknown>;
-    if (raw._services) setServices(raw._services as Service[]);
-    if (raw._containers) setContainers(raw._containers as Container[]);
-  }, [getMachine, id]);
+  const effectiveLastUpdated = useMemo(
+    () => (sseData ? new Date().toISOString() : lastUpdated),
+    [sseData, lastUpdated]
+  );
+  const liveServices = useMemo(() => {
+    const raw = sseData as Record<string, unknown> | undefined;
+    return Array.isArray(raw?._services) ? (raw._services as Service[]) : services;
+  }, [sseData, services]);
+  const liveContainers = useMemo(() => {
+    const raw = sseData as Record<string, unknown> | undefined;
+    return Array.isArray(raw?._containers) ? (raw._containers as Container[]) : containers;
+  }, [sseData, containers]);
 
   useEffect(() => {
     const interval = setInterval(() => setTick((t) => t + 1), 1000);
@@ -221,6 +235,7 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
         if (!d) return;
         setPinInput("");
         setTermSessionId(d.session_id);
+        setTermBrowserToken(d.browser_token);
         setTermState("active");
       })
       .catch(() => {
@@ -236,11 +251,13 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
       }).catch(() => {});
     }
     setTermSessionId(null);
+    setTermBrowserToken(null);
     setTermState("locked");
     setTermExpanded(false);
   }, [termSessionId, id]);
 
   const handleTerminalDisconnect = useCallback(() => {
+    setTermBrowserToken(null);
     setTermState("disconnected");
   }, []);
 
@@ -373,9 +390,9 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
                 {data.latency_ms}ms
               </span>
             )}
-            {lastUpdated && (
+            {effectiveLastUpdated && (
               <span className="text-[10px] text-blox-muted font-mono tabular-nums mr-2">
-                {timeSince(lastUpdated)}
+                {timeSince(effectiveLastUpdated)}
               </span>
             )}
             <Button
@@ -615,10 +632,10 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
         {/* Services + Containers */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.25 }}>
-            <ServicePanel services={services} machineId={id} hubUrl={HUB_URL} />
+            <ServicePanel services={liveServices} machineId={id} hubUrl={HUB_URL} />
           </motion.div>
           <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.3 }}>
-            <ContainerPanel containers={containers} machineId={id} hubUrl={HUB_URL} />
+            <ContainerPanel containers={liveContainers} machineId={id} hubUrl={HUB_URL} />
           </motion.div>
         </div>
 
@@ -736,7 +753,7 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
 
           {termState === "active" && termSessionId && (
             <div className="bg-[#0a0a0f] transition-all duration-200" style={{ height: termExpanded ? "600px" : "360px" }}>
-              <TerminalComponent sessionId={termSessionId} hubWsUrl={HUB_WS_URL} onDisconnect={handleTerminalDisconnect} />
+              <TerminalComponent sessionId={termSessionId} browserToken={termBrowserToken ?? ""} onDisconnect={handleTerminalDisconnect} />
             </div>
           )}
 

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useCallback } from "react";
 import { useSSE } from "@/contexts/SSEContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { demoMachines, MachineMetrics, AlertData } from "@/lib/demo-data";
+import { DEMO_MODE, HUB_URL } from "@/lib/session";
 import { MachineCard } from "@/components/MachineCard";
 import { MachineStatus } from "@/components/StatusBadge";
 import { AlertPanel } from "@/components/AlertPanel";
@@ -35,8 +36,6 @@ import Link from "next/link";
 type SortOption = "name" | "status" | "cpu" | "gpu_temp";
 type StatusFilter = "all" | "online" | "warning" | "offline";
 type ViewMode = "grid" | "list";
-
-const HUB_URL = process.env.NEXT_PUBLIC_HUB_URL || "http://localhost:4000";
 
 function getStatus(m: MachineMetrics): MachineStatus {
   const age = Date.now() - (m.last_seen || 0);
@@ -96,11 +95,8 @@ export default function Home() {
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [addAPIMachineOpen, setAddAPIMachineOpen] = useState(false);
 
-  const machines = hasReceivedData && liveMachines.length > 0
-    ? liveMachines
-    : demoMachines;
-
-  const isDemo = !hasReceivedData || liveMachines.length === 0;
+  const isDemo = DEMO_MODE && !hasReceivedData && liveMachines.length === 0;
+  const machines = isDemo ? demoMachines : liveMachines;
 
   const allTags = useMemo(() => {
     const tagSet = new Set<string>();
@@ -167,7 +163,8 @@ export default function Home() {
 
   const handleAcknowledge = useCallback(async (id: string) => {
     try {
-      await authFetch(`${HUB_URL}/api/alerts/${id}/acknowledge`, { method: "POST" });
+      const res = await authFetch(`${HUB_URL}/api/alerts/${id}/acknowledge`, { method: "POST" });
+      if (!res.ok) return;
       setAlerts((prev: AlertData[]) => prev.filter((a: AlertData) => a.id !== id));
       setAlertCount((prev: number) => Math.max(0, prev - 1));
     } catch { /* ignore */ }
@@ -176,7 +173,8 @@ export default function Home() {
   const handleAcknowledgeAll = useCallback(async () => {
     for (const a of alerts) {
       try {
-        await authFetch(`${HUB_URL}/api/alerts/${a.id}/acknowledge`, { method: "POST" });
+        const res = await authFetch(`${HUB_URL}/api/alerts/${a.id}/acknowledge`, { method: "POST" });
+        if (!res.ok) return;
       } catch { /* ignore */ }
     }
     setAlerts([]);
@@ -204,7 +202,7 @@ export default function Home() {
     if (!confirm(`Reboot ${selected.size} machine(s)? This cannot be undone.`)) return;
     setBulkLoading(true);
     try {
-      await authFetch(`${HUB_URL}/api/bulk/command`, {
+      const res = await authFetch(`${HUB_URL}/api/bulk/command`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -213,6 +211,7 @@ export default function Home() {
           target: "",
         }),
       });
+      if (!res.ok) return;
     } catch { /* ignore */ }
     setBulkLoading(false);
     setSelected(new Set());
@@ -221,7 +220,7 @@ export default function Home() {
   const handleBulkRestart = useCallback(async (service: string) => {
     setBulkLoading(true);
     try {
-      await authFetch(`${HUB_URL}/api/bulk/command`, {
+      const res = await authFetch(`${HUB_URL}/api/bulk/command`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -230,6 +229,7 @@ export default function Home() {
           target: service,
         }),
       });
+      if (!res.ok) return;
     } catch { /* ignore */ }
     setBulkLoading(false);
     setSelected(new Set());
@@ -239,7 +239,8 @@ export default function Home() {
     if (!deleteTarget) return;
     setDeleteLoading(true);
     try {
-      await authFetch(`${HUB_URL}/api/machines/${deleteTarget.id}`, { method: "DELETE" });
+      const res = await authFetch(`${HUB_URL}/api/machines/${deleteTarget.id}`, { method: "DELETE" });
+      if (!res.ok) return;
     } catch { /* ignore */ }
     setDeleteLoading(false);
     setDeleteTarget(null);

--- a/dashboard/src/components/AddMachineModal.tsx
+++ b/dashboard/src/components/AddMachineModal.tsx
@@ -7,8 +7,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-
-const HUB_URL = process.env.NEXT_PUBLIC_HUB_URL || "http://localhost:4000";
+import { HUB_URL, getStoredToken } from "@/lib/session";
 
 interface AddMachineModalProps {
   open: boolean;
@@ -24,7 +23,7 @@ export function AddMachineModal({ open, onClose }: AddMachineModalProps) {
   const generateToken = useCallback(async () => {
     setLoading(true);
     try {
-      const authToken = localStorage.getItem("bloxos_token");
+      const authToken = getStoredToken();
       const headers: Record<string, string> = {};
       if (authToken) headers["Authorization"] = `Bearer ${authToken}`;
       const res = await fetch(`${HUB_URL}/api/tokens`, { method: "POST", headers });

--- a/dashboard/src/components/ChangePasswordModal.tsx
+++ b/dashboard/src/components/ChangePasswordModal.tsx
@@ -2,8 +2,7 @@
 
 import { useState, FormEvent } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-
-const HUB_URL = process.env.NEXT_PUBLIC_HUB_URL || "http://localhost:4000";
+import { HUB_URL } from "@/lib/session";
 
 interface ChangePasswordModalProps {
   type: "password" | "pin";

--- a/dashboard/src/components/ContainerPanel.tsx
+++ b/dashboard/src/components/ContainerPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import { Box, RotateCcw, Play, Loader2 } from "lucide-react";
 import { useToast } from "./Toast";
 import { Button } from "@/components/ui/button";
+import { getStoredToken } from "@/lib/session";
 
 export interface Container {
   id: string;
@@ -51,7 +52,7 @@ function ContainerActions({
   async function runCommand(type: string) {
     setLoading(true);
     try {
-      const token = localStorage.getItem("bloxos_token");
+      const token = getStoredToken();
       const headers: Record<string, string> = { "Content-Type": "application/json" };
       if (token) headers["Authorization"] = `Bearer ${token}`;
       const res = await fetch(`${hubUrl}/api/machines/${machineId}/command`, {

--- a/dashboard/src/components/MachineCard.tsx
+++ b/dashboard/src/components/MachineCard.tsx
@@ -63,7 +63,7 @@ interface MachineCardProps {
 }
 
 export function MachineCard({ machine, onClick, onDelete }: MachineCardProps) {
-  const [now, setNow] = useState(Date.now());
+  const [now, setNow] = useState(() => Date.now());
   const { status, reason } = getStatus(machine);
 
   useEffect(() => {

--- a/dashboard/src/components/MetricCharts.tsx
+++ b/dashboard/src/components/MetricCharts.tsx
@@ -5,8 +5,7 @@ import {
   AreaChart, Area, XAxis, YAxis, ResponsiveContainer, Tooltip,
 } from "recharts";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-
-const HUB_URL = process.env.NEXT_PUBLIC_HUB_URL || "http://localhost:4000";
+import { HUB_URL, getStoredToken } from "@/lib/session";
 
 type Period = "30m" | "1h" | "6h" | "24h" | "7d";
 
@@ -26,9 +25,16 @@ interface MetricChartsProps {
   hasGpu: boolean;
 }
 
-function formatTime(ts: any): string {
+function formatTime(ts: string | number | Date): string {
   const d = new Date(ts);
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function formatTooltipLabel(label: unknown): string {
+  if (typeof label === "string" || typeof label === "number" || label instanceof Date) {
+    return formatTime(label);
+  }
+  return "";
 }
 
 function formatGB(bytes: number | undefined | null): string {
@@ -50,7 +56,7 @@ export function MetricCharts({ machineId, hasGpu }: MetricChartsProps) {
   const [data, setData] = useState<MetricPoint[]>([]);
 
   const fetchData = useCallback(async () => {
-    const token = localStorage.getItem("bloxos_token");
+    const token = getStoredToken();
     const headers: Record<string, string> = {};
     if (token) headers["Authorization"] = `Bearer ${token}`;
 
@@ -66,8 +72,11 @@ export function MetricCharts({ machineId, hasGpu }: MetricChartsProps) {
   }, [machineId, period]);
 
   useEffect(() => {
-    fetchData();
-    const interval = setInterval(fetchData, 30000);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchData();
+    const interval = setInterval(() => {
+      void fetchData();
+    }, 30000);
     return () => clearInterval(interval);
   }, [fetchData]);
 
@@ -129,8 +138,8 @@ export function MetricCharts({ machineId, hasGpu }: MetricChartsProps) {
                 />
                 <Tooltip
                   contentStyle={tooltipStyle}
-                  labelFormatter={formatTime}
-                  formatter={(v: any) => [`${(v ?? 0).toFixed(1)}%`, "CPU"]}
+                  labelFormatter={formatTooltipLabel}
+                  formatter={(v) => [`${Number(v ?? 0).toFixed(1)}%`, "CPU"]}
                 />
                 <Area type="monotone" dataKey="cpu_percent" stroke="#3b82f6" fill="url(#cpuGrad)" strokeWidth={1.5} />
               </AreaChart>
@@ -164,8 +173,8 @@ export function MetricCharts({ machineId, hasGpu }: MetricChartsProps) {
                 />
                 <Tooltip
                   contentStyle={tooltipStyle}
-                  labelFormatter={formatTime}
-                  formatter={(v: any) => [`${(v ?? 0).toFixed(1)} GB`, "RAM"]}
+                  labelFormatter={formatTooltipLabel}
+                  formatter={(v) => [`${Number(v ?? 0).toFixed(1)} GB`, "RAM"]}
                 />
                 <Area type="monotone" dataKey="ram_gb" stroke="#8b5cf6" fill="url(#ramGrad)" strokeWidth={1.5} />
               </AreaChart>
@@ -199,8 +208,8 @@ export function MetricCharts({ machineId, hasGpu }: MetricChartsProps) {
                   />
                   <Tooltip
                     contentStyle={tooltipStyle}
-                    labelFormatter={formatTime}
-                    formatter={(v: any) => [`${(v ?? 0).toFixed(0)} C`, "GPU Temp"]}
+                    labelFormatter={formatTooltipLabel}
+                    formatter={(v) => [`${Number(v ?? 0).toFixed(0)} C`, "GPU Temp"]}
                   />
                   <Area type="monotone" dataKey="gpu_temp" stroke="#f59e0b" fill="url(#gpuTempGrad)" strokeWidth={1.5} />
                 </AreaChart>
@@ -235,8 +244,8 @@ export function MetricCharts({ machineId, hasGpu }: MetricChartsProps) {
                   />
                   <Tooltip
                     contentStyle={tooltipStyle}
-                    labelFormatter={formatTime}
-                    formatter={(v: any) => [`${(v ?? 0).toFixed(1)} GB`, "VRAM"]}
+                    labelFormatter={formatTooltipLabel}
+                    formatter={(v) => [`${Number(v ?? 0).toFixed(1)} GB`, "VRAM"]}
                   />
                   <Area type="monotone" dataKey="vram_gb" stroke="#10b981" fill="url(#vramGrad)" strokeWidth={1.5} />
                 </AreaChart>

--- a/dashboard/src/components/RebootModal.tsx
+++ b/dashboard/src/components/RebootModal.tsx
@@ -8,6 +8,7 @@ import {
   DialogDescription, DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { getStoredToken } from "@/lib/session";
 
 interface RebootModalProps {
   hostname: string;
@@ -23,7 +24,7 @@ export function RebootModal({ hostname, machineId, hubUrl, onClose }: RebootModa
   async function handleReboot() {
     setLoading(true);
     try {
-      const token = localStorage.getItem("bloxos_token");
+      const token = getStoredToken();
       const headers: Record<string, string> = { "Content-Type": "application/json" };
       if (token) headers["Authorization"] = `Bearer ${token}`;
       const res = await fetch(`${hubUrl}/api/machines/${machineId}/command`, {

--- a/dashboard/src/components/ServicePanel.tsx
+++ b/dashboard/src/components/ServicePanel.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo } from "react";
-import { Layers, RotateCcw, Play, Square, Loader2, ChevronDown } from "lucide-react";
+import { useState, useMemo } from "react";
+import { Layers, RotateCcw, Play, Square, Loader2 } from "lucide-react";
 import { useToast } from "./Toast";
 import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
   DropdownMenuItem, DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { getStoredToken } from "@/lib/session";
 
 export interface Service {
   name: string;
@@ -50,7 +51,7 @@ function ServiceActions({
   async function runCommand(type: string) {
     setLoading(true);
     try {
-      const token = localStorage.getItem("bloxos_token");
+      const token = getStoredToken();
       const headers: Record<string, string> = { "Content-Type": "application/json" };
       if (token) headers["Authorization"] = `Bearer ${token}`;
       const res = await fetch(`${hubUrl}/api/machines/${machineId}/command`, {

--- a/dashboard/src/components/Sparkline.tsx
+++ b/dashboard/src/components/Sparkline.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
+import { HUB_URL, getStoredToken } from "@/lib/session";
 
 interface SparklineProps {
   machineId: string;
@@ -8,14 +9,12 @@ interface SparklineProps {
   height?: number;
 }
 
-const HUB_URL = process.env.NEXT_PUBLIC_HUB_URL || "http://localhost:4000";
-
 export function Sparkline({ machineId, width = 120, height = 28 }: SparklineProps) {
   const [points, setPoints] = useState<number[]>([]);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
-    const token = localStorage.getItem("bloxos_token");
+    const token = getStoredToken();
     const headers: Record<string, string> = {};
     if (token) headers["Authorization"] = `Bearer ${token}`;
 

--- a/dashboard/src/components/Terminal.tsx
+++ b/dashboard/src/components/Terminal.tsx
@@ -8,11 +8,11 @@ import "@xterm/xterm/css/xterm.css";
 
 interface TerminalProps {
   sessionId: string;
-  hubWsUrl: string;
+  browserToken: string;
   onDisconnect?: () => void;
 }
 
-export function Terminal({ sessionId, hubWsUrl, onDisconnect }: TerminalProps) {
+export function Terminal({ sessionId, browserToken, onDisconnect }: TerminalProps) {
   const termRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<XTerm | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
@@ -82,8 +82,8 @@ export function Terminal({ sessionId, hubWsUrl, onDisconnect }: TerminalProps) {
     term.writeln("\x1b[36mConnecting to terminal session...\x1b[0m");
 
     // Connect WebSocket.
-    const jwtToken = localStorage.getItem("bloxos_token") || "";
-    const wsUrl = `${hubWsUrl}/ws/terminal/${sessionId}?role=browser&token=${encodeURIComponent(jwtToken)}`;
+    const baseUrl = window.location.origin.replace(/^http/, "ws");
+    const wsUrl = `${baseUrl}/ws/terminal/${sessionId}?role=browser&browser_token=${encodeURIComponent(browserToken)}`;
     const ws = new WebSocket(wsUrl);
     ws.binaryType = "arraybuffer";
     wsRef.current = ws;
@@ -155,7 +155,7 @@ export function Terminal({ sessionId, hubWsUrl, onDisconnect }: TerminalProps) {
       onResize.dispose();
       cleanup();
     };
-  }, [sessionId, hubWsUrl, onDisconnect, cleanup]);
+  }, [sessionId, browserToken, onDisconnect, cleanup]);
 
   return (
     <div className="relative w-full h-full">

--- a/dashboard/src/contexts/AuthContext.tsx
+++ b/dashboard/src/contexts/AuthContext.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useState, useCallback, ReactNode } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { ChangePasswordModal } from "@/components/ChangePasswordModal";
+import { HUB_URL, dispatchAuthChanged } from "@/lib/session";
 
 interface AuthContextType {
   token: string | null;
@@ -20,8 +21,6 @@ export function useAuth() {
   return ctx;
 }
 
-const HUB_URL = process.env.NEXT_PUBLIC_HUB_URL || "http://localhost:4000";
-
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
   const [checked, setChecked] = useState(false);
@@ -37,6 +36,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       try {
         const payload = JSON.parse(atob(stored.split(".")[1]));
         if (payload.exp * 1000 > Date.now()) {
+          // eslint-disable-next-line react-hooks/set-state-in-effect
           setToken(stored);
           // Check stored change requirements.
           const pwReq = localStorage.getItem("bloxos_pw_change_required");
@@ -72,6 +72,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const data = await res.json();
       localStorage.setItem("bloxos_token", data.token);
       setToken(data.token);
+      dispatchAuthChanged();
 
       // Check if password/PIN change is required (Finding #2).
       if (data.password_change_required) {
@@ -96,6 +97,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setToken(null);
     setPasswordChangeRequired(false);
     setPinChangeRequired(false);
+    dispatchAuthChanged();
     router.push("/login");
   }, [router]);
 
@@ -112,11 +114,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (payload.exp * 1000 < Date.now()) {
           localStorage.removeItem("bloxos_token");
           setToken(null);
+          dispatchAuthChanged();
           router.push("/login");
         }
       } catch {
         localStorage.removeItem("bloxos_token");
         setToken(null);
+        dispatchAuthChanged();
         router.push("/login");
       }
     }

--- a/dashboard/src/contexts/SSEContext.tsx
+++ b/dashboard/src/contexts/SSEContext.tsx
@@ -10,8 +10,11 @@ import {
   ReactNode,
 } from "react";
 import { MachineMetrics, AlertData } from "@/lib/demo-data";
-
-const HUB_URL = process.env.NEXT_PUBLIC_HUB_URL || "http://localhost:4000";
+import {
+  AUTH_CHANGED_EVENT,
+  HUB_URL,
+  getStoredToken,
+} from "@/lib/session";
 
 interface SSEContextType {
   machines: MachineMetrics[];
@@ -63,28 +66,42 @@ export function SSEProvider({ children }: { children: ReactNode }) {
   const mountedRef = useRef(true);
   // Refresh SSE token before it expires (every 4 min for a 5-min token).
   const sseTokenRefreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const connectRef = useRef<() => void>(() => {});
+
+  const disconnect = useCallback((clearData = false) => {
+    esRef.current?.close();
+    esRef.current = null;
+    if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+    if (sseTokenRefreshTimer.current) clearTimeout(sseTokenRefreshTimer.current);
+    setConnected(false);
+    if (clearData) {
+      setHasReceivedData(false);
+      setMachineMap(new Map());
+      setAlerts([]);
+      setAlertCount(0);
+    }
+  }, []);
 
   const connect = useCallback(async () => {
     if (!mountedRef.current) return;
 
-    if (esRef.current) {
-      esRef.current.close();
-      esRef.current = null;
-    }
-
-    const token =
-      typeof window !== "undefined"
-        ? localStorage.getItem("bloxos_token")
-        : null;
+    disconnect();
+    const token = getStoredToken();
 
     // Don't connect if no token.
     if (!token) return;
 
     // Get SSE-scoped token (Finding #8).
     const sseToken = await fetchSSEToken();
-    const connectToken = sseToken || token; // Fall back to full token if SSE token fetch fails.
+    if (!sseToken) {
+      reconnectTimer.current = setTimeout(() => {
+        backoffRef.current = Math.min(backoffRef.current * 2, 30000);
+        connectRef.current();
+      }, backoffRef.current);
+      return;
+    }
 
-    const sseUrl = `${HUB_URL}/api/events?token=${encodeURIComponent(connectToken)}`;
+    const sseUrl = `${HUB_URL}/api/events?token=${encodeURIComponent(sseToken)}`;
 
     let es: EventSource;
     try {
@@ -92,7 +109,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
     } catch {
       reconnectTimer.current = setTimeout(() => {
         backoffRef.current = Math.min(backoffRef.current * 2, 30000);
-        connect();
+        connectRef.current();
       }, backoffRef.current);
       return;
     }
@@ -103,31 +120,26 @@ export function SSEProvider({ children }: { children: ReactNode }) {
       setConnected(true);
       backoffRef.current = 3000;
 
-      // Schedule SSE token refresh (reconnect with new token every 4 min).
-      if (sseToken) {
-        if (sseTokenRefreshTimer.current) clearTimeout(sseTokenRefreshTimer.current);
-        sseTokenRefreshTimer.current = setTimeout(() => {
-          if (mountedRef.current) {
-            connect();
-          }
-        }, 4 * 60 * 1000);
-      }
+      if (sseTokenRefreshTimer.current) clearTimeout(sseTokenRefreshTimer.current);
+      sseTokenRefreshTimer.current = setTimeout(() => {
+        if (mountedRef.current) {
+          connectRef.current();
+        }
+      }, 4 * 60 * 1000);
     };
 
     es.addEventListener("snapshot", (event) => {
       if (!mountedRef.current) return;
       try {
         const list = JSON.parse(event.data) as MachineMetrics[];
-        if (list.length > 0) {
-          setHasReceivedData(true);
-          setMachineMap(() => {
-            const next = new Map<string, MachineMetrics>();
-            for (const m of list) {
-              next.set(m.machine_id, { ...m, last_seen: Date.now() });
-            }
-            return next;
-          });
-        }
+        setHasReceivedData(true);
+        setMachineMap(() => {
+          const next = new Map<string, MachineMetrics>();
+          for (const m of list) {
+            next.set(m.machine_id, { ...m, last_seen: Date.now() });
+          }
+          return next;
+        });
       } catch {
         // ignore parse errors
       }
@@ -224,19 +236,22 @@ export function SSEProvider({ children }: { children: ReactNode }) {
 
       const delay = backoffRef.current;
       backoffRef.current = Math.min(backoffRef.current * 2, 30000);
-      reconnectTimer.current = setTimeout(connect, delay);
+      reconnectTimer.current = setTimeout(() => connectRef.current(), delay);
     };
-  }, []);
+  }, [disconnect]);
+
+  useEffect(() => {
+    connectRef.current = () => {
+      void connect();
+    };
+  }, [connect]);
 
   useEffect(() => {
     mountedRef.current = true;
-    connect();
+    connectRef.current();
 
     // Fetch active alerts on mount
-    const token =
-      typeof window !== "undefined"
-        ? localStorage.getItem("bloxos_token")
-        : null;
+    const token = getStoredToken();
     if (token) {
       fetch(`${HUB_URL}/api/alerts`, {
         headers: { Authorization: `Bearer ${token}` },
@@ -254,23 +269,28 @@ export function SSEProvider({ children }: { children: ReactNode }) {
 
     const onStorage = (e: StorageEvent) => {
       if (e.key === "bloxos_token") {
-        if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
-        if (sseTokenRefreshTimer.current) clearTimeout(sseTokenRefreshTimer.current);
         backoffRef.current = 3000;
-        connect();
+        connectRef.current();
+      }
+    };
+    const onAuthChanged = () => {
+      backoffRef.current = 3000;
+      if (getStoredToken()) {
+        connectRef.current();
+      } else {
+        disconnect(true);
       }
     };
     window.addEventListener("storage", onStorage);
+    window.addEventListener(AUTH_CHANGED_EVENT, onAuthChanged);
 
     return () => {
       mountedRef.current = false;
       window.removeEventListener("storage", onStorage);
-      esRef.current?.close();
-      esRef.current = null;
-      if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
-      if (sseTokenRefreshTimer.current) clearTimeout(sseTokenRefreshTimer.current);
+      window.removeEventListener(AUTH_CHANGED_EVENT, onAuthChanged);
+      disconnect();
     };
-  }, [connect]);
+  }, [disconnect]);
 
   const getMachine = useCallback(
     (id: string) => machineMap.get(id),

--- a/dashboard/src/lib/session.ts
+++ b/dashboard/src/lib/session.ts
@@ -1,0 +1,28 @@
+"use client";
+
+export const HUB_URL = process.env.NEXT_PUBLIC_HUB_URL || "";
+export const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE === "true";
+export const AUTH_CHANGED_EVENT = "bloxos-auth-changed";
+
+export function getStoredToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("bloxos_token");
+}
+
+export function getAuthHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  const token = getStoredToken();
+  return token ? { ...extra, Authorization: `Bearer ${token}` } : { ...extra };
+}
+
+export function dispatchAuthChanged() {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(AUTH_CHANGED_EVENT));
+  }
+}
+
+export function getHubWsBaseUrl(): string {
+  const base =
+    HUB_URL ||
+    (typeof window !== "undefined" ? window.location.origin : "");
+  return base.replace(/^http/, "ws");
+}

--- a/hub/main.go
+++ b/hub/main.go
@@ -1621,47 +1621,56 @@ func handleAgentWS(c echo.Context) error {
 			continue
 		}
 
-		switch envelope.Type {
-		case "metrics", "":
-			var m AgentMetrics
-			if err := json.Unmarshal(msg, &m); err != nil {
-				log.Printf("invalid metrics JSON: %v", err)
-				continue
-			}
-			if machineID == "" {
-				machineID = m.MachineID
-
-				// Check if this machine_id already exists (reconnecting agent).
-				var existingID string
-				knownMachine := db.QueryRow(`SELECT id FROM machines WHERE id = ?`, machineID).Scan(&existingID) == nil
-
-				if knownMachine {
-					log.Printf("known agent reconnecting: %s (%s)", m.Hostname, machineID)
-				} else if tokenValidated {
-					// New enrollment with valid token - consume it and issue durable secret.
-					consumeToken(tokenHash)
-					rawSecret, secretHash, err := generateAgentSecret()
-					if err != nil {
-						log.Printf("failed to generate agent secret: %v", err)
-						ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"enrollment failed"}`))
+			switch envelope.Type {
+			case "metrics", "":
+				var m AgentMetrics
+				if err := json.Unmarshal(msg, &m); err != nil {
+					log.Printf("invalid metrics JSON: %v", err)
+					continue
+				}
+				if machineID == "" {
+					machineID = m.MachineID
+					if secretMachineID != "" && machineID != secretMachineID {
+						log.Printf("rejecting agent: claimed machine_id %s does not match credential for %s", machineID, secretMachineID)
+						ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"machine_id does not match credential"}`))
 						return nil
 					}
-					if err := storeAgentCredential(machineID, secretHash); err != nil {
-						log.Printf("failed to store agent credential: %v", err)
-						ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"enrollment failed"}`))
-						return nil
-					}
-					enrolledMsg, _ := json.Marshal(map[string]string{
+
+					// Check if this machine_id already exists (reconnecting agent).
+					var existingID string
+					knownMachine := db.QueryRow(`SELECT id FROM machines WHERE id = ?`, machineID).Scan(&existingID) == nil
+					hasCredential := machineHasCredential(machineID)
+
+					if knownMachine && secretMachineID == machineID {
+						log.Printf("known agent reconnecting with durable credential: %s (%s)", m.Hostname, machineID)
+					} else if tokenValidated {
+						// New enrollment with valid token - consume it and issue durable secret.
+						rawSecret, secretHash, err := generateAgentSecret()
+						if err != nil {
+							log.Printf("failed to generate agent secret: %v", err)
+							ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"enrollment failed"}`))
+							return nil
+						}
+						if err := consumeTokenAndStoreCredential(tokenHash, machineID, secretHash); err != nil {
+							log.Printf("failed to store agent credential: %v", err)
+							ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"enrollment failed"}`))
+							return nil
+						}
+						enrolledMsg, _ := json.Marshal(map[string]string{
 						"type":         "enrolled",
 						"agent_secret": rawSecret,
-					})
-					ws.WriteMessage(websocket.TextMessage, enrolledMsg)
-					log.Printf("new agent enrolled with durable secret: %s (%s)", m.Hostname, machineID)
-				} else {
-					log.Printf("rejecting unknown agent %s (%s): no valid token", m.Hostname, machineID)
-					ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"invalid or used token"}`))
-					return nil
-				}
+						})
+						ws.WriteMessage(websocket.TextMessage, enrolledMsg)
+						log.Printf("new agent enrolled with durable secret: %s (%s)", m.Hostname, machineID)
+					} else if knownMachine || hasCredential {
+						log.Printf("rejecting known agent %s (%s): durable credential required", m.Hostname, machineID)
+						ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"durable credential required"}`))
+						return nil
+					} else {
+						log.Printf("rejecting unknown agent %s (%s): no valid token", m.Hostname, machineID)
+						ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"invalid or used token"}`))
+						return nil
+					}
 
 				agent.MachineID = machineID
 				agentsMu.Lock()
@@ -1778,6 +1787,37 @@ func extractUserIDFromRequest(c echo.Context) string {
 	return userID
 }
 
+func configuredAllowedOrigins() []string {
+	if ao := os.Getenv("ALLOWED_ORIGINS"); ao != "" {
+		parts := strings.Split(ao, ",")
+		out := make([]string, 0, len(parts))
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				out = append(out, part)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	if pu := strings.TrimSpace(os.Getenv("PUBLIC_URL")); pu != "" {
+		return []string{pu}
+	}
+	return nil
+}
+
+func generateTerminalBrowserToken(sessionID, userID string) (string, error) {
+	claims := jwt.MapClaims{
+		"type":       "terminal_browser",
+		"user_id":    userID,
+		"session_id": sessionID,
+		"exp":        time.Now().Add(1 * time.Minute).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(jwtSecret)
+}
+
 // handleStartTerminal creates a terminal session and tells the agent to spawn a PTY.
 func handleStartTerminal(c echo.Context) error {
 	ip := getRealIP(c)
@@ -1795,14 +1835,22 @@ func handleStartTerminal(c echo.Context) error {
 	if err := c.Bind(&body); err != nil || body.Pin == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "pin is required"})
 	}
-	if err := verifyTerminalPIN(body.Pin); err != nil {
+	userID := extractUserIDFromRequest(c)
+	if userID == "" {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
+	}
+	if err := verifyTerminalPIN(userID, body.Pin); err != nil {
 		return c.JSON(http.StatusForbidden, map[string]string{"error": "invalid PIN"})
 	}
 
-	// Enforce max concurrent terminal sessions (hardening plan #13).
-	// TODO: count per-user when multi-user support is added.
+	// Enforce max concurrent terminal sessions per user.
 	termSessionsMu.RLock()
-	activeCount := len(termSessions)
+	activeCount := 0
+	for _, session := range termSessions {
+		if session.UserID == userID {
+			activeCount++
+		}
+	}
 	termSessionsMu.RUnlock()
 	if activeCount >= maxTerminalSessions {
 		log.Printf("terminal session rejected: max concurrent sessions reached (%d)", maxTerminalSessions)
@@ -1815,13 +1863,19 @@ func handleStartTerminal(c echo.Context) error {
 	if !ok {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "agent not connected"})
 	}
+	if agent.Conn == nil {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "agent connection unavailable"})
+	}
 
 	// Extract audit metadata.
-	userID := extractUserIDFromRequest(c)
 	sourceIP := getRealIP(c)
 
 	sessionID := uuid.New().String()
 	terminalToken := uuid.New().String()
+	browserToken, err := generateTerminalBrowserToken(sessionID, userID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create terminal session"})
+	}
 
 	now := time.Now()
 	session := &TerminalSession{
@@ -1854,7 +1908,7 @@ func handleStartTerminal(c echo.Context) error {
 		}
 	}()
 
-	_, err := db.Exec(`INSERT INTO terminal_sessions (id, machine_id, source_ip, user_id) VALUES (?, ?, ?, ?)`, sessionID, machineID, sourceIP, userID)
+	_, err = db.Exec(`INSERT INTO terminal_sessions (id, machine_id, source_ip, user_id) VALUES (?, ?, ?, ?)`, sessionID, machineID, sourceIP, userID)
 	if err != nil {
 		log.Printf("terminal session DB insert error: %v", err)
 	}
@@ -1877,7 +1931,10 @@ func handleStartTerminal(c echo.Context) error {
 	}
 
 	log.Printf("terminal session %s created for machine %s", sessionID, machineID)
-	return c.JSON(http.StatusOK, map[string]string{"session_id": sessionID})
+	return c.JSON(http.StatusOK, map[string]string{
+		"session_id":   sessionID,
+		"browser_token": browserToken,
+	})
 }
 
 func handleCloseTerminal(c echo.Context) error {
@@ -1912,6 +1969,7 @@ func handleCloseTerminal(c echo.Context) error {
 func handleTerminalWS(c echo.Context) error {
 	sessionID := c.Param("session_id")
 	role := c.QueryParam("role")
+	browserUserID := ""
 
 	if role != "agent" && role != "browser" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "role must be 'agent' or 'browser'"})
@@ -1936,9 +1994,9 @@ func handleTerminalWS(c echo.Context) error {
 		}
 	}
 	if role == "browser" {
-		tokenStr := c.QueryParam("token")
+		tokenStr := c.QueryParam("browser_token")
 		if tokenStr == "" {
-			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "token required for browser role"})
+			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "browser_token required for browser role"})
 		}
 		tkn, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -1949,6 +2007,17 @@ func handleTerminalWS(c echo.Context) error {
 		if err != nil || !tkn.Valid {
 			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "invalid or expired token"})
 		}
+		claims, ok := tkn.Claims.(jwt.MapClaims)
+		if !ok {
+			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "invalid token claims"})
+		}
+		if tokenType, _ := claims["type"].(string); tokenType != "terminal_browser" {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "invalid browser token type"})
+		}
+		if tokenSessionID, _ := claims["session_id"].(string); tokenSessionID != sessionID {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "browser token does not match session"})
+		}
+		browserUserID, _ = claims["user_id"].(string)
 	}
 
 	termSessionsMu.RLock()
@@ -1957,27 +2026,28 @@ func handleTerminalWS(c echo.Context) error {
 	if !ok {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "session not found"})
 	}
+	if role == "browser" && session.UserID != "" && browserUserID != session.UserID {
+		return c.JSON(http.StatusForbidden, map[string]string{"error": "browser token does not match session owner"})
+	}
 
 	// Use origin-checking upgrader for terminal WebSocket (Finding #4).
-	termUpgrader := websocket.Upgrader{
-		CheckOrigin: func(r *http.Request) bool {
-			origin := r.Header.Get("Origin")
-			if origin == "" {
-				return true // agent connections have no origin
-			}
-			// Allow known origins.
-			for _, allowed := range []string{"http://localhost:3000", "http://192.168.16.113:3000", "http://localhost:4000", "http://192.168.16.113:4000"} {
-				if origin == allowed {
+		termUpgrader := websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool {
+				origin := r.Header.Get("Origin")
+				if origin == "" {
+					return true // agent connections have no origin
+				}
+				for _, allowed := range configuredAllowedOrigins() {
+					if origin == allowed {
+						return true
+					}
+				}
+				if parsedOrigin, err := url.Parse(origin); err == nil && parsedOrigin.Host == r.Host {
 					return true
 				}
-			}
-			// Also allow if origin matches the request host.
-			if strings.Contains(origin, r.Host) {
-				return true
-			}
-			log.Printf("terminal WS: rejected origin %s", origin)
-			return false
-		},
+				log.Printf("terminal WS: rejected origin %s", origin)
+				return false
+			},
 	}
 	ws, err := termUpgrader.Upgrade(c.Response(), c.Request(), nil)
 	if err != nil {
@@ -2737,6 +2807,32 @@ func consumeToken(tokenHash string) {
 	}
 }
 
+func consumeTokenAndStoreCredential(tokenHash, machineID, secretHash string) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	res, err := tx.Exec(`UPDATE tokens SET used = TRUE WHERE token_hash = ? AND used = FALSE`, tokenHash)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows != 1 {
+		return fmt.Errorf("install token already consumed")
+	}
+
+	if _, err := tx.Exec(`INSERT OR REPLACE INTO agent_credentials (machine_id, secret_hash, created_at, last_used_at)
+		VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, machineID, secretHash); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // generateAgentSecret creates a 32-byte random secret for agent enrollment.
 // Returns the hex-encoded raw secret and its SHA-256 hash.
 func generateAgentSecret() (raw string, hash string, err error) {
@@ -2755,6 +2851,15 @@ func storeAgentCredential(machineID, secretHash string) error {
 	_, err := db.Exec(`INSERT OR REPLACE INTO agent_credentials (machine_id, secret_hash, created_at, last_used_at)
 		VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, machineID, secretHash)
 	return err
+}
+
+func machineHasCredential(machineID string) bool {
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, machineID).Scan(&count); err != nil {
+		log.Printf("failed checking agent credential for %s: %v", machineID, err)
+		return false
+	}
+	return count > 0
 }
 
 // validateAgentSecret looks up a credential by the SHA-256 hash of the provided secret.
@@ -2954,17 +3059,13 @@ func handleChangePassword(c echo.Context) error {
 }
 
 // verifyTerminalPIN checks a PIN against the stored hash (Finding #3).
-func verifyTerminalPIN(pin string) error {
+func verifyTerminalPIN(userID, pin string) error {
+	if userID == "" {
+		return fmt.Errorf("missing user context")
+	}
 	var pinHash sql.NullString
-	err := db.QueryRow(`SELECT terminal_pin_hash FROM users WHERE username = 'admin'`).Scan(&pinHash)
+	err := db.QueryRow(`SELECT terminal_pin_hash FROM users WHERE id = ?`, userID).Scan(&pinHash)
 	if err != nil || !pinHash.Valid || pinHash.String == "" {
-		// No PIN set yet — seed default PIN hash.
-		defaultHash, _ := bcrypt.GenerateFromPassword([]byte("1234"), bcrypt.DefaultCost)
-		db.Exec(`UPDATE users SET terminal_pin_hash = ? WHERE username = 'admin'`, string(defaultHash))
-		// Verify against default.
-		if pin == "1234" {
-			return nil
-		}
 		return fmt.Errorf("invalid PIN")
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(pinHash.String), []byte(pin)); err != nil {
@@ -2986,7 +3087,11 @@ func handleChangePIN(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "new PIN must be at least 4 characters"})
 	}
 
-	if err := verifyTerminalPIN(body.CurrentPIN); err != nil {
+	userID := extractUserIDFromRequest(c)
+	if userID == "" {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
+	}
+	if err := verifyTerminalPIN(userID, body.CurrentPIN); err != nil {
 		return c.JSON(http.StatusForbidden, map[string]string{"error": "current PIN is incorrect"})
 	}
 
@@ -2994,7 +3099,7 @@ func handleChangePIN(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to hash PIN"})
 	}
-	_, err = db.Exec(`UPDATE users SET terminal_pin_hash = ?, pin_changed = TRUE WHERE username = 'admin'`, string(newHash))
+	_, err = db.Exec(`UPDATE users SET terminal_pin_hash = ?, pin_changed = TRUE WHERE id = ?`, string(newHash), userID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update PIN"})
 	}
@@ -3053,22 +3158,23 @@ type tokenRedactingWriter struct {
 
 func (t *tokenRedactingWriter) Write(p []byte) (n int, err error) {
 	s := string(p)
-	// Redact token= query parameter values.
-	for {
-		idx := strings.Index(s, "token=")
-		if idx == -1 {
-			break
-		}
-		end := idx + 6
-		// Find the end of the token value (next & or space or quote or newline).
-		tokenEnd := end
-		for tokenEnd < len(s) && s[tokenEnd] != '&' && s[tokenEnd] != ' ' && s[tokenEnd] != '"' && s[tokenEnd] != '\n' {
-			tokenEnd++
-		}
-		if tokenEnd > end {
-			s = s[:end] + "[REDACTED]" + s[tokenEnd:]
-		} else {
-			break
+	for _, key := range []string{"token", "secret", "terminal_token", "browser_token"} {
+		needle := key + "="
+		for {
+			idx := strings.Index(s, needle)
+			if idx == -1 {
+				break
+			}
+			end := idx + len(needle)
+			valueEnd := end
+			for valueEnd < len(s) && s[valueEnd] != '&' && s[valueEnd] != ' ' && s[valueEnd] != '"' && s[valueEnd] != '\n' {
+				valueEnd++
+			}
+			if valueEnd > end {
+				s = s[:end] + "[REDACTED]" + s[valueEnd:]
+			} else {
+				break
+			}
 		}
 	}
 	return t.w.Write([]byte(s))

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -26,9 +26,13 @@ func seedTestAdmin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hash password: %v", err)
 	}
+	pinHash, err := bcrypt.GenerateFromPassword([]byte("1234"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash pin: %v", err)
+	}
 	id := "test-admin-id"
-	_, err = db.Exec(`INSERT INTO users (id, username, password_hash) VALUES (?, ?, ?)`,
-		id, "admin", string(hash))
+	_, err = db.Exec(`INSERT INTO users (id, username, password_hash, terminal_pin_hash) VALUES (?, ?, ?, ?)`,
+		id, "admin", string(hash), string(pinHash))
 	if err != nil {
 		t.Fatalf("seed test admin: %v", err)
 	}
@@ -1074,6 +1078,79 @@ func TestAgentSecretRevocation(t *testing.T) {
 	server.Close()
 }
 
+func TestKnownMachineReconnectWithoutCredentialRejected(t *testing.T) {
+	e := setupTestServer(t)
+
+	if _, err := db.Exec(`INSERT INTO machines (id, hostname, status) VALUES (?, ?, ?)`,
+		"known-machine-without-secret", "known-host", "online"); err != nil {
+		t.Fatalf("seed known machine: %v", err)
+	}
+
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	conn, err := wsDialAgent(t, server, "token=definitely-invalid")
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	sendMetricsMsg(t, conn, "known-machine-without-secret")
+
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("expected rejection message, got read error: %v", err)
+	}
+	if !strings.Contains(string(msg), "durable credential required") {
+		t.Fatalf("expected durable credential rejection, got %s", string(msg))
+	}
+}
+
+func TestTerminalSessionValidPINForSetupUser(t *testing.T) {
+	e := setupEmptyTestServer(t)
+
+	setupBody := `{"setup_token":"test-setup-token-abc123","username":"myadmin","password":"securepass123","pin":"5678"}`
+	setupReq := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(setupBody))
+	setupReq.Header.Set("Content-Type", "application/json")
+	setupRec := httptest.NewRecorder()
+	e.ServeHTTP(setupRec, setupReq)
+	if setupRec.Code != http.StatusOK {
+		t.Fatalf("setup failed: %d: %s", setupRec.Code, setupRec.Body.String())
+	}
+
+	loginBody := `{"username":"myadmin","password":"securepass123"}`
+	loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(loginBody))
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginRec := httptest.NewRecorder()
+	e.ServeHTTP(loginRec, loginReq)
+	if loginRec.Code != http.StatusOK {
+		t.Fatalf("login failed: %d: %s", loginRec.Code, loginRec.Body.String())
+	}
+	var loginResp map[string]any
+	if err := json.Unmarshal(loginRec.Body.Bytes(), &loginResp); err != nil {
+		t.Fatalf("decode login response: %v", err)
+	}
+	token, _ := loginResp["token"].(string)
+	if token == "" {
+		t.Fatal("login response missing token")
+	}
+
+	body := `{"pin":"5678"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/machines/nonexistent-machine/terminal", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("valid setup-user PIN was rejected: %s", rec.Body.String())
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 after PIN validation succeeds, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 // TestTerminalMaxConcurrentSessions verifies that the 4th terminal session is rejected.
 func TestTerminalMaxConcurrentSessions(t *testing.T) {
 	e := setupTestServer(t)
@@ -1094,15 +1171,16 @@ func TestTerminalMaxConcurrentSessions(t *testing.T) {
 
 	// Pre-populate 3 terminal sessions in the in-memory map.
 	termSessionsMu.Lock()
-	for i := 0; i < 3; i++ {
-		sid := fmt.Sprintf("fake-session-%d", i)
-		termSessions[sid] = &TerminalSession{
-			ID:           sid,
-			MachineID:    "some-machine",
-			CreatedAt:    time.Now(),
-			LastActivity: time.Now(),
+		for i := 0; i < 3; i++ {
+			sid := fmt.Sprintf("fake-session-%d", i)
+			termSessions[sid] = &TerminalSession{
+				ID:           sid,
+				MachineID:    "some-machine",
+				UserID:       "test-admin-id",
+				CreatedAt:    time.Now(),
+				LastActivity: time.Now(),
+			}
 		}
-	}
 	termSessionsMu.Unlock()
 	defer func() {
 		termSessionsMu.Lock()

--- a/scripts/systemd/bloxos-dashboard.service
+++ b/scripts/systemd/bloxos-dashboard.service
@@ -6,11 +6,11 @@ After=network.target bloxos-hub.service
 Type=simple
 User=bokiko
 WorkingDirectory=/home/bokiko/bloxos/dashboard
-ExecStart=/usr/bin/npx next start -H 0.0.0.0 -p 3000
+ExecStart=/usr/bin/npx next start -H 127.0.0.1 -p 3000
 Restart=always
 RestartSec=5
 Environment=NODE_ENV=production
-Environment=NEXT_PUBLIC_HUB_URL=http://192.168.16.113:4000
+Environment=NEXT_PUBLIC_HUB_URL=
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- harden hub agent reconnects so known machine IDs cannot reconnect without a durable credential
- bind terminal PIN validation and browser terminal attach tokens to the authenticated user/session
- move the dashboard back to same-origin runtime defaults, disconnect SSE on auth changes, and stop sending the full JWT in the browser terminal URL
- remove the implicit production demo fallback, fix the current dashboard lint/build failures, and refresh deployment/docs to match the supported `Caddy + systemd` path

## Key changes
- require durable agent credentials for reconnects and add atomic token-consume + credential-store enrollment
- issue short-lived terminal browser tokens from the hub instead of using the full JWT in the terminal websocket query string
- verify/change terminal PIN by `user_id` rather than hardcoded `admin`
- add shared dashboard session/runtime helpers and same-tab auth-change handling for SSE
- update dashboard service to bind to `127.0.0.1` with same-origin API defaults
- refresh `README.md` and `HANDOFF.md` to reflect first-boot setup, 5 migrations, and 41 hub tests

## Verification
- `go test -count=1 ./...` in `hub/`
- `pnpm lint` in `dashboard/`
- `pnpm build` in `dashboard/`

## Follow-up
- agent TLS verification and installer trust bootstrap still need a separate pass
- Docker Compose is still not being promoted as the supported runtime path in this PR