### PR TITLE
fix(hub+dashboard): refresh stale alert messages, clarify versions wording

### DIFF
--- a/dashboard/src/app/versions/page.tsx
+++ b/dashboard/src/app/versions/page.tsx
@@ -208,7 +208,7 @@ export default function VersionsPage() {
                       Status
                     </TableHead>
                     <TableHead className="text-blox-muted text-[11px] uppercase tracking-[0.06em] font-medium">
-                      Last reported
+                      Last connect
                     </TableHead>
                   </TableRow>
                 </TableHeader>

--- a/hub/alerts.go
+++ b/hub/alerts.go
@@ -221,6 +221,21 @@ func evaluateAlerts() {
 				sendTelegram(fmt.Sprintf("BloxOS Alert\n\nMachine: %s\nSeverity: %s\n%s",
 					m.hostname, rule.Severity, msg))
 
+			} else if triggered && hasActive {
+				// Already-active alert: refresh the message so it reflects
+				// current state (e.g. offline duration grows from "144s"
+				// at fire time to "172800s" two days later) instead of
+				// freezing at the moment the threshold was crossed.
+				// We don't broadcast SSE here — would spam every connected
+				// dashboard with one alert event per machine per 30s. The
+				// dashboard picks up the refreshed message on next reload
+				// or fetch of /api/alerts.
+				_, err := db.Exec(`UPDATE alerts SET message = ? WHERE id = ?`, msg, existingID)
+				if err != nil {
+					log.Printf("alert eval: error refreshing alert message: %v", err)
+					continue
+				}
+
 			} else if !triggered && hasActive {
 				// Resolve the alert.
 				_, err := db.Exec(`UPDATE alerts SET status = 'resolved', resolved_at = CURRENT_TIMESTAMP WHERE id = ?`, existingID)


### PR DESCRIPTION
Two cosmetic follow-ups from the Phase 13 postmortem (PR #75).

1. **Stale alert messages.** `alerts.go` had no UPDATE branch for `triggered && hasActive`, so an offline alert's `message` field froze at fire time. After 4 days, AiFarm-01's alert still read 'Machine offline for 144s' instead of '~345600s'. Fix: refresh the message in-place every eval cycle (no SSE broadcast — would spam clients).

2. **/versions 'Last reported' wording.** The field actually shows the agent's last WS-connect timestamp (the `agent_running_version` frame fires once per connect). Stable agents on long-lived connections appear stuck at hub-start time, which read as a liveness signal during the rc2 investigation. Renamed to 'Last connect'.

No behavior change beyond display correctness.
