### PR TITLE
feat(hub): recover panics in long-running goroutines (B1)

### DIFF
--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -81,8 +81,8 @@ var (
 
 // initAgentVersionTracking is called from main() at hub startup.
 func initAgentVersionTracking() {
-	go versionRefreshLoop()
-	go reconnectMonitorLoop()
+	goSafelyForever("versionRefreshLoop", versionRefreshLoop)
+	goSafelyForever("reconnectMonitorLoop", reconnectMonitorLoop)
 }
 
 func versionRefreshLoop() {

--- a/hub/main.go
+++ b/hub/main.go
@@ -200,10 +200,10 @@ func main() {
 	}
 
 	// Start alert evaluation loop.
-	go alertEvalLoop()
+	goSafelyForever("alertEvalLoop", alertEvalLoop)
 
 	// Start cleanup goroutine.
-	go cleanupLoop()
+	goSafelyForever("cleanupLoop", cleanupLoop)
 	startAPIPollers()
 
 	e := echo.New()

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -2463,6 +2464,65 @@ func TestHardwareInfoUpsertPreCreatesRow(t *testing.T) {
 	}
 	if !hwAfter.Valid || hwAfter.String != hardwareJSON {
 		t.Fatalf("upsertMachine clobbered hardware_info: got %q", hwAfter.String)
+	}
+}
+
+// TestRunWithRecoverCatchesPanic locks in B1: every long-running hub
+// goroutine (alertEvalLoop, cleanupLoop, versionRefreshLoop,
+// reconnectMonitorLoop, terminalRelay) was previously a `go funcName()`
+// spawn with no panic recovery. A panic inside any of them silently
+// killed that subsystem until the next hub restart — alerts stop
+// firing, cleanup stops running, agent SHAs go stale, terminals
+// stop relaying. Net effect: invisible degradation.
+//
+// runWithRecover is the inner seam that wraps the panicking call and
+// reports back whether a panic occurred. Tested directly; the outer
+// goSafelyForever (which uses a sleep + for-loop to restart) is a
+// thin wrapper reviewed by inspection.
+func TestRunWithRecoverCatchesPanic(t *testing.T) {
+	cases := []struct {
+		name      string
+		fn        func()
+		wantPanic bool
+	}{
+		{
+			name:      "no_panic_returns_false",
+			fn:        func() {},
+			wantPanic: false,
+		},
+		{
+			name:      "string_panic_returns_true",
+			fn:        func() { panic("boom") },
+			wantPanic: true,
+		},
+		{
+			name:      "error_panic_returns_true",
+			fn:        func() { panic(errors.New("typed")) },
+			wantPanic: true,
+		},
+		{
+			name:      "nil_panic_returns_true",
+			fn:        func() { panic(nil) },
+			wantPanic: true,
+		},
+		{
+			name:      "runtime_panic_returns_true",
+			fn:        func() { var p *int; _ = *p }, // nil-deref
+			wantPanic: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("runWithRecover let a panic propagate to the caller: %v", r)
+				}
+			}()
+			got := runWithRecover("test/"+tc.name, tc.fn)
+			if got != tc.wantPanic {
+				t.Errorf("runWithRecover panicked=%v, want %v", got, tc.wantPanic)
+			}
+		})
 	}
 }
 

--- a/hub/safety.go
+++ b/hub/safety.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"log"
+	"runtime/debug"
+	"time"
+)
+
+// goroutineRestartBackoff is how long goSafelyForever waits before
+// restarting a recovered or unexpectedly-returned goroutine. Long
+// enough that a tight panic loop doesn't overwhelm the log; short
+// enough that real recovery is timely.
+const goroutineRestartBackoff = 5 * time.Second
+
+// runWithRecover runs fn synchronously inside a defer/recover, logs
+// the recovered value + stack on panic, and returns true if a panic
+// was caught. Returns false if fn returned normally.
+//
+// This is the testable seam for the panic-recovery pattern. The outer
+// goSafelyForever / goSafelyOnce wrappers are too coupled to the
+// goroutine + sleep model to test cleanly without polluting the suite
+// with timing — tests target this function directly.
+func runWithRecover(name string, fn func()) (panicked bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("goroutine %s: PANIC recovered: %v\n%s", name, r, debug.Stack())
+			panicked = true
+		}
+	}()
+	fn()
+	return false
+}
+
+// goSafelyForever spawns fn in a new goroutine for an indefinite
+// background loop. If fn panics OR returns unexpectedly, the wrapper
+// logs the event and restarts fn after goroutineRestartBackoff. Use
+// for things that are supposed to run forever — alertEvalLoop,
+// cleanupLoop, versionRefreshLoop, reconnectMonitorLoop. A normal
+// return is treated as a bug too: the loop body in those functions is
+// itself an infinite for-loop, so reaching the end of fn is
+// pathological and we restart anyway.
+func goSafelyForever(name string, fn func()) {
+	go func() {
+		for {
+			panicked := runWithRecover(name, fn)
+			if !panicked {
+				log.Printf("goroutine %s: returned without panic — unexpected for a forever-loop, restarting after backoff",
+					name)
+			}
+			time.Sleep(goroutineRestartBackoff)
+		}
+	}()
+}
+
+// goSafelyOnce spawns fn in a new goroutine for a one-shot task that's
+// expected to terminate (e.g. a per-session terminal relay). Panics
+// are recovered and logged, but the goroutine does not restart — the
+// caller owns the lifecycle and will create a new goroutine for the
+// next session if needed. Without this wrapper, a panic in a session
+// handler would crash the whole hub process.
+func goSafelyOnce(name string, fn func()) {
+	go func() {
+		_ = runWithRecover(name, fn)
+	}()
+}

--- a/hub/terminal.go
+++ b/hub/terminal.go
@@ -315,7 +315,7 @@ func handleTerminalWS(c echo.Context) error {
 	session.mu.Unlock()
 
 	if agentWS != nil && browserWS != nil {
-		go terminalRelay(sessionID, session)
+		goSafelyOnce("terminalRelay/"+sessionID, func() { terminalRelay(sessionID, session) })
 	} else {
 		go func() {
 			time.Sleep(30 * time.Second)


### PR DESCRIPTION
## Summary

**Phase B item.** Five hub goroutines spawned with bare \`go func()\` had no panic recovery. A panic in any of them silently killed that subsystem until the next hub restart:

- \`alertEvalLoop\` (alerts stop firing)
- \`cleanupLoop\` (DB cleanup stops, audit/orphan rows pile up)
- \`versionRefreshLoop\` (agent SHAs go stale, auto-update breaks)
- \`reconnectMonitorLoop\` (rollout circuit breaker stops working)
- \`terminalRelay\` (per-session: WS connection hangs, browser sees dead terminal)

Net effect: invisible degradation that an operator only notices when something downstream breaks.

## Fix

New file \`hub/safety.go\` with three primitives:

- \`runWithRecover(name, fn) bool\` — synchronous recover + log of panic value + stack trace. Returns whether a panic was caught. **Testable seam.**
- \`goSafelyForever(name, fn)\` — for indefinite background loops. Spawns fn; on panic OR unexpected return, logs and restarts after 5s backoff.
- \`goSafelyOnce(name, fn)\` — for one-shot goroutines (e.g. per-session terminal relay). Recover + log, no restart.

Replaces the five spawn sites. Each loop function is unchanged — wrappers are external.

## Test plan

\`TestRunWithRecoverCatchesPanic\` covers five panic shapes table-driven:

| Scenario | Expected |
|---|---|
| no panic | returns false |
| \`panic(\"boom\")\` | returns true |
| \`panic(errors.New(...))\` | returns true |
| \`panic(nil)\` (Go 1.21+ \`runtime.PanicNilError\`) | returns true |
| nil-deref runtime panic | returns true |

Each sub-test also asserts the panic does NOT propagate to the test goroutine — that's the actual contract: the wrapper must contain the panic regardless of shape.

The outer \`goSafelyForever\` / \`goSafelyOnce\` are thin wrappers (for-loop + sleep on panic). Testing them deterministically would require injecting a fake sleep — the cost outweighs the benefit since the only logic is the loop. Reviewed by inspection.

- [x] \`cd hub && go test ./... && go vet ./...\` (5/5 sub-tests, full suite green)
- [x] \`cd agent && go vet ./...\` (no agent changes)
- [ ] Smoke-check post-deploy: \`journalctl -u bloxos-hub\` should be silent on \"goroutine ... PANIC recovered\" under normal operation. If a panic does fire later (real bug), the log line + stack trace make root cause obvious.

## Notes

- First Phase B PR. C1–C5 (Phase A) all merged + tagged \`v1.0.0-rc1\`.
- Next: B2 \`/ws/agent\` rate limit (pattern from \`/api/auth/login\`).