### PR TITLE
fix(hub): close agent reconnect race in handleAgentWS exit path (C2)

### DIFF
--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -42,6 +42,29 @@ func registerAgentConnection(machineID string, agent *ConnectedAgent) {
 	go announceVersionToAgent(machineID, agent)
 }
 
+// unregisterAgentConnection is the symmetric cleanup for
+// registerAgentConnection. Called from handleAgentWS's read-loop exit
+// path. Only flips the machine to offline AND deletes the agents map
+// entry when the entry under machineID still points at THIS connection
+// — otherwise we'd false-offline a fast-reconnecting agent whose new
+// handler already overwrote the entry. Empty machineID (auth never
+// succeeded) is a no-op.
+func unregisterAgentConnection(machineID string, agent *ConnectedAgent) {
+	if machineID == "" {
+		return
+	}
+	agentsMu.Lock()
+	current, ok := agents[machineID]
+	stillOurs := ok && current == agent
+	if stillOurs {
+		delete(agents, machineID)
+	}
+	agentsMu.Unlock()
+	if stillOurs {
+		markOffline(machineID)
+	}
+}
+
 func handleCreateToken(c echo.Context) error {
 	ip := getRealIP(c)
 	if !rateLimiter.Allow("token_create", ip, 3) {
@@ -447,12 +470,7 @@ func handleAgentWS(c echo.Context) error {
 		_, msg, err := ws.ReadMessage()
 		if err != nil {
 			log.Printf("agent disconnected: %v", err)
-			if machineID != "" {
-				markOffline(machineID)
-				agentsMu.Lock()
-				delete(agents, machineID)
-				agentsMu.Unlock()
-			}
+			unregisterAgentConnection(machineID, agent)
 			return nil
 		}
 

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -2466,6 +2466,152 @@ func TestHardwareInfoUpsertPreCreatesRow(t *testing.T) {
 	}
 }
 
+// TestUnregisterAgentConnectionDeletesOwn verifies the happy path:
+// when a connection cleanly exits and no reconnect has happened,
+// unregisterAgentConnection removes the entry. Without this baseline,
+// the identity-check logic in the next test could be vacuous.
+func TestUnregisterAgentConnectionDeletesOwn(t *testing.T) {
+	_ = setupTestServer(t)
+
+	mid := "test-c2-clean-exit"
+	conn := &ConnectedAgent{}
+
+	t.Cleanup(func() {
+		agentsMu.Lock()
+		delete(agents, mid)
+		agentsMu.Unlock()
+	})
+
+	agentsMu.Lock()
+	agents[mid] = conn
+	agentsMu.Unlock()
+
+	unregisterAgentConnection(mid, conn)
+
+	agentsMu.RLock()
+	_, exists := agents[mid]
+	agentsMu.RUnlock()
+	if exists {
+		t.Errorf("agents[%q] should have been deleted by its owning connection", mid)
+	}
+}
+
+// TestUnregisterAgentConnectionLeavesNewerEntry locks in the C2 fix:
+// when a fast-reconnect has installed a new ConnectedAgent at the same
+// machine_id BEFORE the prior handler's defer fires, the prior defer
+// must NOT delete the new entry. Pre-fix code at hub/agentws.go:450-454
+// did `delete(agents, machineID)` unconditionally, causing a real
+// production false-offline on flaky-network agents.
+//
+// Deterministic — no sleeps, no goroutines. Simulates the race by
+// sequentially registering A → registering B (overwrite) → running
+// A's cleanup → asserting B is still there.
+func TestUnregisterAgentConnectionLeavesNewerEntry(t *testing.T) {
+	_ = setupTestServer(t)
+
+	mid := "test-c2-reconnect-race"
+	connA := &ConnectedAgent{}
+	connB := &ConnectedAgent{}
+
+	t.Cleanup(func() {
+		agentsMu.Lock()
+		delete(agents, mid)
+		agentsMu.Unlock()
+	})
+
+	agentsMu.Lock()
+	agents[mid] = connA
+	agentsMu.Unlock()
+
+	// Simulate fast reconnect — B installs itself before A's cleanup runs.
+	agentsMu.Lock()
+	agents[mid] = connB
+	agentsMu.Unlock()
+
+	// A's defer fires. Must not touch B.
+	unregisterAgentConnection(mid, connA)
+
+	agentsMu.RLock()
+	got, exists := agents[mid]
+	agentsMu.RUnlock()
+	if !exists {
+		t.Fatalf("agents[%q] was deleted; expected B's entry to remain", mid)
+	}
+	if got != connB {
+		t.Errorf("agents[%q] = %p, want %p (connB)", mid, got, connB)
+	}
+}
+
+// TestUnregisterAgentConnectionEmptyMachineIDNoOp guards the call site:
+// handleAgentWS may call cleanup with machineID="" if auth never
+// succeeded. Helper must no-op rather than delete the "" key.
+func TestUnregisterAgentConnectionEmptyMachineIDNoOp(t *testing.T) {
+	_ = setupTestServer(t)
+
+	sentinel := &ConnectedAgent{}
+	agentsMu.Lock()
+	agents[""] = sentinel
+	agentsMu.Unlock()
+	t.Cleanup(func() {
+		agentsMu.Lock()
+		delete(agents, "")
+		agentsMu.Unlock()
+	})
+
+	unregisterAgentConnection("", &ConnectedAgent{})
+
+	agentsMu.RLock()
+	got, exists := agents[""]
+	agentsMu.RUnlock()
+	if !exists || got != sentinel {
+		t.Errorf("empty-machineID call must be a no-op; got=%p exists=%v want=%p", got, exists, sentinel)
+	}
+}
+
+// TestUnregisterAgentConnectionMarksOfflineOnlyForOwn validates that
+// markOffline (status='offline' in DB) is also gated by the identity
+// check. Without it, a fast-reconnect briefly flips the dashboard to
+// offline before B's metrics flip it back — visible flicker on the UI.
+func TestUnregisterAgentConnectionMarksOfflineOnlyForOwn(t *testing.T) {
+	_ = setupTestServer(t)
+
+	mid := "test-c2-offline-gating"
+	connA := &ConnectedAgent{}
+	connB := &ConnectedAgent{}
+
+	t.Cleanup(func() {
+		_, _ = db.Exec(`DELETE FROM machines WHERE id = ?`, mid)
+		agentsMu.Lock()
+		delete(agents, mid)
+		agentsMu.Unlock()
+	})
+
+	if _, err := db.Exec(
+		`INSERT INTO machines (id, hostname, status) VALUES (?, ?, 'online')`,
+		mid, "c2-offline-host",
+	); err != nil {
+		t.Fatalf("seed machine: %v", err)
+	}
+
+	// B has reconnected after A's drop.
+	agentsMu.Lock()
+	agents[mid] = connB
+	agentsMu.Unlock()
+
+	// A's cleanup runs. Must NOT flip status to offline because B is alive.
+	unregisterAgentConnection(mid, connA)
+
+	var status string
+	if err := db.QueryRow(
+		`SELECT status FROM machines WHERE id = ?`, mid,
+	).Scan(&status); err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if status != "online" {
+		t.Errorf("status flipped to %q despite B being live; want 'online'", status)
+	}
+}
+
 // TestAPIMachineErrorUpsert locks in the SQL contract for the API-poll
 // error path. Pre-fix bug: the literal `error` keyword in
 // VALUES (?, ?, error, ?, ...) was unquoted, so SQLite parsed it as a


### PR DESCRIPTION
## Summary

**Phase A bug C2.** Reported by external code analysis, verified, fixed with TDD.

When an agent's WebSocket dropped, \`handleAgentWS\` unconditionally ran:

\`\`\`go
markOffline(machineID)
delete(agents, machineID)
\`\`\`

No identity check on \`agents[machineID]\`. If the agent reconnected fast (flaky network, NAT timeout, brief Wi-Fi blip) before the prior handler's defer fired, the new connection's freshly-installed entry got deleted. Dashboard then briefly showed the agent as offline even though it was healthy.

## Fix

Symmetric helper \`unregisterAgentConnection\` next to the existing \`registerAgentConnection\`:

1. No-ops on \`machineID=\"\"\` (auth never succeeded).
2. Locks \`agentsMu\`, reads \`agents[machineID]\`.
3. Only deletes (and only then calls \`markOffline\`) if the entry under that key is still the same \`*ConnectedAgent\` pointer that's exiting.

\`handleAgentWS\` ends its read-loop error path with a single helper call.

## Test plan

Four tests, all deterministic (no goroutines, no \`time.Sleep\`):

- \`TestUnregisterAgentConnectionDeletesOwn\` — happy-path baseline. Without it, the next test's identity-check could be vacuous.
- \`TestUnregisterAgentConnectionLeavesNewerEntry\` — locks in the C2 fix. Sequentially: register A → register B (overwrite) → run A's cleanup → assert B survives.
- \`TestUnregisterAgentConnectionEmptyMachineIDNoOp\` — defensive. Helper must accept \`\"\"\` without deleting the empty-string key.
- \`TestUnregisterAgentConnectionMarksOfflineOnlyForOwn\` — DB-side. \`markOffline\` is gated by the same identity check, otherwise the dashboard flickers offline before B's metrics come in.

**Red→green proof:** temporarily reverted the helper to the original inline behaviour (unconditional delete + markOffline). \`TestUnregisterAgentConnectionLeavesNewerEntry\` and \`TestUnregisterAgentConnectionMarksOfflineOnlyForOwn\` both failed with bug-specific signal. Restored the fix; all four pass; full hub suite stable across 3 consecutive runs.

- [x] \`cd hub && go test ./... && go vet ./...\` (3 stable runs)
- [x] \`cd agent && go vet ./...\` (no agent files touched)
- [ ] Smoke-check post-merge: induce flaky-network reconnect on a fleet member; \`/versions\` page stays \"online\" through the reconnect.

## Notes

- Per the plan's design rule for race tests: deterministic synchronization, not timing.
- One bug, one PR. C3–C5 follow as separate PRs.