### PR TITLE
ui: phase 4 — focus rings, SSE banner, smallest-text polish

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -206,4 +206,23 @@ body {
   html {
     @apply font-sans;
   }
+
+  /*
+   * Canonical focus ring — applied to every interactive element so keyboard
+   * users get consistent feedback without each component inventing its own.
+   * Uses outline (not ring) to stay layout-neutral.
+   */
+  button:focus-visible,
+  a:focus-visible,
+  [role="button"]:focus-visible,
+  [role="tab"]:focus-visible,
+  [role="menuitem"]:focus-visible,
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible,
+  [tabindex="0"]:focus-visible {
+    outline: 2px solid var(--color-blox-blue);
+    outline-offset: 2px;
+    border-radius: 6px;
+  }
 }

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -361,7 +361,7 @@ export default function Home() {
             >
               <Bell className="w-4 h-4" />
               {alertCount > 0 && (
-                <span className="absolute -top-0.5 -right-0.5 w-4 h-4 rounded-full bg-red-500 text-[9px] flex items-center justify-center text-white font-bold">
+                <span className="absolute -top-0.5 -right-0.5 w-4 h-4 rounded-full bg-red-500 text-[10px] flex items-center justify-center text-white font-bold">
                   {alertCount > 9 ? "9+" : alertCount}
                 </span>
               )}
@@ -399,6 +399,24 @@ export default function Home() {
           </div>
         </div>
       </header>
+
+      {/* Degraded connection banner — surfaces SSE disconnect inline so it isn't
+          easy to miss behind the small wifi icon in the header. */}
+      <AnimatePresence>
+        {!connected && !isDemo && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            className="bg-amber-500/5 border-b border-amber-500/20 px-4 sm:px-6 py-2 overflow-hidden"
+          >
+            <div className="max-w-[1600px] mx-auto flex items-center gap-2 text-xs text-amber-400">
+              <WifiOff className="w-3.5 h-3.5" />
+              <span>Live updates paused — reconnecting to hub…</span>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* Bulk action bar */}
       <AnimatePresence>
@@ -726,7 +744,7 @@ export default function Home() {
                       <TableCell className="text-xs hidden xl:table-cell">
                         <div className="flex gap-1 flex-wrap">
                           {tags.map((tag) => (
-                            <Badge key={tag} variant="outline" className="text-[9px] px-1.5 h-auto py-0 border-blox-border text-blox-muted">
+                            <Badge key={tag} variant="outline" className="text-[10px] px-1.5 h-auto py-0 border-blox-border text-blox-muted">
                               {tag}
                             </Badge>
                           ))}

--- a/dashboard/src/components/AlertPanel.tsx
+++ b/dashboard/src/components/AlertPanel.tsx
@@ -86,7 +86,7 @@ export function AlertPanel({ open, onClose, alerts, onAcknowledge, onAcknowledge
                             </span>
                             <Badge
                               variant="outline"
-                              className={`text-[9px] px-1.5 h-auto py-0 ${
+                              className={`text-[10px] px-1.5 h-auto py-0 ${
                                 alert.severity === "critical"
                                   ? "border-red-500/30 bg-red-500/10 text-red-400"
                                   : "border-amber-500/30 bg-amber-500/10 text-amber-400"

--- a/dashboard/src/components/MachineCard.tsx
+++ b/dashboard/src/components/MachineCard.tsx
@@ -115,7 +115,7 @@ export function MachineCard({ machine, onClick, onDelete, onEdit }: MachineCardP
               {machine.hostname}
             </span>
             {isAPIMachine && adapterTag && (
-              <span className="text-[9px] px-1.5 py-0.5 rounded-md bg-violet-500/10 text-violet-400 border border-violet-500/20 font-semibold uppercase tracking-wider">
+              <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-violet-500/10 text-violet-400 border border-violet-500/20 font-semibold uppercase tracking-wider">
                 {adapterTag.trim()}
               </span>
             )}
@@ -154,7 +154,7 @@ export function MachineCard({ machine, onClick, onDelete, onEdit }: MachineCardP
         {/* Sparkline */}
         {status !== "offline" && (
           <div className="mb-3 flex items-center gap-2">
-            <span className="text-[9px] text-blox-muted uppercase tracking-wider font-medium">CPU 30m</span>
+            <span className="text-[10px] text-blox-muted uppercase tracking-wider font-medium">CPU 30m</span>
             <Sparkline machineId={machine.machine_id} width={100} height={24} />
           </div>
         )}
@@ -258,7 +258,7 @@ export function MachineCard({ machine, onClick, onDelete, onEdit }: MachineCardP
         {tags.length > 0 && (
           <div className="flex gap-1.5 flex-wrap mt-2.5 pt-2.5 border-t border-blox-border/50">
             {tags.map((tag) => (
-              <span key={tag} className="text-[9px] px-2 py-0.5 rounded-full bg-blox-blue/10 text-blox-blue/80 border border-blox-blue/20 font-medium">
+              <span key={tag} className="text-[10px] px-2 py-0.5 rounded-full bg-blox-blue/10 text-blox-blue/80 border border-blox-blue/20 font-medium">
                 {tag.trim()}
               </span>
             ))}


### PR DESCRIPTION
## Summary
Small mechanical polish after the three structural phases.

- **globals.css** — canonical \`:focus-visible\` outline rule in \`@layer base\` covering buttons, links, inputs, tabs, menu items, and \`[role=button]\`. Keyboard users now get consistent feedback without each component inventing its own ring.
- **Dashboard main** — inline amber \`Live updates paused — reconnecting to hub…\` banner below the header when SSE disconnects. Previously this was signaled only by a tiny Wi-Fi icon color change.
- **Typography** — \`text-[9px]\` → \`text-[10px]\` across MachineCard, AlertPanel, page.tsx (6 occurrences). 9px was genuinely unreadable; 10px keeps tiny-label character while staying legible.

## Test plan
- [x] \`pnpm lint\` green (Mac)
- [x] \`pnpm build\` green (Mac)
- [x] \`tsc --noEmit\` clean