### PR TITLE
fix(ui): guard sort/filter against missing hostname

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -151,13 +151,15 @@ export default function Home() {
   }, [machines]);
 
   const filteredMachines = useMemo(() => {
-    let result = machines;
+    // Drop records that don't have enough shape to render — avoids the whole
+    // list crashing on a single malformed SSE update.
+    let result = machines.filter((m) => m && typeof m.machine_id === "string");
 
     if (search) {
       const q = search.toLowerCase();
       result = result.filter((m) =>
-        m.hostname.toLowerCase().includes(q) ||
-        (m.ip && m.ip.toLowerCase().includes(q))
+        (m.hostname ?? "").toLowerCase().includes(q) ||
+        (m.ip ?? "").toLowerCase().includes(q)
       );
     }
 
@@ -167,14 +169,14 @@ export default function Home() {
 
     if (tagFilter) {
       result = result.filter((m) =>
-        m.tags && m.tags.split(",").map((t) => t.trim()).includes(tagFilter)
+        m.tags ? m.tags.split(",").map((t) => t.trim()).includes(tagFilter) : false
       );
     }
 
     result = [...result].sort((a, b) => {
       switch (sortBy) {
         case "name":
-          return a.hostname.localeCompare(b.hostname);
+          return (a.hostname ?? "").localeCompare(b.hostname ?? "");
         case "status":
           return statusOrder[getStatus(a)] - statusOrder[getStatus(b)];
         case "cpu":


### PR DESCRIPTION
## Summary
Fixes the runtime crash \`Cannot read properties of undefined (reading 'localeCompare')\` that surfaces after ~5s of dashboard load when the SSE feed contains a machine with null/undefined hostname.

- Drops records missing \`machine_id\` entirely from the filtered list.
- Null-coalesces \`hostname\` and \`ip\` before \`toLowerCase\` / \`localeCompare\`.
- Null-safe tag filter.

The error was caught by the ErrorBoundary and shown as \"Something went wrong.\" Fix makes the list resilient to malformed records so one bad machine doesn't take down the whole page.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`pnpm build\` green
- [ ] Visual QA on 192.168.16.113 after redeploy