### PR TITLE
docs(CLAUDE): add audit conventions + Caddy RSA-2048 rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,10 @@ Update it before any commit that changes project state.
 - All terminal I/O logged for audit
 - Credentials NEVER committed — use env vars or local config
 - Dark mode is the default UI theme
+- Caddy TLS uses RSA-2048 keys, not ECDSA. Do not change without testing on stock Windows PowerShell 5.1.
+
+## Audit conventions
+Every code change has two failure surfaces — audit both:
+- **Forward audit**: what could break *because of* the change?
+- **Backward audit (stale-preamble pass)**: what was relying on the old behavior and is now stranded? Anytime the calling shell, parent context, or invocation model changes (e.g. `iwr | iex` → `powershell.exe -File`, parent-shell env vars → child-process env), code that depended on the old context becomes suspect and needs explicit re-evaluation.
+- **Incidental-deletion audit**: when a cleanup step wipes a directory, registry key, or shared resource, enumerate every consumer that reads from it — not just the producer that wrote the thing you're targeting. Wiping `.bloxos/` to remove a stale `agent-secret` may also delete a `ca.crt` that TLS validation silently depends on.


### PR DESCRIPTION
## Summary

Captures two hard-won lessons in CLAUDE.md so future sessions don't have to re-derive them:

1. **Caddy TLS uses RSA-2048, not ECDSA.** Don't change without testing on stock Windows PowerShell 5.1 — ECDSA leaf certs interact badly with PS 5.1's Schannel / TLS 1.3 stack against self-signed origins.
2. **Three-axis audit convention** for code changes: forward audit (what breaks because of this?), backward audit (what relied on the old behavior?), and **incidental-deletion audit** (when a cleanup wipes a dir, enumerate every consumer that reads from it). The third axis was written after the \`.bloxos/\` cleanup nearly took \`ca.crt\` with it during Phase 9 enrollment work.

## Test plan

- [x] Doc-only change. No build/test impact.

## Notes

These guidance entries are referenced by the Windows-enrollment-hardening PR (#42). Landing them as a separate doc PR keeps the diff there focused on code.