### PR TITLE
ui: phase 2 — card + list correctness (atomic)

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -7,6 +7,7 @@ import { demoMachines, MachineMetrics, AlertData } from "@/lib/demo-data";
 import { DEMO_MODE, HUB_URL } from "@/lib/session";
 import { MachineCard } from "@/components/MachineCard";
 import { MachineStatus } from "@/components/StatusBadge";
+import { Sparkline } from "@/components/Sparkline";
 import { AlertPanel } from "@/components/AlertPanel";
 import { AddMachineModal } from "@/components/AddMachineModal";
 import { AddAPIMachineModal, type EditableAPIMachine } from "@/components/AddAPIMachineModal";
@@ -567,8 +568,8 @@ export default function Home() {
       <main className="max-w-[1600px] mx-auto px-4 sm:px-6 pb-6">
         {viewMode === "grid" ? (
           <motion.div
-            className="grid gap-4"
-            style={{ gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))" }}
+            className="grid gap-4 auto-rows-fr justify-start"
+            style={{ gridTemplateColumns: "repeat(auto-fill, minmax(300px, 360px))" }}
           >
             <AnimatePresence mode="popLayout">
               {filteredMachines.map((m, i) => (
@@ -579,6 +580,7 @@ export default function Home() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, scale: 0.95 }}
                   transition={{ duration: 0.3, delay: i * 0.03 }}
+                  className="h-full"
                 >
                   <MachineCard
                     machine={m}
@@ -608,11 +610,14 @@ export default function Home() {
                   <TableHead className="text-blox-muted text-xs">Hostname</TableHead>
                   <TableHead className="text-blox-muted text-xs hidden md:table-cell">IP</TableHead>
                   <TableHead className="text-blox-muted text-xs">CPU</TableHead>
+                  <TableHead className="text-blox-muted text-xs hidden lg:table-cell">30m</TableHead>
                   <TableHead className="text-blox-muted text-xs">RAM</TableHead>
+                  <TableHead className="text-blox-muted text-xs hidden md:table-cell">Disk</TableHead>
                   <TableHead className="text-blox-muted text-xs hidden lg:table-cell">GPU</TableHead>
                   <TableHead className="text-blox-muted text-xs hidden lg:table-cell">VRAM</TableHead>
                   <TableHead className="text-blox-muted text-xs hidden xl:table-cell">Latency</TableHead>
                   <TableHead className="text-blox-muted text-xs hidden xl:table-cell">Last Seen</TableHead>
+                  <TableHead className="text-blox-muted text-xs hidden xl:table-cell">OS</TableHead>
                   <TableHead className="text-blox-muted text-xs hidden xl:table-cell">Tags</TableHead>
                 </TableRow>
               </TableHeader>
@@ -620,6 +625,7 @@ export default function Home() {
                 {filteredMachines.map((m, i) => {
                   const status = getStatus(m);
                   const ramPct = (m.ram_total_bytes ?? 0) > 0 ? ((m.ram_used_bytes ?? 0) / m.ram_total_bytes) * 100 : 0;
+                  const diskPct = (m.disk_total_bytes ?? 0) > 0 ? ((m.disk_used_bytes ?? 0) / m.disk_total_bytes) * 100 : 0;
                   const tags = m.tags ? m.tags.split(",").filter((t) => t.trim()) : [];
                   const dotColor = status === "online" ? "bg-emerald-500" : status === "warning" ? "bg-amber-500" : "bg-red-500/50";
                   const isSelected = selected.has(m.machine_id);
@@ -669,37 +675,53 @@ export default function Home() {
                           (m.cpu_percent ?? 0) > 85 ? "text-red-400" : (m.cpu_percent ?? 0) > 60 ? "text-amber-400" : "text-blox-text"
                         }`}>{(m.cpu_percent ?? 0).toFixed(0)}%</span>
                       </TableCell>
+                      <TableCell className="hidden lg:table-cell">
+                        {status !== "offline" && (
+                          <Sparkline machineId={m.machine_id} width={90} height={20} />
+                        )}
+                      </TableCell>
                       <TableCell className="text-xs">
                         <span className="tabular-nums font-mono text-blox-text">{ramPct.toFixed(0)}%</span>
-                        <span className="text-blox-muted ml-1 font-mono">{formatBytes(m.ram_used_bytes)}</span>
+                        <span className="text-blox-muted ml-1 font-mono tabular-nums">{formatBytes(m.ram_used_bytes)}</span>
+                      </TableCell>
+                      <TableCell className="text-xs hidden md:table-cell">
+                        {(m.disk_total_bytes ?? 0) > 0 && (
+                          <>
+                            <span className={`tabular-nums font-mono ${
+                              diskPct > 90 ? "text-red-400" : diskPct > 75 ? "text-amber-400" : "text-blox-text"
+                            }`}>{diskPct.toFixed(0)}%</span>
+                            <span className="text-blox-muted ml-1 font-mono tabular-nums">{formatBytes(m.disk_used_bytes)}</span>
+                          </>
+                        )}
                       </TableCell>
                       <TableCell className="text-xs hidden lg:table-cell">
                         {m.gpu_temp ? (
                           <span className={`tabular-nums font-mono ${
                             m.gpu_temp > 80 ? "text-red-400" : m.gpu_temp > 70 ? "text-amber-400" : "text-blox-text"
                           }`}>{m.gpu_temp}&deg;C</span>
-                        ) : (
-                          <span className="text-blox-muted">-</span>
-                        )}
+                        ) : null}
                       </TableCell>
                       <TableCell className="text-xs hidden lg:table-cell">
                         {m.gpu_vram_total_bytes && m.gpu_vram_total_bytes > 0 ? (
                           <span className="tabular-nums font-mono text-blox-text">
                             {formatBytes(m.gpu_vram_used_bytes || 0)}/{formatBytes(m.gpu_vram_total_bytes)}
                           </span>
-                        ) : (
-                          <span className="text-blox-muted">-</span>
-                        )}
+                        ) : null}
                       </TableCell>
                       <TableCell className="text-xs hidden xl:table-cell">
                         {m.latency_ms && m.latency_ms > 0 ? (
                           <span className="tabular-nums font-mono text-blox-muted">{m.latency_ms}ms</span>
-                        ) : (
-                          <span className="text-blox-muted">-</span>
-                        )}
+                        ) : null}
                       </TableCell>
                       <TableCell className="text-xs text-blox-muted hidden xl:table-cell font-mono tabular-nums">
                         {m.last_seen ? timeSince(m.last_seen) : "never"}
+                      </TableCell>
+                      <TableCell className="text-xs hidden xl:table-cell">
+                        {m.os && (
+                          <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-blox-border/50 text-blox-muted font-mono">
+                            {m.os}
+                          </span>
+                        )}
                       </TableCell>
                       <TableCell className="text-xs hidden xl:table-cell">
                         <div className="flex gap-1 flex-wrap">

--- a/dashboard/src/components/MachineCard.tsx
+++ b/dashboard/src/components/MachineCard.tsx
@@ -82,24 +82,24 @@ export function MachineCard({ machine, onClick, onDelete, onEdit }: MachineCardP
     : 0;
 
   const gpu0 = machine.gpus && machine.gpus.length > 0 ? machine.gpus[0] : null;
-  const hasGpu = gpu0 !== null || (machine.gpu_temp && machine.gpu_temp > 0) ||
-    (machine.gpu_vram_total_bytes && machine.gpu_vram_total_bytes > 0);
   const gpuVramUsed = gpu0 ? gpu0.mem_used_bytes : (machine.gpu_vram_used_bytes || 0);
   const gpuVramTotal = gpu0 ? gpu0.mem_total_bytes : (machine.gpu_vram_total_bytes || 0);
+  const hasGpuTemp = (machine.gpu_temp ?? 0) > 0;
+  const hasGpuVram = gpuVramTotal > 0;
 
   const tags = machine.tags ? machine.tags.split(",").filter((t) => t.trim()) : [];
   const adapterTag = tags.find((t) => API_ADAPTER_TYPES.includes(t.trim().toLowerCase()));
   const isAPIMachine = !!adapterTag;
 
   return (
-    <Link href={`/machine/${machine.machine_id}`} className="block">
+    <Link href={`/machine/${machine.machine_id}`} className="block h-full">
       <motion.div
         whileHover={{ scale: 1.02 }}
         transition={{ type: "spring", stiffness: 400, damping: 25 }}
         onClick={onClick}
         className={`
           group bg-blox-card border-l-[3px] ${statusBorderColor[status]}
-          rounded-xl p-5 cursor-pointer
+          rounded-xl p-5 cursor-pointer flex flex-col h-full
           border border-blox-border
           hover:border-blox-muted/20 hover:shadow-xl ${statusGlow[status]}
           transition-all duration-300
@@ -194,53 +194,45 @@ export function MachineCard({ machine, onClick, onDelete, onEdit }: MachineCardP
             </span>
           </div>
 
-          {/* GPU Temp - always rendered for consistent card height */}
-          <div className="flex items-center gap-2">
-            <Thermometer className="w-3.5 h-3.5 text-blox-muted shrink-0" />
-            <span className="text-xs text-blox-muted w-8">GPU</span>
-            {hasGpu && machine.gpu_temp !== undefined && machine.gpu_temp > 0 ? (
-              <>
-                <span className={`text-xs tabular-nums font-mono font-medium ${
-                  machine.gpu_temp > 80 ? "text-red-400" :
-                  machine.gpu_temp > 60 ? "text-amber-400" : "text-emerald-400"
-                }`}>
-                  {machine.gpu_temp}&deg;C
+          {/* GPU Temp — rendered only when the machine actually has a GPU. */}
+          {hasGpuTemp && (
+            <div className="flex items-center gap-2">
+              <Thermometer className="w-3.5 h-3.5 text-blox-muted shrink-0" />
+              <span className="text-xs text-blox-muted w-8">GPU</span>
+              <span className={`text-xs tabular-nums font-mono font-medium ${
+                (machine.gpu_temp ?? 0) > 80 ? "text-red-400" :
+                (machine.gpu_temp ?? 0) > 60 ? "text-amber-400" : "text-emerald-400"
+              }`}>
+                {machine.gpu_temp}&deg;C
+              </span>
+              {machine.gpu_util_percent !== undefined && (
+                <span className="text-[10px] text-blox-muted tabular-nums font-mono ml-1">
+                  ({(machine.gpu_util_percent ?? 0).toFixed(0)}% util)
                 </span>
-                {machine.gpu_util_percent !== undefined && (
-                  <span className="text-[10px] text-blox-muted font-mono ml-1">
-                    ({(machine.gpu_util_percent ?? 0).toFixed(0)}% util)
-                  </span>
-                )}
-              </>
-            ) : (
-              <span className="text-xs text-blox-muted/40 font-mono">&mdash;</span>
-            )}
-          </div>
+              )}
+            </div>
+          )}
 
-          {/* VRAM - always rendered for consistent card height */}
-          <div className="flex items-center gap-2">
-            <MemoryStick className="w-3.5 h-3.5 text-blox-muted shrink-0" />
-            <span className="text-xs text-blox-muted w-8">VRAM</span>
-            {hasGpu && gpuVramTotal > 0 ? (
-              <>
-                <div className="flex-1">
-                  <ProgressBar
-                    value={gpuVramTotal > 0 ? (gpuVramUsed / gpuVramTotal * 100) : 0}
-                    label={`${(gpuVramTotal > 0 ? (gpuVramUsed / gpuVramTotal * 100) : 0).toFixed(0)}%`}
-                  />
-                </div>
-                <span className="text-[10px] text-blox-muted tabular-nums font-mono">
-                  {formatBytes(gpuVramUsed)}/{formatBytes(gpuVramTotal)}
-                </span>
-              </>
-            ) : (
-              <span className="text-xs text-blox-muted/40 font-mono">&mdash;</span>
-            )}
-          </div>
+          {/* VRAM — rendered only when total VRAM is known. */}
+          {hasGpuVram && (
+            <div className="flex items-center gap-2">
+              <MemoryStick className="w-3.5 h-3.5 text-blox-muted shrink-0" />
+              <span className="text-xs text-blox-muted w-8">VRAM</span>
+              <div className="flex-1">
+                <ProgressBar
+                  value={(gpuVramUsed / gpuVramTotal) * 100}
+                  label={`${((gpuVramUsed / gpuVramTotal) * 100).toFixed(0)}%`}
+                />
+              </div>
+              <span className="text-[10px] text-blox-muted tabular-nums font-mono">
+                {formatBytes(gpuVramUsed)}/{formatBytes(gpuVramTotal)}
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between mt-4 pt-3 border-t border-blox-border/50">
+        <div className="flex items-center justify-between mt-auto pt-3 border-t border-blox-border/50">
           <div className="flex items-center gap-1.5">
             <Clock className="w-3 h-3 text-blox-muted" />
             <span className="text-[10px] text-blox-muted font-mono tabular-nums">

--- a/dashboard/src/components/Sparkline.tsx
+++ b/dashboard/src/components/Sparkline.tsx
@@ -73,7 +73,19 @@ export function Sparkline({ machineId, width = 120, height = 28 }: SparklineProp
     ctx.fill();
   }, [points, width, height]);
 
-  if (points.length < 2) return null;
+  if (points.length < 2) {
+    // Keep the slot at full width so adjacent columns / labels don't jump
+    // when sparkline data is still being collected.
+    return (
+      <div
+        style={{ width, height }}
+        className="flex items-center"
+        aria-label="collecting data"
+      >
+        <div className="w-full border-t border-dashed border-blox-muted/30" />
+      </div>
+    );
+  }
 
   return (
     <canvas


### PR DESCRIPTION
## Summary
Fixes the two loudest user complaints from the UI polish pass plan.

**MachineCard**
- Delete the always-rendered GPU/VRAM rows with \`—\` em-dash placeholders. Non-GPU machines render cleanly with no GPU section at all. Absence is the signal.
- Card is now \`flex flex-col h-full\` with the footer pushed to the bottom via \`mt-auto\`, so grid cells of mixed natural heights equalize cleanly.

**Dashboard grid**
- Parent gets \`auto-rows-fr\` so all cards in a row match the tallest.
- Column track: \`repeat(auto-fill, minmax(300px, 1fr))\` → \`minmax(300px, 360px)\` with \`justify-start\`, so cards don't stretch to full-width when few results match the filter.

**Dashboard list view** — now matches the card data contract:
- New Disk column (md+)
- New 30-minute CPU sparkline column (lg+)
- New OS column (xl+)
- \`-\` fallback cells for GPU / VRAM / latency replaced with empty cells (matches card behavior).

**Sparkline**
- When history has fewer than 2 points, render a muted dashed baseline at the same width instead of \`return null\`, so table columns don't jump width while data is still being collected.

## Screenshot expectations (visual QA)
- CPU-only server → card has no GPU rows at all, no em-dash.
- GPU server → card shows GPU + VRAM.
- Grid row with mixed GPU/CPU machines → all cards same height.
- List view on wide screen → Disk, 30m sparkline, OS visible alongside existing columns.
- Filter that returns 1 result → card doesn't stretch to full page width.

## Test plan
- [x] \`pnpm lint\` green (192.168.16.113)
- [x] \`pnpm build\` green (192.168.16.113)
- [x] TypeScript \`tsc --noEmit\` clean

## Follow-ups
- Phase 3a (detail page tab skeleton) already planned.