### PR TITLE
fix(hub): quote 'error' literal in API machine status upsert (C1)

### DIFF
--- a/hub/main.go
+++ b/hub/main.go
@@ -850,6 +850,20 @@ func storeMetrics(m AgentMetrics) {
 	}
 }
 
+// markAPIMachineError upserts an API-polled machine row with status='error'.
+// Called by startAPIPoller when its periodic poll returns an error so the
+// dashboard reflects the failed-poll state. Returns the underlying SQL error
+// (if any) so the caller can log it — the prior call site swallowed errors,
+// which masked a SQL syntax bug for the entire lifetime of the API-machines
+// feature.
+func markAPIMachineError(machineID, hostname, adapterType string) error {
+	_, err := db.Exec(`INSERT INTO machines (id, hostname, status, tags, last_seen)
+		VALUES (?, ?, 'error', ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET status = 'error', last_seen = CURRENT_TIMESTAMP`,
+		machineID, hostname, adapterType)
+	return err
+}
+
 func markOffline(machineID string) {
 	_, err := db.Exec(`UPDATE machines SET status = 'offline' WHERE id = ?`, machineID)
 	if err != nil {
@@ -2305,12 +2319,9 @@ func startAPIPoller(id, name, adapterType, baseURL string, authConfig json.RawMe
 			if err != nil {
 				log.Printf("api poll error: %s (%s): %v", name, adapterType, err)
 				db.Exec("UPDATE api_machines SET last_error = ?, last_poll_at = CURRENT_TIMESTAMP WHERE id = ?", err.Error(), id)
-				// Set machine status to error.
-				machineID := "api-" + id
-				db.Exec(`INSERT INTO machines (id, hostname, status, tags, last_seen)
-					VALUES (?, ?, error, ?, CURRENT_TIMESTAMP)
-					ON CONFLICT(id) DO UPDATE SET status = 'error', last_seen = CURRENT_TIMESTAMP`,
-					machineID, name, adapterType)
+				if mErr := markAPIMachineError("api-"+id, name, adapterType); mErr != nil {
+					log.Printf("api poll: error-status upsert failed for %s: %v", name, mErr)
+				}
 			} else {
 				storeAPIPollResult(id, name, adapterType, result)
 				db.Exec("UPDATE api_machines SET last_poll_at = CURRENT_TIMESTAMP, last_error = NULL WHERE id = ?", id)

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -2419,3 +2419,64 @@ func TestHardwareInfoUpsertPreCreatesRow(t *testing.T) {
 		t.Fatalf("upsertMachine clobbered hardware_info: got %q", hwAfter.String)
 	}
 }
+
+// TestAPIMachineErrorUpsert locks in the SQL contract for the API-poll
+// error path. Pre-fix bug: the literal `error` keyword in
+// VALUES (?, ?, error, ?, ...) was unquoted, so SQLite parsed it as a
+// column reference and the INSERT crashed at runtime — silently, because
+// the caller (startAPIPoller's goroutine in hub/main.go) discarded the
+// error. Result: API-polled machines (Synology / Proxmox / etc.) never
+// transitioned to `status='error'` in the dashboard when their poll
+// failed. The fix quotes the literal as 'error'.
+//
+// This test calls the extracted markAPIMachineError helper directly so
+// failure propagates as a return value, not a swallowed log line.
+func TestAPIMachineErrorUpsert(t *testing.T) {
+	_ = setupTestServer(t)
+
+	machineID := "api-c1-test"
+	displayName := "test-synology"
+	adapter := "synology"
+
+	t.Cleanup(func() {
+		_, _ = db.Exec(`DELETE FROM machines WHERE id = ?`, machineID)
+	})
+
+	// First call: INSERT path. Must not error and must write status='error'.
+	if err := markAPIMachineError(machineID, displayName, adapter); err != nil {
+		t.Fatalf("markAPIMachineError (insert): %v", err)
+	}
+
+	var hostname, status, tags string
+	if err := db.QueryRow(
+		`SELECT hostname, status, COALESCE(tags, '') FROM machines WHERE id = ?`,
+		machineID,
+	).Scan(&hostname, &status, &tags); err != nil {
+		t.Fatalf("read after insert: %v", err)
+	}
+	if status != "error" {
+		t.Errorf("status after insert = %q, want %q", status, "error")
+	}
+	if hostname != displayName {
+		t.Errorf("hostname after insert = %q, want %q", hostname, displayName)
+	}
+	if tags != adapter {
+		t.Errorf("tags after insert = %q, want %q", tags, adapter)
+	}
+
+	// Second call: ON CONFLICT UPDATE path. Must not error and must keep
+	// status='error'. (Also validates the ON CONFLICT branch itself.)
+	if err := markAPIMachineError(machineID, displayName, adapter); err != nil {
+		t.Fatalf("markAPIMachineError (upsert): %v", err)
+	}
+
+	var statusAfterUpsert string
+	if err := db.QueryRow(
+		`SELECT status FROM machines WHERE id = ?`, machineID,
+	).Scan(&statusAfterUpsert); err != nil {
+		t.Fatalf("read after upsert: %v", err)
+	}
+	if statusAfterUpsert != "error" {
+		t.Errorf("status after upsert = %q, want %q", statusAfterUpsert, "error")
+	}
+}


### PR DESCRIPTION
## Summary

**Phase A bug C1.** Reported by external code analysis, verified, fixed with TDD.

The INSERT in \`startAPIPoller\`'s error path used the unquoted token \`error\` in:

\`\`\`sql
INSERT INTO machines (id, hostname, status, tags, last_seen)
VALUES (?, ?, error, ?, CURRENT_TIMESTAMP)
\`\`\`

SQLite parsed \`error\` as a column reference. The column doesn't exist, so the INSERT crashed at runtime — **silently**, because the goroutine called \`db.Exec(...)\` and discarded the return value.

**Net effect:** API-polled machines (Synology, Proxmox, etc.) never transitioned to \`status='error'\` in the dashboard when their poll failed. The per-poll error message did get written to \`api_machines.last_error\`, but the machine row stayed at whatever status it had previously.

## Fix

Two-part:

1. **Extract** the upsert into \`markAPIMachineError(machineID, hostname, adapterType) error\`. The poll goroutine now logs the upsert error if it happens (it shouldn't, after the SQL fix, but the logging closes the visibility gap that hid this bug for so long).
2. **Quote** the literal as \`'error'\`.

## Test plan

- [x] \`TestAPIMachineErrorUpsert\` added in \`hub/main_test.go\`. Covers both INSERT (first call) and ON CONFLICT UPDATE (second call) paths. Asserts \`status='error'\`, \`hostname=name\`, \`tags=adapterType\`.
- [x] Verified red→green flow:
  - Test compile-fails before \`markAPIMachineError\` exists (red)
  - With helper extracted but SQL still buggy: test fails with \`"SQL logic error: no such column: error (1)"\` (red, with bug-specific signal)
  - After \`error\` → \`'error'\`: test passes (green)
- [x] \`cd hub && go test ./... && go vet ./...\` green
- [x] \`cd agent && go vet ./...\` green (no agent files touched)
- [ ] Smoke-check post-merge: induce a poll failure on a real API machine (e.g. Dasman / Dell when re-added) and verify dashboard shows \`status='error'\`.

## Notes

- Test discipline per \`/home/bokiko/.claude/plans/quiet-puzzling-dahl.md\`: failing test first → minimal fix → green. The red was demonstrated as a real SQL error from the bug, not just an absent function.
- Single bug, single PR. Phase A C2–C5 follow as separate PRs.