### PR TITLE
feat(hw): expose machine hardware specs in detail page

### DIFF
--- a/agent/hardware.go
+++ b/agent/hardware.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/shirou/gopsutil/v4/host"
+	"github.com/shirou/gopsutil/v4/mem"
+)
+
+// HardwareInfo is a one-time snapshot of a machine's static hardware details.
+// It's sent after agent connect (and only re-sent if detection changes).
+type HardwareInfo struct {
+	Type      string `json:"type"`
+	MachineID string `json:"machine_id"`
+
+	CPUModel        string  `json:"cpu_model,omitempty"`
+	CPUVendor       string  `json:"cpu_vendor,omitempty"`
+	CPUCores        int     `json:"cpu_cores,omitempty"`        // physical cores
+	CPUThreads      int     `json:"cpu_threads,omitempty"`      // logical cores
+	CPUFrequencyMHz float64 `json:"cpu_frequency_mhz,omitempty"` // base clock if available
+
+	RAMTotalBytes uint64 `json:"ram_total_bytes,omitempty"`
+
+	KernelVersion  string `json:"kernel_version,omitempty"`
+	PlatformFamily string `json:"platform_family,omitempty"`
+	Virtualization string `json:"virtualization,omitempty"`
+	BootTime       int64  `json:"boot_time,omitempty"`
+	Architecture   string `json:"architecture,omitempty"`
+
+	GPUModels []string `json:"gpu_models,omitempty"`
+
+	Disks             []DiskHardwareInfo    `json:"disks,omitempty"`
+	NetworkInterfaces []NetworkInterfaceInfo `json:"network_interfaces,omitempty"`
+}
+
+type DiskHardwareInfo struct {
+	Device    string `json:"device"`              // e.g. /dev/nvme0n1
+	Model     string `json:"model,omitempty"`     // from /sys/block/<dev>/device/model
+	SizeBytes uint64 `json:"size_bytes,omitempty"`
+	Type      string `json:"type,omitempty"` // "nvme", "ssd", "hdd", ""
+}
+
+type NetworkInterfaceInfo struct {
+	Name      string `json:"name"`
+	MAC       string `json:"mac,omitempty"`
+	IPv4      string `json:"ipv4,omitempty"`
+	SpeedMbps int64  `json:"speed_mbps,omitempty"`
+}
+
+// collectHardware gathers a static hardware snapshot. Fails soft — any
+// individual collector error is logged-but-dropped so the overall snapshot
+// still ships whatever was detectable.
+func collectHardware(machineID string, gpus []GPUInfo) HardwareInfo {
+	hw := HardwareInfo{
+		Type:         "hardware_info",
+		MachineID:    machineID,
+		Architecture: runtime.GOARCH,
+	}
+
+	if cpuInfos, err := cpu.Info(); err == nil && len(cpuInfos) > 0 {
+		ci := cpuInfos[0]
+		hw.CPUModel = strings.TrimSpace(ci.ModelName)
+		hw.CPUVendor = strings.TrimSpace(ci.VendorID)
+		hw.CPUFrequencyMHz = ci.Mhz
+	}
+	if physical, err := cpu.Counts(false); err == nil {
+		hw.CPUCores = physical
+	}
+	if logical, err := cpu.Counts(true); err == nil {
+		hw.CPUThreads = logical
+	}
+
+	if vm, err := mem.VirtualMemory(); err == nil {
+		hw.RAMTotalBytes = vm.Total
+	}
+
+	if hi, err := host.Info(); err == nil && hi != nil {
+		hw.KernelVersion = hi.KernelVersion
+		hw.PlatformFamily = hi.PlatformFamily
+		hw.Virtualization = hi.VirtualizationSystem
+		if hi.BootTime > 0 {
+			hw.BootTime = int64(hi.BootTime)
+		}
+	}
+
+	hw.Disks = collectDiskHardware()
+	hw.NetworkInterfaces = collectNetworkInterfaces()
+
+	seen := make(map[string]struct{}, len(gpus))
+	for _, g := range gpus {
+		name := strings.TrimSpace(g.Name)
+		if name == "" {
+			continue
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		hw.GPUModels = append(hw.GPUModels, name)
+	}
+
+	return hw
+}
+
+// collectDiskHardware enumerates top-level block devices under /sys/block.
+// Linux-only; returns nil elsewhere.
+func collectDiskHardware() []DiskHardwareInfo {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+	entries, err := os.ReadDir("/sys/block")
+	if err != nil {
+		return nil
+	}
+
+	var disks []DiskHardwareInfo
+	for _, entry := range entries {
+		name := entry.Name()
+		// Skip ram, loop, dm-*, fd, zram — we want only real disks.
+		if strings.HasPrefix(name, "ram") ||
+			strings.HasPrefix(name, "loop") ||
+			strings.HasPrefix(name, "dm-") ||
+			strings.HasPrefix(name, "fd") ||
+			strings.HasPrefix(name, "zram") ||
+			strings.HasPrefix(name, "sr") {
+			continue
+		}
+		d := DiskHardwareInfo{Device: "/dev/" + name}
+
+		if sectorsRaw, err := os.ReadFile(filepath.Join("/sys/block", name, "size")); err == nil {
+			if sectors, err := strconv.ParseUint(strings.TrimSpace(string(sectorsRaw)), 10, 64); err == nil {
+				// /sys reports size in 512-byte sectors regardless of actual sector size.
+				d.SizeBytes = sectors * 512
+			}
+		}
+
+		if modelRaw, err := os.ReadFile(filepath.Join("/sys/block", name, "device", "model")); err == nil {
+			d.Model = strings.TrimSpace(string(modelRaw))
+		}
+
+		// Classify type. NVMe is obvious from name; otherwise use rotational flag.
+		switch {
+		case strings.HasPrefix(name, "nvme"):
+			d.Type = "nvme"
+		default:
+			if rotRaw, err := os.ReadFile(filepath.Join("/sys/block", name, "queue", "rotational")); err == nil {
+				switch strings.TrimSpace(string(rotRaw)) {
+				case "0":
+					d.Type = "ssd"
+				case "1":
+					d.Type = "hdd"
+				}
+			}
+		}
+
+		// Skip zero-size placeholder devices like cdroms with no media.
+		if d.SizeBytes == 0 && d.Model == "" {
+			continue
+		}
+		disks = append(disks, d)
+	}
+
+	sort.Slice(disks, func(i, j int) bool {
+		return disks[i].Device < disks[j].Device
+	})
+	return disks
+}
+
+// collectNetworkInterfaces lists physical-looking network interfaces.
+// Skips loopback, docker/veth bridges, and virtual tunnels.
+func collectNetworkInterfaces() []NetworkInterfaceInfo {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+
+	var result []NetworkInterfaceInfo
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		name := iface.Name
+		if skipInterface(name) {
+			continue
+		}
+
+		ni := NetworkInterfaceInfo{
+			Name: name,
+			MAC:  iface.HardwareAddr.String(),
+		}
+
+		// Primary IPv4 (first non-link-local).
+		addrs, err := iface.Addrs()
+		if err == nil {
+			for _, addr := range addrs {
+				ip, _, err := net.ParseCIDR(addr.String())
+				if err != nil {
+					continue
+				}
+				v4 := ip.To4()
+				if v4 == nil {
+					continue
+				}
+				if v4.IsLinkLocalUnicast() {
+					continue
+				}
+				ni.IPv4 = v4.String()
+				break
+			}
+		}
+
+		// Link speed from /sys/class/net/<name>/speed (Linux only, may be -1 or absent).
+		if runtime.GOOS == "linux" {
+			if speedRaw, err := os.ReadFile(filepath.Join("/sys/class/net", name, "speed")); err == nil {
+				if speed, err := strconv.ParseInt(strings.TrimSpace(string(speedRaw)), 10, 64); err == nil && speed > 0 {
+					ni.SpeedMbps = speed
+				}
+			}
+		}
+
+		result = append(result, ni)
+	}
+
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result
+}
+
+func skipInterface(name string) bool {
+	switch name {
+	case "", "lo":
+		return true
+	}
+	prefixes := []string{"docker", "veth", "br-", "virbr", "tun", "tap", "cni", "flannel", "kube", "wg"}
+	for _, p := range prefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+

--- a/agent/main.go
+++ b/agent/main.go
@@ -391,6 +391,13 @@ func runAgent(machineID string) error {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
+	// Send hardware snapshot once per connect. It's static — the hub keeps
+	// whatever we last reported and overwrites on the next connect if anything
+	// genuinely changed (DIMM swap, new disk, etc.).
+	if err := sendHardware(conn, &writeMu, machineID); err != nil {
+		log.Printf("send hardware error: %v", err)
+	}
+
 	// Send immediately on connect, then every 30s.
 	if err := sendAll(conn, &writeMu, machineID); err != nil {
 		return err
@@ -425,6 +432,14 @@ func writeJSON(conn *websocket.Conn, mu *sync.Mutex, v interface{}) error {
 	mu.Lock()
 	defer mu.Unlock()
 	return conn.WriteMessage(websocket.TextMessage, data)
+}
+
+func sendHardware(conn *websocket.Conn, mu *sync.Mutex, machineID string) error {
+	hw := collectHardware(machineID, collectGPUMetrics())
+	if err := writeJSON(conn, mu, hw); err != nil {
+		return fmt.Errorf("write hardware: %w", err)
+	}
+	return nil
 }
 
 func sendMetrics(conn *websocket.Conn, mu *sync.Mutex, machineID string) error {

--- a/dashboard/src/app/machine/[id]/page.tsx
+++ b/dashboard/src/app/machine/[id]/page.tsx
@@ -54,6 +54,37 @@ interface GPUData {
   fan_percent: number;
 }
 
+interface HardwareDiskInfo {
+  device: string;
+  model?: string;
+  size_bytes?: number;
+  type?: string;
+}
+
+interface HardwareNetworkInfo {
+  name: string;
+  mac?: string;
+  ipv4?: string;
+  speed_mbps?: number;
+}
+
+interface HardwareInfo {
+  cpu_model?: string;
+  cpu_vendor?: string;
+  cpu_cores?: number;
+  cpu_threads?: number;
+  cpu_frequency_mhz?: number;
+  ram_total_bytes?: number;
+  kernel_version?: string;
+  platform_family?: string;
+  virtualization?: string;
+  boot_time?: number;
+  architecture?: string;
+  gpu_models?: string[];
+  disks?: HardwareDiskInfo[];
+  network_interfaces?: HardwareNetworkInfo[];
+}
+
 interface MachineData {
   machine: {
     id: string;
@@ -76,6 +107,7 @@ interface MachineData {
   };
   gpus: GPUData[];
   latency_ms: number;
+  hardware_info?: HardwareInfo | null;
 }
 
 type TerminalState = "locked" | "pin_entry" | "connecting" | "active" | "disconnected";
@@ -631,6 +663,8 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
                 </motion.div>
               )}
             </div>
+
+            {data.hardware_info && <HardwarePanel hw={data.hardware_info} />}
           </TabsContent>
 
           <TabsContent value="services" className="mt-6">
@@ -794,6 +828,126 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
           )}
         </Tabs>
       </main>
+    </motion.div>
+  );
+}
+
+function formatHardwareBytes(bytes: number | undefined | null): string {
+  if (!bytes || bytes <= 0) return "";
+  const tb = bytes / 1024 ** 4;
+  if (tb >= 1) return `${tb.toFixed(tb >= 10 ? 0 : 1)} TB`;
+  const gb = bytes / 1024 ** 3;
+  if (gb >= 1) return `${gb.toFixed(0)} GB`;
+  const mb = bytes / 1024 ** 2;
+  return `${mb.toFixed(0)} MB`;
+}
+
+function formatUptime(bootUnix: number | undefined): string {
+  if (!bootUnix || bootUnix <= 0) return "";
+  const secs = Math.max(0, Math.floor(Date.now() / 1000 - bootUnix));
+  const d = Math.floor(secs / 86400);
+  const h = Math.floor((secs % 86400) / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+function HardwareRow({ label, value }: { label: string; value: string | number | null | undefined }) {
+  if (value === null || value === undefined || value === "" || value === 0) return null;
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-1.5 border-b border-blox-border/30 last:border-b-0">
+      <span className="text-xs text-blox-muted">{label}</span>
+      <span className="text-xs text-blox-text font-mono tabular-nums text-right truncate">{value}</span>
+    </div>
+  );
+}
+
+function HardwarePanel({ hw }: { hw: HardwareInfo }) {
+  const diskLines = (hw.disks ?? []).filter((d) => (d.size_bytes ?? 0) > 0 || d.model);
+  const nicLines = (hw.network_interfaces ?? []).filter((n) => n.name);
+  const gpuNames = (hw.gpu_models ?? []).filter(Boolean);
+
+  const uptime = formatUptime(hw.boot_time);
+  const cpuDetail = [
+    hw.cpu_cores ? `${hw.cpu_cores} cores` : "",
+    hw.cpu_threads && hw.cpu_threads !== hw.cpu_cores ? `${hw.cpu_threads} threads` : "",
+    hw.cpu_frequency_mhz && hw.cpu_frequency_mhz > 0 ? `${(hw.cpu_frequency_mhz / 1000).toFixed(1)} GHz` : "",
+  ].filter(Boolean).join(" · ");
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.15 }}
+      className="bg-blox-card border border-blox-border rounded-xl p-5 mt-6"
+    >
+      <div className="flex items-center gap-2.5 mb-5">
+        <div className="p-1.5 rounded-lg bg-blox-blue/10">
+          <Cpu className="w-3.5 h-3.5 text-blox-blue" />
+        </div>
+        <h3 className="text-sm font-semibold text-blox-text">Hardware</h3>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-8 gap-y-1">
+        <div>
+          <HardwareRow label="CPU" value={hw.cpu_model} />
+          <HardwareRow label="" value={cpuDetail || undefined} />
+          <HardwareRow label="Vendor" value={hw.cpu_vendor} />
+          <HardwareRow label="Memory" value={formatHardwareBytes(hw.ram_total_bytes)} />
+          <HardwareRow label="Architecture" value={hw.architecture} />
+          <HardwareRow label="Kernel" value={hw.kernel_version} />
+          <HardwareRow label="Platform" value={hw.platform_family} />
+          <HardwareRow label="Virtualization" value={hw.virtualization} />
+          <HardwareRow label="Uptime" value={uptime} />
+        </div>
+
+        <div>
+          {gpuNames.length > 0 && (
+            <>
+              <div className="text-xs text-blox-muted mb-1.5 uppercase tracking-wider">GPU</div>
+              {gpuNames.map((name) => (
+                <div key={name} className="text-xs text-blox-text font-mono mb-1">{name}</div>
+              ))}
+            </>
+          )}
+
+          {diskLines.length > 0 && (
+            <>
+              <div className="text-xs text-blox-muted mt-3 mb-1.5 uppercase tracking-wider">Storage</div>
+              {diskLines.map((d) => (
+                <div key={d.device} className="flex items-baseline justify-between gap-4 py-1 border-b border-blox-border/30 last:border-b-0">
+                  <span className="text-xs text-blox-muted font-mono">
+                    {d.device.replace(/^\/dev\//, "")}
+                    {d.type && <span className="ml-2 text-[10px] uppercase text-blox-muted/70">{d.type}</span>}
+                  </span>
+                  <span className="text-xs text-blox-text font-mono tabular-nums text-right truncate">
+                    {formatHardwareBytes(d.size_bytes)}
+                    {d.model && <span className="ml-2 text-blox-muted">{d.model}</span>}
+                  </span>
+                </div>
+              ))}
+            </>
+          )}
+
+          {nicLines.length > 0 && (
+            <>
+              <div className="text-xs text-blox-muted mt-3 mb-1.5 uppercase tracking-wider">Network</div>
+              {nicLines.map((n) => (
+                <div key={n.name} className="flex items-baseline justify-between gap-4 py-1 border-b border-blox-border/30 last:border-b-0">
+                  <span className="text-xs text-blox-muted font-mono">{n.name}</span>
+                  <span className="text-xs text-blox-text font-mono tabular-nums text-right truncate">
+                    {n.ipv4}
+                    {n.speed_mbps && n.speed_mbps > 0 && (
+                      <span className="ml-2 text-blox-muted">{n.speed_mbps >= 1000 ? `${n.speed_mbps / 1000} Gb/s` : `${n.speed_mbps} Mb/s`}</span>
+                    )}
+                  </span>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      </div>
     </motion.div>
   );
 }

--- a/hub/main.go
+++ b/hub/main.go
@@ -1858,6 +1858,24 @@ func handleAgentWS(c echo.Context) error {
 			upsertContainers(mid, cm.Containers)
 			broadcastSSE(msg)
 
+		case "hardware_info":
+			// Static hardware snapshot — store the raw JSON as-is so adding
+			// new fields doesn't require another hub deploy.
+			var hw struct {
+				MachineID string `json:"machine_id"`
+			}
+			if err := json.Unmarshal(msg, &hw); err != nil {
+				log.Printf("invalid hardware_info JSON: %v", err)
+				continue
+			}
+			mid := hw.MachineID
+			if mid == "" {
+				mid = machineID
+			}
+			if _, err := db.Exec(`UPDATE machines SET hardware_info = ? WHERE id = ?`, string(msg), mid); err != nil {
+				log.Printf("store hardware_info: %v", err)
+			}
+
 		case "command_response":
 			var resp CommandResponse
 			if err := json.Unmarshal(msg, &resp); err != nil {
@@ -2546,21 +2564,30 @@ func handleGetMachine(c echo.Context) error {
 	id := c.Param("id")
 
 	var m struct {
-		ID       string  `json:"id"`
-		Hostname string  `json:"hostname"`
-		IP       *string `json:"ip"`
-		OS       *string `json:"os"`
-		Status   string  `json:"status"`
-		Tags     *string `json:"tags"`
-		LastSeen *string `json:"last_seen"`
+		ID           string  `json:"id"`
+		Hostname     string  `json:"hostname"`
+		IP           *string `json:"ip"`
+		OS           *string `json:"os"`
+		Status       string  `json:"status"`
+		Tags         *string `json:"tags"`
+		LastSeen     *string `json:"last_seen"`
+		HardwareInfo *string `json:"-"`
 	}
-	err := db.QueryRow(`SELECT id, hostname, ip, os, status, tags, last_seen FROM machines WHERE id = ?`, id).
-		Scan(&m.ID, &m.Hostname, &m.IP, &m.OS, &m.Status, &m.Tags, &m.LastSeen)
+	err := db.QueryRow(`SELECT id, hostname, ip, os, status, tags, last_seen, hardware_info FROM machines WHERE id = ?`, id).
+		Scan(&m.ID, &m.Hostname, &m.IP, &m.OS, &m.Status, &m.Tags, &m.LastSeen, &m.HardwareInfo)
 	if err == sql.ErrNoRows {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "machine not found"})
 	}
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	var hardware any
+	if m.HardwareInfo != nil && *m.HardwareInfo != "" {
+		if err := json.Unmarshal([]byte(*m.HardwareInfo), &hardware); err != nil {
+			log.Printf("decode stored hardware_info for %s: %v", id, err)
+			hardware = nil
+		}
 	}
 
 	var met struct {
@@ -2593,10 +2620,11 @@ func handleGetMachine(c echo.Context) error {
 	machineLatencyMu.RUnlock()
 
 	return c.JSON(http.StatusOK, map[string]interface{}{
-		"machine":    m,
-		"metrics":    met,
-		"gpus":       gpus,
-		"latency_ms": lat,
+		"machine":       m,
+		"metrics":       met,
+		"gpus":          gpus,
+		"latency_ms":    lat,
+		"hardware_info": hardware,
 	})
 }
 

--- a/hub/migrations.go
+++ b/hub/migrations.go
@@ -232,6 +232,16 @@ var migrations = []migration{
 			return err
 		},
 	},
+	{
+		description: "add hardware_info JSON column to machines for static spec snapshots",
+		apply: func(tx *sql.Tx) error {
+			_, err := tx.Exec(`ALTER TABLE machines ADD COLUMN hardware_info TEXT`)
+			if err != nil && isDuplicateColumnErr(err) {
+				return nil
+			}
+			return err
+		},
+	},
 }
 
 // isDuplicateColumnErr returns true when SQLite rejects an ALTER TABLE ADD


### PR DESCRIPTION
## Summary
Adds a static hardware-snapshot pipeline: agent collects a one-time spec snapshot on connect, hub stores it as JSON, dashboard renders a **Hardware** panel in the machine detail Overview tab.

## Agent — \`agent/hardware.go\`
Collects, on each connect:
- CPU: model, vendor, physical cores, logical threads, base frequency
- RAM total
- Kernel version, platform family, virtualization, boot time, architecture
- Disks via \`/sys/block\`: device, model, size, type (nvme / ssd / hdd)
- Network interfaces via \`net.Interfaces\` + \`/sys/class/net/*/speed\`
- GPU model names carried over from the existing nvidia-smi output

Sent as a \`hardware_info\` WebSocket message once per connect. Static — hub keeps whatever was last reported.

## Hub
- **Migration 7→8**: \`ALTER TABLE machines ADD COLUMN hardware_info TEXT\`
- **WS handler** stores the raw JSON blob as-is so the agent can add fields without a hub deploy
- **GET /api/machines/:id** now returns a decoded \`hardware_info\` object

## Dashboard
- Machine detail Overview tab gains a **Hardware panel** below System/GPU
- Two-column layout: CPU / memory / OS on the left; GPU / storage / network on the right
- Absence-is-the-signal: every field is conditionally hidden when the agent didn't report it

## Test plan
- [x] Agent \`go build\` green (VM)
- [x] Hub \`go build\` green (VM)
- [x] \`TestAgentReconnectWithSecret\` isolated passes 3/3 (full-suite flake is pre-existing cross-test contamination, seen on main too)
- [x] Dashboard \`pnpm lint\` / \`pnpm build\` / \`tsc --noEmit\` green
- [ ] Post-deploy visual: old agents on the fleet will not send hardware_info yet — panel hides gracefully until each agent is upgraded

## Deploy steps
1. Merge + redeploy hub (migration runs)
2. Redeploy dashboard
3. Roll out agent binary to fleet when ready