### PR TITLE
feat(ui): hide admin actions when role lacks the required scope

### DIFF
--- a/dashboard/src/app/machine/[id]/page.tsx
+++ b/dashboard/src/app/machine/[id]/page.tsx
@@ -27,6 +27,7 @@ import {
   LayoutDashboard, Box, Container as ContainerIcon,
 } from "lucide-react";
 import { HUB_URL, getAuthHeaders } from "@/lib/session";
+import { useAuth } from "@/contexts/AuthContext";
 
 type DetailTab = "overview" | "services" | "containers" | "metrics" | "terminal";
 const DETAIL_TABS: readonly DetailTab[] = ["overview", "services", "containers", "metrics", "terminal"] as const;
@@ -157,6 +158,9 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
   const [showReboot, setShowReboot] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const { hasScope } = useAuth();
+  const canDelete = hasScope("fleet.admin");
+  const canControl = hasScope("fleet.control");
   const router = useRouter();
   const searchParams = useSearchParams();
   const activeTab = parseTab(searchParams.get("tab"));
@@ -446,16 +450,18 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
                 {timeSince(effectiveLastUpdated)}
               </span>
             )}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setShowDeleteConfirm(true)}
-              className="text-xs border-blox-border text-blox-muted hover:text-red-400 hover:border-red-500/30 gap-1.5"
-            >
-              <Trash2 className="w-3.5 h-3.5" />
-              Delete
-            </Button>
-            {!isAPIMachine && (
+            {canDelete && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="text-xs border-blox-border text-blox-muted hover:text-red-400 hover:border-red-500/30 gap-1.5"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+                Delete
+              </Button>
+            )}
+            {!isAPIMachine && canControl && (
               <Button
                 variant="outline"
                 size="sm"
@@ -500,7 +506,7 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
               <BarChart3 className="w-4 h-4" />
               Metrics
             </TabsTrigger>
-            {!isAPIMachine && (
+            {!isAPIMachine && canControl && (
               <TabsTrigger value="terminal" className="px-4 py-1.5 gap-1.5 text-sm">
                 <TerminalIcon className="w-4 h-4" />
                 Terminal
@@ -691,7 +697,7 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
           </TabsContent>
 
           {/* Terminal tab — keepMounted so the PTY WebSocket survives tab switches. */}
-          {!isAPIMachine && (
+          {!isAPIMachine && canControl && (
             <TabsContent value="terminal" keepMounted className="mt-6 data-[hidden]:hidden">
               <motion.div
                 initial={{ opacity: 0, y: 10 }}

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -84,6 +84,10 @@ export default function Home() {
   const { machines: liveMachines, connected, hasReceivedData, alertCount, alerts, setAlerts, setAlertCount } = useSSE();
   const { logout, authFetch, hasScope } = useAuth();
   const canManageUsers = hasScope("users.admin");
+  const canCreateInstallTokens = hasScope("install_tokens.admin");
+  const canManageAPIMachines = hasScope("api_machines.admin");
+  const canControlFleet = hasScope("fleet.control");
+  const canDeleteMachines = hasScope("fleet.admin");
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [sortBy, setSortBy] = useState<SortOption>("name");
@@ -370,25 +374,29 @@ export default function Home() {
               )}
             </Button>
 
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setAddMachineOpen(true)}
-              className="text-blox-blue border-blox-blue/20 bg-blox-blue/5 hover:bg-blox-blue/10 text-xs gap-1.5"
-            >
-              <Plus className="w-3.5 h-3.5" />
-              <span className="hidden sm:inline">Add Machine</span>
-            </Button>
+            {canCreateInstallTokens && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setAddMachineOpen(true)}
+                className="text-blox-blue border-blox-blue/20 bg-blox-blue/5 hover:bg-blox-blue/10 text-xs gap-1.5"
+              >
+                <Plus className="w-3.5 h-3.5" />
+                <span className="hidden sm:inline">Add Machine</span>
+              </Button>
+            )}
 
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setAddAPIMachineOpen(true)}
-              className="text-blox-blue border-blox-blue/20 bg-blox-blue/5 hover:bg-blox-blue/10 text-xs gap-1.5"
-            >
-              <Server className="w-3.5 h-3.5" />
-              <span className="hidden sm:inline">Add API</span>
-            </Button>
+            {canManageAPIMachines && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setAddAPIMachineOpen(true)}
+                className="text-blox-blue border-blox-blue/20 bg-blox-blue/5 hover:bg-blox-blue/10 text-xs gap-1.5"
+              >
+                <Server className="w-3.5 h-3.5" />
+                <span className="hidden sm:inline">Add API</span>
+              </Button>
+            )}
 
             {canManageUsers && (
               <Link
@@ -433,7 +441,7 @@ export default function Home() {
 
       {/* Bulk action bar */}
       <AnimatePresence>
-        {selected.size > 0 && viewMode === "list" && (
+        {selected.size > 0 && viewMode === "list" && canControlFleet && (
           <motion.div
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
@@ -616,8 +624,8 @@ export default function Home() {
                   <MachineCard
                     machine={m}
                     onClick={() => {}}
-                    onDelete={(id, hostname) => setDeleteTarget({id, hostname})}
-                    onEdit={openEditAPIMachine}
+                    onDelete={canDeleteMachines ? (id, hostname) => setDeleteTarget({id, hostname}) : undefined}
+                    onEdit={canManageAPIMachines ? openEditAPIMachine : undefined}
                   />
                 </motion.div>
               ))}
@@ -628,15 +636,17 @@ export default function Home() {
             <Table>
               <TableHeader>
                 <TableRow className="border-b-blox-border hover:bg-transparent">
-                  <TableHead className="w-8 text-blox-muted">
-                    <button onClick={toggleSelectAll} className="text-blox-muted hover:text-blox-text">
-                      {selected.size === filteredMachines.length && filteredMachines.length > 0 ? (
-                        <CheckSquare className="w-3.5 h-3.5 text-blox-blue" />
-                      ) : (
-                        <Square className="w-3.5 h-3.5" />
-                      )}
-                    </button>
-                  </TableHead>
+                  {canControlFleet && (
+                    <TableHead className="w-8 text-blox-muted">
+                      <button onClick={toggleSelectAll} className="text-blox-muted hover:text-blox-text">
+                        {selected.size === filteredMachines.length && filteredMachines.length > 0 ? (
+                          <CheckSquare className="w-3.5 h-3.5 text-blox-blue" />
+                        ) : (
+                          <Square className="w-3.5 h-3.5" />
+                        )}
+                      </button>
+                    </TableHead>
+                  )}
                   <TableHead className="text-blox-muted text-xs">Status</TableHead>
                   <TableHead className="text-blox-muted text-xs">Hostname</TableHead>
                   <TableHead className="text-blox-muted text-xs hidden md:table-cell">IP</TableHead>
@@ -668,15 +678,17 @@ export default function Home() {
                       key={m.machine_id}
                       className={`border-b-blox-border/30 hover:bg-blox-border/10 transition-colors ${isSelected ? "bg-blox-blue/5" : i % 2 === 1 ? "bg-blox-bg/30" : ""}`}
                     >
-                      <TableCell className="text-xs">
-                        <button onClick={(e) => { e.stopPropagation(); toggleSelect(m.machine_id); }} className="text-blox-muted hover:text-blox-text">
-                          {isSelected ? (
-                            <CheckSquare className="w-3.5 h-3.5 text-blox-blue" />
-                          ) : (
-                            <Square className="w-3.5 h-3.5" />
-                          )}
-                        </button>
-                      </TableCell>
+                      {canControlFleet && (
+                        <TableCell className="text-xs">
+                          <button onClick={(e) => { e.stopPropagation(); toggleSelect(m.machine_id); }} className="text-blox-muted hover:text-blox-text">
+                            {isSelected ? (
+                              <CheckSquare className="w-3.5 h-3.5 text-blox-blue" />
+                            ) : (
+                              <Square className="w-3.5 h-3.5" />
+                            )}
+                          </button>
+                        </TableCell>
+                      )}
                       <TableCell className="text-xs">
                         <Link href={`/machine/${m.machine_id}`}>
                           <span className={`inline-block w-2 h-2 rounded-full ${dotColor} ${status === "online" ? "shadow-sm shadow-emerald-500/50" : ""}`} />
@@ -685,7 +697,7 @@ export default function Home() {
                       <TableCell className="text-xs font-medium text-blox-text">
                         <div className="flex items-center gap-2">
                           <Link href={`/machine/${m.machine_id}`} className="hover:text-blox-blue transition-colors">{m.hostname}</Link>
-                          {isAPIMachine && (
+                          {isAPIMachine && canManageAPIMachines && (
                             <button
                               onClick={(e) => {
                                 e.preventDefault();


### PR DESCRIPTION
## Summary
- The backend already enforces RBAC and returns 403 for unauthorized writes, but the dashboard still showed every admin button regardless of role. This PR threads `useAuth().hasScope(...)` into the fleet page and detail page so operators and viewers no longer see affordances they can't use.

## What's hidden for non-admin roles

**Fleet page (`src/app/page.tsx`)**
- Add Machine button — `install_tokens.admin`
- Add API button — `api_machines.admin`
- Bulk-action bar (Restart Ollama / Restart Docker / Reboot All) — `fleet.control`
- List-view selection column — `fleet.control` (no point selecting if you can't bulk-act)
- Inline edit pencil on API-machine list rows — `api_machines.admin`
- MachineCard delete handler — `fleet.admin` (passed `undefined` when not granted, so the trash icon doesn't render)
- MachineCard edit handler — `api_machines.admin`

**Detail page (`src/app/machine/[id]/page.tsx`)**
- Delete button — `fleet.admin`
- Reboot button — `fleet.control`
- Terminal tab trigger + content — `fleet.control`

Scopes follow the existing `routeScopeRequirements` map in `hub/rbac.go` 1:1, so UI gating won't drift from server enforcement.

## Test plan
- [ ] Login as admin — every button still visible (Add Machine / Add API / bulk bar / card delete / detail Delete + Reboot + Terminal tab)
- [ ] Login as operator — Add Machine / Add API / Delete (card and detail) hidden; Reboot / Terminal / bulk bar still visible
- [ ] Login as viewer — only read-only views; bulk bar, all destructive buttons, and Terminal tab gone
- [ ] Backend 403 still fires if a viewer hand-crafts a DELETE (route-audit guard untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)