### PR TITLE
fix(dashboard): use server timestamps on SSE reconnect, not Date.now()

### DIFF
--- a/dashboard/src/contexts/SSEContext.tsx
+++ b/dashboard/src/contexts/SSEContext.tsx
@@ -16,6 +16,7 @@ import {
   getStoredToken,
 } from "@/lib/session";
 import { readCache, clearCache, makeDebouncedWriter } from "@/lib/metrics-cache";
+import { parseServerTimestamp } from "@/lib/timestamps";
 
 interface SSEContextType {
   machines: MachineMetrics[];
@@ -161,7 +162,16 @@ export function SSEProvider({ children }: { children: ReactNode }) {
         setMachineMap(() => {
           const next = new Map<string, MachineMetrics>();
           for (const m of list) {
-            next.set(m.machine_id, { ...m, last_seen: Date.now() });
+            // Snapshot's `timestamp` field carries the latest metric row's
+            // server-side time (COALESCE(met.timestamp, m.last_seen) in
+            // hub/main.go::getEnrichedMachinesJSON). Parse it; never
+            // substitute Date.now() — that would mark every machine "live"
+            // on every reconnect regardless of actual liveness.
+            // See dashboard staleness postmortem in HANDOFF.md.
+            next.set(m.machine_id, {
+              ...m,
+              last_seen: parseServerTimestamp(m.timestamp),
+            });
           }
           // Persist to cache so the next page load hydrates instantly.
           cacheWriterRef.current?.(Array.from(next.values()));
@@ -179,7 +189,14 @@ export function SSEProvider({ children }: { children: ReactNode }) {
         setHasReceivedData(true);
         setMachineMap((prev) => {
           const next = new Map(prev);
-          next.set(m.machine_id, { ...m, last_seen: Date.now() });
+          // Per-metric event carries the agent's `timestamp`. Parse it.
+          // If parsing fails, fall back to 0 (machine flips to "offline" in
+          // 120s) rather than Date.now() — a malformed timestamp is not
+          // evidence the machine is alive.
+          next.set(m.machine_id, {
+            ...m,
+            last_seen: parseServerTimestamp(m.timestamp),
+          });
           cacheWriterRef.current?.(Array.from(next.values()));
           return next;
         });

--- a/dashboard/src/lib/demo-data.ts
+++ b/dashboard/src/lib/demo-data.ts
@@ -27,7 +27,7 @@ export interface MachineMetrics {
   gpus?: GPUInfo[];
   tags?: string;
   timestamp: string;
-  last_seen?: number; // epoch ms, set by dashboard
+  last_seen?: number; // epoch ms, parsed from server `timestamp` (see lib/timestamps.ts)
   latency_ms?: number;
 }
 


### PR DESCRIPTION
## Summary

When the SSE connection reconnects, the dashboard was substituting \`Date.now()\` for any metric timestamp it couldn't parse. That hid stale data — a metric from 5 minutes ago would render as \"just now\" on reconnect, masking agent disconnects.

Routes both the snapshot list handler and the per-metric event handler through \`parseServerTimestamp()\` (added in #42), which:
- Returns 0 on unparseable input — UI then renders \"—\", which is honest about not knowing.
- Handles all three formats the hub emits: RFC3339, SQLite \`CURRENT_TIMESTAMP\`, and Go \`time.Time.String()\`.

Also updates the \`demo-data.ts\` comment to point at the new utility.

## Test plan

- [x] \`pnpm lint && pnpm build\`
- [ ] Manual: kill the SSE connection, wait, reconnect — \`last_seen\` on the snapshot rendering should reflect the original server timestamp, not the moment of reconnect.

## Notes

PR #2 of the cleanup plan. PR #1 (#42) merged first to ship the \`timestamps.ts\` utility this depends on.