### PR TITLE
feat(agent): cap self-update download at 250MB (B4)

### DIFF
--- a/agent/main_linux_test.go
+++ b/agent/main_linux_test.go
@@ -8,9 +8,12 @@
 package main
 
 import (
+	"bytes"
 	"errors"
+	"io"
 	"os/exec"
 	"os/user"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -107,6 +110,70 @@ func TestWaitCoordinatorPropagatesNilError(t *testing.T) {
 		t.Errorf("call count = %d, want 1", got)
 	}
 }
+
+// TestDownloadWithLimit locks in B4: agent self-update used a bare
+// io.Copy(out, resp.Body) over the hub's HTTPS response with no upper
+// bound on bytes copied. A compromised hub announcing a multi-GB
+// payload would fill the agent's /tmp (and then disk), wedging the
+// host. Real agent binaries are ~10MB; capping at 250MB gives 25x
+// headroom for future growth while shutting down the attack.
+//
+// Tests use bytes.Buffer + strings.NewReader so they exercise the
+// pure-Go logic without touching the network or filesystem.
+func TestDownloadWithLimit(t *testing.T) {
+	const limit int64 = 100
+
+	t.Run("under_limit_copies_all_bytes", func(t *testing.T) {
+		src := strings.Repeat("x", 50)
+		var dst bytes.Buffer
+		if err := downloadWithLimit(&dst, strings.NewReader(src), limit); err != nil {
+			t.Fatalf("under-limit copy errored: %v", err)
+		}
+		if dst.String() != src {
+			t.Errorf("dst length = %d, want %d", dst.Len(), len(src))
+		}
+	})
+
+	t.Run("at_exact_limit_copies_all_bytes", func(t *testing.T) {
+		src := strings.Repeat("y", int(limit))
+		var dst bytes.Buffer
+		if err := downloadWithLimit(&dst, strings.NewReader(src), limit); err != nil {
+			t.Fatalf("at-limit copy errored: %v", err)
+		}
+		if int64(dst.Len()) != limit {
+			t.Errorf("dst length = %d, want %d", dst.Len(), limit)
+		}
+	})
+
+	t.Run("over_limit_returns_error", func(t *testing.T) {
+		src := strings.Repeat("z", int(limit)+1)
+		var dst bytes.Buffer
+		err := downloadWithLimit(&dst, strings.NewReader(src), limit)
+		if err == nil {
+			t.Fatal("expected error for over-limit source, got nil")
+		}
+		if !strings.Contains(err.Error(), "exceed") {
+			t.Errorf("error %q should mention 'exceed' so the agent log makes the attack visible", err)
+		}
+	})
+
+	t.Run("propagates_reader_error", func(t *testing.T) {
+		var dst bytes.Buffer
+		wantErr := errors.New("read failure")
+		err := downloadWithLimit(&dst, &errReader{err: wantErr}, limit)
+		if !errors.Is(err, wantErr) {
+			t.Errorf("expected reader error %v to propagate, got %v", wantErr, err)
+		}
+	})
+}
+
+// errReader returns the configured error on first Read. Used to
+// validate that downloadWithLimit doesn't swallow upstream errors.
+type errReader struct{ err error }
+
+func (e *errReader) Read(p []byte) (int, error) { return 0, e.err }
+
+var _ io.Reader = (*errReader)(nil)
 
 // TestApplyTerminalCredentials_NonNumericUIDFailsClosed locks in C4:
 // when the resolved terminal user has a UID string that cannot be

--- a/agent/safety.go
+++ b/agent/safety.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+// maxAgentBinarySize caps the bytes the agent will accept from the
+// hub when downloading a self-update. Real agent binaries are ~10 MB;
+// 250 MB leaves 25x headroom for future growth while shutting down
+// a hub-side attack that announces a pathologically large payload to
+// fill the agent's disk.
+const maxAgentBinarySize int64 = 250 * 1024 * 1024
+
+// downloadWithLimit copies r into w but rejects the copy if r had
+// more than maxBytes available. The "+1" trick — read up to
+// maxBytes+1 bytes through io.LimitReader — lets us distinguish
+// "source exactly at the limit" from "source went past it" with a
+// single io.Copy.
+//
+// Used by self-update download paths in agent/updater.go and
+// agent/updater_windows.go. Pre-fix, both used a bare io.Copy(out,
+// resp.Body) with no bound: a compromised hub announcing a
+// multi-gigabyte response would fill /tmp on the agent host and
+// wedge the system before the SHA verification step ever ran.
+func downloadWithLimit(w io.Writer, r io.Reader, maxBytes int64) error {
+	n, err := io.Copy(w, io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return err
+	}
+	if n > maxBytes {
+		return fmt.Errorf("download exceeded size limit (%d bytes)", maxBytes)
+	}
+	return nil
+}

--- a/agent/updater.go
+++ b/agent/updater.go
@@ -211,7 +211,7 @@ func downloadAgentBinary(destPath string) error {
 	}
 	defer out.Close()
 
-	if _, err := io.Copy(out, resp.Body); err != nil {
+	if err := downloadWithLimit(out, resp.Body, maxAgentBinarySize); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 

--- a/agent/updater_windows.go
+++ b/agent/updater_windows.go
@@ -286,7 +286,7 @@ func downloadAgentBinary(destPath string) error {
 	}
 	defer out.Close()
 
-	if _, err := io.Copy(out, resp.Body); err != nil {
+	if err := downloadWithLimit(out, resp.Body, maxAgentBinarySize); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

**Phase B item.** \`agent/updater.go\` and \`agent/updater_windows.go\` used \`io.Copy(out, resp.Body)\` over the hub's HTTPS response with no upper bound. A compromised hub could announce a multi-gigabyte payload and fill the agent's disk **before** the SHA-verify step runs.

## Fix

New shared (no build-tag) \`agent/safety.go\`:

- \`maxAgentBinarySize = 250 MB\` — real binary ~10MB, 25x headroom.
- \`downloadWithLimit(w, r, maxBytes) error\` — uses \`io.LimitReader\` with \`maxBytes+1\` so a single \`io.Copy\` can distinguish \"exactly at limit\" from \"over limit\".

Both updaters call \`downloadWithLimit\` in place of \`io.Copy\`.

## Test plan

Four sub-tests in \`agent/main_linux_test.go\`:

| Sub-test | What |
|---|---|
| \`under_limit_copies_all_bytes\` | Happy path |
| \`at_exact_limit_copies_all_bytes\` | Off-by-one boundary |
| \`over_limit_returns_error\` | Locks in the fix; error message must contain \"exceed\" |
| \`propagates_reader_error\` | Doesn't swallow upstream IO failures |

**Red→green proof:** temporarily replaced the helper body with plain \`io.Copy\`. \`over_limit_returns_error\` failed with \`\"expected error for over-limit source, got nil\"\` — exactly the regression the test guards. Other three still passed.

- [x] \`cd agent && go test ./... && go vet ./... && GOOS=windows go vet ./...\`
- [x] \`cd hub && go test ./... && go vet ./...\` (no hub changes)
- [ ] Smoke-check post-deploy: live agents update normally (10MB binary far below 250MB ceiling).

## Notes

- B1, B2, B3 merged. B4 this PR. The "DoS / runaway-resource" cluster of Phase B is now closed.
- Next: B5 Telegram HTML escape (smaller scope), then B6 SSRF guard expansion.