### PR TITLE
Edit API machines without hub restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ API-polled integrations like Proxmox and Synology now choose TLS trust per machi
 - `Insecure`: temporary fallback that skips verification only for that machine and logs a warning on every poll
 
 Use `Custom CA` for self-signed appliances instead of a hub-wide insecure override.
+You can edit an existing API machine from the dashboard to change credentials, TLS mode, or poll interval; the hub reloads that machine's poller without a service restart.
 
 ---
 

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { useSSE } from "@/contexts/SSEContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { demoMachines, MachineMetrics, AlertData } from "@/lib/demo-data";
@@ -9,7 +9,7 @@ import { MachineCard } from "@/components/MachineCard";
 import { MachineStatus } from "@/components/StatusBadge";
 import { AlertPanel } from "@/components/AlertPanel";
 import { AddMachineModal } from "@/components/AddMachineModal";
-import { AddAPIMachineModal } from "@/components/AddAPIMachineModal";
+import { AddAPIMachineModal, type EditableAPIMachine } from "@/components/AddAPIMachineModal";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -28,7 +28,7 @@ import {
 import { motion, AnimatePresence } from "framer-motion";
 import {
   Bell, Plus, Wifi, WifiOff, Search, LayoutGrid, List,
-  ChevronDown, LogOut, Square, CheckSquare, RotateCcw, Trash2,
+  ChevronDown, LogOut, Square, CheckSquare, RotateCcw, Trash2, Pencil,
   ArrowUpDown, Filter, Monitor, Server,
 } from "lucide-react";
 import Link from "next/link";
@@ -94,9 +94,47 @@ export default function Home() {
   const [deleteTarget, setDeleteTarget] = useState<{id: string; hostname: string} | null>(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [addAPIMachineOpen, setAddAPIMachineOpen] = useState(false);
+  const [editAPIMachine, setEditAPIMachine] = useState<EditableAPIMachine | null>(null);
+  const [apiMachines, setApiMachines] = useState<EditableAPIMachine[]>([]);
 
   const isDemo = DEMO_MODE && !hasReceivedData && liveMachines.length === 0;
   const machines = isDemo ? demoMachines : liveMachines;
+
+  const loadAPIMachines = useCallback(async () => {
+    try {
+      const res = await authFetch(`${HUB_URL}/api/api-machines`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setApiMachines(Array.isArray(data) ? data : []);
+    } catch {
+      // ignore
+    }
+  }, [authFetch]);
+
+  useEffect(() => {
+    let active = true;
+    const run = async () => {
+      try {
+        const res = await authFetch(`${HUB_URL}/api/api-machines`);
+        if (!res.ok || !active) return;
+        const data = await res.json();
+        if (active) {
+          setApiMachines(Array.isArray(data) ? data : []);
+        }
+      } catch {
+        // ignore
+      }
+    };
+    void run();
+    return () => {
+      active = false;
+    };
+  }, [authFetch]);
+
+  const apiMachineByMachineID = useMemo(
+    () => new Map(apiMachines.map((machine) => [`api-${machine.id}`, machine])),
+    [apiMachines]
+  );
 
   const allTags = useMemo(() => {
     const tagSet = new Set<string>();
@@ -241,10 +279,25 @@ export default function Home() {
     try {
       const res = await authFetch(`${HUB_URL}/api/machines/${deleteTarget.id}`, { method: "DELETE" });
       if (!res.ok) return;
+      if (deleteTarget.id.startsWith("api-")) {
+        const apiID = deleteTarget.id.replace(/^api-/, "");
+        setApiMachines((prev) => prev.filter((machine) => machine.id !== apiID));
+      }
     } catch { /* ignore */ }
     setDeleteLoading(false);
     setDeleteTarget(null);
   }, [deleteTarget, authFetch]);
+
+  const handleAPIMachineSaved = useCallback(() => {
+    void loadAPIMachines();
+  }, [loadAPIMachines]);
+
+  const openEditAPIMachine = useCallback((machineID: string) => {
+    const machine = apiMachineByMachineID.get(machineID);
+    if (machine) {
+      setEditAPIMachine(machine);
+    }
+  }, [apiMachineByMachineID]);
 
   return (
     <motion.div
@@ -527,7 +580,12 @@ export default function Home() {
                   exit={{ opacity: 0, scale: 0.95 }}
                   transition={{ duration: 0.3, delay: i * 0.03 }}
                 >
-                  <MachineCard machine={m} onClick={() => {}} onDelete={(id, hostname) => setDeleteTarget({id, hostname})} />
+                  <MachineCard
+                    machine={m}
+                    onClick={() => {}}
+                    onDelete={(id, hostname) => setDeleteTarget({id, hostname})}
+                    onEdit={openEditAPIMachine}
+                  />
                 </motion.div>
               ))}
             </AnimatePresence>
@@ -565,6 +623,8 @@ export default function Home() {
                   const tags = m.tags ? m.tags.split(",").filter((t) => t.trim()) : [];
                   const dotColor = status === "online" ? "bg-emerald-500" : status === "warning" ? "bg-amber-500" : "bg-red-500/50";
                   const isSelected = selected.has(m.machine_id);
+                  const adapterTag = tags.find((tag) => ["synology", "proxmox"].includes(tag.trim().toLowerCase()));
+                  const isAPIMachine = !!adapterTag;
 
                   return (
                     <TableRow
@@ -586,7 +646,22 @@ export default function Home() {
                         </Link>
                       </TableCell>
                       <TableCell className="text-xs font-medium text-blox-text">
-                        <Link href={`/machine/${m.machine_id}`} className="hover:text-blox-blue transition-colors">{m.hostname}</Link>
+                        <div className="flex items-center gap-2">
+                          <Link href={`/machine/${m.machine_id}`} className="hover:text-blox-blue transition-colors">{m.hostname}</Link>
+                          {isAPIMachine && (
+                            <button
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                openEditAPIMachine(m.machine_id);
+                              }}
+                              className="text-blox-muted hover:text-blox-blue transition-colors"
+                              title="Edit API machine"
+                            >
+                              <Pencil className="w-3.5 h-3.5" />
+                            </button>
+                          )}
+                        </div>
                       </TableCell>
                       <TableCell className="text-xs text-blox-muted font-mono tabular-nums hidden md:table-cell">{m.ip || "-"}</TableCell>
                       <TableCell className="text-xs">
@@ -704,10 +779,22 @@ export default function Home() {
         onClose={() => setAddMachineOpen(false)}
       />
 
-      <AddAPIMachineModal
-        open={addAPIMachineOpen}
-        onClose={() => setAddAPIMachineOpen(false)}
-      />
+      {addAPIMachineOpen && (
+        <AddAPIMachineModal
+          open={addAPIMachineOpen}
+          onClose={() => setAddAPIMachineOpen(false)}
+          onSaved={handleAPIMachineSaved}
+        />
+      )}
+
+      {editAPIMachine && (
+        <AddAPIMachineModal
+          open={!!editAPIMachine}
+          machine={editAPIMachine}
+          onClose={() => setEditAPIMachine(null)}
+          onSaved={handleAPIMachineSaved}
+        />
+      )}
     </motion.div>
   );
 }

--- a/dashboard/src/components/AddAPIMachineModal.tsx
+++ b/dashboard/src/components/AddAPIMachineModal.tsx
@@ -11,50 +11,53 @@ import { Input } from "@/components/ui/input";
 import { getAuthHeaders, HUB_URL } from "@/lib/session";
 
 type AdapterType = "proxmox" | "synology";
-type TlsMode = "system" | "custom_ca" | "insecure";
+export type TlsMode = "system" | "custom_ca" | "insecure";
+
+export interface APIMachineTLSMeta {
+  mode: TlsMode;
+  has_custom_ca?: boolean;
+}
+
+export interface EditableAPIMachine {
+  id: string;
+  name: string;
+  adapter_type: AdapterType;
+  base_url: string;
+  poll_interval_secs: number;
+  tls_config?: APIMachineTLSMeta;
+}
 
 interface AddAPIMachineModalProps {
   open: boolean;
   onClose: () => void;
+  onSaved?: () => void;
+  machine?: EditableAPIMachine | null;
 }
 
-export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
-  const [name, setName] = useState("");
-  const [adapterType, setAdapterType] = useState<AdapterType>("synology");
-  const [baseUrl, setBaseUrl] = useState("");
-  const [pollInterval, setPollInterval] = useState(60);
-  // Synology creds
+function clampInterval(v: number) {
+  return Math.max(30, Math.min(3600, v || 60));
+}
+
+export function AddAPIMachineModal({ open, onClose, onSaved, machine }: AddAPIMachineModalProps) {
+  const editing = !!machine;
+
+  const [name, setName] = useState(machine?.name || "");
+  const [adapterType, setAdapterType] = useState<AdapterType>(machine?.adapter_type || "synology");
+  const [baseUrl, setBaseUrl] = useState(machine?.base_url || "");
+  const [pollInterval, setPollInterval] = useState(machine?.poll_interval_secs || 60);
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  // Proxmox creds
   const [tokenId, setTokenId] = useState("");
   const [tokenSecret, setTokenSecret] = useState("");
-  const [tlsMode, setTlsMode] = useState<TlsMode>("system");
+  const [tlsMode, setTlsMode] = useState<TlsMode>(machine?.tls_config?.mode || "system");
   const [caCertPem, setCaCertPem] = useState("");
-
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
-  const resetForm = useCallback(() => {
-    setName("");
-    setAdapterType("synology");
-    setBaseUrl("");
-    setPollInterval(60);
-    setUsername("");
-    setPassword("");
-    setTokenId("");
-    setTokenSecret("");
-    setTlsMode("system");
-    setCaCertPem("");
-    setError(null);
-    setSuccess(false);
-  }, []);
-
   const handleClose = useCallback(() => {
-    resetForm();
     onClose();
-  }, [onClose, resetForm]);
+  }, [onClose]);
 
   const handleSubmit = useCallback(async () => {
     if (!name.trim() || !baseUrl.trim()) {
@@ -62,21 +65,73 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
       return;
     }
 
-    const authConfig =
-      adapterType === "synology"
-        ? { username, password }
-        : { token_id: tokenId, token_secret: tokenSecret };
+    const payload: Record<string, unknown> = {};
+    const trimmedName = name.trim();
+    const trimmedBaseUrl = baseUrl.trim();
+    const clampedPollInterval = clampInterval(pollInterval);
+    const initialTlsMode = machine?.tls_config?.mode || "system";
 
-    if (adapterType === "synology" && (!username.trim() || !password.trim())) {
-      setError("Username and password are required for Synology.");
-      return;
+    if (!editing || trimmedName !== machine?.name) payload.name = trimmedName;
+    if (!editing || adapterType !== machine?.adapter_type) payload.adapter_type = adapterType;
+    if (!editing || trimmedBaseUrl !== machine?.base_url) payload.base_url = trimmedBaseUrl;
+    if (!editing || clampedPollInterval !== machine?.poll_interval_secs) payload.poll_interval_secs = clampedPollInterval;
+
+    let authConfig: Record<string, string> | null = null;
+    if (adapterType === "synology") {
+      const trimmedUsername = username.trim();
+      const trimmedPassword = password.trim();
+      if (!editing) {
+        if (!trimmedUsername || !trimmedPassword) {
+          setError("Username and password are required for Synology.");
+          return;
+        }
+        authConfig = { username: trimmedUsername, password: trimmedPassword };
+      } else if (trimmedUsername || trimmedPassword) {
+        if (!trimmedUsername || !trimmedPassword) {
+          setError("Enter both username and password, or leave both blank to keep existing credentials.");
+          return;
+        }
+        authConfig = { username: trimmedUsername, password: trimmedPassword };
+      }
+    } else {
+      const trimmedTokenID = tokenId.trim();
+      const trimmedTokenSecret = tokenSecret.trim();
+      if (!editing) {
+        if (!trimmedTokenID || !trimmedTokenSecret) {
+          setError("Token ID and Token Secret are required for Proxmox.");
+          return;
+        }
+        authConfig = { token_id: trimmedTokenID, token_secret: trimmedTokenSecret };
+      } else if (trimmedTokenID || trimmedTokenSecret) {
+        if (!trimmedTokenID || !trimmedTokenSecret) {
+          setError("Enter both token fields, or leave both blank to keep existing credentials.");
+          return;
+        }
+        authConfig = { token_id: trimmedTokenID, token_secret: trimmedTokenSecret };
+      }
     }
-    if (adapterType === "proxmox" && (!tokenId.trim() || !tokenSecret.trim())) {
-      setError("Token ID and Token Secret are required for Proxmox.");
-      return;
-    }
-    if (tlsMode === "custom_ca" && !caCertPem.trim()) {
+    if (authConfig) payload.auth_config = authConfig;
+
+    const trimmedCaPem = caCertPem.trim();
+    const shouldReplaceCustomCA = tlsMode === "custom_ca" && !!trimmedCaPem;
+    const tlsModeChanged = !editing || tlsMode !== initialTlsMode;
+    if (tlsMode === "custom_ca" && !editing && !trimmedCaPem) {
       setError("Paste the CA certificate PEM or switch TLS mode.");
+      return;
+    }
+    if (tlsModeChanged || shouldReplaceCustomCA) {
+      if (tlsMode === "custom_ca" && !trimmedCaPem) {
+        setError("Paste a new CA certificate PEM when switching to Custom CA.");
+        return;
+      }
+      payload.tls_config = {
+        mode: tlsMode,
+        ca_cert_pem: tlsMode === "custom_ca" ? trimmedCaPem : "",
+      };
+    }
+
+    if (editing && Object.keys(payload).length === 0) {
+      setError("No changes to save.");
       return;
     }
 
@@ -87,22 +142,14 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
       const headers: Record<string, string> = getAuthHeaders({
         "Content-Type": "application/json",
       });
-
-      const res = await fetch(`${HUB_URL}/api/api-machines`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          name: name.trim(),
-          adapter_type: adapterType,
-          base_url: baseUrl.trim(),
-          auth_config: authConfig,
-          tls_config: {
-            mode: tlsMode,
-            ca_cert_pem: tlsMode === "custom_ca" ? caCertPem.trim() : "",
-          },
-          poll_interval_secs: pollInterval,
-        }),
-      });
+      const res = await fetch(
+        editing ? `${HUB_URL}/api/api-machines/${machine.id}` : `${HUB_URL}/api/api-machines`,
+        {
+          method: editing ? "PATCH" : "POST",
+          headers,
+          body: JSON.stringify(payload),
+        }
+      );
 
       if (!res.ok) {
         const data = await res.json().catch(() => null);
@@ -110,13 +157,29 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
       }
 
       setSuccess(true);
+      onSaved?.();
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to add machine.");
+      setError(err instanceof Error ? err.message : editing ? "Failed to update machine." : "Failed to add machine.");
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
-  }, [name, adapterType, baseUrl, pollInterval, username, password, tokenId, tokenSecret, tlsMode, caCertPem]);
+  }, [
+    name,
+    adapterType,
+    baseUrl,
+    pollInterval,
+    username,
+    password,
+    tokenId,
+    tokenSecret,
+    tlsMode,
+    caCertPem,
+    editing,
+    machine,
+    onSaved,
+  ]);
 
-  const clampInterval = (v: number) => Math.max(30, Math.min(3600, v || 60));
+  const existingCustomCA = editing && machine?.tls_config?.mode === "custom_ca" && machine.tls_config?.has_custom_ca;
 
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) handleClose(); }}>
@@ -126,7 +189,7 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
             <div className="p-1.5 rounded-lg bg-blox-blue/10">
               <Server className="w-4 h-4 text-blox-blue" />
             </div>
-            <DialogTitle className="text-blox-text">Add API Machine</DialogTitle>
+            <DialogTitle className="text-blox-text">{editing ? "Edit API Machine" : "Add API Machine"}</DialogTitle>
           </div>
         </DialogHeader>
 
@@ -138,10 +201,10 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
                   <CheckCircle className="w-6 h-6 text-emerald-400" />
                 </div>
                 <p className="text-sm text-blox-text text-center font-medium">
-                  Machine added!
+                  {editing ? "Machine updated!" : "Machine added!"}
                 </p>
                 <p className="text-xs text-blox-muted text-center">
-                  It will appear on the dashboard shortly.
+                  {editing ? "The poller was reloaded with the new settings." : "It will appear on the dashboard shortly."}
                 </p>
               </div>
               <Button
@@ -155,10 +218,11 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
           ) : (
             <>
               <DialogDescription className="text-blox-muted text-xs leading-relaxed">
-                Add a machine that BloxOS polls via API (no agent required). Supports Proxmox and Synology.
+                {editing
+                  ? "Update this API-polled machine. Leave credentials blank to keep the existing secret values."
+                  : "Add a machine that BloxOS polls via API (no agent required). Supports Proxmox and Synology."}
               </DialogDescription>
 
-              {/* Name */}
               <div>
                 <label className="text-[10px] text-blox-muted uppercase tracking-wider mb-1.5 block font-medium">
                   Name
@@ -172,30 +236,28 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
                 />
               </div>
 
-              {/* Type toggle */}
               <div>
                 <label className="text-[10px] text-blox-muted uppercase tracking-wider mb-1.5 block font-medium">
                   Type
                 </label>
                 <div className="flex gap-2">
-                  {(["synology", "proxmox"] as const).map((t) => (
+                  {(["synology", "proxmox"] as const).map((value) => (
                     <button
-                      key={t}
+                      key={value}
                       type="button"
-                      onClick={() => setAdapterType(t)}
+                      onClick={() => setAdapterType(value)}
                       className={`flex-1 text-xs py-2 px-3 rounded-lg border transition-colors font-medium ${
-                        adapterType === t
+                        adapterType === value
                           ? "bg-blox-blue/10 text-blox-blue border-blox-blue/30"
                           : "bg-blox-bg text-blox-muted border-blox-border hover:border-blox-muted/30"
                       }`}
                     >
-                      {t.charAt(0).toUpperCase() + t.slice(1)}
+                      {value.charAt(0).toUpperCase() + value.slice(1)}
                     </button>
                   ))}
                 </div>
               </div>
 
-              {/* URL */}
               <div>
                 <label className="text-[10px] text-blox-muted uppercase tracking-wider mb-1.5 block font-medium">
                   URL
@@ -209,7 +271,6 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
                 />
               </div>
 
-              {/* Poll Interval */}
               <div>
                 <label className="text-[10px] text-blox-muted uppercase tracking-wider mb-1.5 block font-medium">
                   Poll Interval (seconds)
@@ -225,7 +286,6 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
                 />
               </div>
 
-              {/* Credentials */}
               <div>
                 <label className="text-[10px] text-blox-muted uppercase tracking-wider mb-1.5 block font-medium">
                   Credentials
@@ -234,14 +294,14 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
                   <div className="space-y-2">
                     <Input
                       type="text"
-                      placeholder="Username"
+                      placeholder={editing ? "Username (leave blank to keep current)" : "Username"}
                       value={username}
                       onChange={(e) => setUsername(e.target.value)}
                       className="h-8 text-xs bg-blox-bg border-blox-border text-blox-text placeholder:text-blox-muted/50"
                     />
                     <Input
                       type="password"
-                      placeholder="Password"
+                      placeholder={editing ? "Password (leave blank to keep current)" : "Password"}
                       value={password}
                       onChange={(e) => setPassword(e.target.value)}
                       className="h-8 text-xs bg-blox-bg border-blox-border text-blox-text placeholder:text-blox-muted/50"
@@ -251,14 +311,14 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
                   <div className="space-y-2">
                     <Input
                       type="text"
-                      placeholder="Token ID (e.g. root@pam!monitor)"
+                      placeholder={editing ? "Token ID (leave blank to keep current)" : "Token ID (e.g. root@pam!monitor)"}
                       value={tokenId}
                       onChange={(e) => setTokenId(e.target.value)}
                       className="h-8 text-xs bg-blox-bg border-blox-border text-blox-text placeholder:text-blox-muted/50 font-mono"
                     />
                     <Input
                       type="password"
-                      placeholder="Token Secret"
+                      placeholder={editing ? "Token Secret (leave blank to keep current)" : "Token Secret"}
                       value={tokenSecret}
                       onChange={(e) => setTokenSecret(e.target.value)}
                       className="h-8 text-xs bg-blox-bg border-blox-border text-blox-text placeholder:text-blox-muted/50 font-mono"
@@ -303,6 +363,11 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
                   <label className="text-[10px] text-blox-muted uppercase tracking-wider mb-1.5 block font-medium">
                     CA Certificate PEM
                   </label>
+                  {existingCustomCA && !caCertPem && (
+                    <p className="mb-2 text-[11px] text-blox-muted">
+                      A custom CA is already stored. Paste a new PEM only if you want to replace it.
+                    </p>
+                  )}
                   <textarea
                     rows={7}
                     placeholder="-----BEGIN CERTIFICATE-----"
@@ -313,21 +378,19 @@ export function AddAPIMachineModal({ open, onClose }: AddAPIMachineModalProps) {
                 </div>
               )}
 
-              {/* Error */}
               {error && (
                 <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
                   {error}
                 </p>
               )}
 
-              {/* Submit */}
               <Button
                 onClick={handleSubmit}
                 disabled={loading}
                 variant="outline"
                 className="w-full text-blox-blue border-blox-blue/20 bg-blox-blue/5 hover:bg-blox-blue/10 text-xs"
               >
-                {loading ? "Adding..." : "Add Machine"}
+                {loading ? (editing ? "Saving..." : "Adding...") : (editing ? "Save Changes" : "Add Machine")}
               </Button>
             </>
           )}

--- a/dashboard/src/components/MachineCard.tsx
+++ b/dashboard/src/components/MachineCard.tsx
@@ -6,7 +6,7 @@ import { MachineMetrics } from "@/lib/demo-data";
 import { ProgressBar } from "./ProgressBar";
 import { StatusBadge, MachineStatus } from "./StatusBadge";
 import { Sparkline } from "./Sparkline";
-import { Cpu, HardDrive, MemoryStick, Thermometer, Clock, Monitor, Wifi, Trash2 } from "lucide-react";
+import { Cpu, HardDrive, MemoryStick, Thermometer, Clock, Monitor, Wifi, Trash2, Pencil } from "lucide-react";
 import { motion } from "framer-motion";
 
 function formatBytes(bytes: number | undefined | null): string {
@@ -60,9 +60,10 @@ interface MachineCardProps {
   machine: MachineMetrics;
   onClick?: () => void;
   onDelete?: (machineId: string, hostname: string) => void;
+  onEdit?: (machineId: string) => void;
 }
 
-export function MachineCard({ machine, onClick, onDelete }: MachineCardProps) {
+export function MachineCard({ machine, onClick, onDelete, onEdit }: MachineCardProps) {
   const [now, setNow] = useState(() => Date.now());
   const { status, reason } = getStatus(machine);
 
@@ -121,6 +122,19 @@ export function MachineCard({ machine, onClick, onDelete }: MachineCardProps) {
           </div>
           <div className="flex items-center gap-2">
             <StatusBadge status={status} reason={reason} />
+            {isAPIMachine && onEdit && (
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onEdit(machine.machine_id);
+                }}
+                className="opacity-0 group-hover:opacity-100 p-1.5 rounded-lg hover:bg-blox-blue/10 text-blox-muted hover:text-blox-blue transition-all duration-200"
+                title="Edit API machine"
+              >
+                <Pencil className="w-3.5 h-3.5" />
+              </button>
+            )}
             {onDelete && (
               <button
                 onClick={(e) => {

--- a/hub/main.go
+++ b/hub/main.go
@@ -274,7 +274,7 @@ func main() {
 	}
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: corsOrigins,
-		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions},
+		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions},
 		AllowHeaders: []string{"Accept", "Content-Type", "Cache-Control", "Authorization"},
 	}))
 
@@ -324,6 +324,7 @@ func main() {
 	api.POST("/api/bulk/command", handleBulkCommand)
 	api.GET("/api/api-machines", handleListAPIMachines)
 	api.POST("/api/api-machines", handleCreateAPIMachine)
+	api.PATCH("/api/api-machines/:id", handleUpdateAPIMachine)
 	api.DELETE("/api/api-machines/:id", handleDeleteAPIMachine)
 	api.POST("/api/api-machines/:id/poll", handleForceAPIPoll)
 
@@ -3799,6 +3800,40 @@ func validateBaseURL(rawURL string) error {
 	return nil
 }
 
+func validateAPIAuthConfig(adapterType string, authConfig json.RawMessage) error {
+	if len(bytes.TrimSpace(authConfig)) == 0 {
+		return fmt.Errorf("auth_config is required")
+	}
+
+	switch adapterType {
+	case "proxmox":
+		var auth struct {
+			TokenID     string `json:"token_id"`
+			TokenSecret string `json:"token_secret"`
+		}
+		if err := json.Unmarshal(authConfig, &auth); err != nil {
+			return fmt.Errorf("invalid proxmox auth_config: %w", err)
+		}
+		if strings.TrimSpace(auth.TokenID) == "" || strings.TrimSpace(auth.TokenSecret) == "" {
+			return fmt.Errorf("proxmox auth_config requires token_id and token_secret")
+		}
+	case "synology":
+		var auth struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+		if err := json.Unmarshal(authConfig, &auth); err != nil {
+			return fmt.Errorf("invalid synology auth_config: %w", err)
+		}
+		if strings.TrimSpace(auth.Username) == "" || strings.TrimSpace(auth.Password) == "" {
+			return fmt.Errorf("synology auth_config requires username and password")
+		}
+	default:
+		return fmt.Errorf("adapter_type must be proxmox or synology")
+	}
+	return nil
+}
+
 // --- API Machine Handlers ---
 
 func handleListAPIMachines(c echo.Context) error {
@@ -3855,8 +3890,8 @@ func handleCreateAPIMachine(c echo.Context) error {
 	if err := validateBaseURL(body.BaseURL); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
-	if len(body.AuthConfig) == 0 {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "auth_config is required"})
+	if err := validateAPIAuthConfig(body.AdapterType, body.AuthConfig); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 	tlsCfg, err := parseAPITLSConfig(body.TLSConfig)
 	if err != nil {
@@ -3907,6 +3942,122 @@ func handleCreateAPIMachine(c echo.Context) error {
 		"base_url":           body.BaseURL,
 		"tls_config":         redactAPITLSConfig(storedTLSCfg),
 		"poll_interval_secs": body.PollIntervalSecs,
+	})
+}
+
+func handleUpdateAPIMachine(c echo.Context) error {
+	id := c.Param("id")
+
+	var current struct {
+		Name             string
+		AdapterType      string
+		BaseURL          string
+		AuthConfig       string
+		TLSConfig        string
+		PollIntervalSecs int
+	}
+	err := db.QueryRow(`SELECT name, adapter_type, base_url, auth_config, tls_config, poll_interval_secs
+		FROM api_machines WHERE id = ?`, id).
+		Scan(&current.Name, &current.AdapterType, &current.BaseURL, &current.AuthConfig, &current.TLSConfig, &current.PollIntervalSecs)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "api machine not found"})
+	}
+
+	var body struct {
+		Name             *string          `json:"name"`
+		AdapterType      *string          `json:"adapter_type"`
+		BaseURL          *string          `json:"base_url"`
+		AuthConfig       *json.RawMessage `json:"auth_config"`
+		TLSConfig        *json.RawMessage `json:"tls_config"`
+		PollIntervalSecs *int             `json:"poll_interval_secs"`
+	}
+	if err := c.Bind(&body); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+	}
+
+	name := current.Name
+	if body.Name != nil {
+		name = strings.TrimSpace(*body.Name)
+	}
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "name is required"})
+	}
+
+	adapterType := current.AdapterType
+	if body.AdapterType != nil {
+		adapterType = strings.TrimSpace(*body.AdapterType)
+	}
+	if adapterType != "proxmox" && adapterType != "synology" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "adapter_type must be proxmox or synology"})
+	}
+
+	baseURL := current.BaseURL
+	if body.BaseURL != nil {
+		baseURL = strings.TrimSpace(*body.BaseURL)
+	}
+	if err := validateBaseURL(baseURL); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	authConfig := json.RawMessage(current.AuthConfig)
+	if body.AuthConfig != nil {
+		authConfig = *body.AuthConfig
+	}
+	if body.AdapterType != nil && *body.AdapterType != current.AdapterType && body.AuthConfig == nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "auth_config is required when adapter_type changes"})
+	}
+	if err := validateAPIAuthConfig(adapterType, authConfig); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	tlsConfig := json.RawMessage(current.TLSConfig)
+	if body.TLSConfig != nil {
+		tlsConfig = *body.TLSConfig
+	}
+	parsedTLSConfig, err := parseAPITLSConfig(tlsConfig)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+	if err := validateAPITLSConfig(baseURL, parsedTLSConfig); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	pollIntervalSecs := current.PollIntervalSecs
+	if body.PollIntervalSecs != nil {
+		pollIntervalSecs = *body.PollIntervalSecs
+	}
+	if pollIntervalSecs < 30 {
+		pollIntervalSecs = 30
+	}
+	if pollIntervalSecs > 3600 {
+		pollIntervalSecs = 3600
+	}
+
+	storedTLSCfg, err := marshalStoredAPITLSConfig(parsedTLSConfig)
+	if err != nil {
+		log.Printf("api machines: tls config marshal error: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
+	}
+
+	_, err = db.Exec(`UPDATE api_machines
+		SET name = ?, adapter_type = ?, base_url = ?, auth_config = ?, tls_config = ?, poll_interval_secs = ?
+		WHERE id = ?`,
+		name, adapterType, baseURL, string(authConfig), storedTLSCfg, pollIntervalSecs, id)
+	if err != nil {
+		log.Printf("api machines: update error: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
+	}
+
+	startAPIPoller(id, name, adapterType, baseURL, authConfig, json.RawMessage(storedTLSCfg), pollIntervalSecs)
+
+	log.Printf("api machine updated: %s (%s, %s)", name, adapterType, id)
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"id":                 id,
+		"name":               name,
+		"adapter_type":       adapterType,
+		"base_url":           baseURL,
+		"tls_config":         redactAPITLSConfig(storedTLSCfg),
+		"poll_interval_secs": pollIntervalSecs,
 	})
 }
 

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -1402,6 +1402,7 @@ func TestCreateAPIMachine(t *testing.T) {
 	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
 	api.GET("/api/api-machines", handleListAPIMachines)
 	api.POST("/api/api-machines", handleCreateAPIMachine)
+	api.PATCH("/api/api-machines/:id", handleUpdateAPIMachine)
 	api.DELETE("/api/api-machines/:id", handleDeleteAPIMachine)
 	api.POST("/api/api-machines/:id/poll", handleForceAPIPoll)
 
@@ -1632,6 +1633,117 @@ func TestDeleteAPIMachine(t *testing.T) {
 
 	stopAllAPIPollers()
 	t.Log("delete api machine: OK")
+}
+
+func TestUpdateAPIMachine(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+
+	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
+	api.POST("/api/api-machines", handleCreateAPIMachine)
+	api.PATCH("/api/api-machines/:id", handleUpdateAPIMachine)
+
+	createBody := `{"name":"Main","adapter_type":"proxmox","base_url":"https://192.168.3.2:8006","auth_config":{"token_id":"root@pam!monitor","token_secret":"xxx"},"tls_config":{"mode":"insecure"},"poll_interval_secs":120}`
+	req := httptest.NewRequest(http.MethodPost, "/api/api-machines", strings.NewReader(createBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var createResp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &createResp); err != nil {
+		t.Fatalf("unmarshal create: %v", err)
+	}
+	id := createResp["id"].(string)
+
+	updateBody := fmt.Sprintf(`{"name":"Main Updated","poll_interval_secs":300,"tls_config":{"mode":"custom_ca","ca_cert_pem":%q}}`, generateTestCertPEM(t))
+	req = httptest.NewRequest(http.MethodPatch, "/api/api-machines/"+id, strings.NewReader(updateBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal update: %v", err)
+	}
+	if resp["name"] != "Main Updated" {
+		t.Fatalf("expected updated name, got %v", resp["name"])
+	}
+	tlsCfg, ok := resp["tls_config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected tls_config object, got %T", resp["tls_config"])
+	}
+	if tlsCfg["mode"] != "custom_ca" || tlsCfg["has_custom_ca"] != true {
+		t.Fatalf("unexpected tls_config response: %v", tlsCfg)
+	}
+
+	var storedName, storedTLS string
+	var storedInterval int
+	if err := db.QueryRow("SELECT name, tls_config, poll_interval_secs FROM api_machines WHERE id = ?", id).Scan(&storedName, &storedTLS, &storedInterval); err != nil {
+		t.Fatalf("query updated machine: %v", err)
+	}
+	if storedName != "Main Updated" {
+		t.Fatalf("expected stored updated name, got %s", storedName)
+	}
+	if storedInterval != 300 {
+		t.Fatalf("expected stored poll interval 300, got %d", storedInterval)
+	}
+	if !strings.Contains(storedTLS, `"mode":"custom_ca"`) {
+		t.Fatalf("expected stored tls_config to be custom_ca, got %s", storedTLS)
+	}
+
+	stopAllAPIPollers()
+}
+
+func TestUpdateAPIMachineRequiresAuthConfigOnAdapterChange(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+
+	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
+	api.POST("/api/api-machines", handleCreateAPIMachine)
+	api.PATCH("/api/api-machines/:id", handleUpdateAPIMachine)
+
+	createBody := `{"name":"Dasman","adapter_type":"synology","base_url":"http://192.168.16.234:5000","auth_config":{"username":"u","password":"p"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/api-machines", strings.NewReader(createBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var createResp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &createResp); err != nil {
+		t.Fatalf("unmarshal create: %v", err)
+	}
+	id := createResp["id"].(string)
+
+	updateBody := `{"adapter_type":"proxmox"}`
+	req = httptest.NewRequest(http.MethodPatch, "/api/api-machines/"+id, strings.NewReader(updateBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "auth_config is required when adapter_type changes") {
+		t.Fatalf("unexpected error: %s", rec.Body.String())
+	}
+
+	stopAllAPIPollers()
 }
 
 func TestDeleteAPIMachineNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `PATCH /api/api-machines/:id` with partial updates for name, adapter, URL, auth, TLS trust, and poll interval
- validate merged update payloads, require fresh auth when adapter type changes, and restart only the affected API poller in-process after save
- reuse the Add API Machine modal as an add/edit form that preserves existing credentials and custom CA unless the operator replaces them
- add edit actions for API machines in the grid and list views
- document the live edit/reload flow and add backend tests for update behavior

## Checks
- `go test -count=1 ./...` in `hub`
- `go test -count=1 ./...` in `agent`
- `pnpm lint` in `dashboard`
- `pnpm build` in `dashboard`

## Rollout Notes
- existing API machines can now be switched from temporary `insecure` to `custom_ca` directly in the dashboard
- changing TLS mode, credentials, URL, or poll interval restarts only that machine's poller; no SQLite edit or hub restart is required
