### PR TITLE
Add first-boot setup UI

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -23,17 +23,18 @@
     - [x] GitHub Actions CI for hub tests, agent tests, dashboard lint/build
 - In progress:
   - [ ] PR `#21` / branch `feat/setup-ui`: frontend `/setup` page for first-boot flow
-    - current branch head: `1692c2d`
+    - current branch head: `3fcb836`
     - latest fixes included:
       - blocking error state when setup status cannot be fetched
       - explicit message when setup succeeds but auto-login fails
       - login page skips setup probe when already authenticated
       - setup retry button retriggers the setup-status fetch correctly
+      - RBAC/action-scope foundation (`admin` / `operator` / `viewer`) with server-side route checks
+      - startup route-audit guard so protected `/api/*` routes cannot drift from the RBAC scope map
 - Remaining:
   - [ ] merge PR `#21`
   - [ ] deploy `/setup` UI after merge
   - [ ] move Proxmox API machine from temporary `insecure` mode to `custom_ca`
-  - [ ] RBAC / action scopes
   - [ ] split `hub/main.go` into packages when the repo stabilizes further
 
 ## Credentials
@@ -86,6 +87,7 @@ Never put raw secrets, tokens, passwords, PINs, or SSH credentials in this file 
 - PR `#21` is still open and not merged into `main` yet.
 - `/setup` UI exists on the feature branch only until PR `#21` lands.
 - Proxmox API polling still uses explicit per-machine `insecure` TLS until its CA PEM is configured.
+- RBAC is currently backend-enforced; dashboard role-aware affordances are still minimal.
 
 ## Current Fleet
 - Last verified rollout state:

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,77 +2,112 @@
 
 ## State
 - Done:
-  - [x] Phase 1-5: All features (hub, agent, dashboard, GPU, terminal, alerts, charts, auth)
-  - [x] UI Redesign: shadcn/ui + Framer Motion + Geist fonts
-  - [x] Codex Security Audit: 3 rounds, 6/8 fixed, 2 accepted
-  - [x] Hardening Do Now: creds rotated, DB 0600, token logging stopped, single-use tokens, Caddy TLS, config model, rate limiting
-  - [x] Hardening Do Next Sprint (all 6 items, 2026-04-22):
-    - [x] #8 Migration versioning (hub/migrations.go, schema_version table, 5 migrations)
-    - [x] #9 Smoke tests (41 tests in hub/main_test.go)
-    - [x] #10 Backend-enforce password/PIN rotation (credentialRotationMiddleware)
-    - [x] #11 First-boot setup flow (POST /api/setup, bootstrap token, no default creds)
-    - [x] #12 Enrollment redesign (durable agent secrets, SHA-256 hashed, revocable)
-    - [x] #13 Terminal privilege tightening (30min timeout, max 3 sessions, audit logging)
-- Now: Code committed and pushed. Service restart needed to activate. Tests green.
+  - [x] Feature baseline: hub, agent, dashboard, GPU metrics, alerts, auth, terminal, API-polled machines
+  - [x] UI refresh: shadcn/ui + Framer Motion + Geist fonts
+  - [x] Security hardening phase:
+    - [x] DB permissions `0600`
+    - [x] bootstrap secrets removed from logs
+    - [x] single-use install tokens
+    - [x] credential rotation enforcement
+    - [x] first-boot setup backend
+    - [x] durable agent secrets (hashed, revocable)
+    - [x] terminal session limits and audit metadata
+  - [x] Trust hardening:
+    - [x] agent TLS verification enabled by default
+    - [x] installer CA bootstrap with fingerprint verification
+    - [x] terminal browser token scoped instead of full JWT in URL
+    - [x] API-machine TLS trust moved from global env override to per-machine config
+  - [x] Product gaps closed:
+    - [x] API machine edit flow (`PATCH /api/api-machines/:id`)
+    - [x] in-process poller restart after API machine update
+    - [x] GitHub Actions CI for hub tests, agent tests, dashboard lint/build
+- In progress:
+  - [ ] PR `#21` / branch `feat/setup-ui`: frontend `/setup` page for first-boot flow
+    - current branch head: `1692c2d`
+    - latest fixes included:
+      - blocking error state when setup status cannot be fetched
+      - explicit message when setup succeeds but auto-login fails
+      - login page skips setup probe when already authenticated
+      - setup retry button retriggers the setup-status fetch correctly
 - Remaining:
-  - [ ] Split hub/main.go into packages (do at ~4000 LOC or second contributor)
-  - [ ] Separate terminal-gateway service
-  - [ ] Full test suite beyond smoke tests
-  - [ ] Dashboard setup page (/setup) -- frontend for first-boot flow
+  - [ ] merge PR `#21`
+  - [ ] deploy `/setup` UI after merge
+  - [ ] move Proxmox API machine from temporary `insecure` mode to `custom_ca`
+  - [ ] RBAC / action scopes
+  - [ ] split `hub/main.go` into packages when the repo stabilizes further
 
 ## Credentials
-All credentials are in memory/credentials.md on the Mac Mini.
-NEVER put secrets in this file or any committed file.
+All live credentials are stored outside git.
+Never put raw secrets, tokens, passwords, PINs, or SSH credentials in this file or any committed file.
 
-## Deployment Notes
-The hardening sprint code is committed and pushed but NOT yet deployed.
-To activate on the hub VM:
+## Current Deployment
+- Supported deployment path: `Caddy + systemd`
+- Topology:
+  - Caddy terminates HTTPS on `:443`
+  - hub listens on `127.0.0.1:4000`
+  - dashboard listens on `127.0.0.1:3000`
+  - agents connect through Caddy over `wss://.../ws/agent`
+- CI is active in GitHub Actions for:
+  - `go test -count=1 ./...` in `hub`
+  - `go test -count=1 ./...` in `agent`
+  - `pnpm lint` in `dashboard`
+  - `pnpm build` in `dashboard`
 
-1. SSH to hub (creds in memory/credentials.md)
-2. Stop services: `sudo systemctl stop bloxos-hub bloxos-agent`
-3. Rebuild hub: `cd ~/bloxos/hub && /usr/local/go/bin/go build -o bloxos-hub .`
-4. Rebuild agent: `cd ~/bloxos/agent && /usr/local/go/bin/go build -o bloxos-agent .`
-5. Restart: `sudo systemctl start bloxos-hub bloxos-agent`
-6. On first start: schema migrations run automatically (version 0 to 5)
-7. Existing admin user will hit rotation enforcement -- change password and PIN via API
+## First-Boot Setup
+- Backend setup flow already exists and is the only supported bootstrap path for new deployments.
+- Status endpoint: `GET /api/setup/status`
+- Setup endpoint: `POST /api/setup`
+- Setup token sources:
+  - `~/.bloxos/setup-token` (owner-readable only) when no users exist
+  - or `BLOXOS_SETUP_TOKEN`
+- PR `#21` adds the frontend `/setup` page on top of this backend flow.
 
-### First-boot setup (new deployments only)
-- Hub writes setup token to `~/.bloxos/setup-token` (0600) if no users exist
-- Or set `BLOXOS_SETUP_TOKEN` env var
-- `GET /api/setup/status` returns `{"needs_setup": true/false}`
-- `POST /api/setup` with `{"setup_token":"...","username":"...","password":"...","pin":"..."}` creates admin
-- Dashboard needs a setup page (not built yet -- API-only for now)
+## Agent Enrollment
+- Legacy reconnect fallback has been removed.
+- Agents must authenticate with durable secrets on reconnect.
+- Install tokens are single-use and mint durable agent credentials.
+- Durable agent secret is stored locally on the machine and hashed in the hub DB.
+- Re-enrollment path for an older or broken agent:
+  1. generate a fresh install token
+  2. reinstall or re-run the agent bootstrap flow
+  3. verify the new durable secret is present locally
 
-### Agent enrollment (existing agents)
-- Existing agents must reconnect with a durable secret, or enroll once with a valid install token to mint one
-- New agents receive a durable secret on enrollment (stored at /etc/bloxos/agent-secret)
-- To re-enroll: delete machine from DB, generate new install token, re-run install script
+## API Machines
+- TLS trust is now per machine:
+  - `system`
+  - `custom_ca`
+  - temporary `insecure`
+- Existing self-signed HTTPS endpoints must be configured explicitly.
+- Current follow-up still needed:
+  - move the Proxmox API machine from temporary `insecure` mode to `custom_ca`
+- API machines can now be edited from the dashboard; direct SQLite edits should no longer be necessary.
 
 ## Known Issues
-- Self-signed TLS: agents need InsecureSkipVerify for Caddy's cert
-- Dashboard setup page not built yet -- first-boot setup is API-only
-- Credentials were previously committed to HANDOFF.md and must be rotated
+- PR `#21` is still open and not merged into `main` yet.
+- `/setup` UI exists on the feature branch only until PR `#21` lands.
+- Proxmox API polling still uses explicit per-machine `insecure` TLS until its CA PEM is configured.
 
 ## Current Fleet
-- bloxOs (192.168.16.113) -- hub VM, online
-- ic-brain (192.168.16.78) -- InContext Research, online
-
-## Architecture
-LAN -> Caddy (:443 TLS) -> Hub (127.0.0.1:4000) + Dashboard (127.0.0.1:3000)
-Agents connect via WSS through Caddy to /ws/agent
+- Last verified rollout state:
+  - 3 enrolled agents online
+  - 2 API machines polling
+- Recheck live fleet state from the dashboard or hub API before any ops work.
 
 ## Key URLs
-- Dashboard: https://192.168.16.113
-- Repo: https://github.com/bokiko/bloxos (PRIVATE)
-- Branch: main
-- Hardening plan: /Users/bokiko/.claude/plans/calm-baking-eclipse.md
+- Dashboard: `https://192.168.16.113`
+- Repo: `https://github.com/bokiko/bloxos`
+- Active feature branch: `feat/setup-ui`
+- Open setup PR: `#21`
 
-## Test Commands
-- Run tests: `cd ~/bloxos/hub && /usr/local/go/bin/go test -v -count=1 ./...`
-- Build hub: `cd ~/bloxos/hub && /usr/local/go/bin/go build -o bloxos-hub .`
-- Build agent: `cd ~/bloxos/agent && /usr/local/go/bin/go build -o bloxos-agent .`
+## Useful Commands
+- Hub tests: `cd ~/bloxos/hub && /usr/local/go/bin/go test -count=1 ./...`
+- Agent tests: `cd ~/bloxos/agent && /usr/local/go/bin/go test -count=1 ./...`
+- Dashboard lint: `cd ~/bloxos/dashboard && pnpm lint`
+- Dashboard build: `cd ~/bloxos/dashboard && pnpm build`
+- Hub build: `cd ~/bloxos/hub && /usr/local/go/bin/go build -o bloxos-hub .`
+- Agent build: `cd ~/bloxos/agent && /usr/local/go/bin/go build -o bloxos-agent .`
 
 ## Tech Stack
-Go 1.25, Echo, gorilla/websocket, gopsutil, modernc.org/sqlite, creack/pty, golang-jwt, bcrypt
-Next.js 16, React 19, Tailwind v4, shadcn/ui, Framer Motion, Recharts, xterm.js
-Caddy (internal TLS), SQLite WAL (0600), Ubuntu 22.04
+- Backend: Go 1.25, Echo, gorilla/websocket, modernc.org/sqlite, JWT, bcrypt
+- Frontend: Next.js 16, React 19, Tailwind v4, shadcn/ui, Framer Motion, Recharts, xterm.js
+- Infra: Caddy, systemd, SQLite WAL

--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ BLOXOS_CA_CERT=/etc/bloxos/ca.crt ./bloxos-agent --hub wss://<hub>/ws/agent --to
 
 1. Start the hub.
 2. Read the one-time setup token from `~/.bloxos/setup-token`, or set `BLOXOS_SETUP_TOKEN`.
-3. `POST /api/setup` with your setup token, admin username, password, and terminal PIN.
-4. Log in with the credentials you just created.
+3. Open `https://<hub>/setup`.
+4. Enter the setup token, admin username, password, and terminal PIN.
+5. The dashboard completes setup and then hands off to the normal login/dashboard flow.
 
 ### API-Polled Machines
 

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, FormEvent } from "react";
+import { useState, FormEvent, useEffect, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
+import { HUB_URL } from "@/lib/session";
 import { motion } from "framer-motion";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -13,8 +14,34 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const { login } = useAuth();
+  const [checkingSetup, startSetupCheck] = useTransition();
+  const { login, isAuthenticated } = useAuth();
   const router = useRouter();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.replace("/");
+    }
+  }, [isAuthenticated, router]);
+
+  useEffect(() => {
+    let active = true;
+    startSetupCheck(async () => {
+      try {
+        const res = await fetch(`${HUB_URL}/api/setup/status`);
+        if (!res.ok || !active) return;
+        const data = await res.json();
+        if (active && data?.needs_setup) {
+          router.replace("/setup");
+        }
+      } catch {
+        // ignore setup status failures and keep login usable
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [router]);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -62,6 +89,7 @@ export default function LoginPage() {
                   placeholder="admin"
                   autoFocus
                   autoComplete="username"
+                  disabled={checkingSetup}
                 />
               </div>
               <div>
@@ -73,6 +101,7 @@ export default function LoginPage() {
                   className="bg-blox-bg border-blox-border text-blox-text placeholder:text-blox-muted/50 h-9 text-sm"
                   placeholder="password"
                   autoComplete="current-password"
+                  disabled={checkingSetup}
                 />
               </div>
 
@@ -88,10 +117,10 @@ export default function LoginPage() {
 
               <Button
                 type="submit"
-                disabled={loading || !username || !password}
+                disabled={loading || checkingSetup || !username || !password}
                 className="w-full bg-blox-blue hover:bg-blox-blue/90 text-white h-9 text-sm font-medium"
               >
-                {loading ? "Signing in..." : "Sign In"}
+                {checkingSetup ? "Checking setup..." : loading ? "Signing in..." : "Sign In"}
               </Button>
             </form>
           </CardContent>

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -25,6 +25,9 @@ export default function LoginPage() {
   }, [isAuthenticated, router]);
 
   useEffect(() => {
+    if (isAuthenticated) {
+      return;
+    }
     let active = true;
     startSetupCheck(async () => {
       try {
@@ -41,7 +44,7 @@ export default function LoginPage() {
     return () => {
       active = false;
     };
-  }, [router]);
+  }, [isAuthenticated, router]);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();

--- a/dashboard/src/app/setup/page.tsx
+++ b/dashboard/src/app/setup/page.tsx
@@ -113,10 +113,11 @@ export default function SetupPage() {
         throw new Error(setupData?.error || `Setup failed (${setupRes.status})`);
       }
 
-      setCreatedUsername(setupData?.username || trimmedUsername);
+      const loginUsername = setupData?.username || trimmedUsername;
+      setCreatedUsername(loginUsername);
       setSetupState("complete");
 
-      const loggedIn = await login(trimmedUsername, password);
+      const loggedIn = await login(loginUsername, password);
       if (loggedIn) {
         startNavigation(() => {
           router.replace("/");

--- a/dashboard/src/app/setup/page.tsx
+++ b/dashboard/src/app/setup/page.tsx
@@ -32,12 +32,11 @@ export default function SetupPage() {
     if (isAuthenticated) {
       router.replace("/");
     }
-  }, [isAuthenticated, router, setupCheckNonce]);
+  }, [isAuthenticated, router]);
 
   useEffect(() => {
     let active = true;
     const checkSetup = async () => {
-      if (!active) return;
       setSetupState("checking");
       setError("");
       try {
@@ -65,7 +64,7 @@ export default function SetupPage() {
     return () => {
       active = false;
     };
-  }, [isAuthenticated, router]);
+  }, [isAuthenticated, router, setupCheckNonce]);
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();

--- a/dashboard/src/app/setup/page.tsx
+++ b/dashboard/src/app/setup/page.tsx
@@ -10,10 +10,11 @@ import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
 import { HUB_URL } from "@/lib/session";
 
-type SetupState = "checking" | "ready" | "complete" | "redirecting";
+type SetupState = "checking" | "ready" | "error" | "complete";
 
 export default function SetupPage() {
   const [setupState, setSetupState] = useState<SetupState>("checking");
+  const [setupCheckNonce, setSetupCheckNonce] = useState(0);
   const [setupToken, setSetupToken] = useState("");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -31,11 +32,14 @@ export default function SetupPage() {
     if (isAuthenticated) {
       router.replace("/");
     }
-  }, [isAuthenticated, router]);
+  }, [isAuthenticated, router, setupCheckNonce]);
 
   useEffect(() => {
     let active = true;
     const checkSetup = async () => {
+      if (!active) return;
+      setSetupState("checking");
+      setError("");
       try {
         const res = await fetch(`${HUB_URL}/api/setup/status`);
         if (!res.ok) {
@@ -46,7 +50,6 @@ export default function SetupPage() {
         if (data?.needs_setup) {
           setSetupState("ready");
         } else {
-          setSetupState("redirecting");
           startNavigation(() => {
             router.replace(isAuthenticated ? "/" : "/login");
           });
@@ -54,7 +57,7 @@ export default function SetupPage() {
       } catch {
         if (active) {
           setError("Unable to reach the setup service. Check the hub and try again.");
-          setSetupState("ready");
+          setSetupState("error");
         }
       }
     };
@@ -119,6 +122,8 @@ export default function SetupPage() {
         startNavigation(() => {
           router.replace("/");
         });
+      } else {
+        setError("Setup succeeded, but automatic sign-in failed. Use the button below to go to login.");
       }
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Setup failed.");
@@ -128,7 +133,7 @@ export default function SetupPage() {
     }
   };
 
-  const disabled = loading || setupState === "checking" || setupState === "redirecting" || navigating;
+  const disabled = loading || setupState === "checking" || navigating;
 
   return (
     <div className="min-h-screen bg-blox-bg relative overflow-hidden">
@@ -219,6 +224,15 @@ export default function SetupPage() {
                         Admin <span className="text-blox-text font-medium">{createdUsername}</span> is ready. {navigating ? "Opening the dashboard..." : "You can sign in now."}
                       </p>
                     </div>
+                    {error && (
+                      <motion.p
+                        initial={{ opacity: 0, y: -4 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        className="rounded-xl border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs leading-5 text-blox-red"
+                      >
+                        {error}
+                      </motion.p>
+                    )}
                     {!navigating && (
                       <Button
                         onClick={() => router.replace("/login")}
@@ -227,6 +241,28 @@ export default function SetupPage() {
                         Go to Login
                       </Button>
                     )}
+                  </div>
+                ) : setupState === "error" ? (
+                  <div className="space-y-5 text-center">
+                    <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border border-red-500/20 bg-red-500/10 text-blox-red">
+                      <LockKeyhole className="w-7 h-7" />
+                    </div>
+                    <div>
+                      <h3 className="text-xl font-semibold text-blox-text">Setup service unavailable</h3>
+                      <p className="mt-2 text-sm leading-6 text-blox-muted">
+                        {error || "The dashboard could not verify whether first-boot setup is still required."}
+                      </p>
+                    </div>
+                    <Button
+                      onClick={() => {
+                        setSetupState("checking");
+                        setError("");
+                        setSetupCheckNonce((value) => value + 1);
+                      }}
+                      className="w-full bg-blox-blue hover:bg-blox-blue/90 text-white"
+                    >
+                      Retry Setup Check
+                    </Button>
                   </div>
                 ) : (
                   <form onSubmit={handleSubmit} className="space-y-5">
@@ -330,9 +366,7 @@ export default function SetupPage() {
                     >
                       {setupState === "checking"
                         ? "Checking setup status..."
-                        : setupState === "redirecting"
-                          ? "Redirecting..."
-                          : loading
+                        : loading
                             ? "Creating admin..."
                             : "Complete First-Boot Setup"}
                     </Button>

--- a/dashboard/src/app/setup/page.tsx
+++ b/dashboard/src/app/setup/page.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { FormEvent, useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+import { ShieldCheck, KeyRound, LockKeyhole, Sparkles } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/contexts/AuthContext";
+import { HUB_URL } from "@/lib/session";
+
+type SetupState = "checking" | "ready" | "complete" | "redirecting";
+
+export default function SetupPage() {
+  const [setupState, setSetupState] = useState<SetupState>("checking");
+  const [setupToken, setSetupToken] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [pin, setPin] = useState("");
+  const [confirmPin, setConfirmPin] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [createdUsername, setCreatedUsername] = useState("");
+  const [navigating, startNavigation] = useTransition();
+  const router = useRouter();
+  const { login, isAuthenticated } = useAuth();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.replace("/");
+    }
+  }, [isAuthenticated, router]);
+
+  useEffect(() => {
+    let active = true;
+    const checkSetup = async () => {
+      try {
+        const res = await fetch(`${HUB_URL}/api/setup/status`);
+        if (!res.ok) {
+          throw new Error("Failed to check setup status.");
+        }
+        const data = await res.json();
+        if (!active) return;
+        if (data?.needs_setup) {
+          setSetupState("ready");
+        } else {
+          setSetupState("redirecting");
+          startNavigation(() => {
+            router.replace(isAuthenticated ? "/" : "/login");
+          });
+        }
+      } catch {
+        if (active) {
+          setError("Unable to reach the setup service. Check the hub and try again.");
+          setSetupState("ready");
+        }
+      }
+    };
+    void checkSetup();
+    return () => {
+      active = false;
+    };
+  }, [isAuthenticated, router]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+
+    const trimmedToken = setupToken.trim();
+    const trimmedUsername = username.trim();
+
+    if (!trimmedToken || !trimmedUsername || !password || !pin) {
+      setError("Setup token, username, password, and PIN are required.");
+      return;
+    }
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+    if (!/^\d{4,}$/.test(pin)) {
+      setError("PIN must be at least 4 digits.");
+      return;
+    }
+    if (pin !== confirmPin) {
+      setError("PIN values do not match.");
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+
+    try {
+      const setupRes = await fetch(`${HUB_URL}/api/setup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          setup_token: trimmedToken,
+          username: trimmedUsername,
+          password,
+          pin,
+        }),
+      });
+
+      const setupData = await setupRes.json().catch(() => null);
+      if (!setupRes.ok) {
+        throw new Error(setupData?.error || `Setup failed (${setupRes.status})`);
+      }
+
+      setCreatedUsername(setupData?.username || trimmedUsername);
+      setSetupState("complete");
+
+      const loggedIn = await login(trimmedUsername, password);
+      if (loggedIn) {
+        startNavigation(() => {
+          router.replace("/");
+        });
+      }
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Setup failed.");
+      setSetupState("ready");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const disabled = loading || setupState === "checking" || setupState === "redirecting" || navigating;
+
+  return (
+    <div className="min-h-screen bg-blox-bg relative overflow-hidden">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(59,130,246,0.12),_transparent_36%),radial-gradient(circle_at_bottom_right,_rgba(34,197,94,0.08),_transparent_28%)]" />
+      <div className="absolute inset-0 bg-[linear-gradient(rgba(59,130,246,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(59,130,246,0.03)_1px,transparent_1px)] bg-[size:72px_72px]" />
+      <div className="absolute inset-y-0 right-0 w-1/3 bg-[radial-gradient(circle_at_center,_rgba(255,255,255,0.04),_transparent_60%)]" />
+
+      <div className="relative z-10 min-h-screen grid lg:grid-cols-[1.1fr_0.9fr]">
+        <section className="hidden lg:flex flex-col justify-between px-10 py-12 border-r border-blox-border/60">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full border border-blox-blue/20 bg-blox-blue/8 px-3 py-1 text-[11px] uppercase tracking-[0.28em] text-blox-blue">
+              <Sparkles className="w-3.5 h-3.5" />
+              First Boot
+            </div>
+            <h1 className="mt-8 max-w-xl text-5xl font-semibold tracking-tight text-blox-text">
+              Turn a blank install into a locked-down control plane.
+            </h1>
+            <p className="mt-5 max-w-lg text-sm leading-7 text-blox-muted">
+              This one-time setup flow creates your first admin, seals the default credential path, and sets the terminal PIN before the dashboard ever opens.
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            {[
+              {
+                icon: ShieldCheck,
+                title: "Bootstrap proof",
+                body: "Use the setup token from the server to prove you control the host before the first admin exists.",
+              },
+              {
+                icon: KeyRound,
+                title: "Rotated from minute one",
+                body: "The admin account and terminal PIN are stored as already-changed credentials, not shipped defaults.",
+              },
+              {
+                icon: LockKeyhole,
+                title: "One path, one time",
+                body: "Once setup completes, the backend closes this path and the dashboard falls back to the normal login flow.",
+              },
+            ].map(({ icon: Icon, title, body }) => (
+              <motion.div
+                key={title}
+                initial={{ opacity: 0, y: 18 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.45 }}
+                className="rounded-2xl border border-blox-border/70 bg-blox-card/55 px-5 py-4 shadow-lg shadow-black/15 backdrop-blur-sm"
+              >
+                <div className="flex items-start gap-3">
+                  <div className="mt-0.5 rounded-xl border border-blox-blue/20 bg-blox-blue/10 p-2 text-blox-blue">
+                    <Icon className="w-4 h-4" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-blox-text">{title}</p>
+                    <p className="mt-1 text-xs leading-6 text-blox-muted">{body}</p>
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        </section>
+
+        <section className="flex items-center justify-center px-4 py-10 sm:px-6">
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, ease: "easeOut" }}
+            className="w-full max-w-xl"
+          >
+            <div className="mb-8 text-center lg:text-left">
+              <h2 className="text-3xl font-semibold tracking-tight text-blox-text">
+                <span className="text-blox-blue">Blox</span>OS Setup
+              </h2>
+              <p className="mt-2 text-sm text-blox-muted">
+                Create the first administrator and secure terminal access.
+              </p>
+            </div>
+
+            <Card className="border-blox-border/80 bg-blox-card/82 shadow-2xl shadow-black/25 backdrop-blur-md">
+              <CardContent className="px-6 py-6 sm:px-7">
+                {setupState === "complete" ? (
+                  <div className="space-y-5 text-center">
+                    <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border border-emerald-500/20 bg-emerald-500/10 text-emerald-400">
+                      <ShieldCheck className="w-7 h-7" />
+                    </div>
+                    <div>
+                      <h3 className="text-xl font-semibold text-blox-text">Setup complete</h3>
+                      <p className="mt-2 text-sm leading-6 text-blox-muted">
+                        Admin <span className="text-blox-text font-medium">{createdUsername}</span> is ready. {navigating ? "Opening the dashboard..." : "You can sign in now."}
+                      </p>
+                    </div>
+                    {!navigating && (
+                      <Button
+                        onClick={() => router.replace("/login")}
+                        className="w-full bg-blox-blue hover:bg-blox-blue/90 text-white"
+                      >
+                        Go to Login
+                      </Button>
+                    )}
+                  </div>
+                ) : (
+                  <form onSubmit={handleSubmit} className="space-y-5">
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <div className="sm:col-span-2">
+                        <label className="block text-[11px] uppercase tracking-[0.24em] text-blox-muted mb-1.5">Setup Token</label>
+                        <Input
+                          type="text"
+                          value={setupToken}
+                          onChange={(e) => setSetupToken(e.target.value)}
+                          placeholder="Paste the one-time setup token"
+                          className="h-10 bg-blox-bg border-blox-border text-blox-text placeholder:text-blox-muted/50 font-mono"
+                          autoComplete="off"
+                          autoFocus
+                          disabled={disabled}
+                        />
+                      </div>
+
+                      <div className="sm:col-span-2">
+                        <label className="block text-[11px] uppercase tracking-[0.24em] text-blox-muted mb-1.5">Admin Username</label>
+                        <Input
+                          type="text"
+                          value={username}
+                          onChange={(e) => setUsername(e.target.value)}
+                          placeholder="admin"
+                          className="h-10 bg-blox-bg border-blox-border text-blox-text placeholder:text-blox-muted/50"
+                          autoComplete="username"
+                          disabled={disabled}
+                        />
+                      </div>
+
+                      <div>
+                        <label className="block text-[11px] uppercase tracking-[0.24em] text-blox-muted mb-1.5">Password</label>
+                        <Input
+                          type="password"
+                          value={password}
+                          onChange={(e) => setPassword(e.target.value)}
+                          placeholder="Minimum 8 characters"
+                          className="h-10 bg-blox-bg border-blox-border text-blox-text placeholder:text-blox-muted/50"
+                          autoComplete="new-password"
+                          disabled={disabled}
+                        />
+                      </div>
+
+                      <div>
+                        <label className="block text-[11px] uppercase tracking-[0.24em] text-blox-muted mb-1.5">Confirm Password</label>
+                        <Input
+                          type="password"
+                          value={confirmPassword}
+                          onChange={(e) => setConfirmPassword(e.target.value)}
+                          placeholder="Repeat password"
+                          className="h-10 bg-blox-bg border-blox-border text-blox-text placeholder:text-blox-muted/50"
+                          autoComplete="new-password"
+                          disabled={disabled}
+                        />
+                      </div>
+
+                      <div>
+                        <label className="block text-[11px] uppercase tracking-[0.24em] text-blox-muted mb-1.5">Terminal PIN</label>
+                        <Input
+                          type="password"
+                          inputMode="numeric"
+                          value={pin}
+                          onChange={(e) => setPin(e.target.value)}
+                          placeholder="At least 4 digits"
+                          className="h-10 bg-blox-bg border-blox-border text-blox-text placeholder:text-blox-muted/50 font-mono"
+                          autoComplete="off"
+                          disabled={disabled}
+                        />
+                      </div>
+
+                      <div>
+                        <label className="block text-[11px] uppercase tracking-[0.24em] text-blox-muted mb-1.5">Confirm PIN</label>
+                        <Input
+                          type="password"
+                          inputMode="numeric"
+                          value={confirmPin}
+                          onChange={(e) => setConfirmPin(e.target.value)}
+                          placeholder="Repeat PIN"
+                          className="h-10 bg-blox-bg border-blox-border text-blox-text placeholder:text-blox-muted/50 font-mono"
+                          autoComplete="off"
+                          disabled={disabled}
+                        />
+                      </div>
+                    </div>
+
+                    {error && (
+                      <motion.p
+                        initial={{ opacity: 0, y: -4 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        className="rounded-xl border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs leading-5 text-blox-red"
+                      >
+                        {error}
+                      </motion.p>
+                    )}
+
+                    <Button
+                      type="submit"
+                      disabled={disabled}
+                      className="h-10 w-full bg-blox-blue hover:bg-blox-blue/90 text-white text-sm font-medium"
+                    >
+                      {setupState === "checking"
+                        ? "Checking setup status..."
+                        : setupState === "redirecting"
+                          ? "Redirecting..."
+                          : loading
+                            ? "Creating admin..."
+                            : "Complete First-Boot Setup"}
+                    </Button>
+
+                    <p className="text-[11px] leading-6 text-blox-muted">
+                      The setup token is read from `~/.bloxos/setup-token` or provided through `BLOXOS_SETUP_TOKEN` on the server.
+                    </p>
+                  </form>
+                )}
+              </CardContent>
+            </Card>
+          </motion.div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/contexts/AuthContext.tsx
+++ b/dashboard/src/contexts/AuthContext.tsx
@@ -56,7 +56,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    if (checked && !token && pathname !== "/login") {
+    if (checked && !token && pathname !== "/login" && pathname !== "/setup") {
       router.push("/login");
     }
   }, [checked, token, pathname, router]);

--- a/hub/main.go
+++ b/hub/main.go
@@ -289,7 +289,7 @@ func main() {
 	e.POST("/api/setup", handleSetup)
 
 	// Protected endpoints.
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
+	api := e.Group("", jwtMiddleware, credentialRotationMiddleware, permissionMiddleware)
 	api.GET("/api/events", handleSSE)
 	api.GET("/api/machines", handleListMachines)
 	api.GET("/api/machines/:id", handleGetMachine)
@@ -522,8 +522,8 @@ func handleSetup(c echo.Context) error {
 
 	// Create admin user with credentials already rotated.
 	id := uuid.New().String()
-	_, err = db.Exec(`INSERT INTO users (id, username, password_hash, terminal_pin_hash, password_changed, pin_changed) VALUES (?, ?, ?, ?, TRUE, TRUE)`,
-		id, body.Username, string(passwordHash), string(pinHash))
+	_, err = db.Exec(`INSERT INTO users (id, username, password_hash, terminal_pin_hash, password_changed, pin_changed, role) VALUES (?, ?, ?, ?, TRUE, TRUE, ?)`,
+		id, body.Username, string(passwordHash), string(pinHash), RoleAdmin)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create user"})
 	}
@@ -558,14 +558,18 @@ func handleLogin(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid body"})
 	}
 
-	var userID, passwordHash string
-	err := db.QueryRow(`SELECT id, password_hash FROM users WHERE username = ?`, body.Username).
-		Scan(&userID, &passwordHash)
+	var userID, storedUsername, passwordHash, rawRole string
+	err := db.QueryRow(`SELECT id, username, password_hash, COALESCE(role, 'admin') FROM users WHERE username = ?`, body.Username).
+		Scan(&userID, &storedUsername, &passwordHash, &rawRole)
 	if err == sql.ErrNoRows {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "invalid credentials"})
 	}
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
+	}
+	role, ok := normalizeUserRole(rawRole)
+	if !ok {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "invalid user role"})
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(body.Password)); err != nil {
@@ -575,7 +579,7 @@ func handleLogin(c echo.Context) error {
 	// Generate JWT.
 	claims := jwt.MapClaims{
 		"user_id":  userID,
-		"username": body.Username,
+		"username": storedUsername,
 		"exp":      time.Now().Add(24 * time.Hour).Unix(),
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -586,17 +590,19 @@ func handleLogin(c echo.Context) error {
 
 	// Check if password change is required (Finding #2).
 	var passwordChanged sql.NullBool
-	db.QueryRow(`SELECT password_changed FROM users WHERE username = ?`, body.Username).Scan(&passwordChanged)
+	db.QueryRow(`SELECT password_changed FROM users WHERE username = ?`, storedUsername).Scan(&passwordChanged)
 	pwChangeRequired := !passwordChanged.Valid || !passwordChanged.Bool
 
 	// Check if PIN change is required (Finding #2).
 	var pinChanged sql.NullBool
-	db.QueryRow(`SELECT pin_changed FROM users WHERE username = ?`, body.Username).Scan(&pinChanged)
+	db.QueryRow(`SELECT pin_changed FROM users WHERE username = ?`, storedUsername).Scan(&pinChanged)
 	pinChangeRequired := !pinChanged.Valid || !pinChanged.Bool
 
 	return c.JSON(http.StatusOK, map[string]interface{}{
 		"token":                    tokenStr,
 		"expires_in":               86400,
+		"role":                     role,
+		"scopes":                   scopesForRole(role),
 		"password_change_required": pwChangeRequired,
 		"pin_change_required":      pinChangeRequired,
 	})
@@ -636,6 +642,9 @@ func jwtMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 					return c.JSON(http.StatusForbidden, map[string]string{"error": "SSE token cannot access this endpoint"})
 				}
 			}
+			userID, _ := claims["user_id"].(string)
+			username, _ := claims["username"].(string)
+			setAuthClaimsOnContext(c, userID, username)
 		}
 
 		return next(c)
@@ -661,30 +670,11 @@ func credentialRotationMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			return next(c)
 		}
 
-		// Extract user_id from JWT claims (token already validated by jwtMiddleware).
-		auth := c.Request().Header.Get("Authorization")
-		tokenStr := ""
-		if strings.HasPrefix(auth, "Bearer ") {
-			tokenStr = auth[7:]
-		}
-		if tokenStr == "" {
-			tokenStr = c.QueryParam("token")
-		}
-		if tokenStr == "" {
-			return next(c) // no token means jwtMiddleware will reject anyway
-		}
-
-		tkn, _ := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
-			return jwtSecret, nil
-		})
-		if tkn == nil {
-			return next(c)
-		}
-		claims, ok := tkn.Claims.(jwt.MapClaims)
+		claims, ok := authClaimsFromContext(c)
 		if !ok {
 			return next(c)
 		}
-		userID, _ := claims["user_id"].(string)
+		userID := claims.UserID
 		if userID == "" {
 			return next(c)
 		}
@@ -1890,6 +1880,9 @@ const maxTerminalSessions = 3
 
 // extractUserIDFromRequest extracts user_id from the JWT in the Authorization header.
 func extractUserIDFromRequest(c echo.Context) string {
+	if claims, ok := authClaimsFromContext(c); ok && claims.UserID != "" {
+		return claims.UserID
+	}
 	auth := c.Request().Header.Get("Authorization")
 	tokenStr := ""
 	if len(auth) > 7 && auth[:7] == "Bearer " {
@@ -3225,31 +3218,15 @@ func handleChangePIN(c echo.Context) error {
 
 // handleSSEToken generates a short-lived SSE-scoped JWT (Finding #8).
 func handleSSEToken(c echo.Context) error {
-	// Get user info from the current (full) JWT.
-	auth := c.Request().Header.Get("Authorization")
-	tokenStr := ""
-	if strings.HasPrefix(auth, "Bearer ") {
-		tokenStr = auth[7:]
-	}
-	if tokenStr == "" {
-		tokenStr = c.QueryParam("token")
-	}
-
-	tkn, _ := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
-		return jwtSecret, nil
-	})
-	claims, ok := tkn.Claims.(jwt.MapClaims)
-	if !ok {
+	claims, ok := authClaimsFromContext(c)
+	if !ok || claims.UserID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "invalid token"})
 	}
 
-	userID, _ := claims["user_id"].(string)
-	username, _ := claims["username"].(string)
-
 	// Generate SSE-scoped token with 5-minute expiry.
 	sseClaims := jwt.MapClaims{
-		"user_id":  userID,
-		"username": username,
+		"user_id":  claims.UserID,
+		"username": claims.Username,
 		"type":     "sse",
 		"exp":      time.Now().Add(5 * time.Minute).Unix(),
 	}

--- a/hub/main.go
+++ b/hub/main.go
@@ -278,6 +278,26 @@ func main() {
 		AllowHeaders: []string{"Accept", "Content-Type", "Cache-Control", "Authorization"},
 	}))
 
+	registerRoutes(e)
+
+	if err := auditRBACRouteCoverage(e, routeScopeRequirements); err != nil {
+		log.Fatalf("RBAC route audit failed: %v", err)
+	}
+
+	listenAddr := os.Getenv("HUB_LISTEN")
+	if listenAddr == "" {
+		listenAddr = "127.0.0.1:4000"
+	}
+	log.Printf("hub listening on %s", listenAddr)
+	if err := e.Start(listenAddr); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("server error: %v", err)
+	}
+}
+
+// registerRoutes wires every public and RBAC-protected handler onto e.
+// Shared between main() and tests so the production route set and the audit
+// can never drift.
+func registerRoutes(e *echo.Echo) {
 	// Public endpoints (no auth).
 	e.GET("/health", handleHealth)
 	e.GET("/ws/agent", handleAgentWS)
@@ -300,42 +320,28 @@ func main() {
 	api.GET("/api/machines/:id/metrics/history", handleMetricsHistory)
 	api.DELETE("/api/machines/:id", handleDeleteMachine)
 
-	// Terminal endpoints.
 	api.POST("/api/machines/:id/terminal", handleStartTerminal)
 	api.DELETE("/api/machines/:id/terminal/:session_id", handleCloseTerminal)
 	e.GET("/ws/terminal/:session_id", handleTerminalWS)
 
-	// Alert endpoints.
 	api.GET("/api/alerts", handleListAlerts)
 	api.GET("/api/alerts/active/count", handleAlertCount)
 	api.POST("/api/alerts/:id/acknowledge", handleAcknowledgeAlert)
 	api.GET("/api/alert-rules", handleListAlertRules)
 	api.PUT("/api/alert-rules/:id", handleUpdateAlertRule)
 
-	// Auth management endpoints (Finding #2, #3).
 	api.POST("/api/auth/change-password", handleChangePassword)
 	api.POST("/api/auth/change-pin", handleChangePIN)
 	api.POST("/api/auth/sse-token", handleSSEToken)
 
-	// Install endpoints.
 	api.POST("/api/tokens", handleCreateToken)
 
-	// Bulk endpoints.
 	api.POST("/api/bulk/command", handleBulkCommand)
 	api.GET("/api/api-machines", handleListAPIMachines)
 	api.POST("/api/api-machines", handleCreateAPIMachine)
 	api.PATCH("/api/api-machines/:id", handleUpdateAPIMachine)
 	api.DELETE("/api/api-machines/:id", handleDeleteAPIMachine)
 	api.POST("/api/api-machines/:id/poll", handleForceAPIPoll)
-
-	listenAddr := os.Getenv("HUB_LISTEN")
-	if listenAddr == "" {
-		listenAddr = "127.0.0.1:4000"
-	}
-	log.Printf("hub listening on %s", listenAddr)
-	if err := e.Start(listenAddr); err != nil && err != http.ErrServerClosed {
-		log.Fatalf("server error: %v", err)
-	}
 }
 
 func getEnvOrDefault(key, def string) string {

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -135,43 +135,7 @@ func setupTestServer(t *testing.T) *echo.Echo {
 
 	e := echo.New()
 	e.HideBanner = true
-
-	// Public endpoints.
-	e.GET("/health", handleHealth)
-	e.GET("/ws/agent", handleAgentWS)
-	e.POST("/api/auth/login", handleLogin)
-	e.GET("/install.sh", handleInstallScript)
-	e.GET("/download/ca.crt", handleDownloadCACert)
-	e.GET("/api/setup/status", handleSetupStatus)
-	e.POST("/api/setup", handleSetup)
-
-	// Protected endpoints.
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware, permissionMiddleware)
-	api.GET("/api/machines", handleListMachines)
-	api.GET("/api/machines/:id", handleGetMachine)
-	api.GET("/api/machines/:id/services", handleGetServices)
-	api.GET("/api/machines/:id/containers", handleGetContainers)
-	api.POST("/api/machines/:id/command", handleCommand)
-	api.PUT("/api/machines/:id/tags", handleSetTags)
-	api.GET("/api/machines/:id/metrics/history", handleMetricsHistory)
-	api.DELETE("/api/machines/:id", handleDeleteMachine)
-
-	api.POST("/api/machines/:id/terminal", handleStartTerminal)
-	api.DELETE("/api/machines/:id/terminal/:session_id", handleCloseTerminal)
-	e.GET("/ws/terminal/:session_id", handleTerminalWS)
-
-	api.GET("/api/alerts", handleListAlerts)
-	api.GET("/api/alerts/active/count", handleAlertCount)
-	api.POST("/api/alerts/:id/acknowledge", handleAcknowledgeAlert)
-	api.GET("/api/alert-rules", handleListAlertRules)
-	api.PUT("/api/alert-rules/:id", handleUpdateAlertRule)
-
-	api.POST("/api/auth/change-password", handleChangePassword)
-	api.POST("/api/auth/change-pin", handleChangePIN)
-	api.POST("/api/auth/sse-token", handleSSEToken)
-
-	api.POST("/api/tokens", handleCreateToken)
-	api.POST("/api/bulk/command", handleBulkCommand)
+	registerRoutes(e)
 
 	return e
 }
@@ -205,15 +169,7 @@ func setupEmptyTestServer(t *testing.T) *echo.Echo {
 
 	e := echo.New()
 	e.HideBanner = true
-
-	e.GET("/health", handleHealth)
-	e.POST("/api/auth/login", handleLogin)
-	e.GET("/api/setup/status", handleSetupStatus)
-	e.POST("/api/setup", handleSetup)
-
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware, permissionMiddleware)
-	api.GET("/api/machines", handleListMachines)
-	api.POST("/api/machines/:id/terminal", handleStartTerminal)
+	registerRoutes(e)
 
 	return e
 }
@@ -257,6 +213,54 @@ func markCredentialsRotated(t *testing.T) {
 	_, err := db.Exec(`UPDATE users SET password_changed = TRUE, pin_changed = TRUE WHERE username = 'admin'`)
 	if err != nil {
 		t.Fatalf("mark credentials rotated: %v", err)
+	}
+}
+
+func TestRBACRouteAuditPassesForProductionRoutes(t *testing.T) {
+	e := echo.New()
+	e.HideBanner = true
+	registerRoutes(e)
+
+	if err := auditRBACRouteCoverage(e, routeScopeRequirements); err != nil {
+		t.Fatalf("production route set failed RBAC audit: %v", err)
+	}
+}
+
+func TestRBACRouteAuditDetectsMissingMapping(t *testing.T) {
+	e := echo.New()
+	e.HideBanner = true
+	registerRoutes(e)
+	// Add an extra protected route that has no scope mapping.
+	api := e.Group("", jwtMiddleware, credentialRotationMiddleware, permissionMiddleware)
+	api.GET("/api/ghost", func(c echo.Context) error { return nil })
+
+	err := auditRBACRouteCoverage(e, routeScopeRequirements)
+	if err == nil {
+		t.Fatal("expected audit to fail for unmapped protected route, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing scope mapping") || !strings.Contains(err.Error(), "/api/ghost") {
+		t.Fatalf("expected error to name the unmapped route, got: %v", err)
+	}
+}
+
+func TestRBACRouteAuditDetectsOrphanMapping(t *testing.T) {
+	e := echo.New()
+	e.HideBanner = true
+	registerRoutes(e)
+
+	// Clone production requirements and add an entry for a route that isn't registered.
+	requirements := make(map[string]string, len(routeScopeRequirements)+1)
+	for k, v := range routeScopeRequirements {
+		requirements[k] = v
+	}
+	requirements[routeScopeKey(http.MethodGet, "/api/nonexistent")] = scopeFleetRead
+
+	err := auditRBACRouteCoverage(e, requirements)
+	if err == nil {
+		t.Fatal("expected audit to fail for orphan scope mapping, got nil")
+	}
+	if !strings.Contains(err.Error(), "orphan scope mapping") || !strings.Contains(err.Error(), "/api/nonexistent") {
+		t.Fatalf("expected error to name the orphan route, got: %v", err)
 	}
 }
 

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -44,6 +45,35 @@ func seedTestAdmin(t *testing.T) {
 		id, "admin", string(hash), string(pinHash))
 	if err != nil {
 		t.Fatalf("seed test admin: %v", err)
+	}
+}
+
+func seedTestUser(t *testing.T, username, password, pin string, role UserRole, passwordChanged, pinChanged bool) string {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	pinHash, err := bcrypt.GenerateFromPassword([]byte(pin), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash pin: %v", err)
+	}
+	id := "test-user-" + username
+	_, err = db.Exec(
+		`INSERT INTO users (id, username, password_hash, terminal_pin_hash, password_changed, pin_changed, role) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		id, username, string(hash), string(pinHash), passwordChanged, pinChanged, role,
+	)
+	if err != nil {
+		t.Fatalf("seed test user: %v", err)
+	}
+	return id
+}
+
+func seedTestMachine(t *testing.T, id string) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO machines (id, hostname, status) VALUES (?, ?, 'online')`, id, "machine-"+id)
+	if err != nil {
+		t.Fatalf("seed test machine: %v", err)
 	}
 }
 
@@ -116,7 +146,7 @@ func setupTestServer(t *testing.T) *echo.Echo {
 	e.POST("/api/setup", handleSetup)
 
 	// Protected endpoints.
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
+	api := e.Group("", jwtMiddleware, credentialRotationMiddleware, permissionMiddleware)
 	api.GET("/api/machines", handleListMachines)
 	api.GET("/api/machines/:id", handleGetMachine)
 	api.GET("/api/machines/:id/services", handleGetServices)
@@ -181,8 +211,9 @@ func setupEmptyTestServer(t *testing.T) *echo.Echo {
 	e.GET("/api/setup/status", handleSetupStatus)
 	e.POST("/api/setup", handleSetup)
 
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
+	api := e.Group("", jwtMiddleware, credentialRotationMiddleware, permissionMiddleware)
 	api.GET("/api/machines", handleListMachines)
+	api.POST("/api/machines/:id/terminal", handleStartTerminal)
 
 	return e
 }
@@ -192,7 +223,13 @@ func setupEmptyTestServer(t *testing.T) *echo.Echo {
 func loginAndGetToken(t *testing.T, e *echo.Echo) string {
 	t.Helper()
 
-	body := `{"username":"admin","password":"bloxos"}`
+	return loginAndGetTokenForCredentials(t, e, "admin", "bloxos")
+}
+
+func loginAndGetTokenForCredentials(t *testing.T, e *echo.Echo, username, password string) string {
+	t.Helper()
+
+	body := fmt.Sprintf(`{"username":%q,"password":%q}`, username, password)
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -220,6 +257,97 @@ func markCredentialsRotated(t *testing.T) {
 	_, err := db.Exec(`UPDATE users SET password_changed = TRUE, pin_changed = TRUE WHERE username = 'admin'`)
 	if err != nil {
 		t.Fatalf("mark credentials rotated: %v", err)
+	}
+}
+
+func TestLoginIncludesRoleAndScopes(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	seedTestUser(t, "viewer1", "viewerpass123", "1234", RoleViewer, true, true)
+
+	body := `{"username":"viewer1","password":"viewerpass123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Role   string   `json:"role"`
+		Scopes []string `json:"scopes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal login response: %v", err)
+	}
+	if resp.Role != string(RoleViewer) {
+		t.Fatalf("expected role %q, got %q", RoleViewer, resp.Role)
+	}
+	if !slices.Contains(resp.Scopes, scopeFleetRead) {
+		t.Fatalf("expected scopes to include %q, got %v", scopeFleetRead, resp.Scopes)
+	}
+	if slices.Contains(resp.Scopes, scopeFleetControl) {
+		t.Fatalf("expected viewer scopes to exclude %q, got %v", scopeFleetControl, resp.Scopes)
+	}
+}
+
+func TestViewerCanReadMachinesButCannotCreateInstallToken(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	seedTestUser(t, "viewer2", "viewerpass123", "1234", RoleViewer, true, true)
+	viewerToken := loginAndGetTokenForCredentials(t, e, "viewer2", "viewerpass123")
+
+	readReq := httptest.NewRequest(http.MethodGet, "/api/machines", nil)
+	readReq.Header.Set("Authorization", "Bearer "+viewerToken)
+	readRec := httptest.NewRecorder()
+	e.ServeHTTP(readRec, readReq)
+
+	if readRec.Code != http.StatusOK {
+		t.Fatalf("expected viewer machine read to succeed, got %d: %s", readRec.Code, readRec.Body.String())
+	}
+
+	writeReq := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
+	writeReq.Header.Set("Authorization", "Bearer "+viewerToken)
+	writeRec := httptest.NewRecorder()
+	e.ServeHTTP(writeRec, writeReq)
+
+	if writeRec.Code != http.StatusForbidden {
+		t.Fatalf("expected viewer install token create to be forbidden, got %d: %s", writeRec.Code, writeRec.Body.String())
+	}
+	if !strings.Contains(writeRec.Body.String(), scopeTokensAdmin) {
+		t.Fatalf("expected forbidden response to mention scope %q, got %s", scopeTokensAdmin, writeRec.Body.String())
+	}
+}
+
+func TestOperatorCanUpdateTagsButCannotDeleteMachine(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	seedTestUser(t, "operator1", "operatorpass123", "1234", RoleOperator, true, true)
+	seedTestMachine(t, "machine-1")
+	operatorToken := loginAndGetTokenForCredentials(t, e, "operator1", "operatorpass123")
+
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/machines/machine-1/tags", strings.NewReader(`{"tags":["gpu","lab"]}`))
+	updateReq.Header.Set("Authorization", "Bearer "+operatorToken)
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateRec := httptest.NewRecorder()
+	e.ServeHTTP(updateRec, updateReq)
+
+	if updateRec.Code != http.StatusOK {
+		t.Fatalf("expected operator tag update to succeed, got %d: %s", updateRec.Code, updateRec.Body.String())
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/machines/machine-1", nil)
+	deleteReq.Header.Set("Authorization", "Bearer "+operatorToken)
+	deleteRec := httptest.NewRecorder()
+	e.ServeHTTP(deleteRec, deleteReq)
+
+	if deleteRec.Code != http.StatusForbidden {
+		t.Fatalf("expected operator delete to be forbidden, got %d: %s", deleteRec.Code, deleteRec.Body.String())
+	}
+	if !strings.Contains(deleteRec.Body.String(), scopeFleetAdmin) {
+		t.Fatalf("expected forbidden response to mention scope %q, got %s", scopeFleetAdmin, deleteRec.Body.String())
 	}
 }
 

--- a/hub/migrations.go
+++ b/hub/migrations.go
@@ -222,6 +222,16 @@ var migrations = []migration{
 			return err
 		},
 	},
+	{
+		description: "add role column to users for RBAC",
+		apply: func(tx *sql.Tx) error {
+			_, err := tx.Exec(`ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'admin'`)
+			if err != nil && isDuplicateColumnErr(err) {
+				return nil
+			}
+			return err
+		},
+	},
 }
 
 // isDuplicateColumnErr returns true when SQLite rejects an ALTER TABLE ADD

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+type UserRole string
+
+const (
+	RoleAdmin    UserRole = "admin"
+	RoleOperator UserRole = "operator"
+	RoleViewer   UserRole = "viewer"
+)
+
+const (
+	scopeAuthSelf         = "auth.self"
+	scopeFleetRead        = "fleet.read"
+	scopeFleetControl     = "fleet.control"
+	scopeFleetMetadata    = "fleet.metadata"
+	scopeFleetAdmin       = "fleet.admin"
+	scopeAlertsRead       = "alerts.read"
+	scopeAlertsAck        = "alerts.ack"
+	scopeAlertsAdmin      = "alerts.admin"
+	scopeAPIMachinesRead  = "api_machines.read"
+	scopeAPIMachinesCtrl  = "api_machines.control"
+	scopeAPIMachinesAdmin = "api_machines.admin"
+	scopeTokensAdmin      = "install_tokens.admin"
+)
+
+const authClaimsContextKey = "auth_claims"
+
+type requestAuthClaims struct {
+	UserID   string
+	Username string
+}
+
+var roleScopes = map[UserRole][]string{
+	RoleAdmin: {
+		scopeAuthSelf,
+		scopeFleetRead,
+		scopeFleetControl,
+		scopeFleetMetadata,
+		scopeFleetAdmin,
+		scopeAlertsRead,
+		scopeAlertsAck,
+		scopeAlertsAdmin,
+		scopeAPIMachinesRead,
+		scopeAPIMachinesCtrl,
+		scopeAPIMachinesAdmin,
+		scopeTokensAdmin,
+	},
+	RoleOperator: {
+		scopeAuthSelf,
+		scopeFleetRead,
+		scopeFleetControl,
+		scopeFleetMetadata,
+		scopeAlertsRead,
+		scopeAlertsAck,
+		scopeAPIMachinesRead,
+		scopeAPIMachinesCtrl,
+	},
+	RoleViewer: {
+		scopeAuthSelf,
+		scopeFleetRead,
+		scopeAlertsRead,
+		scopeAPIMachinesRead,
+	},
+}
+
+var routeScopeRequirements = map[string]string{
+	routeScopeKey(http.MethodGet, "/api/events"):                               scopeFleetRead,
+	routeScopeKey(http.MethodGet, "/api/machines"):                             scopeFleetRead,
+	routeScopeKey(http.MethodGet, "/api/machines/:id"):                         scopeFleetRead,
+	routeScopeKey(http.MethodGet, "/api/machines/:id/services"):                scopeFleetRead,
+	routeScopeKey(http.MethodGet, "/api/machines/:id/containers"):              scopeFleetRead,
+	routeScopeKey(http.MethodGet, "/api/machines/:id/metrics/history"):         scopeFleetRead,
+	routeScopeKey(http.MethodPost, "/api/machines/:id/command"):                scopeFleetControl,
+	routeScopeKey(http.MethodPut, "/api/machines/:id/tags"):                    scopeFleetMetadata,
+	routeScopeKey(http.MethodDelete, "/api/machines/:id"):                      scopeFleetAdmin,
+	routeScopeKey(http.MethodPost, "/api/machines/:id/terminal"):               scopeFleetControl,
+	routeScopeKey(http.MethodDelete, "/api/machines/:id/terminal/:session_id"): scopeFleetControl,
+	routeScopeKey(http.MethodGet, "/api/alerts"):                               scopeAlertsRead,
+	routeScopeKey(http.MethodGet, "/api/alerts/active/count"):                  scopeAlertsRead,
+	routeScopeKey(http.MethodPost, "/api/alerts/:id/acknowledge"):              scopeAlertsAck,
+	routeScopeKey(http.MethodGet, "/api/alert-rules"):                          scopeAlertsRead,
+	routeScopeKey(http.MethodPut, "/api/alert-rules/:id"):                      scopeAlertsAdmin,
+	routeScopeKey(http.MethodPost, "/api/auth/change-password"):                scopeAuthSelf,
+	routeScopeKey(http.MethodPost, "/api/auth/change-pin"):                     scopeAuthSelf,
+	routeScopeKey(http.MethodPost, "/api/auth/sse-token"):                      scopeAuthSelf,
+	routeScopeKey(http.MethodPost, "/api/tokens"):                              scopeTokensAdmin,
+	routeScopeKey(http.MethodPost, "/api/bulk/command"):                        scopeFleetControl,
+	routeScopeKey(http.MethodGet, "/api/api-machines"):                         scopeAPIMachinesRead,
+	routeScopeKey(http.MethodPost, "/api/api-machines"):                        scopeAPIMachinesAdmin,
+	routeScopeKey(http.MethodPatch, "/api/api-machines/:id"):                   scopeAPIMachinesAdmin,
+	routeScopeKey(http.MethodDelete, "/api/api-machines/:id"):                  scopeAPIMachinesAdmin,
+	routeScopeKey(http.MethodPost, "/api/api-machines/:id/poll"):               scopeAPIMachinesCtrl,
+}
+
+func permissionMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		path := c.Path()
+		if path == "" {
+			return next(c)
+		}
+
+		requiredScope, ok := routeScopeRequirements[routeScopeKey(c.Request().Method, path)]
+		if !ok {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "missing RBAC scope mapping"})
+		}
+
+		claims, ok := authClaimsFromContext(c)
+		if !ok || claims.UserID == "" {
+			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
+		}
+
+		role, err := lookupUserRole(claims.UserID)
+		if err == sql.ErrNoRows {
+			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "user not found"})
+		}
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
+		}
+		if !roleHasScope(role, requiredScope) {
+			return c.JSON(http.StatusForbidden, map[string]string{
+				"error":          "insufficient_scope",
+				"required_scope": requiredScope,
+				"role":           string(role),
+			})
+		}
+
+		return next(c)
+	}
+}
+
+func setAuthClaimsOnContext(c echo.Context, userID, username string) {
+	c.Set(authClaimsContextKey, requestAuthClaims{
+		UserID:   userID,
+		Username: username,
+	})
+}
+
+func authClaimsFromContext(c echo.Context) (requestAuthClaims, bool) {
+	claims, ok := c.Get(authClaimsContextKey).(requestAuthClaims)
+	return claims, ok
+}
+
+func routeScopeKey(method, path string) string {
+	return method + " " + path
+}
+
+func lookupUserRole(userID string) (UserRole, error) {
+	var rawRole string
+	err := db.QueryRow(`SELECT COALESCE(role, 'admin') FROM users WHERE id = ?`, userID).Scan(&rawRole)
+	if err != nil {
+		return "", err
+	}
+	role, ok := normalizeUserRole(rawRole)
+	if !ok {
+		return "", fmt.Errorf("invalid role %q", rawRole)
+	}
+	return role, nil
+}
+
+func normalizeUserRole(raw string) (UserRole, bool) {
+	switch UserRole(strings.TrimSpace(raw)) {
+	case "", RoleAdmin:
+		return RoleAdmin, true
+	case RoleOperator:
+		return RoleOperator, true
+	case RoleViewer:
+		return RoleViewer, true
+	default:
+		return "", false
+	}
+}
+
+func scopesForRole(role UserRole) []string {
+	granted := append([]string(nil), roleScopes[role]...)
+	slices.Sort(granted)
+	return granted
+}
+
+func roleHasScope(role UserRole, requiredScope string) bool {
+	return slices.Contains(roleScopes[role], requiredScope)
+}

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -188,4 +189,55 @@ func scopesForRole(role UserRole) []string {
 
 func roleHasScope(role UserRole, requiredScope string) bool {
 	return slices.Contains(roleScopes[role], requiredScope)
+}
+
+// publicAPIRoutes lists the /api/* endpoints that are served without RBAC enforcement.
+var publicAPIRoutes = map[string]struct{}{
+	routeScopeKey(http.MethodPost, "/api/auth/login"):  {},
+	routeScopeKey(http.MethodGet, "/api/setup/status"): {},
+	routeScopeKey(http.MethodPost, "/api/setup"):       {},
+}
+
+// auditRBACRouteCoverage verifies every protected /api/* route registered on e has a
+// scope mapping in requirements, and that requirements has no entries for routes
+// that aren't registered. Called at startup so a missing or orphaned mapping fails
+// the boot instead of surfacing as a per-request 500.
+func auditRBACRouteCoverage(e *echo.Echo, requirements map[string]string) error {
+	registered := make(map[string]struct{})
+	var missing []string
+	for _, r := range e.Routes() {
+		if !strings.HasPrefix(r.Path, "/api/") {
+			continue
+		}
+		key := routeScopeKey(r.Method, r.Path)
+		if _, isPublic := publicAPIRoutes[key]; isPublic {
+			continue
+		}
+		registered[key] = struct{}{}
+		if _, ok := requirements[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+
+	var orphans []string
+	for key := range requirements {
+		if _, ok := registered[key]; !ok {
+			orphans = append(orphans, key)
+		}
+	}
+
+	if len(missing) == 0 && len(orphans) == 0 {
+		return nil
+	}
+	slices.Sort(missing)
+	slices.Sort(orphans)
+
+	var parts []string
+	if len(missing) > 0 {
+		parts = append(parts, fmt.Sprintf("missing scope mapping for %d route(s): %v", len(missing), missing))
+	}
+	if len(orphans) > 0 {
+		parts = append(parts, fmt.Sprintf("orphan scope mapping for %d route(s): %v", len(orphans), orphans))
+	}
+	return errors.New(strings.Join(parts, "; "))
 }


### PR DESCRIPTION
## Summary
- add a dedicated `/setup` page for the first-boot flow with setup token, admin username, password, and terminal PIN entry
- auto-check `GET /api/setup/status` so the dashboard redirects to `/setup` before login when initialization is still pending
- auto-login and hand off into the normal dashboard flow after a successful setup submission
- allow unauthenticated access to `/setup` while preserving the existing auth guard for the rest of the app
- update README first-boot steps to match the new product flow instead of raw API calls

## Checks
- `go test -count=1 ./...` in `hub`
- `go test -count=1 ./...` in `agent`
- `pnpm lint` in `dashboard`
- `pnpm build` in `dashboard`

## Notes
- if setup is already complete, `/setup` redirects back into the normal login or dashboard path
- the backend setup contract is unchanged; this PR turns it into a real first-boot product flow
