### PR TITLE
feat(hub): rate limit /ws/agent to 30 upgrades/min/IP (B2)

### DIFF
--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -412,7 +412,22 @@ func handleDownloadCACert(c echo.Context) error {
 	return c.Blob(http.StatusOK, "application/x-pem-file", caPEM)
 }
 
+// wsAgentRateLimit caps WebSocket-upgrade requests to /ws/agent at this
+// many per minute, per source IP. Real agents reconnect at most a few
+// times per minute (a cycling Caddy-loopback agent peaks around 2/min,
+// fleet-wide reconnect after hub restart hits maybe 5/min). 30/min/IP
+// gives ~10x headroom for legitimate use while shutting down an
+// FD-exhaustion flood from any single source. The full fleet still
+// scales fine because each agent gets its own bucket.
+const wsAgentRateLimit = 30
+
 func handleAgentWS(c echo.Context) error {
+	ip := getRealIP(c)
+	if !rateLimiter.Allow("ws_agent", ip, wsAgentRateLimit) {
+		log.Printf("rate limit exceeded: ws_agent from %s", ip)
+		return c.JSON(http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
+	}
+
 	token := c.QueryParam("token")
 	agentSecret := c.QueryParam("secret")
 

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -2467,6 +2467,56 @@ func TestHardwareInfoUpsertPreCreatesRow(t *testing.T) {
 	}
 }
 
+// TestAgentWSRateLimited locks in B2: /ws/agent had no rate limit
+// before this fix. A flood of WebSocket upgrade requests could exhaust
+// the hub's file descriptors and goroutine count — the agent endpoint
+// was the only request handler in the hub without a rateLimiter.Allow
+// gate. Modeled on TestLoginRateLimiting.
+//
+// The handler now rejects the (N+1)th request from the same IP within
+// a one-minute window with HTTP 429. Real agents reconnect at most a
+// few times per minute even on flaky networks, so wsAgentRateLimit=30
+// per minute leaves significant headroom while shutting down a flood.
+func TestAgentWSRateLimited(t *testing.T) {
+	e := setupTestServer(t)
+
+	const ip = "10.99.0.1:55555"
+	var lastCode int
+	for i := 0; i < wsAgentRateLimit+1; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/ws/agent?secret=test", nil)
+		req.RemoteAddr = ip
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		lastCode = rec.Code
+	}
+	if lastCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 on request %d (limit=%d), got %d",
+			wsAgentRateLimit+1, wsAgentRateLimit, lastCode)
+	}
+}
+
+// TestAgentWSRateLimitPerIP confirms the limit is per-source-IP, not
+// global. Fleet-wide reconnect after a hub restart must not be blocked
+// — each agent has its own IP so each gets its own bucket.
+func TestAgentWSRateLimitPerIP(t *testing.T) {
+	e := setupTestServer(t)
+
+	for i := 0; i < wsAgentRateLimit+1; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/ws/agent?secret=test", nil)
+		req.RemoteAddr = "10.99.0.1:1111"
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ws/agent?secret=test", nil)
+	req.RemoteAddr = "10.99.0.2:2222"
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code == http.StatusTooManyRequests {
+		t.Fatalf("rate limit leaked across IPs — IP-B should not be limited by IP-A's bucket")
+	}
+}
+
 // TestRunWithRecoverCatchesPanic locks in B1: every long-running hub
 // goroutine (alertEvalLoop, cleanupLoop, versionRefreshLoop,
 // reconnectMonitorLoop, terminalRelay) was previously a `go funcName()`


### PR DESCRIPTION
## Summary

**Phase B item.** \`/ws/agent\` was the only request handler in the hub without a \`rateLimiter.Allow\` gate. A flood of WS-upgrade requests could exhaust file descriptors and goroutine count — each upgraded connection holds both for its lifetime.

## Fix

Standard rate-limit pattern at the top of \`handleAgentWS\` (matching \`/api/auth/login\`, \`/api/auth/setup\`, \`/api/tokens\`, etc.):

\`\`\`go
ip := getRealIP(c)
if !rateLimiter.Allow(\"ws_agent\", ip, wsAgentRateLimit) {
    log.Printf(\"rate limit exceeded: ws_agent from %s\", ip)
    return 429
}
\`\`\`

\`wsAgentRateLimit = 30\` per minute per source IP. Sized for the cycling pattern observed on flaky agents (~2/min) plus fleet-wide reconnect after a hub restart (~5/min from any single subnet through NAT). Real fleets hit nowhere near 30; an attacker spamming upgrades hits it immediately. Each agent has its own bucket → fleet scale unaffected.

## Test plan

- \`TestAgentWSRateLimited\` — fires \`wsAgentRateLimit+1\` requests from a single \`RemoteAddr\`, asserts last is 429. Modeled on \`TestLoginRateLimiting\`.
- \`TestAgentWSRateLimitPerIP\` — burns IP-A's budget then asserts IP-B is NOT rate-limited. Guards against future regressions where the limit is mistakenly made global.

**Red→green proof:** temporarily removed the rate-limit gate. \`TestAgentWSRateLimited\` failed with \`\"expected 429 on request 31 (limit=30), got 401\"\` — without the gate the 31st request just hit the auth path. \`TestAgentWSRateLimitPerIP\` still passed (it tests scoping, not presence).

- [x] \`cd hub && go test ./... && go vet ./...\` (full suite green)
- [x] \`cd agent && go vet ./...\` (no agent changes)
- [ ] Smoke-check post-deploy: live fleet should be unaffected (each agent reconnects ~once per cycle, far below 30/min).

## Notes

- B1 (#66) merged, B2 this PR. Next: B3 \`handleBulkCommand\` semaphore.