### PR TITLE
feat(hub): refuse to start instead of wildcard CORS fallback (B7)

### DIFF
--- a/hub/main.go
+++ b/hub/main.go
@@ -219,15 +219,9 @@ func main() {
 	e.IPExtractor = echo.ExtractIPFromXFFHeader(
 		echo.TrustLoopback(true),
 	)
-	// CORS: use ALLOWED_ORIGINS env var (comma-separated), fall back to PUBLIC_URL, then wildcard.
-	corsOrigins := []string{"*"}
-	if ao := os.Getenv("ALLOWED_ORIGINS"); ao != "" {
-		corsOrigins = strings.Split(ao, ",")
-		for i := range corsOrigins {
-			corsOrigins[i] = strings.TrimSpace(corsOrigins[i])
-		}
-	} else if pu := os.Getenv("PUBLIC_URL"); pu != "" {
-		corsOrigins = []string{pu}
+	corsOrigins, err := resolveCORSOrigins()
+	if err != nil {
+		log.Fatalf("startup: %v", err)
 	}
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: corsOrigins,
@@ -1846,6 +1840,38 @@ func parseJSONInt(raw json.RawMessage) int64 {
 		return n
 	}
 	return 0
+}
+
+// resolveCORSOrigins returns the list of allowed origins for the CORS
+// middleware, derived from ALLOWED_ORIGINS (comma-separated) or
+// PUBLIC_URL. Pre-fix, when neither was set the hub fell back to
+// AllowOrigins=[]string{"*"} — combined with JWT-in-localStorage,
+// that meant any malicious page could read authenticated responses
+// if the user happened to have a hub session in another tab.
+//
+// The hardened behaviour: refuse to start (caller log.Fatals on the
+// returned error) so operators must opt in to origin policy
+// explicitly. The error message names both env vars so the operator
+// knows the fix without reading source.
+func resolveCORSOrigins() ([]string, error) {
+	if ao := os.Getenv("ALLOWED_ORIGINS"); ao != "" {
+		parts := strings.Split(ao, ",")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				out = append(out, p)
+			}
+		}
+		if len(out) > 0 {
+			return out, nil
+		}
+		// fall through: ALLOWED_ORIGINS was set but empty / whitespace-only
+	}
+	if pu := strings.TrimSpace(os.Getenv("PUBLIC_URL")); pu != "" {
+		return []string{pu}, nil
+	}
+	return nil, fmt.Errorf("CORS: neither ALLOWED_ORIGINS nor PUBLIC_URL is set; refusing to start with wildcard origin")
 }
 
 // rfc1918Networks are the IPv4 private-use ranges from RFC 1918.

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -2509,6 +2509,82 @@ func TestHardwareInfoUpsertPreCreatesRow(t *testing.T) {
 	}
 }
 
+// TestResolveCORSOrigins locks in B7: the prior CORS setup fell back
+// to AllowOrigins=[]string{"*"} when neither ALLOWED_ORIGINS nor
+// PUBLIC_URL was set. Combined with JWT-in-localStorage, that means
+// any malicious page could read authenticated responses if the user
+// happened to have a hub session in another tab. The fix is to
+// REFUSE TO START in that configuration — operators must opt in to
+// origin policy explicitly.
+func TestResolveCORSOrigins(t *testing.T) {
+	t.Run("explicit_ALLOWED_ORIGINS_wins", func(t *testing.T) {
+		t.Setenv("ALLOWED_ORIGINS", "https://app.example.com,https://staging.example.com")
+		t.Setenv("PUBLIC_URL", "https://ignored.example.com")
+		got, err := resolveCORSOrigins()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"https://app.example.com", "https://staging.example.com"}
+		if !slices.Equal(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("ALLOWED_ORIGINS_trims_whitespace", func(t *testing.T) {
+		t.Setenv("ALLOWED_ORIGINS", "  https://a.example.com ,https://b.example.com  ")
+		t.Setenv("PUBLIC_URL", "")
+		got, err := resolveCORSOrigins()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"https://a.example.com", "https://b.example.com"}
+		if !slices.Equal(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("falls_back_to_PUBLIC_URL", func(t *testing.T) {
+		t.Setenv("ALLOWED_ORIGINS", "")
+		t.Setenv("PUBLIC_URL", "https://192.168.16.113")
+		got, err := resolveCORSOrigins()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !slices.Equal(got, []string{"https://192.168.16.113"}) {
+			t.Errorf("got %v, want [https://192.168.16.113]", got)
+		}
+	})
+
+	t.Run("both_unset_returns_error", func(t *testing.T) {
+		t.Setenv("ALLOWED_ORIGINS", "")
+		t.Setenv("PUBLIC_URL", "")
+		got, err := resolveCORSOrigins()
+		if err == nil {
+			t.Fatalf("expected error for missing CORS config, got origins=%v", got)
+		}
+		if got != nil {
+			t.Errorf("expected nil origins on error, got %v", got)
+		}
+		// Error message must NOT silently fall back to "*" — that's
+		// exactly the regression the test guards.
+		if !strings.Contains(err.Error(), "PUBLIC_URL") || !strings.Contains(err.Error(), "ALLOWED_ORIGINS") {
+			t.Errorf("error %q should mention both env vars so the operator knows the fix", err)
+		}
+	})
+
+	t.Run("ALLOWED_ORIGINS_only_whitespace_falls_through_to_PUBLIC_URL", func(t *testing.T) {
+		t.Setenv("ALLOWED_ORIGINS", "  , , ")
+		t.Setenv("PUBLIC_URL", "https://example.com")
+		got, err := resolveCORSOrigins()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !slices.Equal(got, []string{"https://example.com"}) {
+			t.Errorf("got %v, want [https://example.com]", got)
+		}
+	})
+}
+
 // TestBuildTelegramPayloadIsPlainText locks in B5: the alert
 // notification path used parse_mode="HTML" and substituted
 // agent-reported strings (m.hostname, rule.Name) into the message


### PR DESCRIPTION
## Summary

**Phase B item.** The CORS setup in \`main()\` had a three-tier fallback:

1. \`ALLOWED_ORIGINS\` env var (comma-separated)
2. \`PUBLIC_URL\` env var (single origin)
3. \`AllowOrigins=[]string{\"*\"}\` ← **regression**

Tier 3 is the bug. Combined with JWT-in-localStorage, wildcard CORS means any malicious page can read authenticated API responses if the user has a hub session in another tab.

## Fix

Extract \`resolveCORSOrigins()\` returning an error when neither env var is set. Caller \`log.Fatal\`s, so the hub refuses to start. Operators must opt in to origin policy explicitly. Error message names both env vars.

## Test plan

5 sub-cases in \`TestResolveCORSOrigins\`:
- \`explicit_ALLOWED_ORIGINS_wins\` — multi-origin + precedence over PUBLIC_URL
- \`ALLOWED_ORIGINS_trims_whitespace\`
- \`falls_back_to_PUBLIC_URL\` — when only PUBLIC_URL is set
- \`both_unset_returns_error\` — **locks in the fix**; error must mention both env vars
- \`ALLOWED_ORIGINS_only_whitespace_falls_through_to_PUBLIC_URL\` — handles the \`ALLOWED_ORIGINS=,\` footgun

**Red→green proof:** replaced the error return with \`[]string{\"*\"}, nil\`. \`both_unset\` failed with \`\"expected error for missing CORS config, got origins=[*]\"\` — exact regression. Restored.

- [x] \`cd hub && go test ./... && go vet ./...\` (full suite green)
- [x] \`cd agent && go vet ./...\` (no agent changes)

## ⚠ DEPLOY NOTE

Live deployment is **fine** — the systemd unit already has \`PUBLIC_URL=https://192.168.16.113\`, so \`resolveCORSOrigins\` returns \`[https://192.168.16.113]\` (matches what the old fallback would have produced for this host). No config change needed for the next deploy.

If you ever copy-deploy this hub binary to a fresh host without setting either env var, it will now refuse to start with a clear error instead of silently allowing wildcard CORS.

## Notes

- B1–B7 done. Next: B8 dead-code removal (\`ensureDefaultAdmin\` + \`warnDefaultPassword\`), then B9 MachineCard nested-button.