### PR TITLE
feat(hub): cap and bound concurrency on /api/bulk/command (B3)

### DIFF
--- a/hub/main.go
+++ b/hub/main.go
@@ -511,6 +511,22 @@ func handleMetricsHistory(c echo.Context) error {
 
 // --- Bulk Command ---
 
+// maxBulkCommandTargets caps the number of machine_ids a single
+// /api/bulk/command request may target. Without this, an authenticated
+// operator (or a compromised dashboard session) could spawn an
+// unbounded number of goroutines, each holding a pendingCmds entry +
+// a 15s timeout + per-agent WriteMu contention. 100 targets is well
+// past any reasonable real-world fleet operation; legitimate "restart
+// nginx everywhere" uses cases stay comfortably under this.
+const maxBulkCommandTargets = 100
+
+// bulkCommandConcurrency caps the number of in-flight goroutines for
+// a single bulk request. With 100 targets and a 15s per-target
+// timeout, an unbounded fan-out would spike to 100 simultaneous WS
+// writes; capping at 20 spreads the load over time without sacrificing
+// throughput on the common case (most targets reply in <1s).
+const bulkCommandConcurrency = 20
+
 func handleBulkCommand(c echo.Context) error {
 	var body struct {
 		MachineIDs []string `json:"machine_ids"`
@@ -519,6 +535,11 @@ func handleBulkCommand(c echo.Context) error {
 	}
 	if err := c.Bind(&body); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid body"})
+	}
+	if len(body.MachineIDs) > maxBulkCommandTargets {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("too many targets: %d > %d", len(body.MachineIDs), maxBulkCommandTargets),
+		})
 	}
 
 	type BulkResult struct {
@@ -531,11 +552,18 @@ func handleBulkCommand(c echo.Context) error {
 	var results []BulkResult
 	var mu sync.Mutex
 	var wg sync.WaitGroup
+	// Buffered channel acts as a counting semaphore. Acquire BEFORE
+	// spawning the goroutine so the for-loop itself blocks once
+	// bulkCommandConcurrency goroutines are in flight — that bounds
+	// the spawn rate, not just the active work.
+	sem := make(chan struct{}, bulkCommandConcurrency)
 
 	for _, mid := range body.MachineIDs {
 		wg.Add(1)
+		sem <- struct{}{}
 		go func(machineID string) {
 			defer wg.Done()
+			defer func() { <-sem }()
 
 			agentsMu.RLock()
 			agent, ok := agents[machineID]

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -2467,6 +2467,74 @@ func TestHardwareInfoUpsertPreCreatesRow(t *testing.T) {
 	}
 }
 
+// TestBulkCommandRejectsOversize locks in B3 (size cap): the bulk
+// command endpoint had no upper bound on machine_ids. A request with
+// 10000 IDs would spawn 10000 goroutines instantly, each holding a
+// pendingCmds entry + a goroutine + (per WriteMessage) a per-agent
+// write-mutex contention. Easy DoS surface for any authenticated
+// operator. The fix caps the request size at maxBulkCommandTargets
+// and returns 400 above that.
+func TestBulkCommandRejectsOversize(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	adminToken := loginAndGetToken(t, e)
+
+	ids := make([]string, maxBulkCommandTargets+1)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("machine-%d", i)
+	}
+	bodyBytes, _ := json.Marshal(map[string]interface{}{
+		"machine_ids": ids,
+		"type":        "restart_service",
+		"target":      "nginx",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/bulk/command", strings.NewReader(string(bodyBytes)))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for %d targets (limit=%d), got %d: %s",
+			len(ids), maxBulkCommandTargets, rec.Code, rec.Body.String())
+	}
+}
+
+// TestBulkCommandAcceptsAtLimit confirms the cap is exactly
+// maxBulkCommandTargets — exactly that many IDs must be accepted.
+// Without this, the off-by-one between < and <= silently bites only
+// at the boundary. (None of the IDs are real, so the response will
+// still be 200 with N rows containing "agent not connected" — the
+// per-machine error is fine here, we only assert the request itself
+// wasn't bounced at the size check.)
+func TestBulkCommandAcceptsAtLimit(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	adminToken := loginAndGetToken(t, e)
+
+	ids := make([]string, maxBulkCommandTargets)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("machine-%d", i)
+	}
+	bodyBytes, _ := json.Marshal(map[string]interface{}{
+		"machine_ids": ids,
+		"type":        "restart_service",
+		"target":      "nginx",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/bulk/command", strings.NewReader(string(bodyBytes)))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusBadRequest {
+		t.Fatalf("expected acceptance at exactly the limit (%d), got 400: %s",
+			maxBulkCommandTargets, rec.Body.String())
+	}
+}
+
 // TestAgentWSRateLimited locks in B2: /ws/agent had no rate limit
 // before this fix. A flood of WebSocket upgrade requests could exhaust
 // the hub's file descriptors and goroutine count — the agent endpoint


### PR DESCRIPTION
## Summary

**Phase B item.** \`handleBulkCommand\` had no upper bound on \`body.MachineIDs\` and spawned one goroutine per ID with no semaphore. An authenticated operator could submit 10000 IDs and spawn 10000 simultaneous goroutines — each holding a pendingCmds entry, a 15s timeout, and per-agent WriteMu contention. Easy DoS surface even from a legitimate session.

## Fix

| Constant | Value | Why |
|---|---|---|
| \`maxBulkCommandTargets\` | 100 | Hard ceiling. Returns 400 above this. Real \"restart nginx everywhere\" use cases stay well under it. |
| \`bulkCommandConcurrency\` | 20 | Buffered-channel semaphore caps in-flight goroutines. **Acquired before \`go\`** so the for-loop blocks once 20 are working — bounds spawn rate, not just active work. |

## Test plan

- \`TestBulkCommandRejectsOversize\` — submits \`maxBulkCommandTargets+1\` IDs, asserts 400. Bug-probe verified: without the cap, request returns 200 with 101 result rows.
- \`TestBulkCommandAcceptsAtLimit\` — submits exactly \`maxBulkCommandTargets\` IDs, asserts non-400. Guards off-by-one at boundary.

The semaphore is reviewed by inspection — a deterministic test would require fake agents that block on receive to observe in-flight count, which is more setup than the small loop deserves. The risky part (size cap) is fully covered.

- [x] \`cd hub && go test ./... && go vet ./...\` (full suite green)
- [x] \`cd agent && go vet ./...\` (no agent changes)
- [ ] Smoke-check post-deploy: any normal operation in dashboard still works (UI never sends >100 IDs in a single request).

## Notes

- B1 + B2 + B3 → all of Phase B's "limit the surface area for DoS / runaway-concurrency" cluster done. Next: B4 \`io.LimitReader\` on agent updater download.