### PR TITLE
fix(hub/test): pin SetMaxOpenConns(1) to fix :memory: pool flake

### DIFF
--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -123,6 +123,13 @@ func setupTestServer(t *testing.T) *echo.Echo {
 	if err != nil {
 		t.Fatalf("open in-memory db: %v", err)
 	}
+	// SQLite ":memory:" gives each *connection* its own database. database/sql's
+	// pool can spin up extra connections under concurrent load (e.g. a
+	// handleAgentWS goroutine racing the test's own queries), and those new
+	// connections see an empty schema — manifests as "no such table:
+	// agent_credentials" flakes. Pin to one connection so all queries hit the
+	// same in-memory DB.
+	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { db.Close() })
 
 	if err := runMigrations(db); err != nil {
@@ -157,6 +164,13 @@ func setupEmptyTestServer(t *testing.T) *echo.Echo {
 	if err != nil {
 		t.Fatalf("open in-memory db: %v", err)
 	}
+	// SQLite ":memory:" gives each *connection* its own database. database/sql's
+	// pool can spin up extra connections under concurrent load (e.g. a
+	// handleAgentWS goroutine racing the test's own queries), and those new
+	// connections see an empty schema — manifests as "no such table:
+	// agent_credentials" flakes. Pin to one connection so all queries hit the
+	// same in-memory DB.
+	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { db.Close() })
 
 	if err := runMigrations(db); err != nil {


### PR DESCRIPTION
## Summary
The `TestAgentReconnectWithSecret` / `TestAgentEnrollmentWithToken` flake has been on the backlog as "needs *Hub struct refactor." Turns out it's actually a one-line fix in test setup, and the root cause isn't what HANDOFF said.

## Root cause (not what we thought)

HANDOFF documented the cause as "global db var + leaked goroutines from a prior test hitting the next test's freshly-reset in-memory DB." That hypothesis predicts wrong-row reads or constraint violations.

What we actually saw on a `-race` repro on M-series:

```
agent secret validation failed: database error: SQL logic error: no such table: agent_credentials (1)
--- FAIL: TestAgentReconnectWithSecret (1.23s)
    main_test.go:1450: reconnect with secret failed: websocket: bad handshake
```

The **table doesn't exist** on the connection that ran the query. That points squarely at SQLite `:memory:` + `database/sql` connection-pool semantics:

- `sql.Open("sqlite", ":memory:")` returns a `*sql.DB` (a pool).
- Each connection in that pool gets its own brand-new in-memory database.
- The test runs migrations on connection #1.
- When a concurrent goroutine fires (e.g. `handleAgentWS` racing the test's own queries), the pool opens connection #2.
- Connection #2 sees an empty schema → "no such table: agent_credentials".

This is a documented SQLite footgun: https://www.sqlite.org/inmemorydb.html

## Fix

Add `db.SetMaxOpenConns(1)` immediately after `sql.Open` in `setupTestServer` and `setupEmptyTestServer`. The pool is now pinned to the one connection that ran the migrations.

## Why this didn't show up in production
`bloxos.db` is a real file path, not `:memory:`. SQLite file-mode shares state across all connections in the pool — the per-connection isolation only bites the in-memory case. So no production change.

## Verification
- **Pre-fix repro on M-series:** `-race -count=20` triggered the failure on iteration 1 (in ~1.23s).
- **Pre-fix repro on Linux/x86_64 VM** (per VM-side Claude on 192.168.16.113): ~1/200 iterations.
- **Pre-fix on GHA:** ~50% (CPU contention on shared runners amplifies the race window).
- **Post-fix:** `go test -race -run 'TestAgentReconnectWithSecret|TestAgentEnrollmentWithToken' -count=20 ./...` × 3 = 60/60 green.
- **Post-fix full suite:** `go test -count=1 ./...` × 5 = 5/5 green.

## Side effect
Retires the open backlog item to introduce a `*Hub` struct that retires the package-level globals. That refactor would have been valuable for other reasons (testability, encapsulation) but isn't needed to kill the flake.

## Test plan
- [x] `go test -race -count=20` on the two flaky tests, ×3 → 60/60 green
- [x] `go test -count=1 ./...` ×5 → all green
- [ ] CI green on push (the real proof — GHA is where the flake amplified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)