### PR TITLE
fix(hub): derive API-polled machine IP from baseURL, not display name (C5)

### DIFF
--- a/hub/main.go
+++ b/hub/main.go
@@ -2167,7 +2167,7 @@ func handleForceAPIPoll(c echo.Context) error {
 		return c.JSON(http.StatusBadGateway, map[string]string{"error": pollErr.Error()})
 	}
 
-	storeAPIPollResult(id, m.Name, m.AdapterType, result)
+	storeAPIPollResult(id, m.Name, m.AdapterType, m.BaseURL, result)
 	db.Exec("UPDATE api_machines SET last_poll_at = CURRENT_TIMESTAMP, last_error = NULL WHERE id = ?", id)
 
 	return c.JSON(http.StatusOK, map[string]interface{}{
@@ -2193,23 +2193,46 @@ func doPoll(adapterType, baseURL string, authConfig json.RawMessage, tlsConfig j
 	}
 }
 
+// extractAPIMachineIP returns the IP address (or hostname) for an
+// API-polled machine. If the adapter has already discovered the IP,
+// that wins — it's the authoritative answer from inside the device.
+// Otherwise we parse baseURL (a well-formed URL the user typed when
+// registering the machine) and return its hostname.
+//
+// Pre-fix bug at hub/main.go:2208 fed the *display name* into the
+// strip-and-split logic instead of baseURL. For a machine named e.g.
+// "dasman-syn" this produced "dasman-syn" as the IP — meaningless,
+// and rendered as a garbage value in the dashboard's IP column.
+func extractAPIMachineIP(baseURL, resultIP string) string {
+	if resultIP != "" {
+		return resultIP
+	}
+	if baseURL == "" {
+		return ""
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return ""
+	}
+	// url.Parse accepts "not-a-valid-url" because RFC 3986 allows
+	// path-only refs. Reject anything without a scheme — those aren't
+	// the well-formed baseURLs handleCreateAPIMachine validates and
+	// stores.
+	if u.Scheme == "" {
+		return ""
+	}
+	return u.Hostname()
+}
+
 // storeAPIPollResult upserts the machine and inserts metrics.
-func storeAPIPollResult(apiMachineID, name, adapterType string, result *APIPollResult) {
+func storeAPIPollResult(apiMachineID, name, adapterType, baseURL string, result *APIPollResult) {
 	machineID := "api-" + apiMachineID
 	hostname := result.Hostname
 	if hostname == "" {
 		hostname = name
 	}
 
-	// Extract IP from base_url if not provided.
-	ip := result.IP
-	if ip == "" {
-		// Try to extract host from URL.
-		parts := strings.Split(strings.TrimPrefix(strings.TrimPrefix(name, "https://"), "http://"), ":")
-		if len(parts) > 0 {
-			ip = parts[0]
-		}
-	}
+	ip := extractAPIMachineIP(baseURL, result.IP)
 
 	// Upsert machine.
 	_, err := db.Exec(`INSERT INTO machines (id, hostname, ip, os, status, tags, last_seen)
@@ -2323,7 +2346,7 @@ func startAPIPoller(id, name, adapterType, baseURL string, authConfig json.RawMe
 					log.Printf("api poll: error-status upsert failed for %s: %v", name, mErr)
 				}
 			} else {
-				storeAPIPollResult(id, name, adapterType, result)
+				storeAPIPollResult(id, name, adapterType, baseURL, result)
 				db.Exec("UPDATE api_machines SET last_poll_at = CURRENT_TIMESTAMP, last_error = NULL WHERE id = ?", id)
 			}
 

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -2466,6 +2466,78 @@ func TestHardwareInfoUpsertPreCreatesRow(t *testing.T) {
 	}
 }
 
+// TestExtractAPIMachineIP locks in C5: the IP for an API-polled
+// machine must be derived from the baseURL field (which is always a
+// well-formed URL the user typed when registering the machine), NOT
+// from the display-name field. The pre-fix code at hub/main.go:2208
+// did `strings.TrimPrefix(strings.TrimPrefix(name, "https://"), "http://")`
+// against the wrong variable — for typical display names like
+// "dasman-syn" or "Synology NAS" this produced garbage IP values like
+// "dasman-syn" in the machines table.
+//
+// When the adapter has already discovered the IP via its API
+// (result.IP), prefer that — it's the canonical answer. Fall back to
+// parsing baseURL only when the adapter didn't report one.
+func TestExtractAPIMachineIP(t *testing.T) {
+	cases := []struct {
+		name      string
+		baseURL   string
+		resultIP  string
+		want      string
+	}{
+		{
+			name:     "adapter_provided_ip_wins",
+			baseURL:  "https://192.168.16.50:5001",
+			resultIP: "10.0.0.1",
+			want:     "10.0.0.1",
+		},
+		{
+			name:    "extract_ip_from_https_url_with_port",
+			baseURL: "https://192.168.16.50:5001",
+			want:    "192.168.16.50",
+		},
+		{
+			name:    "extract_ip_from_https_url_no_port",
+			baseURL: "https://192.168.16.50",
+			want:    "192.168.16.50",
+		},
+		{
+			name:    "extract_hostname_from_url",
+			baseURL: "https://syn.local:5001",
+			want:    "syn.local",
+		},
+		{
+			name:    "extract_from_http_url",
+			baseURL: "http://10.20.30.40:8006",
+			want:    "10.20.30.40",
+		},
+		{
+			name:    "ipv6_url",
+			baseURL: "https://[2001:db8::1]:5001",
+			want:    "2001:db8::1",
+		},
+		{
+			name:    "garbage_baseurl_returns_empty",
+			baseURL: "not-a-valid-url",
+			want:    "",
+		},
+		{
+			name:    "empty_inputs_return_empty",
+			baseURL: "",
+			want:    "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractAPIMachineIP(tc.baseURL, tc.resultIP)
+			if got != tc.want {
+				t.Errorf("extractAPIMachineIP(%q, %q) = %q, want %q",
+					tc.baseURL, tc.resultIP, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestUnregisterAgentConnectionDeletesOwn verifies the happy path:
 // when a connection cleanly exits and no reconnect has happened,
 // unregisterAgentConnection removes the entry. Without this baseline,


### PR DESCRIPTION
## Summary

**Phase A bug C5.** Final Phase A bug. Reported by external code analysis, verified, fixed with TDD.

\`storeAPIPollResult\` at \`hub/main.go:2208\` did:

\`\`\`go
parts := strings.Split(strings.TrimPrefix(strings.TrimPrefix(name,
    \"https://\"), \"http://\"), \":\")
if len(parts) > 0 { ip = parts[0] }
\`\`\`

against the **display name** parameter, not \`baseURL\`. For typical machine names like \`\"dasman-syn\"\` or \`\"Synology NAS\"\` this produced garbage IP values like \`\"dasman-syn\"\` being written into the \`machines\` table — the dashboard's IP column then showed an unhelpful copy of the name.

## Fix

Extract \`extractAPIMachineIP(baseURL, resultIP) string\`:

1. Adapter-provided \`resultIP\` wins (it's the authoritative answer from inside the device).
2. Else parse \`baseURL\` via \`net/url\` and return \`Hostname()\`.
3. \`\"\"\` for garbage / scheme-less / empty input.

\`storeAPIPollResult\` now takes \`baseURL\` as a parameter; both call sites (\`handleForceAPIPoll\` at line 2170 and the periodic polling goroutine at line 2349) already had it in scope so this is plumbing, not new state.

## Test plan

\`TestExtractAPIMachineIP\` is table-driven across eight input shapes:

| baseURL | resultIP | want |
|---|---|---|
| \`https://192.168.16.50:5001\` | \`10.0.0.1\` | \`10.0.0.1\` (adapter wins) |
| \`https://192.168.16.50:5001\` | (empty) | \`192.168.16.50\` |
| \`https://192.168.16.50\` | (empty) | \`192.168.16.50\` |
| \`https://syn.local:5001\` | (empty) | \`syn.local\` |
| \`http://10.20.30.40:8006\` | (empty) | \`10.20.30.40\` |
| \`https://[2001:db8::1]:5001\` | (empty) | \`2001:db8::1\` |
| \`not-a-valid-url\` | (empty) | \`\"\"\` |
| (empty) | (empty) | \`\"\"\` |

- [x] \`cd hub && go test ./... && go vet ./...\` (8/8 sub-cases pass)
- [x] \`cd agent && go vet ./...\` (no agent changes)
- [ ] Smoke-check post-deploy: re-add a Dasman / Dell / Synology API machine via the dashboard with a friendly name and a separate URL; verify the dashboard IP column shows the URL's hostname, not the friendly name.

## Phase A status after this merges

| | Status |
|---|---|
| A0.1 \`-race\` baseline | deferred via #60 |
| A0.2 dashboard CI | already in place |
| C1 SQL \`error\` literal | merged #61 |
| C2 agent reconnect race | merged #62 |
| C3 terminal Wait() | merged #63 |
| C4 UID parse → root | merged #64 |
| **C5 API machine IP** | this PR |

After this merges: tag \`v1.0.0-rc1\`, hot-deploy with full smoke test, then begin Phase B.