### PR TITLE
fix(agent): coordinate terminal Wait() through once-gated waiter (C3)

### DIFF
--- a/agent/main_linux.go
+++ b/agent/main_linux.go
@@ -13,11 +13,41 @@ import (
 	"os/signal"
 	"os/user"
 	"strconv"
+	"sync"
 	"syscall"
 
 	"github.com/creack/pty"
 	"github.com/gorilla/websocket"
 )
+
+// waitable is what waitOnce coordinates over. Defined as an interface
+// so tests can substitute a fake without spawning a real process.
+// *exec.Cmd satisfies it via its Wait() method.
+type waitable interface {
+	Wait() error
+}
+
+// waitOnce ensures Wait() is called exactly once on the underlying
+// waitable, regardless of how many goroutines race for the result.
+// Used by handleStartTerminal where both the cleanup defer and the
+// waitCh goroutine would otherwise call cmd.Wait() — calling Wait()
+// twice on a *exec.Cmd is undefined per stdlib contract.
+type waitOnce struct {
+	once sync.Once
+	err  error
+	cmd  waitable
+}
+
+func newWaitOnce(cmd waitable) *waitOnce {
+	return &waitOnce{cmd: cmd}
+}
+
+func (w *waitOnce) Wait() error {
+	w.once.Do(func() {
+		w.err = w.cmd.Wait()
+	})
+	return w.err
+}
 
 // buildPlatformCommand returns the OS-specific *exec.Cmd for an incoming
 // hub command. Linux uses sudo+systemd+docker.
@@ -162,10 +192,14 @@ func handleStartTerminal(cmd Command, rawMsg []byte) {
 		log.Printf("terminal: pty.Start failed: %v", err)
 		return
 	}
+	// waitOnce coordinates Wait() between the cleanup defer below and
+	// the waitCh goroutine further down. Calling cmd.Wait() twice is
+	// undefined per stdlib; the coordinator caches the first result.
+	waiter := newWaitOnce(bashCmd)
 	defer func() {
 		ptmx.Close()
 		_ = bashCmd.Process.Kill()
-		_, _ = bashCmd.Process.Wait()
+		_ = waiter.Wait()
 		log.Printf("terminal session %s: PTY cleaned up", sessionID)
 	}()
 
@@ -256,9 +290,11 @@ func handleStartTerminal(cmd Command, rawMsg []byte) {
 	}()
 
 	// Wait for either direction to finish, or for the bash process to exit.
+	// Routed through waiter so the cleanup defer's Wait() and this Wait()
+	// share the same single underlying call.
 	waitCh := make(chan error, 1)
 	go func() {
-		waitCh <- bashCmd.Wait()
+		waitCh <- waiter.Wait()
 	}()
 
 	select {

--- a/agent/main_linux_test.go
+++ b/agent/main_linux_test.go
@@ -1,0 +1,107 @@
+//go:build linux
+
+// First-ever test file in agent/. Establishes the test pattern for the
+// package. Future Linux-only agent tests anchor here. PTY-touching tests
+// must be gated behind BLOXOS_PTY_TEST=1 to keep CI runs portable
+// across runner environments that lack /dev/ptmx.
+
+package main
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+// fakeWaitable counts the number of times Wait() is invoked. Used by
+// the waitOnce coordinator tests to prove the underlying Wait is called
+// exactly once regardless of how many goroutines race for it.
+type fakeWaitable struct {
+	mu    sync.Mutex
+	calls int
+	err   error
+}
+
+func (f *fakeWaitable) Wait() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.err
+}
+
+func (f *fakeWaitable) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// TestWaitCoordinatorCallsUnderlyingWaitOnce locks in the C3 fix:
+// in agent/main_linux.go, both the cleanup defer and the waitCh
+// goroutine called bashCmd.Wait() / bashCmd.Process.Wait() on the
+// same command. Per stdlib contract, Wait may only be called once
+// per *exec.Cmd; the second call's behaviour is undefined.
+//
+// Fix introduces a waitOnce coordinator: many callers can ask for
+// the result, only the first triggers the underlying Wait. This test
+// runs five concurrent Wait calls against a fake and asserts the fake
+// observes exactly one call. Pure unit test — no PTY, no /dev/ptmx,
+// runs in any CI.
+func TestWaitCoordinatorCallsUnderlyingWaitOnce(t *testing.T) {
+	const goroutines = 5
+	wantErr := errors.New("test-exit-status")
+	fake := &fakeWaitable{err: wantErr}
+	waiter := newWaitOnce(fake)
+
+	var wg sync.WaitGroup
+	results := make([]error, goroutines)
+	start := make(chan struct{})
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		i := i
+		go func() {
+			defer wg.Done()
+			<-start // synchronise so all goroutines call Wait() simultaneously
+			results[i] = waiter.Wait()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := fake.callCount(); got != 1 {
+		t.Errorf("underlying Wait was called %d times, want 1", got)
+	}
+	for i, r := range results {
+		if !errors.Is(r, wantErr) {
+			t.Errorf("results[%d] = %v, want %v", i, r, wantErr)
+		}
+	}
+
+	// Subsequent calls must also return the cached error without
+	// calling the underlying Wait again.
+	if got := waiter.Wait(); !errors.Is(got, wantErr) {
+		t.Errorf("post-completion Wait() = %v, want %v", got, wantErr)
+	}
+	if got := fake.callCount(); got != 1 {
+		t.Errorf("post-completion call count = %d, want 1", got)
+	}
+}
+
+// TestWaitCoordinatorPropagatesNilError covers the happy-path case
+// where the underlying command exited cleanly (Wait returned nil).
+// All callers must see nil; the cached-result path must not synthesise
+// a fake "already finished" error.
+func TestWaitCoordinatorPropagatesNilError(t *testing.T) {
+	fake := &fakeWaitable{err: nil}
+	waiter := newWaitOnce(fake)
+
+	if err := waiter.Wait(); err != nil {
+		t.Errorf("first Wait() = %v, want nil", err)
+	}
+	if err := waiter.Wait(); err != nil {
+		t.Errorf("second Wait() = %v, want nil", err)
+	}
+	if got := fake.callCount(); got != 1 {
+		t.Errorf("call count = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

**Phase A bug C3.** Reported by external code analysis, verified, fixed with TDD.

\`handleStartTerminal\` in \`agent/main_linux.go\` called Wait() on the same \`*exec.Cmd\` from two paths:

- Cleanup defer at line 168: \`_, _ = bashCmd.Process.Wait()\`
- Bash-exit goroutine at line 261: \`waitCh <- bashCmd.Wait()\`

Calling Wait twice is undefined per Go's stdlib contract. In practice on Linux it returns \`\"wait: no child processes\"\` on the second call, and both sites discarded the error — so the bug was invisible, but the contract violation could surface as a panic on a future Go version or under unusual scheduling.

## Fix

Small \`waitOnce\` coordinator (\`sync.Once\` around the underlying Wait). Both call sites route through it. Many callers can ask for the result; only the first triggers Wait. Subsequent callers see the cached error.

Defined over a \`waitable\` interface (\`Wait() error\`) so tests can use a fake — no PTY required for unit coverage. \`*exec.Cmd\` satisfies the interface implicitly.

## Test plan

**\`agent/main_linux_test.go\` is the first agent test file in the project.** Two unit tests, no \`/dev/ptmx\`:

- \`TestWaitCoordinatorCallsUnderlyingWaitOnce\` — five concurrent goroutines call \`waiter.Wait()\`. Asserts the fake's underlying \`Wait\` was invoked exactly once and every caller observes the same returned error.
- \`TestWaitCoordinatorPropagatesNilError\` — happy-path. Coordinator must propagate \`nil\` when the underlying Wait returned cleanly (no synthesised \"already finished\" errors).

**Red→green proof:** temporarily replaced the once-gated body with a direct \`w.cmd.Wait()\` call. Both tests failed with bug-specific signal (\`\"Wait was called 5 times, want 1\"\` and \`\"call count = 2, want 1\"\`). Restored the fix; tests pass.

- [x] \`cd agent && go test ./... && go vet ./... && GOOS=windows go vet ./...\`
- [x] \`cd hub && go test ./... && go vet ./...\` (no hub changes but discipline gate)
- [ ] **PTY integration test deferred** to a follow-up PR gated behind \`BLOXOS_PTY_TEST=1\`. Not in CI by default per plan note about \`creack/pty\` portability across runner environments.
- [ ] Smoke-check post-merge: open a terminal session in dashboard, close the browser tab, verify no panics in agent log on the next \`journalctl -u bloxos-agent\`.

## Notes

- C4 (UID/GID parse → root) reuses this same \`agent/main_linux_test.go\` file, so the next PR will be cheaper.