### PR TITLE
fix(agent): drop unused Stepping field from win32Processor struct

### DIFF
--- a/agent/hardware_windows.go
+++ b/agent/hardware_windows.go
@@ -41,7 +41,6 @@ type win32Processor struct {
 	NumberOfCores             uint32
 	NumberOfLogicalProcessors uint32
 	MaxClockSpeed             uint32
-	Stepping                  string
 	L2CacheSize               uint32
 	L3CacheSize               uint32
 	SocketDesignation         string


### PR DESCRIPTION
Crashes every Windows agent on startup with `panic: reflect: call of reflect.Value.Uint on int32 Value`. WMI returns `Win32_Processor.Stepping` as int32; struct declared it as string; StackExchange/wmi library reflection panics. Field was never used — SELECT doesn't include it and CPU stepping comes from gopsutil. Removing the field stops the panic.

Same root cause as ai-07's parked flap loop. Verified on Win10 22H2 (admin's test box) — agent now reaches steady-state.
