### PR TITLE
chore: add OSS readiness files (LICENSE, SECURITY, CONTRIBUTING, templates, dependabot)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: ""
+labels: bug
+assignees: ""
+---
+
+**What happened**
+
+<!-- Concise description of the actual behaviour. -->
+
+**What you expected**
+
+<!-- What should have happened instead. -->
+
+**Steps to reproduce**
+
+1.
+2.
+3.
+
+**Environment**
+
+- BloxOS commit / version:
+- Component: [ ] hub  [ ] agent  [ ] dashboard
+- Hub OS:
+- Agent OS (if applicable):
+- Browser (if dashboard):
+
+**Logs / screenshots**
+
+<!-- Hub: `journalctl -u bloxos-hub` (Linux) or the systemd-equivalent.
+     Agent: `journalctl -u bloxos-agent` / Windows Event Log.
+     Dashboard: browser console.
+     REDACT any IPs, hostnames, tokens, or secrets before pasting. -->
+
+```
+```
+
+**Additional context**
+
+<!-- Anything else relevant. Delete if none. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+**Problem**
+
+<!-- What pain point or missing capability is this addressing?
+     Skip generic "it would be nice if…" — describe a concrete situation. -->
+
+**Proposed solution**
+
+<!-- Describe the change you'd like to see. UI sketch, API shape, or
+     pseudocode is welcome. -->
+
+**Alternatives considered**
+
+<!-- Other ways this could be solved, and why they're worse. Delete if none. -->
+
+**Component**
+
+[ ] hub  [ ] agent  [ ] dashboard  [ ] cross-cutting
+
+**Additional context**
+
+<!-- Links, references, related issues. Delete if none. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- 1-3 bullets: what changed and why. Link any related issue. -->
+
+## Test plan
+
+<!-- How you verified this. Examples:
+- `cd hub && go test -count=1 ./...` green
+- `cd dashboard && pnpm lint && pnpm build` green
+- Manual: redeployed hub on local VM, enrolled a fresh agent, confirmed X
+-->
+
+## Notes for reviewers
+
+<!-- Anything non-obvious: known follow-ups, deferred work, gotchas. Delete if none. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/hub"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "gomod"
+    directory: "/agent"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/dashboard"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at bokiko@users.noreply.github.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to BloxOS
+
+Thanks for your interest in BloxOS. The repo is currently maintained by a
+single operator; PRs are welcome but please open an issue first for anything
+larger than a small fix so we can agree on direction before you spend time on
+it.
+
+## Code of Conduct
+
+By participating in this project you agree to abide by the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Development setup
+
+The repo has three components, each runnable independently:
+
+```sh
+# Hub (Go API server, port 4000)
+cd hub && go run .
+
+# Agent (connects to a running hub)
+cd agent && go run . --hub ws://localhost:4000/ws/agent --token <install-token>
+
+# Dashboard (Next.js, port 3000)
+cd dashboard && pnpm install && pnpm dev
+```
+
+See `CLAUDE.md` for repo conventions and `HANDOFF.md` for the current state of
+in-progress work.
+
+## Pull request gates
+
+Before pushing, run the same checks CI runs:
+
+```sh
+( cd hub      && go test -count=1 ./... && go vet ./... )
+( cd agent    && go test -count=1 ./... && go vet ./... )
+( cd dashboard && pnpm lint && pnpm build )
+```
+
+For agent changes that affect the Windows build, also run:
+
+```sh
+( cd agent && GOOS=windows go vet ./... )
+```
+
+## Commit messages
+
+This repo uses Conventional Commits with a multi-target scope when changes
+span components:
+
+```
+<type>(<scope>): <subject>
+
+<optional body>
+```
+
+- `type` — `feat`, `fix`, `chore`, `docs`, `refactor`, `test`.
+- `scope` — one or more of `hub`, `agent`, `ui` (or `dashboard`), joined with
+  `+` when a single change touches several. Examples from the log:
+  `feat(hub+agent): Phase 9 — native Windows agent`,
+  `fix(dashboard): use server timestamps on SSE reconnect`.
+- `subject` — imperative, no trailing period, lowercase after the colon.
+
+Phase-style umbrella commits (e.g. `feat(hub+agent+ui): Phase N — …`) are
+reserved for shipped product phases tracked in `HANDOFF.md`.
+
+## Branch naming
+
+- `feat/<short-topic>`
+- `fix/<short-topic>`
+- `chore/<short-topic>`
+- `docs/<short-topic>`
+
+## What changes need a test
+
+- Hub: new endpoints, bug fixes that have a clear failure surface, security
+  changes (auth, RBAC, password/PIN policy). Use the helpers in
+  `hub/main_test.go` (`setupTestServer`, `loginAndGetToken`, etc.).
+- Agent: there are no agent unit tests yet. New code is welcome to land its
+  own `_test.go`; we'd like to start a coverage baseline rather than ship
+  another untested module.
+- Dashboard: lint + build must pass. There is no test runner yet.
+
+## Reporting bugs / requesting features
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/`. Security issues
+follow the separate process in [SECURITY.md](SECURITY.md) — do not file them
+publicly.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 bokiko
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you believe you have found a security vulnerability in BloxOS, please report
+it privately. **Do not open a public GitHub issue.**
+
+Send a description of the issue, reproduction steps, and any proof-of-concept
+to **bokiko@users.noreply.github.com**, or use GitHub's
+[private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+on this repository.
+
+You can expect:
+
+- An acknowledgement within **5 business days**.
+- A reply with our assessment and intended fix timeline within **15 business
+  days**.
+- Public disclosure (advisory + patched release) coordinated with you once a
+  fix is available.
+
+## Supported versions
+
+Only the current `main` branch receives security fixes. There are no
+long-term-support branches yet.
+
+## Scope
+
+In scope:
+
+- The hub HTTP/WebSocket API (`hub/`).
+- The agent binary and its installer (`agent/`, `scripts/install.sh`,
+  `scripts/install.ps1`).
+- The dashboard (`dashboard/`) when served by an unmodified hub.
+
+Out of scope:
+
+- Misconfigurations of operator-controlled infrastructure (Caddy reverse
+  proxy, systemd unit overrides, third-party API endpoints).
+- Vulnerabilities requiring a pre-compromised admin account or physical
+  access to the hub host.
+
+## Hardening notes
+
+- Agents must authenticate with durable, per-machine secrets. Install tokens
+  are single-use.
+- Terminal sessions require a per-session PIN gate and produce an audit log.
+- Database file permissions are enforced at `0600`.
+- Browser-side terminal tokens are short-lived (1-minute) and scoped to a
+  single session ID.


### PR DESCRIPTION
## Summary

Lays the groundwork for eventually publishing the repo without committing to a publish date. None of these files affect runtime or build.

- **LICENSE** — Apache-2.0 verbatim from apache.org with copyright filled.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1.
- **SECURITY.md** — private vuln-disclosure policy with the existing \`bokiko@users.noreply.github.com\` address; documents in-scope components and current hardening posture.
- **CONTRIBUTING.md** — dev-setup commands mirroring CLAUDE.md, plus CI gate commands and the existing commit-message convention from the log.
- **.github/PULL_REQUEST_TEMPLATE.md** — Summary / Test plan / Notes.
- **.github/ISSUE_TEMPLATE/{bug_report,feature_request}.md** — minimal templates with redaction reminders.
- **.github/dependabot.yml** — weekly updates for hub gomod, agent gomod, dashboard npm, and github-actions.

CodeQL and THREAT_MODEL.md stay deferred until the actual publish moment per \`thoughts/shared/plans/2026-04-27-go-public.md\`.

## Test plan

- [x] No code changes — runtime/build untouched.
- [ ] Post-merge: verify GitHub auto-detects LICENSE as Apache-2.0 (visible in repo sidebar).

## Notes

Cherry-picked from the cloud-session refinement branch \`claude/refine-local-plan-xLlSr\`. Original commit: cc47df4.