### PR TITLE
fix(agent): fail-closed on UID/GID parse error in terminal session (C4)

### DIFF
--- a/agent/main_linux.go
+++ b/agent/main_linux.go
@@ -49,6 +49,48 @@ func (w *waitOnce) Wait() error {
 	return w.err
 }
 
+// applyTerminalCredentials configures bashCmd to run as termUser, or
+// returns an error if the user's UID/GID cannot be parsed. Pre-fix
+// behaviour at agent/main_linux.go:139-140 was
+// `uid, _ := strconv.ParseUint(...)` — discarding the error meant a
+// malformed /etc/passwd entry would silently produce uid=0 (root) and
+// the spawned shell would inherit root privileges. Now any parse
+// failure aborts the call site rather than falling back to root.
+//
+// Nil termUser and termUser.Uid == "0" both fall through with
+// SysProcAttr unset, matching the existing behaviour where the spawned
+// shell inherits the agent's identity (root). The caller logs a
+// WARNING in that case so the deployment misconfiguration is visible.
+func applyTerminalCredentials(bashCmd *exec.Cmd, termUser *user.User) error {
+	if termUser == nil || termUser.Uid == "0" {
+		bashCmd.Env = append(os.Environ(), "TERM=xterm-256color")
+		return nil
+	}
+	uid, err := strconv.ParseUint(termUser.Uid, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parse uid %q for user %q: %w", termUser.Uid, termUser.Username, err)
+	}
+	gid, err := strconv.ParseUint(termUser.Gid, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parse gid %q for user %q: %w", termUser.Gid, termUser.Username, err)
+	}
+	bashCmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{
+			Uid: uint32(uid),
+			Gid: uint32(gid),
+		},
+	}
+	bashCmd.Dir = termUser.HomeDir
+	bashCmd.Env = []string{
+		"TERM=xterm-256color",
+		"HOME=" + termUser.HomeDir,
+		"USER=" + termUser.Username,
+		"SHELL=/bin/bash",
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	}
+	return nil
+}
+
 // buildPlatformCommand returns the OS-specific *exec.Cmd for an incoming
 // hub command. Linux uses sudo+systemd+docker.
 func buildPlatformCommand(cmdType, target string) (*exec.Cmd, error) {
@@ -165,26 +207,17 @@ func handleStartTerminal(cmd Command, rawMsg []byte) {
 	// agent binary's parent directory, or "bokiko", or current user.
 	bashCmd := exec.Command("bash", "-l")
 	termUser := resolveTerminalUser()
+	if err := applyTerminalCredentials(bashCmd, termUser); err != nil {
+		// Fail-closed: if the resolved user's UID/GID strings cannot be
+		// parsed, refuse to start the session rather than silently
+		// running bash as the agent's identity (root). Better to surface
+		// a confusing terminal failure than escalate.
+		log.Printf("terminal: refusing to start session — credential setup failed: %v", err)
+		return
+	}
 	if termUser != nil && termUser.Uid != "0" {
-		uid, _ := strconv.ParseUint(termUser.Uid, 10, 32)
-		gid, _ := strconv.ParseUint(termUser.Gid, 10, 32)
-		bashCmd.SysProcAttr = &syscall.SysProcAttr{
-			Credential: &syscall.Credential{
-				Uid: uint32(uid),
-				Gid: uint32(gid),
-			},
-		}
-		bashCmd.Dir = termUser.HomeDir
-		bashCmd.Env = []string{
-			"TERM=xterm-256color",
-			"HOME=" + termUser.HomeDir,
-			"USER=" + termUser.Username,
-			"SHELL=/bin/bash",
-			fmt.Sprintf("PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"),
-		}
 		log.Printf("terminal: spawning shell as user %s (uid=%s)", termUser.Username, termUser.Uid)
 	} else {
-		bashCmd.Env = append(os.Environ(), "TERM=xterm-256color")
 		log.Printf("terminal: WARNING spawning shell as current user (root)")
 	}
 	ptmx, err := pty.Start(bashCmd)

--- a/agent/main_linux_test.go
+++ b/agent/main_linux_test.go
@@ -9,6 +9,8 @@ package main
 
 import (
 	"errors"
+	"os/exec"
+	"os/user"
 	"sync"
 	"testing"
 )
@@ -103,5 +105,126 @@ func TestWaitCoordinatorPropagatesNilError(t *testing.T) {
 	}
 	if got := fake.callCount(); got != 1 {
 		t.Errorf("call count = %d, want 1", got)
+	}
+}
+
+// TestApplyTerminalCredentials_NonNumericUIDFailsClosed locks in C4:
+// when the resolved terminal user has a UID string that cannot be
+// parsed as an integer, applyTerminalCredentials must return an error
+// rather than silently defaulting to UID 0 (root). The pre-fix code
+// at agent/main_linux.go:139-140 used `uid, _ := strconv.ParseUint(...)`
+// which made parse failure a privilege-escalation vector by malformed
+// /etc/passwd content.
+func TestApplyTerminalCredentials_NonNumericUIDFailsClosed(t *testing.T) {
+	bashCmd := exec.Command("/bin/true")
+	termUser := &user.User{
+		Uid:      "not-a-number",
+		Gid:      "1000",
+		Username: "nope",
+		HomeDir:  "/home/nope",
+	}
+
+	err := applyTerminalCredentials(bashCmd, termUser)
+	if err == nil {
+		t.Fatal("expected error for non-numeric UID, got nil")
+	}
+	// SysProcAttr must NOT have been set — the whole point is that we
+	// abort BEFORE configuring the process to run as anything.
+	if bashCmd.SysProcAttr != nil {
+		t.Errorf("SysProcAttr was set despite parse failure: %+v", bashCmd.SysProcAttr)
+	}
+}
+
+// TestApplyTerminalCredentials_NonNumericGIDFailsClosed mirrors the
+// UID test for GID. A valid UID + invalid GID must still abort —
+// otherwise a malformed group entry would put us in root's gid (0).
+func TestApplyTerminalCredentials_NonNumericGIDFailsClosed(t *testing.T) {
+	bashCmd := exec.Command("/bin/true")
+	termUser := &user.User{
+		Uid:      "1000",
+		Gid:      "junk",
+		Username: "nope",
+		HomeDir:  "/home/nope",
+	}
+
+	err := applyTerminalCredentials(bashCmd, termUser)
+	if err == nil {
+		t.Fatal("expected error for non-numeric GID, got nil")
+	}
+	if bashCmd.SysProcAttr != nil {
+		t.Errorf("SysProcAttr was set despite GID parse failure: %+v", bashCmd.SysProcAttr)
+	}
+}
+
+// TestApplyTerminalCredentials_ValidUser is the happy-path baseline.
+// Without it the fail-closed tests could pass by always returning an
+// error, even on valid input.
+func TestApplyTerminalCredentials_ValidUser(t *testing.T) {
+	bashCmd := exec.Command("/bin/true")
+	termUser := &user.User{
+		Uid:      "1000",
+		Gid:      "1000",
+		Username: "ok",
+		HomeDir:  "/home/ok",
+	}
+
+	if err := applyTerminalCredentials(bashCmd, termUser); err != nil {
+		t.Fatalf("unexpected error for valid user: %v", err)
+	}
+	if bashCmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr was not set for a valid user")
+	}
+	if bashCmd.SysProcAttr.Credential == nil {
+		t.Fatal("Credential was not set for a valid user")
+	}
+	if got := bashCmd.SysProcAttr.Credential.Uid; got != 1000 {
+		t.Errorf("Credential.Uid = %d, want 1000", got)
+	}
+	if got := bashCmd.SysProcAttr.Credential.Gid; got != 1000 {
+		t.Errorf("Credential.Gid = %d, want 1000", got)
+	}
+	if bashCmd.Dir != "/home/ok" {
+		t.Errorf("Dir = %q, want /home/ok", bashCmd.Dir)
+	}
+}
+
+// TestApplyTerminalCredentials_NilUserFallback covers the existing
+// pre-Phase-A behaviour: if no non-root user can be resolved, we fall
+// back to running as the current user (which on the agent host means
+// root). The helper must accept this without error — it's the right
+// behaviour for a misconfigured single-user host where no
+// BLOXOS_TERMINAL_USER, "bokiko", or other candidate exists. SysProcAttr
+// stays nil so the spawned process inherits the agent's identity.
+func TestApplyTerminalCredentials_NilUserFallback(t *testing.T) {
+	bashCmd := exec.Command("/bin/true")
+
+	if err := applyTerminalCredentials(bashCmd, nil); err != nil {
+		t.Fatalf("nil user must not error (it's the documented fallback): %v", err)
+	}
+	if bashCmd.SysProcAttr != nil {
+		t.Errorf("SysProcAttr was set for nil user: %+v", bashCmd.SysProcAttr)
+	}
+}
+
+// TestApplyTerminalCredentials_RootUserFallback covers the same
+// fallback path when the resolved user happens to be root (UID 0).
+// We deliberately skip the credential setup in that case rather than
+// setting Credential{Uid:0, Gid:0} — both produce the same effect but
+// the no-SysProcAttr form is what the existing code does and what
+// callers test against.
+func TestApplyTerminalCredentials_RootUserFallback(t *testing.T) {
+	bashCmd := exec.Command("/bin/true")
+	termUser := &user.User{
+		Uid:      "0",
+		Gid:      "0",
+		Username: "root",
+		HomeDir:  "/root",
+	}
+
+	if err := applyTerminalCredentials(bashCmd, termUser); err != nil {
+		t.Fatalf("root user must not error (existing fallback): %v", err)
+	}
+	if bashCmd.SysProcAttr != nil {
+		t.Errorf("SysProcAttr was set for root fallback: %+v", bashCmd.SysProcAttr)
 	}
 }


### PR DESCRIPTION
## Summary

**Phase A bug C4.** Reported by external code analysis as a privilege-escalation vector. Verified, fixed with TDD.

\`handleStartTerminal\` at \`agent/main_linux.go:139-140\` did:

\`\`\`go
uid, _ := strconv.ParseUint(termUser.Uid, 10, 32)
gid, _ := strconv.ParseUint(termUser.Gid, 10, 32)
\`\`\`

Discarded errors. On parse failure both vars defaulted to **0 (root)**, and the spawned bash inherited \`Credential{Uid: 0, Gid: 0}\` — so any malformed user record reaching this path produced a privilege escalation instead of a refusal.

Realistically the resolved user comes from \`os/user\` lookups against \`/etc/passwd\`, so a parse failure would only happen on a corrupted host. Even so: silent root-fallback violates the documented intent of the surrounding code (\"Spawn bash PTY as non-root user for security\") and is exactly the kind of thing a security audit demands fail-closed handling for.

## Fix

Extract the credential-setup logic into \`applyTerminalCredentials(bashCmd, termUser) error\`:

1. Returns \`nil\` + leaves \`SysProcAttr\` unset for \`nil\` termUser or \`termUser.Uid == \"0\"\` (matches existing fallback semantics).
2. Returns a wrapped error on \`ParseUint\` failure for either UID or GID.
3. Otherwise sets \`Credential\`, \`Dir\`, and the same fixed \`Env\` list the pre-fix inline code wrote.

\`handleStartTerminal\` calls the helper and \`return\`s early on error. Session simply does not start; no fallback to root.

## Test plan

Five tests in \`agent/main_linux_test.go\` (extending the C3 file):

- \`TestApplyTerminalCredentials_NonNumericUIDFailsClosed\` — locks in the fix
- \`TestApplyTerminalCredentials_NonNumericGIDFailsClosed\` — same for GID
- \`TestApplyTerminalCredentials_ValidUser\` — happy-path baseline (otherwise the fail-closed tests could pass by always returning an error)
- \`TestApplyTerminalCredentials_NilUserFallback\` — existing nil-user fallback intact
- \`TestApplyTerminalCredentials_RootUserFallback\` — existing root fallback intact

**Red→green proof:** temporarily reverted to the original \`uid, _ := strconv.ParseUint(...)\` body. The two fail-closed tests failed with \`\"expected error for non-numeric UID, got nil\"\` (and GID equivalent). The other three still passed because they don't depend on parse-error handling. Restored the fix; all five pass.

- [x] \`cd agent && go test ./... && go vet ./... && GOOS=windows go vet ./...\`
- [x] \`cd hub && go test ./... && go vet ./...\` (no hub changes; discipline gate)
- [ ] Smoke-check post-deploy: open a terminal session in dashboard against the live agent. Should still work normally for \`bokiko\` user.

## Notes

- Last bug in Phase A's \`agent/main_linux.go\` thread. C5 closes Phase A with the API machine IP fix in hub/.