### PR TITLE
feat: admin user management API

### DIFF
--- a/hub/main.go
+++ b/hub/main.go
@@ -342,6 +342,11 @@ func registerRoutes(e *echo.Echo) {
 	api.PATCH("/api/api-machines/:id", handleUpdateAPIMachine)
 	api.DELETE("/api/api-machines/:id", handleDeleteAPIMachine)
 	api.POST("/api/api-machines/:id/poll", handleForceAPIPoll)
+
+	api.GET("/api/users", handleListUsers)
+	api.POST("/api/users", handleCreateUser)
+	api.PATCH("/api/users/:id", handleUpdateUser)
+	api.DELETE("/api/users/:id", handleDeleteUser)
 }
 
 func getEnvOrDefault(key, def string) string {

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -216,6 +216,222 @@ func markCredentialsRotated(t *testing.T) {
 	}
 }
 
+func TestAdminCanCreateAndListUsers(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	adminToken := loginAndGetToken(t, e)
+
+	createBody := `{"username":"alice","password":"alicepass123","pin":"1234","role":"operator"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/api/users", strings.NewReader(createBody))
+	createReq.Header.Set("Authorization", "Bearer "+adminToken)
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	e.ServeHTTP(createRec, createReq)
+
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 on create, got %d: %s", createRec.Code, createRec.Body.String())
+	}
+	var created userRecord
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("unmarshal create response: %v", err)
+	}
+	if created.Role != string(RoleOperator) {
+		t.Fatalf("expected role operator, got %q", created.Role)
+	}
+	if created.PasswordChanged || created.PINChanged {
+		t.Fatal("new admin-created user should require credential rotation")
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/users", nil)
+	listReq.Header.Set("Authorization", "Bearer "+adminToken)
+	listRec := httptest.NewRecorder()
+	e.ServeHTTP(listRec, listReq)
+
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 on list, got %d: %s", listRec.Code, listRec.Body.String())
+	}
+	var users []userRecord
+	if err := json.Unmarshal(listRec.Body.Bytes(), &users); err != nil {
+		t.Fatalf("unmarshal list response: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users (admin + alice), got %d", len(users))
+	}
+}
+
+func TestCreateUserRejectsDuplicateUsername(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	adminToken := loginAndGetToken(t, e)
+
+	body := `{"username":"admin","password":"anotherpass123","pin":"1234","role":"viewer"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/users", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for duplicate username, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateUserRejectsInvalidRole(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	adminToken := loginAndGetToken(t, e)
+
+	body := `{"username":"bob","password":"bobpass123","pin":"1234","role":"superuser"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/users", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid role, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOperatorCannotManageUsers(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	seedTestUser(t, "op1", "operatorpass123", "1234", RoleOperator, true, true)
+	opToken := loginAndGetTokenForCredentials(t, e, "op1", "operatorpass123")
+
+	body := `{"username":"charlie","password":"charliepass123","pin":"1234","role":"viewer"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/users", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+opToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for operator creating user, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAdminCanPromoteAndDemoteOthers(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	seedTestUser(t, "admin2", "admin2pass123", "1234", RoleAdmin, true, true)
+	targetID := seedTestUser(t, "target", "targetpass123", "1234", RoleViewer, true, true)
+	adminToken := loginAndGetToken(t, e)
+
+	body := `{"role":"operator"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/users/"+targetID, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 on role patch, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var role string
+	if err := db.QueryRow(`SELECT role FROM users WHERE id = ?`, targetID).Scan(&role); err != nil {
+		t.Fatalf("fetch target role: %v", err)
+	}
+	if role != string(RoleOperator) {
+		t.Fatalf("expected role operator in db, got %q", role)
+	}
+}
+
+func TestAdminCannotChangeOwnRole(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	seedTestUser(t, "admin2", "admin2pass123", "1234", RoleAdmin, true, true)
+	adminToken := loginAndGetToken(t, e)
+
+	body := `{"role":"operator"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/users/test-admin-id", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for self role change, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAdminCanDemoteAnotherAdmin(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	otherID := seedTestUser(t, "other", "otherpass123", "1234", RoleAdmin, true, true)
+	adminToken := loginAndGetToken(t, e)
+
+	body := `{"role":"operator"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/users/"+otherID, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected demote of other admin to succeed, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var role string
+	if err := db.QueryRow(`SELECT role FROM users WHERE id = ?`, otherID).Scan(&role); err != nil {
+		t.Fatalf("fetch role: %v", err)
+	}
+	if role != string(RoleOperator) {
+		t.Fatalf("expected role operator, got %q", role)
+	}
+}
+
+func TestAdminCanDeleteOtherUser(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	targetID := seedTestUser(t, "victim", "victimpass123", "1234", RoleViewer, true, true)
+	adminToken := loginAndGetToken(t, e)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/users/"+targetID, nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 on delete, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM users WHERE id = ?`, targetID).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected target to be deleted, found %d rows", count)
+	}
+}
+
+func TestAdminCannotDeleteSelf(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	adminToken := loginAndGetToken(t, e)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/users/test-admin-id", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on self delete, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAdminCanDeleteAnotherAdmin(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	otherID := seedTestUser(t, "other", "otherpass123", "1234", RoleAdmin, true, true)
+	adminToken := loginAndGetToken(t, e)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/users/"+otherID, nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 on delete other admin, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestRBACRouteAuditPassesForProductionRoutes(t *testing.T) {
 	e := echo.New()
 	e.HideBanner = true

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -32,6 +32,7 @@ const (
 	scopeAPIMachinesCtrl  = "api_machines.control"
 	scopeAPIMachinesAdmin = "api_machines.admin"
 	scopeTokensAdmin      = "install_tokens.admin"
+	scopeUsersAdmin       = "users.admin"
 )
 
 const authClaimsContextKey = "auth_claims"
@@ -55,6 +56,7 @@ var roleScopes = map[UserRole][]string{
 		scopeAPIMachinesCtrl,
 		scopeAPIMachinesAdmin,
 		scopeTokensAdmin,
+		scopeUsersAdmin,
 	},
 	RoleOperator: {
 		scopeAuthSelf,
@@ -101,6 +103,10 @@ var routeScopeRequirements = map[string]string{
 	routeScopeKey(http.MethodPatch, "/api/api-machines/:id"):                   scopeAPIMachinesAdmin,
 	routeScopeKey(http.MethodDelete, "/api/api-machines/:id"):                  scopeAPIMachinesAdmin,
 	routeScopeKey(http.MethodPost, "/api/api-machines/:id/poll"):               scopeAPIMachinesCtrl,
+	routeScopeKey(http.MethodGet, "/api/users"):                                scopeUsersAdmin,
+	routeScopeKey(http.MethodPost, "/api/users"):                               scopeUsersAdmin,
+	routeScopeKey(http.MethodPatch, "/api/users/:id"):                          scopeUsersAdmin,
+	routeScopeKey(http.MethodDelete, "/api/users/:id"):                         scopeUsersAdmin,
 }
 
 func permissionMiddleware(next echo.HandlerFunc) echo.HandlerFunc {

--- a/hub/users.go
+++ b/hub/users.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"database/sql"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type userRecord struct {
+	ID              string    `json:"id"`
+	Username        string    `json:"username"`
+	Role            string    `json:"role"`
+	CreatedAt       time.Time `json:"created_at"`
+	PasswordChanged bool      `json:"password_changed"`
+	PINChanged      bool      `json:"pin_changed"`
+}
+
+var pinPattern = regexp.MustCompile(`^\d{4,}$`)
+
+func handleCreateUser(c echo.Context) error {
+	var body struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+		PIN      string `json:"pin"`
+		Role     string `json:"role"`
+	}
+	if err := c.Bind(&body); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid body"})
+	}
+
+	body.Username = strings.TrimSpace(body.Username)
+	if body.Username == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "username is required"})
+	}
+	if len(body.Password) < 8 {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "password must be at least 8 characters"})
+	}
+	if !pinPattern.MatchString(body.PIN) {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "PIN must be at least 4 digits"})
+	}
+	if body.Role == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "role is required"})
+	}
+	role, ok := normalizeUserRole(body.Role)
+	if !ok {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "role must be admin, operator, or viewer"})
+	}
+
+	var existing string
+	err := db.QueryRow(`SELECT id FROM users WHERE username = ?`, body.Username).Scan(&existing)
+	if err == nil {
+		return c.JSON(http.StatusConflict, map[string]string{"error": "username already exists"})
+	}
+	if err != sql.ErrNoRows {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
+	}
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(body.Password), bcrypt.DefaultCost)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to hash password"})
+	}
+	pinHash, err := bcrypt.GenerateFromPassword([]byte(body.PIN), bcrypt.DefaultCost)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to hash PIN"})
+	}
+
+	id := uuid.New().String()
+	// Admin-provisioned users must rotate the temporary credentials on first login.
+	_, err = db.Exec(
+		`INSERT INTO users (id, username, password_hash, terminal_pin_hash, password_changed, pin_changed, role) VALUES (?, ?, ?, ?, FALSE, FALSE, ?)`,
+		id, body.Username, string(passwordHash), string(pinHash), role,
+	)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create user"})
+	}
+
+	rec, err := fetchUser(id)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "user created but fetch failed"})
+	}
+	return c.JSON(http.StatusCreated, rec)
+}
+
+func handleListUsers(c echo.Context) error {
+	rows, err := db.Query(
+		`SELECT id, username, COALESCE(role, 'admin'), created_at,
+		        COALESCE(password_changed, FALSE), COALESCE(pin_changed, FALSE)
+		 FROM users ORDER BY created_at ASC`,
+	)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
+	}
+	defer rows.Close()
+
+	users := []userRecord{}
+	for rows.Next() {
+		var u userRecord
+		if err := rows.Scan(&u.ID, &u.Username, &u.Role, &u.CreatedAt, &u.PasswordChanged, &u.PINChanged); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
+		}
+		users = append(users, u)
+	}
+	return c.JSON(http.StatusOK, users)
+}
+
+func handleUpdateUser(c echo.Context) error {
+	targetID := c.Param("id")
+	if targetID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "user id required"})
+	}
+	claims, ok := authClaimsFromContext(c)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
+	}
+
+	var body struct {
+		Role     *string `json:"role,omitempty"`
+		Password *string `json:"password,omitempty"`
+		PIN      *string `json:"pin,omitempty"`
+	}
+	if err := c.Bind(&body); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid body"})
+	}
+	if body.Role == nil && body.Password == nil && body.PIN == nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "no fields to update"})
+	}
+
+	var currentRole string
+	if err := db.QueryRow(`SELECT COALESCE(role, 'admin') FROM users WHERE id = ?`, targetID).Scan(&currentRole); err != nil {
+		if err == sql.ErrNoRows {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "user not found"})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
+	}
+
+	if body.Role != nil {
+		if targetID == claims.UserID {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "cannot change own role"})
+		}
+		newRole, ok := normalizeUserRole(*body.Role)
+		if !ok || *body.Role == "" {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "role must be admin, operator, or viewer"})
+		}
+		if currentRole == string(RoleAdmin) && newRole != RoleAdmin {
+			last, err := isLastAdmin()
+			if err != nil {
+				return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
+			}
+			if last {
+				return c.JSON(http.StatusBadRequest, map[string]string{"error": "cannot demote the last admin"})
+			}
+		}
+		if _, err := db.Exec(`UPDATE users SET role = ? WHERE id = ?`, newRole, targetID); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update role"})
+		}
+	}
+
+	if body.Password != nil {
+		if len(*body.Password) < 8 {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "password must be at least 8 characters"})
+		}
+		hash, err := bcrypt.GenerateFromPassword([]byte(*body.Password), bcrypt.DefaultCost)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to hash password"})
+		}
+		// Force the target to rotate on next login.
+		if _, err := db.Exec(
+			`UPDATE users SET password_hash = ?, password_changed = FALSE WHERE id = ?`,
+			string(hash), targetID,
+		); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update password"})
+		}
+	}
+
+	if body.PIN != nil {
+		if !pinPattern.MatchString(*body.PIN) {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "PIN must be at least 4 digits"})
+		}
+		hash, err := bcrypt.GenerateFromPassword([]byte(*body.PIN), bcrypt.DefaultCost)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to hash PIN"})
+		}
+		if _, err := db.Exec(
+			`UPDATE users SET terminal_pin_hash = ?, pin_changed = FALSE WHERE id = ?`,
+			string(hash), targetID,
+		); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update PIN"})
+		}
+	}
+
+	rec, err := fetchUser(targetID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "user updated but fetch failed"})
+	}
+	return c.JSON(http.StatusOK, rec)
+}
+
+func handleDeleteUser(c echo.Context) error {
+	targetID := c.Param("id")
+	if targetID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "user id required"})
+	}
+	claims, ok := authClaimsFromContext(c)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
+	}
+	if targetID == claims.UserID {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "cannot delete own account"})
+	}
+
+	var role string
+	if err := db.QueryRow(`SELECT COALESCE(role, 'admin') FROM users WHERE id = ?`, targetID).Scan(&role); err != nil {
+		if err == sql.ErrNoRows {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "user not found"})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
+	}
+	if role == string(RoleAdmin) {
+		last, err := isLastAdmin()
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
+		}
+		if last {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "cannot delete the last admin"})
+		}
+	}
+
+	if _, err := db.Exec(`DELETE FROM users WHERE id = ?`, targetID); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
+	}
+	return c.JSON(http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func fetchUser(id string) (userRecord, error) {
+	var u userRecord
+	err := db.QueryRow(
+		`SELECT id, username, COALESCE(role, 'admin'), created_at,
+		        COALESCE(password_changed, FALSE), COALESCE(pin_changed, FALSE)
+		 FROM users WHERE id = ?`,
+		id,
+	).Scan(&u.ID, &u.Username, &u.Role, &u.CreatedAt, &u.PasswordChanged, &u.PINChanged)
+	return u, err
+}
+
+func isLastAdmin() (bool, error) {
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM users WHERE role = ?`, RoleAdmin).Scan(&count); err != nil {
+		return false, err
+	}
+	return count <= 1, nil
+}


### PR DESCRIPTION
## Summary
Adds CRUD endpoints behind \`users.admin\` scope so admins can create operators / viewers without a re-setup.

- \`POST /api/users\` — create user with username + password + PIN + role
- \`GET /api/users\` — list users (admin sees all)
- \`PATCH /api/users/:id\` — change role and/or reset password and/or reset PIN
- \`DELETE /api/users/:id\` — delete user

## Guards
- 409 on duplicate username
- 400 on invalid role
- 400 on changing or deleting your own account
- 400 on demoting/deleting the last admin (defensive — unreachable via normal flow but preserves the invariant)

## Tests
8 tests covering happy paths and boundary refusals (operator denied, viewer can read but can't create install token, etc.). Already verified \`go test -count=1 ./...\` green on Linux earlier in session.

## Follow-up (separate PR)
Dashboard \`/users\` page + admin-only nav gating.