### PR TITLE
chore: ignore local dev-tool and audit artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,11 @@ Thumbs.db
 /hub/hub
 *.db-shm
 .bak
+
+# Local Claude Code / dev tool artifacts
+.backups/
+.claude/
+.turbo/
+
+# Local-only audit / analysis drafts (not meant to live in git)
+SECURITY_AUDIT_*.md


### PR DESCRIPTION
Adds `.backups/`, `.claude/`, `.turbo/`, and `SECURITY_AUDIT_*.md` to `.gitignore`. These only ever exist locally — hook output, Claude Code per-project state, and prior local audit drafts. Keeps `git status` clean.