### PR TITLE
fix(hub): unify password policy at 8+ chars across all endpoints

### DIFF
--- a/hub/auth.go
+++ b/hub/auth.go
@@ -169,8 +169,8 @@ func handleSetup(c echo.Context) error {
 	if body.Username == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "username is required"})
 	}
-	if len(body.Password) < 8 {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "password must be at least 8 characters"})
+	if err := validatePassword(body.Password); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 	if !regexp.MustCompile(`^\d{4,}$`).MatchString(body.PIN) {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "PIN must be at least 4 digits"})
@@ -467,8 +467,8 @@ func handleChangePassword(c echo.Context) error {
 	if err := c.Bind(&body); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid body"})
 	}
-	if body.NewPassword == "" || len(body.NewPassword) < 6 {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "new password must be at least 6 characters"})
+	if err := validatePassword(body.NewPassword); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 
 	// Get user from JWT.

--- a/hub/password.go
+++ b/hub/password.go
@@ -1,0 +1,18 @@
+package main
+
+import "errors"
+
+const minPasswordLength = 8
+
+var errPasswordTooShort = errors.New("password must be at least 8 characters")
+
+// validatePassword enforces the single source of truth for password policy
+// across first-boot setup, admin user create/update, and the self-service
+// change-password endpoint. Keep all sites routed through this helper so the
+// policy can never silently diverge again.
+func validatePassword(s string) error {
+	if len(s) < minPasswordLength {
+		return errPasswordTooShort
+	}
+	return nil
+}

--- a/hub/password_test.go
+++ b/hub/password_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestValidatePassword(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		wantErr  bool
+		wantText string
+	}{
+		{"empty", "", true, "password must be at least 8 characters"},
+		{"seven_chars", "1234567", true, "password must be at least 8 characters"},
+		{"eight_chars", "12345678", false, ""},
+		{"nine_chars", "123456789", false, ""},
+		{"long", strings.Repeat("a", 200), false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePassword(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if err.Error() != tc.wantText {
+					t.Fatalf("error text: got %q want %q", err.Error(), tc.wantText)
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// Regression: handleChangePassword used to enforce 6 chars while every other
+// endpoint enforced 8. A 7-char password should now be rejected by all four
+// password-accepting endpoints with the same error message.
+func TestChangePasswordRejectsSevenCharPassword(t *testing.T) {
+	e := setupTestServer(t)
+	token := loginAndGetToken(t, e)
+
+	body := `{"current_password":"bloxos","new_password":"7chars7"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/change-password", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "at least 8 characters") {
+		t.Fatalf("expected unified policy error, got %s", rec.Body.String())
+	}
+}
+
+func TestAdminCreateUserRejectsSevenCharPassword(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	adminToken := loginAndGetToken(t, e)
+
+	body := `{"username":"shorty","password":"7chars7","pin":"1234","role":"viewer"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/users", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "at least 8 characters") {
+		t.Fatalf("expected unified policy error, got %s", rec.Body.String())
+	}
+}

--- a/hub/users.go
+++ b/hub/users.go
@@ -38,8 +38,8 @@ func handleCreateUser(c echo.Context) error {
 	if body.Username == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "username is required"})
 	}
-	if len(body.Password) < 8 {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "password must be at least 8 characters"})
+	if err := validatePassword(body.Password); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 	if !pinPattern.MatchString(body.PIN) {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "PIN must be at least 4 digits"})
@@ -162,8 +162,8 @@ func handleUpdateUser(c echo.Context) error {
 	}
 
 	if body.Password != nil {
-		if len(*body.Password) < 8 {
-			return c.JSON(http.StatusBadRequest, map[string]string{"error": "password must be at least 8 characters"})
+		if err := validatePassword(*body.Password); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 		}
 		hash, err := bcrypt.GenerateFromPassword([]byte(*body.Password), bcrypt.DefaultCost)
 		if err != nil {


### PR DESCRIPTION
## Summary

Verified bug from a Codex audit: \`handleChangePassword\` enforced \`len(NewPassword) < 6\` while every other password-accepting endpoint (first-boot setup, admin user create, admin user update) enforced \`< 8\`. An account could start strong then silently degrade through the self-service change-password flow.

- Extracts \`validatePassword(s)\` into \`hub/password.go\` with a typed sentinel error.
- Routes all four call-sites through it so the policy can never diverge again.
- Unit tests on the helper at the 0/7/8/9-char boundary.
- HTTP regression test on \`/api/auth/change-password\` (the previously buggy endpoint) confirming a 7-char password is now rejected with the unified error.
- HTTP test on \`/api/users\` (admin-create) for symmetric coverage.

## Test plan

- [x] \`cd hub && go test ./... && go vet ./...\`
- [ ] Smoke-check: try changing your own password to a 7-char string in the dashboard — expect rejection.

## Notes

Cherry-picked from the cloud-session refinement branch \`claude/refine-local-plan-xLlSr\`. Original commit: 7597327.