### PR TITLE
chore(hub): remove dead default-admin code paths (B8)

### DIFF
--- a/hub/auth.go
+++ b/hub/auth.go
@@ -18,33 +18,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-func ensureDefaultAdmin() {
-	var count int
-	err := db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&count)
-	if err != nil {
-		log.Printf("error checking users count: %v", err)
-		return
-	}
-	if count > 0 {
-		return
-	}
-
-	hash, err := bcrypt.GenerateFromPassword([]byte("bloxos"), bcrypt.DefaultCost)
-	if err != nil {
-		log.Printf("error hashing default password: %v", err)
-		return
-	}
-
-	id := uuid.New().String()
-	_, err = db.Exec(`INSERT INTO users (id, username, password_hash) VALUES (?, ?, ?)`,
-		id, "admin", string(hash))
-	if err != nil {
-		log.Printf("error creating default admin: %v", err)
-		return
-	}
-	log.Println("created default admin user (admin/bloxos)")
-}
-
 // --- First-Boot Setup (Finding #11) ---
 
 // setupTokenValue holds the current setup token in memory (for env-provided tokens
@@ -441,21 +414,6 @@ func generateRandomSecret() []byte {
 		log.Fatalf("failed to generate random JWT secret: %v", err)
 	}
 	return secret
-}
-
-// warnDefaultPassword logs a warning if admin still uses default password (Finding #2).
-func warnDefaultPassword() {
-	var passwordHash string
-	err := db.QueryRow(`SELECT password_hash FROM users WHERE username = 'admin'`).Scan(&passwordHash)
-	if err != nil {
-		return
-	}
-	if bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte("bloxos")) == nil {
-		log.Println("==========================================================")
-		log.Println("WARNING: Using default admin password. Change it via the API.")
-		log.Println("  POST /api/auth/change-password")
-		log.Println("==========================================================")
-	}
 }
 
 // handleChangePassword allows authenticated users to change their password (Finding #2).


### PR DESCRIPTION
## Summary

**Phase B item.** Pure cleanup. Two dead functions in \`hub/auth.go\`:

- \`ensureDefaultAdmin\` (line 21): would have inserted \`admin\` / \`bloxos\` on first boot
- \`warnDefaultPassword\` (line 447): would have logged a banner if the default was still in use

Both replaced long ago by the first-boot setup-token flow (\`handleSetup\`). Both retained as dead code — never called from anywhere.

## Why it matters

Dead code that encodes \`bloxos\` as a literal admin password is exactly the kind of thing a security audit flags as a footgun. If someone wires it up by accident later, instant default-cred backdoor. Removing eliminates that risk.

## Test plan

No new tests needed — pure deletion of unreachable code, no behaviour change.

- [x] \`grep -r 'ensureDefaultAdmin\\|warnDefaultPassword' hub/ | grep -v _test.go\` returns empty
- [x] \`cd hub && go build ./... && go vet ./... && go test ./...\` (full suite green)
- [x] \`cd agent && go vet ./...\` (no agent changes)

## Notes

- B1–B8 done. Only B9 left in Phase B (MachineCard nested-button HTML fix). After that → tag \`v1.0.0-rc2\` and end-of-Phase-B deploy with the systemd env-var update for B6.