### PR TITLE
Add per-machine TLS trust for API-polled machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ BLOXOS_CA_CERT=/etc/bloxos/ca.crt ./bloxos-agent --hub wss://<hub>/ws/agent --to
 3. `POST /api/setup` with your setup token, admin username, password, and terminal PIN.
 4. Log in with the credentials you just created.
 
+### API-Polled Machines
+
+API-polled integrations like Proxmox and Synology now choose TLS trust per machine:
+
+- `System`: use the hub host's normal system trust store
+- `Custom CA`: paste the target API's CA PEM into the add-machine form
+- `Insecure`: temporary fallback that skips verification only for that machine and logs a warning on every poll
+
+Use `Custom CA` for self-signed appliances instead of a hub-wide insecure override.
+
 ---
 
 ## Features

--- a/dashboard/src/components/AddAPIMachineModal.tsx
+++ b/dashboard/src/components/AddAPIMachineModal.tsx
@@ -8,10 +8,10 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-
-const HUB_URL = process.env.NEXT_PUBLIC_HUB_URL || "http://localhost:4000";
+import { getAuthHeaders, HUB_URL } from "@/lib/session";
 
 type AdapterType = "proxmox" | "synology";
+type TlsMode = "system" | "custom_ca" | "insecure";
 
 interface AddAPIMachineModalProps {
   open: boolean;
@@ -29,6 +29,8 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
   // Proxmox creds
   const [tokenId, setTokenId] = useState("");
   const [tokenSecret, setTokenSecret] = useState("");
+  const [tlsMode, setTlsMode] = useState<TlsMode>("system");
+  const [caCertPem, setCaCertPem] = useState("");
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,6 +45,8 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
     setPassword("");
     setTokenId("");
     setTokenSecret("");
+    setTlsMode("system");
+    setCaCertPem("");
     setError(null);
     setSuccess(false);
   }, []);
@@ -71,16 +75,18 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
       setError("Token ID and Token Secret are required for Proxmox.");
       return;
     }
+    if (tlsMode === "custom_ca" && !caCertPem.trim()) {
+      setError("Paste the CA certificate PEM or switch TLS mode.");
+      return;
+    }
 
     setLoading(true);
     setError(null);
 
     try {
-      const authToken = localStorage.getItem("bloxos_token");
-      const headers: Record<string, string> = {
+      const headers: Record<string, string> = getAuthHeaders({
         "Content-Type": "application/json",
-      };
-      if (authToken) headers["Authorization"] = `Bearer ${authToken}`;
+      });
 
       const res = await fetch(`${HUB_URL}/api/api-machines`, {
         method: "POST",
@@ -90,6 +96,10 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
           adapter_type: adapterType,
           base_url: baseUrl.trim(),
           auth_config: authConfig,
+          tls_config: {
+            mode: tlsMode,
+            ca_cert_pem: tlsMode === "custom_ca" ? caCertPem.trim() : "",
+          },
           poll_interval_secs: pollInterval,
         }),
       });
@@ -104,7 +114,7 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
       setError(err instanceof Error ? err.message : "Failed to add machine.");
     }
     setLoading(false);
-  }, [name, adapterType, baseUrl, pollInterval, username, password, tokenId, tokenSecret]);
+  }, [name, adapterType, baseUrl, pollInterval, username, password, tokenId, tokenSecret, tlsMode, caCertPem]);
 
   const clampInterval = (v: number) => Math.max(30, Math.min(3600, v || 60));
 
@@ -256,6 +266,52 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
                   </div>
                 )}
               </div>
+
+              <div>
+                <label className="text-[10px] text-blox-muted uppercase tracking-wider mb-1.5 block font-medium">
+                  TLS Trust
+                </label>
+                <div className="flex gap-2">
+                  {([
+                    { value: "system", label: "System" },
+                    { value: "custom_ca", label: "Custom CA" },
+                    { value: "insecure", label: "Insecure" },
+                  ] as const).map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setTlsMode(option.value)}
+                      className={`flex-1 text-xs py-2 px-3 rounded-lg border transition-colors font-medium ${
+                        tlsMode === option.value
+                          ? "bg-blox-blue/10 text-blox-blue border-blox-blue/30"
+                          : "bg-blox-bg text-blox-muted border-blox-border hover:border-blox-muted/30"
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+                <p className="mt-1.5 text-[11px] text-blox-muted leading-relaxed">
+                  {tlsMode === "system" && "Use the hub's normal system trust store. Best for publicly trusted certs."}
+                  {tlsMode === "custom_ca" && "Paste the API endpoint's root or self-signed CA certificate PEM."}
+                  {tlsMode === "insecure" && "Temporary only. Skips TLS verification for this machine and logs a warning on every poll."}
+                </p>
+              </div>
+
+              {tlsMode === "custom_ca" && (
+                <div>
+                  <label className="text-[10px] text-blox-muted uppercase tracking-wider mb-1.5 block font-medium">
+                    CA Certificate PEM
+                  </label>
+                  <textarea
+                    rows={7}
+                    placeholder="-----BEGIN CERTIFICATE-----"
+                    value={caCertPem}
+                    onChange={(e) => setCaCertPem(e.target.value)}
+                    className="w-full rounded-lg border border-blox-border bg-blox-bg px-3 py-2 text-xs font-mono text-blox-text placeholder:text-blox-muted/50 outline-none focus:border-blox-blue/40"
+                  />
+                </div>
+              )}
 
               {/* Error */}
               {error && (

--- a/hub/main.go
+++ b/hub/main.go
@@ -3397,11 +3397,17 @@ type APIMachine struct {
 	AdapterType      string          `json:"adapter_type"`
 	BaseURL          string          `json:"base_url"`
 	AuthConfig       json.RawMessage `json:"auth_config"`
+	TLSConfig        json.RawMessage `json:"tls_config,omitempty"`
 	PollIntervalSecs int             `json:"poll_interval_secs"`
 	Enabled          bool            `json:"enabled"`
 	LastPollAt       *string         `json:"last_poll_at"`
 	LastError        *string         `json:"last_error"`
 	CreatedAt        string          `json:"created_at"`
+}
+
+type APITLSConfig struct {
+	Mode      string `json:"mode"`
+	CACertPEM string `json:"ca_cert_pem,omitempty"`
 }
 
 // apiPollerEntry tracks a running poller goroutine for an API machine.
@@ -3414,24 +3420,94 @@ var (
 	apiPollersMu sync.Mutex
 )
 
-func apiHTTPClient() (*http.Client, error) {
+func parseAPITLSConfig(raw json.RawMessage) (APITLSConfig, error) {
+	if len(bytes.TrimSpace(raw)) == 0 || string(bytes.TrimSpace(raw)) == "{}" || string(bytes.TrimSpace(raw)) == "null" {
+		return APITLSConfig{Mode: "system"}, nil
+	}
+
+	var cfg APITLSConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return APITLSConfig{}, fmt.Errorf("invalid tls_config: %w", err)
+	}
+	if cfg.Mode == "" {
+		cfg.Mode = "system"
+	}
+	switch cfg.Mode {
+	case "system":
+		cfg.CACertPEM = ""
+	case "insecure":
+		cfg.CACertPEM = ""
+	case "custom_ca":
+		if strings.TrimSpace(cfg.CACertPEM) == "" {
+			return APITLSConfig{}, fmt.Errorf("tls_config.ca_cert_pem is required when mode is custom_ca")
+		}
+		pool := x509.NewCertPool()
+		if ok := pool.AppendCertsFromPEM([]byte(cfg.CACertPEM)); !ok {
+			return APITLSConfig{}, fmt.Errorf("tls_config.ca_cert_pem must contain a valid PEM certificate")
+		}
+	default:
+		return APITLSConfig{}, fmt.Errorf("tls_config.mode must be system, insecure, or custom_ca")
+	}
+	return cfg, nil
+}
+
+func validateAPITLSConfig(baseURL string, cfg APITLSConfig) error {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return fmt.Errorf("base_url is not a valid URL")
+	}
+	if parsed.Scheme != "https" && cfg.Mode != "system" {
+		return fmt.Errorf("tls_config is only supported for https base_url values")
+	}
+	return nil
+}
+
+func marshalStoredAPITLSConfig(cfg APITLSConfig) (string, error) {
+	if cfg.Mode == "" {
+		cfg.Mode = "system"
+	}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func redactAPITLSConfig(raw string) json.RawMessage {
+	cfg, err := parseAPITLSConfig(json.RawMessage(raw))
+	if err != nil {
+		return json.RawMessage(`"[REDACTED]"`)
+	}
+	redacted := map[string]interface{}{
+		"mode":          cfg.Mode,
+		"has_custom_ca": cfg.Mode == "custom_ca",
+	}
+	b, err := json.Marshal(redacted)
+	if err != nil {
+		return json.RawMessage(`"[REDACTED]"`)
+	}
+	return json.RawMessage(b)
+}
+
+func apiHTTPClient(baseURL string, tlsConfigRaw json.RawMessage) (*http.Client, error) {
 	transport := &http.Transport{}
 	tlsConfig := &tls.Config{}
+	cfg, err := parseAPITLSConfig(tlsConfigRaw)
+	if err != nil {
+		return nil, err
+	}
 
-	if os.Getenv("BLOXOS_API_TLS_INSECURE") == "1" {
+	switch cfg.Mode {
+	case "insecure":
 		tlsConfig.InsecureSkipVerify = true
-		log.Printf("WARNING: BLOXOS_API_TLS_INSECURE=1 disables TLS verification for API-polled machines")
-	} else if caPath := os.Getenv("BLOXOS_API_CA_CERT"); caPath != "" {
+		log.Printf("WARNING: api machine %s is using insecure TLS polling", baseURL)
+	case "custom_ca":
 		pool, err := x509.SystemCertPool()
 		if err != nil || pool == nil {
 			pool = x509.NewCertPool()
 		}
-		caPEM, err := os.ReadFile(caPath)
-		if err != nil {
-			return nil, fmt.Errorf("read BLOXOS_API_CA_CERT %s: %w", caPath, err)
-		}
-		if ok := pool.AppendCertsFromPEM(caPEM); !ok {
-			return nil, fmt.Errorf("parse BLOXOS_API_CA_CERT %s: no certificates found", caPath)
+		if ok := pool.AppendCertsFromPEM([]byte(cfg.CACertPEM)); !ok {
+			return nil, fmt.Errorf("parse tls_config.ca_cert_pem: no certificates found")
 		}
 		tlsConfig.RootCAs = pool
 	}
@@ -3445,9 +3521,9 @@ func apiHTTPClient() (*http.Client, error) {
 
 // --- Proxmox Adapter ---
 
-func pollProxmox(baseURL string, authConfig json.RawMessage) (*APIPollResult, error) {
+func pollProxmox(baseURL string, authConfig json.RawMessage, tlsConfig json.RawMessage) (*APIPollResult, error) {
 	baseURL = strings.TrimRight(baseURL, "/")
-	client, err := apiHTTPClient()
+	client, err := apiHTTPClient(baseURL, tlsConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -3558,9 +3634,9 @@ func pollProxmox(baseURL string, authConfig json.RawMessage) (*APIPollResult, er
 
 // --- Synology Adapter ---
 
-func pollSynology(baseURL string, authConfig json.RawMessage) (*APIPollResult, error) {
+func pollSynology(baseURL string, authConfig json.RawMessage, tlsConfig json.RawMessage) (*APIPollResult, error) {
 	baseURL = strings.TrimRight(baseURL, "/")
-	client, err := apiHTTPClient()
+	client, err := apiHTTPClient(baseURL, tlsConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -3726,7 +3802,7 @@ func validateBaseURL(rawURL string) error {
 // --- API Machine Handlers ---
 
 func handleListAPIMachines(c echo.Context) error {
-	rows, err := db.Query(`SELECT id, name, adapter_type, base_url, auth_config, poll_interval_secs, enabled, last_poll_at, last_error, created_at FROM api_machines ORDER BY name`)
+	rows, err := db.Query(`SELECT id, name, adapter_type, base_url, auth_config, tls_config, poll_interval_secs, enabled, last_poll_at, last_error, created_at FROM api_machines ORDER BY name`)
 	if err != nil {
 		log.Printf("api machines: list query error: %v", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
@@ -3736,13 +3812,14 @@ func handleListAPIMachines(c echo.Context) error {
 	var machines []APIMachine
 	for rows.Next() {
 		var m APIMachine
-		var authCfg string
-		if err := rows.Scan(&m.ID, &m.Name, &m.AdapterType, &m.BaseURL, &authCfg, &m.PollIntervalSecs, &m.Enabled, &m.LastPollAt, &m.LastError, &m.CreatedAt); err != nil {
+		var authCfg, tlsCfg string
+		if err := rows.Scan(&m.ID, &m.Name, &m.AdapterType, &m.BaseURL, &authCfg, &tlsCfg, &m.PollIntervalSecs, &m.Enabled, &m.LastPollAt, &m.LastError, &m.CreatedAt); err != nil {
 			log.Printf("api machines: list scan error: %v", err)
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		}
 		// Redact auth_config — never expose credentials to the dashboard
 		m.AuthConfig = json.RawMessage(`"[REDACTED]"`)
+		m.TLSConfig = redactAPITLSConfig(tlsCfg)
 		machines = append(machines, m)
 	}
 	if machines == nil {
@@ -3762,6 +3839,7 @@ func handleCreateAPIMachine(c echo.Context) error {
 		AdapterType      string          `json:"adapter_type"`
 		BaseURL          string          `json:"base_url"`
 		AuthConfig       json.RawMessage `json:"auth_config"`
+		TLSConfig        json.RawMessage `json:"tls_config"`
 		PollIntervalSecs int             `json:"poll_interval_secs"`
 	}
 	if err := c.Bind(&body); err != nil {
@@ -3779,6 +3857,13 @@ func handleCreateAPIMachine(c echo.Context) error {
 	}
 	if len(body.AuthConfig) == 0 {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "auth_config is required"})
+	}
+	tlsCfg, err := parseAPITLSConfig(body.TLSConfig)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+	if err := validateAPITLSConfig(body.BaseURL, tlsCfg); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 	if body.PollIntervalSecs < 30 {
 		body.PollIntervalSecs = 30
@@ -3798,8 +3883,13 @@ func handleCreateAPIMachine(c echo.Context) error {
 	}
 
 	id := uuid.New().String()
-	_, err := db.Exec(`INSERT INTO api_machines (id, name, adapter_type, base_url, auth_config, poll_interval_secs) VALUES (?, ?, ?, ?, ?, ?)`,
-		id, body.Name, body.AdapterType, body.BaseURL, string(body.AuthConfig), body.PollIntervalSecs)
+	storedTLSCfg, err := marshalStoredAPITLSConfig(tlsCfg)
+	if err != nil {
+		log.Printf("api machines: tls config marshal error: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
+	}
+	_, err = db.Exec(`INSERT INTO api_machines (id, name, adapter_type, base_url, auth_config, tls_config, poll_interval_secs) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		id, body.Name, body.AdapterType, body.BaseURL, string(body.AuthConfig), storedTLSCfg, body.PollIntervalSecs)
 	if err != nil {
 		log.Printf("api machines: create insert error: %v", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
@@ -3808,13 +3898,14 @@ func handleCreateAPIMachine(c echo.Context) error {
 	log.Printf("api machine created: %s (%s, %s)", body.Name, body.AdapterType, id)
 
 	// Start poller for the new machine.
-	startAPIPoller(id, body.Name, body.AdapterType, body.BaseURL, body.AuthConfig, body.PollIntervalSecs)
+	startAPIPoller(id, body.Name, body.AdapterType, body.BaseURL, body.AuthConfig, json.RawMessage(storedTLSCfg), body.PollIntervalSecs)
 
 	return c.JSON(http.StatusCreated, map[string]interface{}{
 		"id":                 id,
 		"name":               body.Name,
 		"adapter_type":       body.AdapterType,
 		"base_url":           body.BaseURL,
+		"tls_config":         redactAPITLSConfig(storedTLSCfg),
 		"poll_interval_secs": body.PollIntervalSecs,
 	})
 }
@@ -3861,14 +3952,15 @@ func handleForceAPIPoll(c echo.Context) error {
 		AdapterType string `json:"adapter_type"`
 		BaseURL     string `json:"base_url"`
 		AuthConfig  string `json:"auth_config"`
+		TLSConfig   string `json:"tls_config"`
 	}
-	err := db.QueryRow("SELECT name, adapter_type, base_url, auth_config FROM api_machines WHERE id = ?", id).
-		Scan(&m.Name, &m.AdapterType, &m.BaseURL, &m.AuthConfig)
+	err := db.QueryRow("SELECT name, adapter_type, base_url, auth_config, tls_config FROM api_machines WHERE id = ?", id).
+		Scan(&m.Name, &m.AdapterType, &m.BaseURL, &m.AuthConfig, &m.TLSConfig)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "api machine not found"})
 	}
 
-	result, pollErr := doPoll(m.AdapterType, m.BaseURL, json.RawMessage(m.AuthConfig))
+	result, pollErr := doPoll(m.AdapterType, m.BaseURL, json.RawMessage(m.AuthConfig), json.RawMessage(m.TLSConfig))
 	if pollErr != nil {
 		db.Exec("UPDATE api_machines SET last_error = ?, last_poll_at = CURRENT_TIMESTAMP WHERE id = ?", pollErr.Error(), id)
 		return c.JSON(http.StatusBadGateway, map[string]string{"error": pollErr.Error()})
@@ -3889,12 +3981,12 @@ func handleForceAPIPoll(c echo.Context) error {
 }
 
 // doPoll dispatches to the correct adapter.
-func doPoll(adapterType, baseURL string, authConfig json.RawMessage) (*APIPollResult, error) {
+func doPoll(adapterType, baseURL string, authConfig json.RawMessage, tlsConfig json.RawMessage) (*APIPollResult, error) {
 	switch adapterType {
 	case "proxmox":
-		return pollProxmox(baseURL, authConfig)
+		return pollProxmox(baseURL, authConfig, tlsConfig)
 	case "synology":
-		return pollSynology(baseURL, authConfig)
+		return pollSynology(baseURL, authConfig, tlsConfig)
 	default:
 		return nil, fmt.Errorf("unknown adapter type: %s", adapterType)
 	}
@@ -3976,7 +4068,7 @@ func storeAPIPollResult(apiMachineID, name, adapterType string, result *APIPollR
 // --- Background Poller ---
 
 func startAPIPollers() {
-	rows, err := db.Query("SELECT id, name, adapter_type, base_url, auth_config, poll_interval_secs FROM api_machines WHERE enabled = TRUE")
+	rows, err := db.Query("SELECT id, name, adapter_type, base_url, auth_config, tls_config, poll_interval_secs FROM api_machines WHERE enabled = TRUE")
 	if err != nil {
 		log.Printf("failed to load api_machines: %v", err)
 		return
@@ -3985,13 +4077,13 @@ func startAPIPollers() {
 
 	count := 0
 	for rows.Next() {
-		var id, name, adapterType, baseURL, authConfig string
+		var id, name, adapterType, baseURL, authConfig, tlsConfig string
 		var pollInterval int
-		if err := rows.Scan(&id, &name, &adapterType, &baseURL, &authConfig, &pollInterval); err != nil {
+		if err := rows.Scan(&id, &name, &adapterType, &baseURL, &authConfig, &tlsConfig, &pollInterval); err != nil {
 			log.Printf("failed to scan api_machine: %v", err)
 			continue
 		}
-		startAPIPoller(id, name, adapterType, baseURL, json.RawMessage(authConfig), pollInterval)
+		startAPIPoller(id, name, adapterType, baseURL, json.RawMessage(authConfig), json.RawMessage(tlsConfig), pollInterval)
 		count++
 	}
 	if count > 0 {
@@ -3999,7 +4091,7 @@ func startAPIPollers() {
 	}
 }
 
-func startAPIPoller(id, name, adapterType, baseURL string, authConfig json.RawMessage, intervalSecs int) {
+func startAPIPoller(id, name, adapterType, baseURL string, authConfig json.RawMessage, tlsConfig json.RawMessage, intervalSecs int) {
 	apiPollersMu.Lock()
 	defer apiPollersMu.Unlock()
 
@@ -4022,7 +4114,7 @@ func startAPIPoller(id, name, adapterType, baseURL string, authConfig json.RawMe
 			default:
 			}
 
-			result, err := doPoll(adapterType, baseURL, authConfig)
+			result, err := doPoll(adapterType, baseURL, authConfig, tlsConfig)
 			if err != nil {
 				log.Printf("api poll error: %s (%s): %v", name, adapterType, err)
 				db.Exec("UPDATE api_machines SET last_error = ?, last_poll_at = CURRENT_TIMESTAMP WHERE id = ?", err.Error(), id)

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -38,6 +45,31 @@ func seedTestAdmin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seed test admin: %v", err)
 	}
+}
+
+func generateTestCertPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate test key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "bloxos-test-ca",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create test cert: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
 }
 
 // setupTestServer creates a fresh in-memory DB, seeds a test admin user,
@@ -1401,10 +1433,57 @@ func TestCreateAPIMachine(t *testing.T) {
 	if pollInterval != 120 {
 		t.Errorf("expected poll_interval_secs 120, got %v", pollInterval)
 	}
+	if tlsCfg, ok := resp["tls_config"].(map[string]interface{}); !ok {
+		t.Fatalf("expected tls_config object, got %T", resp["tls_config"])
+	} else {
+		if tlsCfg["mode"] != "system" {
+			t.Errorf("expected tls_config.mode 'system', got %v", tlsCfg["mode"])
+		}
+		if tlsCfg["has_custom_ca"] != false {
+			t.Errorf("expected has_custom_ca false, got %v", tlsCfg["has_custom_ca"])
+		}
+	}
 
 	// Stop any pollers started during the test.
 	stopAllAPIPollers()
 	t.Log("create api machine: OK")
+}
+
+func TestCreateAPIMachineWithCustomCATrust(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+
+	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
+	api.POST("/api/api-machines", handleCreateAPIMachine)
+
+	body := fmt.Sprintf(`{"name":"Secure Synology","adapter_type":"synology","base_url":"https://192.168.16.10:5001","auth_config":{"username":"u","password":"p"},"tls_config":{"mode":"custom_ca","ca_cert_pem":%q},"poll_interval_secs":60}`, generateTestCertPEM(t))
+	req := httptest.NewRequest(http.MethodPost, "/api/api-machines", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	tlsCfg, ok := resp["tls_config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected tls_config object, got %T", resp["tls_config"])
+	}
+	if tlsCfg["mode"] != "custom_ca" {
+		t.Errorf("expected tls_config.mode 'custom_ca', got %v", tlsCfg["mode"])
+	}
+	if tlsCfg["has_custom_ca"] != true {
+		t.Errorf("expected has_custom_ca true, got %v", tlsCfg["has_custom_ca"])
+	}
+
+	stopAllAPIPollers()
 }
 
 func TestCreateAPIMachineInvalidAdapter(t *testing.T) {
@@ -1426,6 +1505,29 @@ func TestCreateAPIMachineInvalidAdapter(t *testing.T) {
 		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 	}
 	t.Log("invalid adapter rejected: OK")
+}
+
+func TestCreateAPIMachineInvalidTLSConfig(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+
+	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
+	api.POST("/api/api-machines", handleCreateAPIMachine)
+
+	body := `{"name":"Bad TLS","adapter_type":"synology","base_url":"https://192.168.1.1:5001","auth_config":{"username":"u","password":"p"},"tls_config":{"mode":"custom_ca","ca_cert_pem":"not a cert"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/api-machines", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "tls_config.ca_cert_pem") {
+		t.Fatalf("expected tls_config validation error, got %s", rec.Body.String())
+	}
 }
 
 func TestListAPIMachines(t *testing.T) {
@@ -1466,6 +1568,15 @@ func TestListAPIMachines(t *testing.T) {
 	}
 	if len(machines) != 2 {
 		t.Fatalf("expected 2 machines, got %d", len(machines))
+	}
+	for _, machine := range machines {
+		var tlsCfg map[string]interface{}
+		if err := json.Unmarshal(machine.TLSConfig, &tlsCfg); err != nil {
+			t.Fatalf("unmarshal tls_config: %v", err)
+		}
+		if tlsCfg["mode"] != "system" {
+			t.Fatalf("expected redacted tls_config.mode system, got %v", tlsCfg["mode"])
+		}
 	}
 
 	stopAllAPIPollers()

--- a/hub/migrations.go
+++ b/hub/migrations.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"database/sql"
-	"strings"
 	"fmt"
 	"log"
+	"strings"
 )
 
 // migration is a numbered schema change. Version is implicit from slice index.
@@ -209,6 +209,16 @@ var migrations = []migration{
 				created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 			);
 			`)
+			return err
+		},
+	},
+	{
+		description: "add tls_config to api_machines for per-machine TLS trust",
+		apply: func(tx *sql.Tx) error {
+			_, err := tx.Exec(`ALTER TABLE api_machines ADD COLUMN tls_config TEXT NOT NULL DEFAULT '{}'`)
+			if err != nil && isDuplicateColumnErr(err) {
+				return nil
+			}
 			return err
 		},
 	},


### PR DESCRIPTION
## Summary
- replace hub-global API polling trust env toggles with per-machine `tls_config` stored alongside each API machine
- support three explicit TLS modes for API-polled machines: `system`, `custom_ca`, and temporary `insecure`
- validate custom CA PEM on create, redact TLS config in list responses, and thread the new trust config through force-poll and background pollers
- extend the Add API Machine modal with TLS trust controls and custom CA input
- document the supported per-machine trust model and add migration/test coverage

## Checks
- `go test -count=1 ./...` in `hub`
- `go test -count=1 ./...` in `agent`
- `pnpm lint` in `dashboard`
- `pnpm build` in `dashboard`

## Rollout Notes
- existing API machines pick up `system` trust by default after migration
- self-signed Proxmox/Synology endpoints should be updated to use `custom_ca` in the UI instead of relying on a hub-wide insecure override
- `insecure` remains available only as a per-machine temporary fallback and logs a warning on each poll
