### PR TITLE
feat(agent+hub): harden Windows enrollment

### DIFF
--- a/agent/hardware_windows.go
+++ b/agent/hardware_windows.go
@@ -297,6 +297,10 @@ func collectCPUFlagsWindows() []string {
 	}
 	if name == "" {
 		// Fall back to PowerShell's Get-WmiObject.
+		// Uses -Command inline string, not -File. Safe under Restricted
+		// execution policy (default on stock Windows): policy gates loading
+		// .ps1 files from disk, not inline expressions. Do not change to
+		// -File without also adding -ExecutionPolicy Bypass.
 		out, err := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive",
 			"-Command", "(Get-WmiObject Win32_Processor).Name").Output()
 		if err == nil {

--- a/agent/main.go
+++ b/agent/main.go
@@ -118,6 +118,13 @@ var (
 	token       string
 	agentSecret string
 
+	// tokenCleanupOnce gates the post-bootstrap BLOXOS_TOKEN wipe to once
+	// per process. After a service restart this runs again — which is correct:
+	// if the credential file still exists, the wipe is idempotent (env var is
+	// already gone). If the credential file is missing, the wipe condition
+	// guards us. Implementation is platform-specific; see main_<os>.go.
+	tokenCleanupOnce sync.Once
+
 	// validTarget allows alphanumeric, hyphens, underscores, dots only.
 	validTarget = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
@@ -347,10 +354,16 @@ func runAgent(machineID string) error {
 	}
 
 	q := u.Query()
-	// Prefer secret for reconnection, fall back to token for initial enrollment.
+	// Send whichever credentials we have. The hub will try the secret first
+	// (if present) and fall back to the token (if also present) when the secret
+	// fails validation. This handles credential drift cleanly: stale agent-secret
+	// + fresh enrollment token re-enrolls instead of looping with an invalid
+	// secret. See hub/agentws.go::handleAgentWS for the fallback contract:
+	// secret error → agentSecret = "" → drop into the token-mode branch.
 	if agentSecret != "" {
 		q.Set("secret", agentSecret)
-	} else if token != "" {
+	}
+	if token != "" {
 		q.Set("token", token)
 	}
 	u.RawQuery = q.Encode()
@@ -389,6 +402,13 @@ func runAgent(machineID string) error {
 				log.Printf("invalid message from hub: %v", err)
 				continue
 			}
+
+			// First successful message decode = we're authenticated. If a
+			// durable secret exists on disk, BLOXOS_TOKEN env var is no longer
+			// needed and persisting it lets re-installs accidentally inherit
+			// it. Best-effort wipe; failures don't affect this agent's
+			// operation. Platform-specific implementation in main_<os>.go.
+			tokenCleanupOnce.Do(wipeMachineTokenIfBootstrapped)
 
 			switch envelope.Type {
 			case "enrolled":

--- a/agent/main_linux.go
+++ b/agent/main_linux.go
@@ -62,6 +62,15 @@ func platformUninstallService() error {
 	return fmt.Errorf("uninstall-service is Windows-only")
 }
 
+// wipeMachineTokenIfBootstrapped is a no-op on Linux. BLOXOS_TOKEN is set in
+// the systemd unit's Environment= line, not the machine env, so wiping it
+// requires editing /etc/systemd/system/bloxos-agent.service and a daemon-
+// reload — intentionally invasive and tracked separately. The install.sh
+// flow on Linux also doesn't suffer from the bug this guards against on
+// Windows: install.sh exchanges the token for a secret before starting the
+// service, so a stale token never persists past a successful install.
+func wipeMachineTokenIfBootstrapped() {}
+
 // runPlatformAgent runs the agent in foreground mode on Linux. The systemd
 // unit invokes the binary directly, so all we need is the connection loop
 // plus signal-driven shutdown.

--- a/agent/main_windows.go
+++ b/agent/main_windows.go
@@ -4,7 +4,11 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"os/exec"
+
+	"golang.org/x/sys/windows/registry"
 )
 
 // buildPlatformCommand returns the OS-specific *exec.Cmd for an incoming
@@ -51,4 +55,40 @@ func platformUninstallService() error { return uninstallService() }
 // running under SCM and dispatches accordingly.
 func runPlatformAgent() {
 	runWindowsService()
+}
+
+// wipeMachineTokenIfBootstrapped removes BLOXOS_TOKEN from the persistent
+// machine environment (HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\
+// Environment) once the agent has a durable credential on disk. No-op if the
+// env var is unset or no credential file exists. Best-effort: failures are
+// logged but do not affect agent operation.
+//
+// Why: install.ps1 persists BLOXOS_TOKEN to machine env so the agent service
+// can read it on first start. After successful enrollment the agent has a
+// durable secret in credentialFilePath() and the token is no longer needed.
+// Persisting it indefinitely (a) is a small security smell and (b) lets a
+// re-install accidentally inherit a now-stale token.
+func wipeMachineTokenIfBootstrapped() {
+	if os.Getenv("BLOXOS_TOKEN") == "" {
+		return
+	}
+	info, err := os.Stat(credentialFilePath())
+	if err != nil || info.Size() == 0 {
+		return
+	}
+	key, err := registry.OpenKey(
+		registry.LOCAL_MACHINE,
+		`SYSTEM\CurrentControlSet\Control\Session Manager\Environment`,
+		registry.SET_VALUE,
+	)
+	if err != nil {
+		log.Printf("token-wipe: open registry: %v", err)
+		return
+	}
+	defer key.Close()
+	if err := key.DeleteValue("BLOXOS_TOKEN"); err != nil {
+		log.Printf("token-wipe: delete BLOXOS_TOKEN: %v", err)
+		return
+	}
+	log.Printf("token-wipe: removed BLOXOS_TOKEN from machine env (durable secret in place at %s)", credentialFilePath())
 }

--- a/dashboard/src/components/AddMachineModal.tsx
+++ b/dashboard/src/components/AddMachineModal.tsx
@@ -53,18 +53,33 @@ function deriveWsHubBase(): string {
 function buildWindowsCommand(token: string): string {
   const wsBase = deriveWsHubBase();
   const httpBase = deriveHttpHubBase();
-  // PHASE12-NOTE: deliberately omitting `-SkipCertificateCheck` — that
-  // flag is PowerShell 7+ only. install.ps1 itself installs a
-  // TrustAllCerts shim (see hub/agentws.go handleWindowsInstallScript)
-  // so the bootstrap IWR is the only call that needs cert tolerance.
-  // We add a Tls12 + ServerCertificateValidationCallback={$true} prelude
-  // so the IWR succeeds on PS 5.1 against a self-signed Caddy cert.
+  // Bootstrap with curl.exe (ships on Win10 1803+ and all Win11) instead
+  // of Invoke-WebRequest. IWR sits on .NET HttpWebRequest, which fails
+  // against self-signed Caddy certs over TLS 1.3 — Schannel mislabels the
+  // TLS 1.3 NewSessionTicket frame as renegotiation and HttpWebRequest
+  // bails with "underlying connection was closed". curl.exe uses Schannel
+  // for TLS but its own HTTP stack and handles both cleanly.
+  //
+  // The downloaded install.ps1 is then run via `powershell.exe
+  // -ExecutionPolicy Bypass -File`. Stock Windows PowerShell 5.1 has
+  // ExecutionPolicy=Restricted by default (all scopes Undefined → falls
+  // back to Restricted), which blocks running .ps1 files from disk. The
+  // Bypass flag scopes ONLY to that single child PowerShell process — it
+  // does NOT modify the system, user, or process-scope policy persistently.
+  // Same pattern used by winget, scoop, oh-my-posh.
+  //
+  // Why this works under Restricted: execution policy gates loading .ps1
+  // files from disk. It does NOT gate (a) inline `-Command "..."` strings,
+  // (b) string `iex`/Invoke-Expression of in-memory content, (c) built-in
+  // cmdlets, or (d) `Add-Type` C# compilation. install.ps1 itself uses
+  // only built-in cmdlets and Win32 binaries (sc.exe, curl.exe, the agent
+  // .exe), so no nested .ps1 invocations exist that would need the same
+  // bypass treatment.
   return [
     `$env:BLOXOS_HUB="${wsBase}"`,
     `$env:BLOXOS_TOKEN="${token}"`,
-    `[System.Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12`,
-    `[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}`,
-    `iwr -UseBasicParsing ${httpBase}/install.ps1 | iex`,
+    `curl.exe -ksfL -o $env:TEMP\\bloxos-install.ps1 ${httpBase}/install.ps1`,
+    `powershell.exe -ExecutionPolicy Bypass -File $env:TEMP\\bloxos-install.ps1`,
   ].join("; ");
 }
 

--- a/dashboard/src/lib/timestamps.ts
+++ b/dashboard/src/lib/timestamps.ts
@@ -1,0 +1,28 @@
+/**
+ * Parse a server-side timestamp into epoch milliseconds.
+ *
+ * Handles the timestamp formats the hub emits over the SSE stream:
+ *   1. RFC3339 / ISO 8601              — "YYYY-MM-DDTHH:MM:SS.nnnZ" (agent-emitted)
+ *   2. SQLite CURRENT_TIMESTAMP        — "YYYY-MM-DD HH:MM:SS" (UTC, no zone)
+ *   3. Go time.Time.String() via SQL   — "YYYY-MM-DD HH:MM:SS.nnnnnnnnn +0000 UTC"
+ *
+ * Returns 0 for any unparseable input. Callers MUST treat 0 as "unknown / never";
+ * never substitute Date.now() — that's the bug this helper exists to prevent.
+ * (See dashboard staleness postmortem in HANDOFF.md.)
+ */
+export function parseServerTimestamp(raw: string | number | undefined | null): number {
+  if (typeof raw === "number") return raw;
+  if (!raw) return 0;
+
+  // Try direct JS Date parse first — handles RFC3339/ISO 8601 natively.
+  const direct = Date.parse(raw);
+  if (!isNaN(direct)) return direct;
+
+  // Fall back to Go/SQLite "YYYY-MM-DD HH:MM:SS[.fff] [+0000 UTC]" normalization.
+  const isoish = raw
+    .replace(" +0000 UTC", "")
+    .replace(" UTC", "")
+    .replace(" ", "T") + "Z";
+  const fallback = Date.parse(isoish);
+  return isNaN(fallback) ? 0 : fallback;
+}

--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -280,8 +280,21 @@ func announcedSHAFor(osName string) string {
 		// Don't announce a Linux SHA to a Windows agent — that would
 		// trigger a perpetual update loop. Better to stay quiet.
 		return ""
-	default:
+	case "linux":
 		return hubAgentBinarySHA
+	default:
+		// Unknown/empty OS — don't announce a SHA at all. Same logic as
+		// the Windows protective comment above: announcing the wrong-OS
+		// SHA loops the agent through perpetual self-update. The legacy
+		// "fall back to Linux SHA for pre-Phase-9 agents" behavior is
+		// dropped because (a) every agent in the fleet now sends an `os`
+		// field with agent_running_version, and (b) lookupMetricsOS
+		// recovers the OS from DB-stored metrics for any agent that has
+		// previously sent metrics. recordAgentRunningVersion triggers a
+		// fresh announce as soon as the OS is learned, so brand-new
+		// agents still get auto-update propagation — just deferred from
+		// WS-upgrade time to first-message-arrival time.
+		return ""
 	}
 }
 
@@ -344,7 +357,9 @@ func clearReconnectExpectation(machineID string) {
 // inferred lazily from the machine's metrics OS string.
 func recordAgentRunningVersion(machineID, runningSHA, osName string) {
 	// Resolve the per-OS expected SHA. If we don't yet know the agent's
-	// OS (legacy agent), treat the linux SHA as authoritative.
+	// OS, lookupAgentOS will check the DB metrics for it. New-on-this-hub
+	// agents return "" here and that's fine — we'll announce after we
+	// learn the OS below.
 	if osName == "" {
 		osName = lookupAgentOS(machineID)
 	}
@@ -353,6 +368,7 @@ func recordAgentRunningVersion(machineID, runningSHA, osName string) {
 	hostname := lookupVersionHostname(machineID)
 
 	agentRunningVersionsMu.Lock()
+	prev, hadPrev := agentRunningVersions[machineID]
 	agentRunningVersions[machineID] = agentVersionInfo{
 		MachineID:     machineID,
 		Hostname:      hostname,
@@ -366,6 +382,20 @@ func recordAgentRunningVersion(machineID, runningSHA, osName string) {
 	if expectedSHA != "" && runningSHA == expectedSHA {
 		clearReconnectExpectation(machineID)
 		recordRolloutSuccess(machineID)
+	}
+
+	// If we just learned (or relearned) the OS, the first-connect announce
+	// was suppressed because OS was unknown at WS-upgrade time. Trigger
+	// one now. Without this, brand-new agents would never receive an
+	// update notification on their very first connect, and would have to
+	// reconnect (e.g. after a hub restart) before auto-update could fire.
+	if osName != "" && (!hadPrev || prev.OS != osName) {
+		agentsMu.RLock()
+		agent, online := agents[machineID]
+		agentsMu.RUnlock()
+		if online {
+			go announceVersionToAgent(machineID, agent)
+		}
 	}
 }
 

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -654,8 +654,7 @@ func handleAgentWS(c echo.Context) error {
 func handleWindowsInstallScript(c echo.Context) error {
 	// PowerShell raw block. Go raw strings can't contain backticks, and
 	// PowerShell doesn't strictly need them here — we keep the script
-	// backtick-free. The C# add-type block uses an @"..."@ here-string
-	// for its source which is fine inside a Go raw string.
+	// backtick-free.
 	script := `# BloxOS Windows Agent installer
 $ErrorActionPreference = 'Stop'
 
@@ -677,16 +676,9 @@ $HubHttp = $Hub -replace '^wss://','https://' -replace '^ws://','http://'
 Write-Host "Hub:    $HubHttp"
 Write-Host "WS hub: $Hub"
 
-# Allow self-signed cert during bootstrap (mirrors install.sh's curl -k).
-add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCerts {
-    public static bool Validate(object sender, X509Certificate cert, X509Chain chain, System.Net.Security.SslPolicyErrors err) { return true; }
-}
-"@
-[System.Net.ServicePointManager]::ServerCertificateValidationCallback = [TrustAllCerts]::Validate
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+# install.ps1 is invoked via 'powershell.exe -ExecutionPolicy Bypass -File'.
+# All HTTP downloads use curl.exe with -k for self-signed cert tolerance, so
+# no PowerShell-side cert callback or SecurityProtocol pinning is needed.
 
 # Stop + remove existing service if present.
 $svc = Get-Service -Name BloxOSAgent -ErrorAction SilentlyContinue
@@ -700,6 +692,35 @@ if ($svc) {
     Start-Sleep -Seconds 2
 }
 
+# Wipe stale credentials from any prior install. The Windows agent runs as
+# LocalSystem so its credential dir is C:\Windows\System32\config\systemprofile\.bloxos.
+# Without this cleanup, a re-install would inherit the prior secret and the
+# agent would attempt to authenticate with stale credentials instead of using
+# the new enrollment token. (See agent/main.go credentialFilePath() and the
+# secret>token priority in the WebSocket URL builder.)
+$CredDir = "C:\Windows\System32\config\systemprofile\.bloxos"
+if (Test-Path $CredDir) {
+    Write-Host "Removing stale agent credentials at $CredDir ..."
+    Remove-Item -Path $CredDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# Fetch the hub's local CA so the agent can validate wss:// without depending
+# on the Windows system trust store. Linux install.sh does the equivalent
+# (writes /etc/bloxos/ca.crt and sets BLOXOS_CA_CERT). Windows install.ps1
+# historically did not — fleet trust silently relied on whatever ca.crt was
+# already in .bloxos\ from a previous-era install.
+$CaPath = Join-Path $CredDir "ca.crt"
+if (-not (Test-Path $CredDir)) {
+    New-Item -ItemType Directory -Path $CredDir -Force | Out-Null
+}
+Write-Host "Downloading hub CA certificate to $CaPath ..."
+& curl.exe -ksfL -o $CaPath "$HubHttp/download/ca.crt"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "CA cert download failed (curl exit code $LASTEXITCODE)"
+    exit 1
+}
+[Environment]::SetEnvironmentVariable("BLOXOS_CA_CERT", $CaPath, "Machine")
+
 $InstallDir = "C:\Program Files\BloxOS"
 $AgentExe   = Join-Path $InstallDir "bloxos-agent.exe"
 if (-not (Test-Path $InstallDir)) {
@@ -708,7 +729,16 @@ if (-not (Test-Path $InstallDir)) {
 
 Write-Host "Downloading agent binary to $AgentExe ..."
 $DownloadUrl = "$HubHttp/download/agent?os=windows"
-Invoke-WebRequest -Uri $DownloadUrl -OutFile $AgentExe -UseBasicParsing
+# Use curl.exe (ships with Win10 1803+ and Win11) instead of Invoke-WebRequest.
+# IWR uses .NET HttpWebRequest, which mishandles TLS 1.3 post-handshake frames
+# (NewSessionTicket) and HTTP/2 ALPN against self-signed Caddy certs and bails
+# with "underlying connection was closed". curl.exe uses Schannel for TLS but
+# its own HTTP stack, which handles both cleanly.
+& curl.exe -ksfL -o $AgentExe $DownloadUrl
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Agent binary download failed (curl exit code $LASTEXITCODE)"
+    exit 1
+}
 
 # Persist HUB + TOKEN for the service to pick up at next start.
 [Environment]::SetEnvironmentVariable("BLOXOS_HUB", $Hub, "Machine")

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -1603,10 +1603,18 @@ func TestAnnouncedSHAIsPerPlatform(t *testing.T) {
 	if got := announcedSHAFor("windows"); got != windowsSHA {
 		t.Fatalf("announcedSHAFor(windows) = %s, want %s", got, windowsSHA)
 	}
-	// Empty / unknown OS should fall back to the Linux SHA so legacy
-	// agents stay coherent.
-	if got := announcedSHAFor(""); got != linuxSHA {
-		t.Fatalf("announcedSHAFor(\"\") = %s, want %s (fallback)", got, linuxSHA)
+	// Empty / unknown OS must NOT announce a SHA — the legacy "fall back
+	// to Linux SHA" behavior caused perpetual update loops on Windows
+	// agents whose OS hadn't been learned yet at WS-upgrade time.
+	// recordAgentRunningVersion now triggers an announce after the OS is
+	// learned from the first agent_running_version message, so brand-new
+	// agents still get auto-update — just deferred from WS-upgrade time
+	// to first-message-arrival time.
+	if got := announcedSHAFor(""); got != "" {
+		t.Fatalf("announcedSHAFor(\"\") = %q, want %q (no announce until OS is known)", got, "")
+	}
+	if got := announcedSHAFor("unknown"); got != "" {
+		t.Fatalf("announcedSHAFor(unknown) = %q, want %q", got, "")
 	}
 }
 


### PR DESCRIPTION
## Summary

Bundles four interrelated improvements to the Windows enrollment flow that have been sitting uncommitted in the working tree.

- **HKLM token cleanup** (`agent/main_windows.go`, `agent/main.go`, platform stubs): wipe `BLOXOS_TOKEN` from machine env once a durable agent-secret exists on disk. Gated with `sync.Once` on first successful message decode.
- **Send-both-credentials enrollment** (`agent/main.go`): send both secret AND token when both exist. Hub falls back from secret to token on validation error — handles credential drift without an agent reconnect loop.
- **Don't announce wrong-OS SHA** (`hub/agent_versions.go`): stop falling back to the Linux SHA for agents whose OS hasn't been learned yet. The legacy fallback caused perpetual self-update loops on Windows agents. `recordAgentRunningVersion` now triggers an announce as soon as the OS is learned from the first `agent_running_version` message.
- **Windows install script hardening** (`hub/agentws.go`, `dashboard/src/components/AddMachineModal.tsx`): drop the PowerShell `TrustAllCerts` C# shim, switch to `curl.exe` for HTTPS downloads (avoids IWR's TLS 1.3 NewSessionTicket bug against self-signed Caddy), bootstrap `.bloxos/ca.crt`, two-step `curl.exe + powershell.exe -File` for PS 5.1 compat.
- **Shared timestamp utility** (`dashboard/src/lib/timestamps.ts`): `parseServerTimestamp()` for RFC3339 / SQLite / Go time formats. Used by the follow-up SSE staleness PR.
- **Test contract update** (`hub/main_test.go`): `TestAnnouncedSHAIsPerPlatform` now locks in the new "no announce until OS is known" behavior + adds an unknown-OS case.

## Test plan

- [x] `cd hub && go test ./... && go vet ./...`
- [x] `cd agent && go vet ./... && GOOS=windows go vet ./... && GOOS=linux go build ./...`
- [x] `cd dashboard && pnpm lint && pnpm build`
- [ ] **Post-merge fleet smoke test (mandatory — agent CI is vacuous):**
  - `/versions` page shows ai-03 / ai-04 / FAT-LOLO online with `running_sha` matching `hubAgentBinarySHA`
  - On at least one Linux agent: `cat /etc/bloxos/ca.crt | head -1` still returns `-----BEGIN CERTIFICATE-----` (the `.bloxos/` cleanup logic must not incidentally delete the CA)
  - `journalctl -u bloxos-agent --since '5 minutes ago'` clean of `x509: certificate signed by unknown authority`
- [ ] If a real Windows host is available, smoke-test the new `curl.exe + powershell.exe -File` enrollment command end-to-end against stock PowerShell 5.1

## Notes

- The four concerns above ride together because `agent/main.go` carries interleaved hunks for the token-cleanup story and the credential-precedence story; clean per-concern splitting would require `git add -p` and risk leaving a mid-stack non-compilable commit. See plan at `/home/bokiko/.claude/plans/quiet-puzzling-dahl.md` Step 2 for the rationale.
- Agent CI runs `go test -count=1 ./...` but `agent/` ships zero `_test.go` files, so the gate is vacuous. The post-merge fleet smoke test is the actual safety net here.