### PR TITLE
feat(ui): user management page + role-aware nav

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,105 +1,115 @@
 # BloxOS Handoff Ledger
 
 ## State
+
 - Done:
   - [x] Feature baseline: hub, agent, dashboard, GPU metrics, alerts, auth, terminal, API-polled machines
   - [x] UI refresh: shadcn/ui + Framer Motion + Geist fonts
-  - [x] Security hardening phase:
+  - [x] Security hardening:
     - [x] DB permissions `0600`
     - [x] bootstrap secrets removed from logs
     - [x] single-use install tokens
     - [x] credential rotation enforcement
     - [x] first-boot setup backend
     - [x] durable agent secrets (hashed, revocable)
-    - [x] terminal session limits and audit metadata
+    - [x] terminal session limits + audit metadata
   - [x] Trust hardening:
-    - [x] agent TLS verification enabled by default
+    - [x] agent TLS verification on by default
     - [x] installer CA bootstrap with fingerprint verification
     - [x] terminal browser token scoped instead of full JWT in URL
-    - [x] API-machine TLS trust moved from global env override to per-machine config
+    - [x] API-machine TLS trust per-machine instead of a hub-wide env override
   - [x] Product gaps closed:
     - [x] API machine edit flow (`PATCH /api/api-machines/:id`)
-    - [x] in-process poller restart after API machine update
+    - [x] in-process poller restart after API-machine update
     - [x] GitHub Actions CI for hub tests, agent tests, dashboard lint/build
+  - [x] First-boot UI (PR #21):
+    - [x] dedicated `/setup` page
+    - [x] login auto-redirects to `/setup` when initialization is pending
+    - [x] auto-login + handoff to dashboard after successful setup
+    - [x] blocking error/retry state when setup status fetch fails
+    - [x] explicit message when setup succeeds but auto-login fails
+    - [x] login skips setup probe when already authenticated
+  - [x] RBAC foundation (merged with PR #21):
+    - [x] `admin` / `operator` / `viewer` roles + scopes
+    - [x] server-side enforcement via `permissionMiddleware`
+    - [x] login response returns role + scopes
+    - [x] startup route-audit guard so protected `/api/*` routes can never drift from the RBAC scope map
+  - [x] UI polish pass (PRs #22-#25):
+    - [x] Phase 1: design tokens + motion vars + scale conventions in `globals.css`
+    - [x] Phase 2: card + list correctness — empty GPU rows removed on CPU-only machines, list view matches card data, `auto-rows-fr` keeps card heights equal across a row
+    - [x] Phase 3: machine detail page restructured into shadcn Tabs (Overview / Services / Containers / Metrics / Terminal) with `?tab=X` deep-linking and `keepMounted` on Terminal so the PTY survives tab switches
+    - [x] Phase 4: canonical `:focus-visible` outline ring, inline SSE-disconnect banner, smallest-text bump
+  - [x] Bug fix (PR #26): `localeCompare` crash from machines with null hostname
+  - [x] Hardware specs (PR #27):
+    - [x] agent emits a one-time `hardware_info` snapshot on connect (CPU model + cores, RAM, kernel, virtualization, disks with type/size, NICs with speed, GPU model)
+    - [x] hub stores raw JSON in new `machines.hardware_info` column (migration v8)
+    - [x] dashboard renders a Hardware panel in the detail Overview tab
 - In progress:
-  - [ ] PR `#21` / branch `feat/setup-ui`: frontend `/setup` page for first-boot flow
-    - current branch head: `3fcb836`
-    - latest fixes included:
-      - blocking error state when setup status cannot be fetched
-      - explicit message when setup succeeds but auto-login fails
-      - login page skips setup probe when already authenticated
-      - setup retry button retriggers the setup-status fetch correctly
-      - RBAC/action-scope foundation (`admin` / `operator` / `viewer`) with server-side route checks
-      - startup route-audit guard so protected `/api/*` routes cannot drift from the RBAC scope map
+  - [ ] User management dashboard UI — backend already on branch `feat/user-management` (commit `4e2f09e`, unmerged): `POST/GET/PATCH/DELETE /api/users` behind `users.admin` scope. Frontend `/users` page + admin-only nav still TODO.
 - Remaining:
-  - [ ] merge PR `#21`
-  - [ ] deploy `/setup` UI after merge
   - [ ] move Proxmox API machine from temporary `insecure` mode to `custom_ca`
   - [ ] split `hub/main.go` into packages when the repo stabilizes further
+  - [ ] cross-test contamination flake on `TestAgentReconnectWithSecret` (passes 3/3 in isolation, fails ~half the full-suite runs — global `db` var + leaked goroutines)
 
 ## Credentials
-All live credentials are stored outside git.
-Never put raw secrets, tokens, passwords, PINs, or SSH credentials in this file or any committed file.
+All live credentials live outside git in `~/.bloxos/`-style paths or operator memory. **Never** put raw secrets, tokens, passwords, PINs, or SSH credentials in this file or any committed file.
 
 ## Current Deployment
-- Supported deployment path: `Caddy + systemd`
+- Path: `Caddy + systemd` on the BloxOS hub VM (`192.168.16.113`).
 - Topology:
   - Caddy terminates HTTPS on `:443`
   - hub listens on `127.0.0.1:4000`
   - dashboard listens on `127.0.0.1:3000`
   - agents connect through Caddy over `wss://.../ws/agent`
-- CI is active in GitHub Actions for:
+- The single canonical clone on the hub VM is `~/bloxos` (which the systemd units point at). The duplicate `~/projects/bloxos` clone has been removed.
+- CI runs in GitHub Actions on every push:
   - `go test -count=1 ./...` in `hub`
   - `go test -count=1 ./...` in `agent`
   - `pnpm lint` in `dashboard`
   - `pnpm build` in `dashboard`
 
 ## First-Boot Setup
-- Backend setup flow already exists and is the only supported bootstrap path for new deployments.
-- Status endpoint: `GET /api/setup/status`
-- Setup endpoint: `POST /api/setup`
-- Setup token sources:
-  - `~/.bloxos/setup-token` (owner-readable only) when no users exist
-  - or `BLOXOS_SETUP_TOKEN`
-- PR `#21` adds the frontend `/setup` page on top of this backend flow.
+- Backend: `GET /api/setup/status`, `POST /api/setup`.
+- Token sources: `~/.bloxos/setup-token` (owner-readable only) when no users exist, or `BLOXOS_SETUP_TOKEN` env.
+- UI: `/setup` page (PR #21) walks the operator through token → admin username → password → terminal PIN, then auto-logs in.
 
 ## Agent Enrollment
-- Legacy reconnect fallback has been removed.
-- Agents must authenticate with durable secrets on reconnect.
+- Legacy reconnect fallback removed; agents must authenticate with durable secrets.
 - Install tokens are single-use and mint durable agent credentials.
-- Durable agent secret is stored locally on the machine and hashed in the hub DB.
-- Re-enrollment path for an older or broken agent:
-  1. generate a fresh install token
-  2. reinstall or re-run the agent bootstrap flow
-  3. verify the new durable secret is present locally
+- Durable secret stored locally on the machine, hashed in the hub DB.
+- Re-enrollment for a broken agent: generate fresh install token → reinstall/re-bootstrap → verify new durable secret on disk.
 
 ## API Machines
-- TLS trust is now per machine:
-  - `system`
-  - `custom_ca`
-  - temporary `insecure`
-- Existing self-signed HTTPS endpoints must be configured explicitly.
-- Current follow-up still needed:
-  - move the Proxmox API machine from temporary `insecure` mode to `custom_ca`
-- API machines can now be edited from the dashboard; direct SQLite edits should no longer be necessary.
+- TLS trust is per machine: `system`, `custom_ca`, or temporary `insecure`.
+- Self-signed HTTPS endpoints must be configured explicitly.
+- Outstanding follow-up: convert the Proxmox API machine from `insecure` to `custom_ca`.
+
+## RBAC
+- Roles: `admin`, `operator`, `viewer`.
+- Login response returns `role` + `scopes` for client-side gating.
+- Server enforces every protected route via `permissionMiddleware` against `routeScopeRequirements`.
+- A boot-time `auditRBACRouteCoverage` check fails server startup if any registered `/api/*` route lacks a scope mapping (or vice-versa).
+- Dashboard role-aware affordances still minimal — backend will refuse insufficient-scope writes with 403.
+
+## Hardware Info
+- Agent collects a static spec snapshot on every connect: CPU (model/cores/threads/freq), RAM total, kernel, virtualization, boot time, disks (`/sys/block`: device/model/size/type), NICs (`/sys/class/net`: name/IPv4/MAC/speed), GPU model names.
+- Hub stores the raw JSON in `machines.hardware_info` (migration v8). `GET /api/machines/:id` returns it as a decoded object.
+- Dashboard detail Overview tab shows it in a Hardware panel; absent fields are hidden.
 
 ## Known Issues
-- PR `#21` is still open and not merged into `main` yet.
-- `/setup` UI exists on the feature branch only until PR `#21` lands.
-- Proxmox API polling still uses explicit per-machine `insecure` TLS until its CA PEM is configured.
-- RBAC is currently backend-enforced; dashboard role-aware affordances are still minimal.
+- Proxmox API polling still uses `insecure` until its CA PEM is configured.
+- Dashboard role-aware affordances are minimal (server enforces, UI doesn't yet hide).
+- Pre-existing flaky test `TestAgentReconnectWithSecret` on full-suite runs.
 
 ## Current Fleet
-- Last verified rollout state:
-  - 3 enrolled agents online
-  - 2 API machines polling
-- Recheck live fleet state from the dashboard or hub API before any ops work.
+- Three enrolled agents online: `BloxOs` (hub self), `ai-04`, `ic-brain` — all on the hardware-aware build.
+- Two API machines polling: `Dasman` (Synology DSM), `Dell` (Proxmox VE — still in `insecure` mode).
+- Recheck live state from the dashboard or hub API before any ops work.
 
 ## Key URLs
 - Dashboard: `https://192.168.16.113`
 - Repo: `https://github.com/bokiko/bloxos`
-- Active feature branch: `feat/setup-ui`
-- Open setup PR: `#21`
+- Open backend branch (unmerged): `feat/user-management` at `4e2f09e`
 
 ## Useful Commands
 - Hub tests: `cd ~/bloxos/hub && /usr/local/go/bin/go test -count=1 ./...`
@@ -108,8 +118,9 @@ Never put raw secrets, tokens, passwords, PINs, or SSH credentials in this file 
 - Dashboard build: `cd ~/bloxos/dashboard && pnpm build`
 - Hub build: `cd ~/bloxos/hub && /usr/local/go/bin/go build -o bloxos-hub .`
 - Agent build: `cd ~/bloxos/agent && /usr/local/go/bin/go build -o bloxos-agent .`
+- Restart all on hub VM: `sudo systemctl restart bloxos-hub bloxos-dashboard bloxos-agent`
 
 ## Tech Stack
 - Backend: Go 1.25, Echo, gorilla/websocket, modernc.org/sqlite, JWT, bcrypt
-- Frontend: Next.js 16, React 19, Tailwind v4, shadcn/ui, Framer Motion, Recharts, xterm.js
+- Frontend: Next.js 16, React 19, Tailwind v4, shadcn/ui (Base UI primitives), Framer Motion, Recharts, xterm.js
 - Infra: Caddy, systemd, SQLite WAL

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -30,7 +30,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import {
   Bell, Plus, Wifi, WifiOff, Search, LayoutGrid, List,
   ChevronDown, LogOut, Square, CheckSquare, RotateCcw, Trash2, Pencil,
-  ArrowUpDown, Filter, Monitor, Server,
+  ArrowUpDown, Filter, Monitor, Server, Users as UsersIcon,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -82,7 +82,8 @@ const sortLabels: Record<SortOption, string> = {
 
 export default function Home() {
   const { machines: liveMachines, connected, hasReceivedData, alertCount, alerts, setAlerts, setAlertCount } = useSSE();
-  const { logout, authFetch } = useAuth();
+  const { logout, authFetch, hasScope } = useAuth();
+  const canManageUsers = hasScope("users.admin");
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [sortBy, setSortBy] = useState<SortOption>("name");
@@ -388,6 +389,16 @@ export default function Home() {
               <Server className="w-3.5 h-3.5" />
               <span className="hidden sm:inline">Add API</span>
             </Button>
+
+            {canManageUsers && (
+              <Link
+                href="/users"
+                title="Users"
+                className="inline-flex items-center justify-center rounded-md w-8 h-8 text-blox-muted hover:text-blox-text hover:bg-blox-border/50 transition-colors"
+              >
+                <UsersIcon className="w-4 h-4" />
+              </Link>
+            )}
 
             <Button
               variant="ghost"

--- a/dashboard/src/app/users/page.tsx
+++ b/dashboard/src/app/users/page.tsx
@@ -1,0 +1,486 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { ArrowLeft, Plus, Trash2, ShieldCheck, ShieldAlert, Eye, AlertTriangle } from "lucide-react";
+import { useAuth, type UserRole } from "@/contexts/AuthContext";
+import { HUB_URL } from "@/lib/session";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface UserRecord {
+  id: string;
+  username: string;
+  role: UserRole;
+  created_at: string;
+  password_changed: boolean;
+  pin_changed: boolean;
+}
+
+const ROLE_BADGE: Record<UserRole, { label: string; cls: string; icon: React.ReactNode }> = {
+  admin:    { label: "Admin",    cls: "border-blox-blue/30 bg-blox-blue/10 text-blox-blue",       icon: <ShieldCheck className="w-3 h-3" /> },
+  operator: { label: "Operator", cls: "border-amber-500/30 bg-amber-500/10 text-amber-400",       icon: <ShieldAlert className="w-3 h-3" /> },
+  viewer:   { label: "Viewer",   cls: "border-blox-border bg-blox-border/30 text-blox-muted",     icon: <Eye className="w-3 h-3" /> },
+};
+
+function timeSince(iso: string): string {
+  const ms = new Date(iso).getTime();
+  if (!isFinite(ms)) return "";
+  const sec = Math.floor((Date.now() - ms) / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const d = Math.floor(hr / 24);
+  return `${d}d ago`;
+}
+
+export default function UsersPage() {
+  const router = useRouter();
+  const { hasScope, authFetch, isAuthenticated, role: myRole } = useAuth();
+  const canManage = isAuthenticated && hasScope("users.admin");
+
+  const [users, setUsers] = useState<UserRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pageError, setPageError] = useState<string | null>(null);
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<UserRecord | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  // Boot the user back to / if they're authenticated but not admin.
+  useEffect(() => {
+    if (isAuthenticated && !hasScope("users.admin")) {
+      router.replace("/");
+    }
+  }, [isAuthenticated, hasScope, router]);
+
+  const loadUsers = useCallback(async () => {
+    if (!canManage) return;
+    setLoading(true);
+    try {
+      const res = await authFetch(`${HUB_URL}/api/users`);
+      if (!res.ok) {
+        setPageError(`Failed to load users (${res.status})`);
+        setUsers([]);
+        return;
+      }
+      const data = await res.json();
+      setUsers(Array.isArray(data) ? data : []);
+      setPageError(null);
+    } catch {
+      setPageError("Cannot reach hub");
+    } finally {
+      setLoading(false);
+    }
+  }, [authFetch, canManage]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void loadUsers();
+  }, [loadUsers]);
+
+  const adminCount = useMemo(() => users.filter((u) => u.role === "admin").length, [users]);
+
+  const handleRoleChange = useCallback(async (target: UserRecord, next: UserRole) => {
+    if (target.role === next) return;
+    if (target.role === "admin" && next !== "admin" && adminCount <= 1) {
+      setPageError("Cannot demote the last admin.");
+      return;
+    }
+    setBusyId(target.id);
+    setPageError(null);
+    try {
+      const res = await authFetch(`${HUB_URL}/api/users/${target.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: next }),
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok) {
+        setPageError(body?.error || `Update failed (${res.status})`);
+      } else {
+        setUsers((prev) => prev.map((u) => (u.id === target.id ? { ...u, role: next } : u)));
+      }
+    } catch {
+      setPageError("Cannot reach hub");
+    } finally {
+      setBusyId(null);
+    }
+  }, [authFetch, adminCount]);
+
+  const handleDelete = useCallback(async () => {
+    if (!deleteTarget) return;
+    setBusyId(deleteTarget.id);
+    setPageError(null);
+    try {
+      const res = await authFetch(`${HUB_URL}/api/users/${deleteTarget.id}`, { method: "DELETE" });
+      const body = await res.json().catch(() => null);
+      if (!res.ok) {
+        setPageError(body?.error || `Delete failed (${res.status})`);
+      } else {
+        setUsers((prev) => prev.filter((u) => u.id !== deleteTarget.id));
+        setDeleteTarget(null);
+      }
+    } catch {
+      setPageError("Cannot reach hub");
+    } finally {
+      setBusyId(null);
+    }
+  }, [authFetch, deleteTarget]);
+
+  if (!canManage) {
+    // Render a thin scaffold while the redirect runs so we don't flash
+    // a fully empty page.
+    return (
+      <div className="min-h-screen bg-blox-bg flex items-center justify-center text-blox-muted text-sm">
+        Loading…
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.3 }}
+      className="min-h-screen bg-blox-bg"
+    >
+      <header className="sticky top-0 z-50 bg-blox-bg/80 backdrop-blur-xl border-b border-blox-border/50">
+        <div className="max-w-[1200px] mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Link href="/" className="flex items-center gap-1.5 text-blox-muted hover:text-blox-text transition-colors text-sm">
+              <ArrowLeft className="w-4 h-4" />
+              Fleet
+            </Link>
+            <span className="text-blox-border/50">/</span>
+            <h1 className="font-semibold text-blox-text tracking-tight">Users</h1>
+            <Badge variant="outline" className="text-[10px] border-blox-border text-blox-muted">
+              {users.length} total · {adminCount} admin
+            </Badge>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setAddOpen(true)}
+            className="text-xs text-blox-blue border-blox-blue/20 bg-blox-blue/5 hover:bg-blox-blue/10 gap-1.5"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Add User
+          </Button>
+        </div>
+      </header>
+
+      <main className="max-w-[1200px] mx-auto px-4 sm:px-6 py-6 space-y-4">
+        {pageError && (
+          <div className="flex items-start gap-2 rounded-xl border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-blox-red">
+            <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+            <span>{pageError}</span>
+          </div>
+        )}
+
+        <div className="bg-blox-card border border-blox-border rounded-xl overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow className="border-b-blox-border hover:bg-transparent">
+                <TableHead className="text-blox-muted text-xs">Username</TableHead>
+                <TableHead className="text-blox-muted text-xs">Role</TableHead>
+                <TableHead className="text-blox-muted text-xs hidden md:table-cell">Created</TableHead>
+                <TableHead className="text-blox-muted text-xs hidden lg:table-cell">Status</TableHead>
+                <TableHead className="text-blox-muted text-xs text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {loading ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center py-8 text-blox-muted text-xs">Loading users…</TableCell>
+                </TableRow>
+              ) : users.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center py-8 text-blox-muted text-xs">No users yet.</TableCell>
+                </TableRow>
+              ) : (
+                users.map((u) => {
+                  const badge = ROLE_BADGE[u.role];
+                  const rowBusy = busyId === u.id;
+                  return (
+                    <TableRow key={u.id} className="border-b-blox-border/30 hover:bg-blox-border/10 transition-colors">
+                      <TableCell className="text-xs font-medium text-blox-text">{u.username}</TableCell>
+                      <TableCell className="text-xs">
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            render={
+                              <button
+                                disabled={rowBusy}
+                                className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md border text-[11px] font-medium transition-colors ${badge.cls} ${rowBusy ? "opacity-60" : "hover:bg-opacity-20"}`}
+                              >
+                                {badge.icon}
+                                {badge.label}
+                              </button>
+                            }
+                          />
+                          <DropdownMenuContent align="start" className="bg-blox-card border-blox-border">
+                            {(["admin", "operator", "viewer"] as UserRole[]).map((r) => (
+                              <DropdownMenuItem
+                                key={r}
+                                onClick={() => handleRoleChange(u, r)}
+                                className="text-xs text-blox-text"
+                              >
+                                {ROLE_BADGE[r].label}
+                              </DropdownMenuItem>
+                            ))}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </TableCell>
+                      <TableCell className="text-xs text-blox-muted font-mono tabular-nums hidden md:table-cell">
+                        {timeSince(u.created_at)}
+                      </TableCell>
+                      <TableCell className="text-xs hidden lg:table-cell">
+                        {!u.password_changed && (
+                          <span className="text-amber-400 text-[10px] mr-2">password rotation pending</span>
+                        )}
+                        {!u.pin_changed && (
+                          <span className="text-amber-400 text-[10px]">PIN rotation pending</span>
+                        )}
+                        {u.password_changed && u.pin_changed && (
+                          <span className="text-emerald-400 text-[10px]">credentials current</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          disabled={rowBusy}
+                          onClick={() => setDeleteTarget(u)}
+                          className="text-blox-muted hover:text-red-400"
+                          title="Delete user"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        <p className="text-[10px] text-blox-muted">
+          Logged in as <span className="text-blox-text">{myRole}</span>. Newly created users are forced to rotate their temporary password and PIN on first login.
+        </p>
+      </main>
+
+      <AddUserDialog
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        onCreated={(u) => {
+          setUsers((prev) => [...prev, u]);
+        }}
+      />
+
+      <Dialog open={!!deleteTarget} onOpenChange={(o) => { if (!o) setDeleteTarget(null); }}>
+        <DialogContent className="bg-blox-card border-blox-border text-blox-text ring-0 sm:max-w-md" showCloseButton={false}>
+          <DialogHeader>
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-xl bg-red-500/10">
+                <Trash2 className="w-5 h-5 text-red-400" />
+              </div>
+              <DialogTitle>Delete User</DialogTitle>
+            </div>
+            <DialogDescription className="text-blox-muted text-xs mt-2">
+              Remove <span className="text-blox-text font-medium">{deleteTarget?.username}</span>? This will revoke their access immediately.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setDeleteTarget(null)}
+              disabled={!!busyId}
+              className="text-xs text-blox-muted border-blox-border"
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleDelete}
+              disabled={!!busyId}
+              className="text-xs"
+            >
+              {busyId ? "Deleting…" : "Delete User"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </motion.div>
+  );
+}
+
+function AddUserDialog({
+  open,
+  onClose,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (u: UserRecord) => void;
+}) {
+  const { authFetch } = useAuth();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [pin, setPin] = useState("");
+  const [role, setRole] = useState<UserRole>("operator");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Reset form when reopened.
+  useEffect(() => {
+    if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setUsername("");
+      setPassword("");
+      setPin("");
+      setRole("operator");
+      setError(null);
+    }
+  }, [open]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!username.trim() || password.length < 8 || !/^\d{4,}$/.test(pin)) {
+      setError("Username, 8+ char password, and 4+ digit PIN are required.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await authFetch(`${HUB_URL}/api/users`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: username.trim(), password, pin, role }),
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok) {
+        setError(body?.error || `Create failed (${res.status})`);
+        return;
+      }
+      onCreated(body as UserRecord);
+      onClose();
+    } catch {
+      setError("Cannot reach hub");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent className="bg-blox-card border-blox-border text-blox-text ring-0 sm:max-w-md" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Add User</DialogTitle>
+          <DialogDescription className="text-blox-muted text-xs">
+            They&apos;ll have to rotate this password and PIN the first time they sign in.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="block text-[11px] uppercase tracking-[0.18em] text-blox-muted mb-1">Username</label>
+            <Input
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              autoFocus
+              autoComplete="off"
+              className="h-9 text-sm bg-blox-bg border-blox-border text-blox-text"
+              placeholder="alice"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-[11px] uppercase tracking-[0.18em] text-blox-muted mb-1">Temp password</label>
+              <Input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="new-password"
+                className="h-9 text-sm bg-blox-bg border-blox-border text-blox-text"
+                placeholder="8+ chars"
+              />
+            </div>
+            <div>
+              <label className="block text-[11px] uppercase tracking-[0.18em] text-blox-muted mb-1">Temp PIN</label>
+              <Input
+                type="password"
+                inputMode="numeric"
+                value={pin}
+                onChange={(e) => setPin(e.target.value)}
+                autoComplete="off"
+                className="h-9 text-sm bg-blox-bg border-blox-border text-blox-text font-mono"
+                placeholder="4+ digits"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-[11px] uppercase tracking-[0.18em] text-blox-muted mb-1">Role</label>
+            <div className="flex gap-2">
+              {(["admin", "operator", "viewer"] as UserRole[]).map((r) => {
+                const active = role === r;
+                const badge = ROLE_BADGE[r];
+                return (
+                  <button
+                    key={r}
+                    type="button"
+                    onClick={() => setRole(r)}
+                    className={`flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md border text-xs transition-colors ${
+                      active ? badge.cls : "border-blox-border text-blox-muted hover:text-blox-text"
+                    }`}
+                  >
+                    {badge.icon}
+                    {badge.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          {error && (
+            <p className="text-xs text-blox-red bg-red-500/10 border border-red-500/20 rounded-md px-3 py-2">{error}</p>
+          )}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onClose}
+              disabled={submitting}
+              className="text-xs text-blox-muted border-blox-border"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={submitting}
+              className="text-xs bg-blox-blue hover:bg-blox-blue/90 text-white"
+            >
+              {submitting ? "Creating…" : "Create User"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dashboard/src/contexts/AuthContext.tsx
+++ b/dashboard/src/contexts/AuthContext.tsx
@@ -5,8 +5,13 @@ import { useRouter, usePathname } from "next/navigation";
 import { ChangePasswordModal } from "@/components/ChangePasswordModal";
 import { HUB_URL, dispatchAuthChanged } from "@/lib/session";
 
+export type UserRole = "admin" | "operator" | "viewer";
+
 interface AuthContextType {
   token: string | null;
+  role: UserRole | null;
+  scopes: string[];
+  hasScope: (scope: string) => boolean;
   login: (username: string, password: string) => Promise<boolean>;
   logout: () => void;
   isAuthenticated: boolean;
@@ -21,8 +26,15 @@ export function useAuth() {
   return ctx;
 }
 
+function normalizeRole(raw: string | null): UserRole | null {
+  if (raw === "admin" || raw === "operator" || raw === "viewer") return raw;
+  return null;
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
+  const [role, setRole] = useState<UserRole | null>(null);
+  const [scopes, setScopes] = useState<string[]>([]);
   const [checked, setChecked] = useState(false);
   const [passwordChangeRequired, setPasswordChangeRequired] = useState(false);
   const [pinChangeRequired, setPinChangeRequired] = useState(false);
@@ -38,6 +50,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (payload.exp * 1000 > Date.now()) {
           // eslint-disable-next-line react-hooks/set-state-in-effect
           setToken(stored);
+          setRole(normalizeRole(localStorage.getItem("bloxos_role")));
+          try {
+            const storedScopes = JSON.parse(localStorage.getItem("bloxos_scopes") || "[]");
+            if (Array.isArray(storedScopes)) setScopes(storedScopes.filter((s) => typeof s === "string"));
+          } catch {
+            setScopes([]);
+          }
           // Check stored change requirements.
           const pwReq = localStorage.getItem("bloxos_pw_change_required");
           const pinReq = localStorage.getItem("bloxos_pin_change_required");
@@ -45,11 +64,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           if (pinReq === "true") setPinChangeRequired(true);
         } else {
           localStorage.removeItem("bloxos_token");
+          localStorage.removeItem("bloxos_role");
+          localStorage.removeItem("bloxos_scopes");
           localStorage.removeItem("bloxos_pw_change_required");
           localStorage.removeItem("bloxos_pin_change_required");
         }
       } catch {
         localStorage.removeItem("bloxos_token");
+        localStorage.removeItem("bloxos_role");
+        localStorage.removeItem("bloxos_scopes");
       }
     }
     setChecked(true);
@@ -72,6 +95,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const data = await res.json();
       localStorage.setItem("bloxos_token", data.token);
       setToken(data.token);
+
+      const nextRole = normalizeRole(typeof data.role === "string" ? data.role : null);
+      setRole(nextRole);
+      if (nextRole) {
+        localStorage.setItem("bloxos_role", nextRole);
+      } else {
+        localStorage.removeItem("bloxos_role");
+      }
+
+      const nextScopes = Array.isArray(data.scopes)
+        ? data.scopes.filter((s: unknown): s is string => typeof s === "string")
+        : [];
+      setScopes(nextScopes);
+      localStorage.setItem("bloxos_scopes", JSON.stringify(nextScopes));
+
       dispatchAuthChanged();
 
       // Check if password/PIN change is required (Finding #2).
@@ -92,14 +130,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(() => {
     localStorage.removeItem("bloxos_token");
+    localStorage.removeItem("bloxos_role");
+    localStorage.removeItem("bloxos_scopes");
     localStorage.removeItem("bloxos_pw_change_required");
     localStorage.removeItem("bloxos_pin_change_required");
     setToken(null);
+    setRole(null);
+    setScopes([]);
     setPasswordChangeRequired(false);
     setPinChangeRequired(false);
     dispatchAuthChanged();
     router.push("/login");
   }, [router]);
+
+  const hasScope = useCallback((scope: string) => scopes.includes(scope), [scopes]);
 
   const authFetch = useCallback(async (url: string, init?: RequestInit): Promise<Response> => {
     const currentToken = localStorage.getItem("bloxos_token");
@@ -146,7 +190,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ token, login, logout, isAuthenticated: !!token, authFetch }}>
+    <AuthContext.Provider value={{ token, role, scopes, hasScope, login, logout, isAuthenticated: !!token, authFetch }}>
       {/* Force password change modal (Finding #2) */}
       {token && passwordChangeRequired && (
         <ChangePasswordModal type="password" onComplete={handlePasswordChanged} />


### PR DESCRIPTION
## Summary
Closes the user-management loop. The backend (PR #28) gave admins CRUD over users; this PR gives them the dashboard to actually use it.

### AuthContext
- Stores \`role\` and \`scopes\` from the login response, persists them in localStorage alongside the JWT.
- New \`hasScope(scope)\` helper plus a \`role\` field on the auth context.
- \`logout()\` clears role + scopes too.

### Dashboard header
- New Users icon link, only rendered when \`hasScope('users.admin')\`. Operators and viewers don't see it.

### New \`/users\` page (admin-only)
- Table: username, role badge, created-at, credential-rotation status.
- **Add User** dialog: username + temp password + temp PIN + role. Newly-created users land with \`password_changed=FALSE\` so they go through the rotation flow on first login.
- Per-row role dropdown (PATCH). Defensive client-side guard refuses to demote when only one admin remains, matching the server's last-admin guard.
- Per-row delete with confirmation dialog.
- Non-admins land here → bounced to \`/\`. Server also returns 403, so the page is locked down on both ends.

### HANDOFF.md
Refreshed Done / In progress / Remaining to reflect everything that shipped this session.

## Test plan
- [x] \`pnpm lint\` green
- [x] \`pnpm build\` green
- [x] \`tsc --noEmit\` clean
- [ ] After deploy: log in as admin → /users link visible → create operator → log in as operator → /users link absent