### PR TITLE
Add GitHub Actions quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hub:
+    name: Hub Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: hub
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.9"
+          cache-dependency-path: hub/go.sum
+
+      - name: Run hub tests
+        run: go test -count=1 ./...
+
+  agent:
+    name: Agent Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: agent
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.9"
+          cache-dependency-path: agent/go.sum
+
+      - name: Run agent tests
+        run: go test -count=1 ./...
+
+  dashboard:
+    name: Dashboard Lint + Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+
+      - name: Install dashboard dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint dashboard
+        run: pnpm lint
+
+      - name: Build dashboard
+        run: pnpm build


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow for pushes to `main`, pull requests, and manual runs
- run the existing repo baseline checks in separate jobs: `hub` tests, `agent` tests, dashboard lint, and dashboard build
- pin Go to `1.25.9` and use pnpm/node setup with dependency caching so CI matches the current local toolchain
- add workflow concurrency cancellation to avoid piling up stale runs on active branches

## Checks mirrored by CI
- `go test -count=1 ./...` in `hub`
- `go test -count=1 ./...` in `agent`
- `pnpm lint` in `dashboard`
- `pnpm build` in `dashboard`

## Why now
- the repo now has meaningful backend, frontend, and migration checks that should block bad merges automatically
- this protects the recent hardening/setup/API-machine work from regressions in future PRs
