### PR TITLE
Fix machine delete credential cleanup

### DIFF
--- a/hub/main.go
+++ b/hub/main.go
@@ -110,7 +110,6 @@ type CommandResponse struct {
 	Error   string `json:"error"`
 }
 
-
 // TerminalSession tracks an active terminal relay session.
 var (
 	db       *sql.DB
@@ -693,14 +692,6 @@ func handleSetTags(c echo.Context) error {
 
 // --- Install Script + Token ---
 
-
-
-
-
-
-
-
-
 // --- Existing Handlers ---
 
 func handleDeleteMachine(c echo.Context) error {
@@ -720,7 +711,7 @@ func handleDeleteMachine(c echo.Context) error {
 	}
 	defer tx.Rollback()
 
-	tables := []string{"metrics", "gpu_metrics", "services", "containers", "alerts", "terminal_sessions"}
+	tables := []string{"metrics", "gpu_metrics", "services", "containers", "alerts", "terminal_sessions", "agent_credentials"}
 	for _, table := range tables {
 		if _, err := tx.Exec("DELETE FROM "+table+" WHERE machine_id = ?", id); err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to delete " + table})
@@ -748,7 +739,6 @@ func handleDeleteMachine(c echo.Context) error {
 func handleHealth(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 }
-
 
 func upsertServices(machineID string, services []ServiceInfo) {
 	tx, err := db.Begin()
@@ -1423,15 +1413,6 @@ func getMachinesJSON() ([]byte, error) {
 }
 
 // --- Security Functions ---
-
-
-
-
-
-
-
-
-
 
 // tokenRedactingWriter redacts JWT tokens from log output (Finding #8).
 type tokenRedactingWriter struct {

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -606,6 +606,35 @@ func TestOperatorCanUpdateTagsButCannotDeleteMachine(t *testing.T) {
 	}
 }
 
+func TestDeleteMachineRemovesAgentCredential(t *testing.T) {
+	e := setupTestServer(t)
+	markCredentialsRotated(t)
+	seedTestMachine(t, "machine-delete-credential")
+	adminToken := loginAndGetToken(t, e)
+
+	if _, err := db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`,
+		"machine-delete-credential", "test-secret-hash"); err != nil {
+		t.Fatalf("seed agent credential: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/machines/machine-delete-credential", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected delete to succeed, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, "machine-delete-credential").Scan(&count); err != nil {
+		t.Fatalf("query agent credential count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected agent credential to be deleted, got %d row(s)", count)
+	}
+}
+
 // --- Tests ---
 
 // 1. Login with valid credentials -> 200 + JWT
@@ -2811,10 +2840,10 @@ func TestRunWithRecoverCatchesPanic(t *testing.T) {
 // parsing baseURL only when the adapter didn't report one.
 func TestExtractAPIMachineIP(t *testing.T) {
 	cases := []struct {
-		name      string
-		baseURL   string
-		resultIP  string
-		want      string
+		name     string
+		baseURL  string
+		resultIP string
+		want     string
 	}{
 		{
 			name:     "adapter_provided_ip_wins",


### PR DESCRIPTION
## Summary
- Delete durable `agent_credentials` rows when deleting a machine
- Add a regression test proving machine deletion invalidates the stored agent credential

## Verification
- `go test -count=1 -run 'TestDeleteMachineRemovesAgentCredential|TestOperatorCanUpdateTagsButCannotDeleteMachine' ./...`
- `go test -count=1 ./...`

git diff --check passed locally.