### PR TITLE
fix(dashboard): replace Link wrapper with router-driven div in MachineCard (B9)

### DIFF
--- a/dashboard/src/components/MachineCard.tsx
+++ b/dashboard/src/components/MachineCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { Trash2, Pencil, Zap, RefreshCw, Star, Thermometer } from "lucide-react";
 import type { MachineMetrics } from "@/lib/demo-data";
@@ -102,6 +102,16 @@ export function MachineCard({ machine, onDelete, onEdit, onRefresh }: MachineCar
   // The footer's "12s ago" timer is owned by <LiveTimeSince/> below — it
   // mounts its own 1Hz ticker, so the parent doesn't need to force re-renders.
 
+  // B9 — was previously wrapped in a <Link>, which produced invalid
+  // <a><button>...</button></a> nesting because the action buttons
+  // (pin / refresh / edit / delete) live inside the card body. Now the
+  // card is a div with role=link + programmatic navigation. Trade-off:
+  // loses middle-click-to-open-in-new-tab (no real <a href>). Worth it
+  // for valid HTML + working keyboard a11y.
+  const router = useRouter();
+  const detailPath = `/machine/${machine.machine_id}`;
+  const navigateToDetail = () => router.push(detailPath);
+
   // Phase 8 — version info from /api/versions for the update-pending badge.
   const { getMachineVersion } = useVersions();
   const versionInfo = getMachineVersion(machine.machine_id);
@@ -167,7 +177,19 @@ export function MachineCard({ machine, onDelete, onEdit, onRefresh }: MachineCar
       : "text-emerald-400";
 
   return (
-    <Link href={`/machine/${machine.machine_id}`} className="block h-full">
+    <div
+      role="link"
+      tabIndex={0}
+      onClick={navigateToDetail}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          navigateToDetail();
+        }
+      }}
+      aria-label={`Open ${machine.hostname} details`}
+      className="block h-full cursor-pointer"
+    >
       <motion.div
         whileHover={{ y: -2 }}
         transition={{ type: "spring", stiffness: 420, damping: 28 }}
@@ -428,7 +450,7 @@ export function MachineCard({ machine, onDelete, onEdit, onRefresh }: MachineCar
           )}
         </div>
       </motion.div>
-    </Link>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

**Final Phase B item.** \`MachineCard\` had \`<Link><motion.div>...buttons...</motion.div></Link>\` — invalid HTML (\`<a><button>\` is forbidden). React 19 hydration warns, Safari prematurely closes the \`<a>\` tag mid-card, keyboard nav was unpredictable. Existing button \`stopPropagation\` masked the symptom but the markup was wrong.

## Fix

Replace outer \`<Link>\` with \`<div role=\"link\">\` + \`useRouter().push()\`. \`onKeyDown\` handles Enter / Space for keyboard activation. \`aria-label\` fills the accessible name.

## Trade-offs

| Lost | Gained |
|---|---|
| Middle-click-to-new-tab (no real href) | Valid HTML |
| Right-click \"Copy Link Address\" / \"Open in New Tab\" | Predictable keyboard nav |
| Real \`<a>\` element for assistive tech | No more React 19 hydration warnings |
| | Buttons can live in card body without nesting violation |

For a homelab dashboard with 30–50 cards, the new-tab loss is acceptable. Power users who want it can keyboard-nav into a button or paste the detail URL directly. Phase C+ could revisit with the absolute-positioned-link overlay pattern if needed.

## Test plan

No new automated tests — dashboard has zero test infrastructure today (Phase C/D scope). Verified by:

- [x] \`cd dashboard && pnpm lint && pnpm build\` (TypeScript strict mode caught my staged half-fix; clean now)
- [x] \`cd hub && go test ./... && go vet ./...\` (no hub changes)
- [x] \`cd agent && go vet ./...\` (no agent changes)
- [ ] Smoke-check post-deploy: click a card → navigate; click a button → expected action without navigation; keyboard-Tab to card + Enter → navigate.

## Notes

- B1–B9 done. **Phase B is complete.** Next steps: tag \`v1.0.0-rc2\`, end-of-Phase-B deploy with the systemd unit update for B6's \`BLOXOS_ALLOW_PRIVATE_TARGETS=1\`, full smoke test.