### PR TITLE
fix(hub): detail page 500s for API-polled machines (NULL gpu_temp)

### DIFF
--- a/hub/main.go
+++ b/hub/main.go
@@ -816,8 +816,14 @@ func handleMetricsHistory(c echo.Context) error {
 	}
 
 	rows, err := db.Query(`
-		SELECT timestamp, cpu_percent, ram_used_bytes, ram_total_bytes,
-			gpu_temp, gpu_util_percent, gpu_vram_used_bytes, gpu_vram_total_bytes
+		SELECT timestamp,
+			COALESCE(cpu_percent, 0),
+			COALESCE(ram_used_bytes, 0),
+			COALESCE(ram_total_bytes, 0),
+			COALESCE(gpu_temp, 0),
+			COALESCE(gpu_util_percent, 0),
+			COALESCE(gpu_vram_used_bytes, 0),
+			COALESCE(gpu_vram_total_bytes, 0)
 		FROM metrics
 		WHERE machine_id = ? AND timestamp > datetime('now', ?)
 		ORDER BY timestamp ASC
@@ -2606,9 +2612,20 @@ func handleGetMachine(c echo.Context) error {
 		GPUVRAMUsed    int64   `json:"gpu_vram_used_bytes"`
 		GPUVRAMTotal   int64   `json:"gpu_vram_total_bytes"`
 	}
+	// COALESCE every column because API-polled machines (and agents that
+	// haven't reported GPU yet) store NULLs here, and Scan of NULL into
+	// float64/int64 fails with a 500.
 	err = db.QueryRow(`
-		SELECT cpu_percent, ram_used_bytes, ram_total_bytes, disk_used_bytes, disk_total_bytes,
-			gpu_temp, gpu_util_percent, gpu_vram_used_bytes, gpu_vram_total_bytes
+		SELECT
+			COALESCE(cpu_percent, 0),
+			COALESCE(ram_used_bytes, 0),
+			COALESCE(ram_total_bytes, 0),
+			COALESCE(disk_used_bytes, 0),
+			COALESCE(disk_total_bytes, 0),
+			COALESCE(gpu_temp, 0),
+			COALESCE(gpu_util_percent, 0),
+			COALESCE(gpu_vram_used_bytes, 0),
+			COALESCE(gpu_vram_total_bytes, 0)
 		FROM metrics WHERE machine_id = ? ORDER BY timestamp DESC LIMIT 1
 	`, id).Scan(&met.CPUPercent, &met.RAMUsedBytes, &met.RAMTotalBytes,
 		&met.DiskUsedBytes, &met.DiskTotalBytes, &met.GPUTemp, &met.GPUUtil,


### PR DESCRIPTION
## Summary
Clicking a Proxmox or Synology card from the fleet view crashed the detail page with \"Something went wrong.\"

Root cause: \`GET /api/machines/:id\` scans \`gpu_temp\` / \`gpu_util_percent\` / \`gpu_vram_*\` into \`float64\` / \`int64\`. For API-polled machines those columns are NULL (adapters don't populate GPU fields), and the SQL driver returns \`sql: Scan error on column index 5, name \"gpu_temp\": converting NULL to float64 is unsupported\`. The frontend caught the 500 with its ErrorBoundary.

## Fix
Wrap every scanned metric column in \`COALESCE(col, 0)\` in both \`handleGetMachine\` and \`handleMetricsHistory\`. NULLs become zero at the SQL boundary instead of crashing the scan. Absence-is-the-signal still applies in the UI — zero values hide their rows/tiles.

## Test plan
- [x] \`go build\` green on VM
- [ ] After deploy: click Proxmox / Synology card → detail page loads with no error