### PR TITLE
fix(hub): drop Telegram parse_mode=HTML, default to plain text (B5)

### DIFF
--- a/hub/alerts.go
+++ b/hub/alerts.go
@@ -305,16 +305,29 @@ func broadcastAlertSSE(alert Alert) {
 	}
 }
 
+// buildTelegramPayload returns the JSON body for the Telegram
+// sendMessage API. parse_mode is intentionally omitted so the API
+// treats text as plain (no HTML parsing). Pre-fix, this set
+// parse_mode="HTML" while substituting agent-reported strings
+// (machine hostnames, alert-rule names) into the body unescaped —
+// an agent that reported its hostname as <script>... would either
+// crash Telegram's parser or smuggle markup through to operators.
+func buildTelegramPayload(chatID, text string) ([]byte, error) {
+	return json.Marshal(map[string]string{
+		"chat_id": chatID,
+		"text":    text,
+	})
+}
+
 func sendTelegram(text string) {
 	if telegramToken == "" || telegramChatID == "" {
 		return
 	}
-	payload := map[string]string{
-		"chat_id":    telegramChatID,
-		"text":       text,
-		"parse_mode": "HTML",
+	body, err := buildTelegramPayload(telegramChatID, text)
+	if err != nil {
+		log.Printf("telegram payload error: %v", err)
+		return
 	}
-	body, _ := json.Marshal(payload)
 	url := fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", telegramToken)
 	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
 	if err != nil {

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -2467,6 +2467,41 @@ func TestHardwareInfoUpsertPreCreatesRow(t *testing.T) {
 	}
 }
 
+// TestBuildTelegramPayloadIsPlainText locks in B5: the alert
+// notification path used parse_mode="HTML" and substituted
+// agent-reported strings (m.hostname, rule.Name) into the message
+// body unescaped. An agent that reported its hostname as something
+// containing `<` or `&` would either get rendered weirdly by Telegram
+// or cause the API to reject the message as malformed HTML — either
+// way, the alert silently fails. A malicious agent hostname could
+// also smuggle markup through to operators reading the alerts.
+//
+// Fix: drop parse_mode entirely. Telegram's default is plain text.
+// Future "I want bold formatting" callers would explicitly opt in
+// via a separate path.
+func TestBuildTelegramPayloadIsPlainText(t *testing.T) {
+	payload, err := buildTelegramPayload("chat-id-123", "alert with <script>tag")
+	if err != nil {
+		t.Fatalf("build payload: %v", err)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		t.Fatalf("payload is not valid JSON: %v", err)
+	}
+	if _, ok := parsed["parse_mode"]; ok {
+		t.Errorf("payload still contains parse_mode=%q — this is the regression we just fixed; Telegram will parse user-supplied strings as HTML",
+			parsed["parse_mode"])
+	}
+	if got := parsed["chat_id"]; got != "chat-id-123" {
+		t.Errorf("chat_id = %q, want chat-id-123", got)
+	}
+	// Text is preserved verbatim — no escaping applied here. Plain-text
+	// mode means Telegram doesn't interpret it, so we don't need to.
+	if got := parsed["text"]; got != "alert with <script>tag" {
+		t.Errorf("text = %q, want verbatim original", got)
+	}
+}
+
 // TestBulkCommandRejectsOversize locks in B3 (size cap): the bulk
 // command endpoint had no upper bound on machine_ids. A request with
 // 10000 IDs would spawn 10000 goroutines instantly, each holding a


### PR DESCRIPTION
## Summary

**Phase B item.** \`sendTelegram\` set \`parse_mode=\"HTML\"\` while substituting agent-reported strings (machine hostnames, alert-rule names) into the body unescaped. An agent reporting hostname \`<script>\` or anything containing \`<\` / \`&\` / \`>\` would either render weirdly or get rejected by Telegram as malformed HTML — alert silently fails. Malicious agent could also smuggle markup through.

## Fix

Drop \`parse_mode\` entirely. Telegram's default is plain text — no parsing of substring tags. No escaping needed at call sites. Existing callers don't use HTML formatting (just newline-separated text), so legitimate behavior is unchanged.

Extract \`buildTelegramPayload(chatID, text)\` from \`sendTelegram\` so the test can assert on the JSON body without mocking the Telegram API.

## Test plan

\`TestBuildTelegramPayloadIsPlainText\` asserts:
- \`parse_mode\` is **absent** from the marshaled payload
- \`text\` preserved verbatim (no escaping in plain-text mode)
- \`chat_id\` plumbed through correctly

**Red→green proof:** restored the \`\"parse_mode\": \"HTML\"\` line. Test failed with \`\"payload still contains parse_mode=\\\"HTML\\\" — this is the regression we just fixed\"\`. Restored the fix.

- [x] \`cd hub && go test ./... && go vet ./...\` (full suite green)
- [x] \`cd agent && go vet ./...\` (no agent changes)
- [ ] Smoke: trigger a real alert; the existing message format works fine in plain-text mode (it's already newline-formatted, no markup needed).

## Notes

- B1–B5 done. Next: B6 SSRF guard expansion to RFC 1918 ranges.