### PR TITLE
feat(dashboard): fleet dashboard visual redesign

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -64,43 +64,61 @@
 }
 
 .dark {
-  /* Surfaces */
-  --surface-base: #0a0a0f;
-  --surface-raised: #12121a;
-  --surface-overlay: #1a1a24;
-  --surface-sunken: #050508;
+  /* Surfaces — cool-neutral OKLCH ramp (not slate, not zinc).
+     Sunken < base < raised < overlay < elevated. Tint surfaces are used
+     for state-aware card backgrounds without color flooding. */
+  --surface-sunken: oklch(0.115 0.008 240);
+  --surface-base: oklch(0.155 0.008 240);
+  --surface-raised: oklch(0.195 0.008 240);
+  --surface-elevated: oklch(0.225 0.008 240);
+  --surface-overlay: oklch(0.245 0.008 240);
 
-  /* Text */
-  --text-primary: #fafafa;
-  --text-secondary: #a1a1aa;
-  --text-tertiary: #71717a;
-  --text-disabled: #52525b;
+  /* Text — cool-neutral, four-step descending emphasis */
+  --text-primary: oklch(0.97 0.005 240);
+  --text-secondary: oklch(0.72 0.012 240);
+  --text-tertiary: oklch(0.52 0.012 240);
+  --text-disabled: oklch(0.36 0.008 240);
 
   /* Borders */
-  --border-subtle: rgba(255, 255, 255, 0.06);
-  --border-default: rgba(255, 255, 255, 0.10);
-  --border-strong: rgba(255, 255, 255, 0.18);
+  --border-subtle: rgba(255, 255, 255, 0.05);
+  --border-default: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.16);
 
-  /* Brand + intent — slightly brighter in dark theme to stay legible */
-  --accent: #3b82f6;
-  --accent-hover: #60a5fa;
-  --accent-subtle: rgba(59, 130, 246, 0.15);
-  --accent-foreground: #ffffff;
+  /* Accent — instrument-cyan-shifted blue, not Tailwind blue-500.
+     Used for selection, focus, primary actions, "alive" state hints. */
+  --accent: oklch(0.7 0.155 230);
+  --accent-hover: oklch(0.76 0.14 230);
+  --accent-subtle: oklch(0.7 0.155 230 / 0.14);
+  --accent-foreground: oklch(0.155 0.008 240);
 
-  --success: #22c55e;
-  --success-subtle: rgba(34, 197, 94, 0.15);
+  /* Status — 5 intent states for fleet health.
+     Tints are translucent surfaces used as card backgrounds for state. */
+  --status-ok: oklch(0.74 0.16 158);
+  --status-ok-tint: oklch(0.74 0.16 158 / 0.08);
+  --status-warning: oklch(0.8 0.16 75);
+  --status-warning-tint: oklch(0.8 0.16 75 / 0.07);
+  --status-critical: oklch(0.7 0.21 25);
+  --status-critical-tint: oklch(0.7 0.21 25 / 0.08);
+  --status-stale: oklch(0.62 0.06 285);
+  --status-stale-tint: oklch(0.62 0.06 285 / 0.06);
+  --status-offline: oklch(0.48 0.008 240);
+  --status-offline-tint: oklch(0.4 0.005 240 / 0.5);
 
-  --warning: #f59e0b;
-  --warning-subtle: rgba(245, 158, 11, 0.15);
+  /* Legacy intent aliases — keep so other pages don't break.
+     These now alias the new status namespace. */
+  --success: var(--status-ok);
+  --success-subtle: var(--status-ok-tint);
+  --warning: var(--status-warning);
+  --warning-subtle: var(--status-warning-tint);
+  --danger: var(--status-critical);
+  --danger-subtle: var(--status-critical-tint);
 
-  --danger: #ef4444;
-  --danger-subtle: rgba(239, 68, 68, 0.15);
-
-  /* Shadows — dark theme uses deeper, harder shadows */
-  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.30);
-  --shadow-md: 0 4px 12px -2px rgba(0, 0, 0, 0.40);
-  --shadow-lg: 0 12px 32px -8px rgba(0, 0, 0, 0.50);
-  --shadow-overlay: 0 24px 64px -16px rgba(0, 0, 0, 0.70);
+  /* Shadows — deeper, more defined edges suited to layered console UI */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.32);
+  --shadow-md: 0 4px 14px -2px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 18px 40px -10px rgba(0, 0, 0, 0.55);
+  --shadow-overlay: 0 28px 72px -18px rgba(0, 0, 0, 0.72);
+  --shadow-focus-ring: 0 0 0 1px var(--accent), 0 0 0 4px oklch(0.7 0.155 230 / 0.18);
 }
 
 /* ============================================================================
@@ -353,6 +371,19 @@
   --color-surface-raised: var(--surface-raised);
   --color-surface-overlay: var(--surface-overlay);
   --color-surface-sunken: var(--surface-sunken);
+  --color-surface-elevated: var(--surface-elevated, var(--surface-overlay));
+
+  /* Status palette — 5 intent states for fleet health */
+  --color-status-ok: var(--status-ok, var(--success));
+  --color-status-ok-tint: var(--status-ok-tint, var(--success-subtle));
+  --color-status-warning: var(--status-warning, var(--warning));
+  --color-status-warning-tint: var(--status-warning-tint, var(--warning-subtle));
+  --color-status-critical: var(--status-critical, var(--danger));
+  --color-status-critical-tint: var(--status-critical-tint, var(--danger-subtle));
+  --color-status-stale: var(--status-stale, var(--text-tertiary));
+  --color-status-stale-tint: var(--status-stale-tint, var(--surface-sunken));
+  --color-status-offline: var(--status-offline, var(--text-tertiary));
+  --color-status-offline-tint: var(--status-offline-tint, var(--surface-sunken));
 
   --color-text-primary: var(--text-primary);
   --color-text-secondary: var(--text-secondary);
@@ -437,14 +468,47 @@
   --color-chart-4: var(--danger);
   --color-chart-5: var(--text-secondary);
 
-  --radius: 0.625rem;
-  --radius-sm: calc(var(--radius) * 0.6);
-  --radius-md: calc(var(--radius) * 0.8);
+  --radius: 0.5rem;
+  --radius-sm: calc(var(--radius) * 0.5);
+  --radius-md: calc(var(--radius) * 0.75);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) * 1.4);
-  --radius-2xl: calc(var(--radius) * 1.8);
-  --radius-3xl: calc(var(--radius) * 2.2);
-  --radius-4xl: calc(var(--radius) * 2.6);
+  --radius-xl: calc(var(--radius) * 1.5);
+  --radius-2xl: calc(var(--radius) * 2);
+  --radius-3xl: calc(var(--radius) * 2.5);
+  --radius-4xl: calc(var(--radius) * 3);
+}
+
+/* ============================================================================
+ * Metric typography — applies to all numeric readouts in the fleet UI.
+ *
+ * Pairs Geist Mono with tabular-nums + slashed-zero + a tight tracking
+ * so values like "0.8%" and "73%" align reliably and read at a glance.
+ * Apply via `.metric-value` (display values) or `.metric-figure`
+ * (inline figures). Critical for any dashboard cell where columns of
+ * numbers need to scan visually as one block.
+ * ============================================================================ */
+.metric-value,
+.metric-figure {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums slashed-zero;
+  font-feature-settings: "ss06", "ss07";
+  letter-spacing: -0.01em;
+}
+.metric-value {
+  font-weight: 500;
+  line-height: 1;
+}
+.metric-figure {
+  font-weight: 400;
+}
+
+/* Unit suffix paired with a metric-value — sized down, muted, baseline-aligned. */
+.metric-unit {
+  font-family: var(--font-sans);
+  color: var(--text-tertiary);
+  font-feature-settings: normal;
+  font-variant-numeric: normal;
+  letter-spacing: 0;
 }
 
 /* ============================================================================

--- a/dashboard/src/app/machine/[id]/page.tsx
+++ b/dashboard/src/app/machine/[id]/page.tsx
@@ -116,7 +116,7 @@ function getStatus(data: MachineData): MachineStatus {
   const diskPct = (data.metrics?.disk_total_bytes ?? 0) > 0
     ? ((data.metrics?.disk_used_bytes ?? 0) / data.metrics.disk_total_bytes) * 100 : 0;
   if (diskPct > 90) return "warning";
-  return "online";
+  return "live";
 }
 
 export default function MachineDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -467,7 +467,7 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
             <span
               className={[
                 "shrink-0 w-2.5 h-2.5 rounded-full",
-                status === "online"
+                status === "live"
                   ? "bg-emerald-500 animate-status-pulse"
                   : status === "warning"
                   ? "bg-amber-500 animate-status-pulse"

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -9,7 +9,7 @@ import { SavedFiltersDropdown } from "@/components/SavedFiltersDropdown";
 import { demoMachines, MachineMetrics, AlertData } from "@/lib/demo-data";
 import { DEMO_MODE, HUB_URL } from "@/lib/session";
 import { MachineCard, MachineCardSkeleton } from "@/components/MachineCard";
-import { MachineStatus } from "@/components/StatusBadge";
+import { MachineStatus, classifyMachine, isProblem, STATUS_ORDER } from "@/components/StatusBadge";
 import { Sparkline } from "@/components/Sparkline";
 import { AlertPanel } from "@/components/AlertPanel";
 import { AddMachineModal } from "@/components/AddMachineModal";
@@ -39,29 +39,17 @@ import Link from "next/link";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { CommandPalette, useCommandPaletteHotkey } from "@/components/CommandPalette";
 import { FleetPulse } from "@/components/FleetPulse";
+import { NeedsAttention } from "@/components/NeedsAttention";
 import { UserMenu } from "@/components/UserMenu";
 import { BrandedHeader } from "@/components/BrandedHeader";
 
 type SortOption = "name" | "status" | "cpu" | "gpu_temp";
-type StatusFilter = "all" | "online" | "warning" | "offline";
+type StatusFilter = "all" | "live" | "warning" | "critical" | "offline" | "stale";
 type ViewMode = "grid" | "list";
 
 function getStatus(m: MachineMetrics): MachineStatus {
-  const age = Date.now() - (m.last_seen || 0);
-  if (age > 120_000) return "offline";
-  if (m.gpu_temp && m.gpu_temp > 80) return "warning";
-  const diskPct = (m.disk_total_bytes ?? 0) > 0 ? ((m.disk_used_bytes ?? 0) / m.disk_total_bytes) * 100 : 0;
-  if (diskPct > 90) return "warning";
-  const ramPct = (m.ram_total_bytes ?? 0) > 0 ? ((m.ram_used_bytes ?? 0) / m.ram_total_bytes) * 100 : 0;
-  if (ramPct > 95) return "warning";
-  return "online";
+  return classifyMachine(m).status;
 }
-
-const statusOrder: Record<MachineStatus, number> = {
-  offline: 0,
-  warning: 1,
-  online: 2,
-};
 
 function formatBytes(bytes: number | undefined | null): string {
   if (!bytes || bytes === 0) return "0";
@@ -140,11 +128,14 @@ export default function Home() {
       if (typeof f.search === "string") setSearch(f.search);
       if (
         f.statusFilter === "all" ||
-        f.statusFilter === "online" ||
+        f.statusFilter === "live" ||
         f.statusFilter === "warning" ||
-        f.statusFilter === "offline"
+        f.statusFilter === "critical" ||
+        f.statusFilter === "offline" ||
+        f.statusFilter === "stale" ||
+        f.statusFilter === "online"
       ) {
-        setStatusFilter(f.statusFilter);
+        setStatusFilter(f.statusFilter === "online" ? "live" : f.statusFilter);
       }
       setTagFilter(typeof f.tagFilter === "string" ? f.tagFilter : null);
       if (f.sortBy === "name" || f.sortBy === "status" || f.sortBy === "cpu" || f.sortBy === "gpu_temp") {
@@ -240,12 +231,12 @@ export default function Home() {
       );
     }
 
-    result = [...result].sort((a, b) => {
+    const primaryCompare = (a: MachineMetrics, b: MachineMetrics) => {
       switch (sortBy) {
         case "name":
           return (a.hostname ?? "").localeCompare(b.hostname ?? "");
         case "status":
-          return statusOrder[getStatus(a)] - statusOrder[getStatus(b)];
+          return STATUS_ORDER[getStatus(a)] - STATUS_ORDER[getStatus(b)];
         case "cpu":
           return (b.cpu_percent ?? 0) - (a.cpu_percent ?? 0);
         case "gpu_temp":
@@ -253,6 +244,20 @@ export default function Home() {
         default:
           return 0;
       }
+    };
+
+    result = [...result].sort((a, b) => {
+      const statusA = getStatus(a);
+      const statusB = getStatus(b);
+      const problemA = isProblem(statusA);
+      const problemB = isProblem(statusB);
+
+      if (problemA || problemB) {
+        const statusDiff = STATUS_ORDER[statusA] - STATUS_ORDER[statusB];
+        if (statusDiff !== 0) return statusDiff;
+      }
+
+      return primaryCompare(a, b);
     });
 
     // Phase 11 — pinned machines float to the top while preserving the
@@ -453,6 +458,9 @@ export default function Home() {
       {/* Fleet Pulse Strip — sits directly below the header */}
       <FleetPulse onAlertsClick={() => setAlertPanelOpen(true)} />
 
+      {/* Needs-Attention stripe — only renders when problems exist */}
+      <NeedsAttention machines={machines} />
+
       {/* Degraded connection banner — surfaces SSE disconnect inline so it isn't
           easy to miss behind the small wifi icon in the header. */}
       <AnimatePresence>
@@ -563,9 +571,11 @@ export default function Home() {
             />
             <DropdownMenuContent align="start" className="bg-blox-card border-blox-border">
               <DropdownMenuItem onClick={() => setStatusFilter("all")} className="text-xs text-blox-text">All Status</DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setStatusFilter("online")} className="text-xs text-emerald-400">Online</DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setStatusFilter("warning")} className="text-xs text-amber-400">Warning</DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setStatusFilter("offline")} className="text-xs text-red-400">Offline</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setStatusFilter("live")} className="text-xs text-status-ok">Live</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setStatusFilter("warning")} className="text-xs text-status-warning">Warning</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setStatusFilter("critical")} className="text-xs text-status-critical">Critical</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setStatusFilter("offline")} className="text-xs text-status-offline">Offline</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setStatusFilter("stale")} className="text-xs text-status-stale">Stale</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
 
@@ -735,7 +745,12 @@ export default function Home() {
                   const ramPct = (m.ram_total_bytes ?? 0) > 0 ? ((m.ram_used_bytes ?? 0) / m.ram_total_bytes) * 100 : 0;
                   const diskPct = (m.disk_total_bytes ?? 0) > 0 ? ((m.disk_used_bytes ?? 0) / m.disk_total_bytes) * 100 : 0;
                   const tags = m.tags ? m.tags.split(",").filter((t) => t.trim()) : [];
-                  const dotColor = status === "online" ? "bg-emerald-500" : status === "warning" ? "bg-amber-500" : "bg-red-500/50";
+                  const dotColor =
+                    status === "live" ? "bg-status-ok" :
+                    status === "stale" ? "bg-status-stale" :
+                    status === "warning" ? "bg-status-warning" :
+                    status === "critical" ? "bg-status-critical" :
+                    "bg-status-offline";
                   const isSelected = selected.has(m.machine_id);
                   const adapterTag = tags.find((tag) => ["synology", "proxmox"].includes(tag.trim().toLowerCase()));
                   const isAPIMachine = !!adapterTag;
@@ -758,7 +773,7 @@ export default function Home() {
                       )}
                       <TableCell className="text-xs">
                         <Link href={`/machine/${m.machine_id}`}>
-                          <span className={`inline-block w-2 h-2 rounded-full ${dotColor} ${status === "online" ? "shadow-sm shadow-emerald-500/50" : ""}`} />
+                          <span className={`inline-block w-2 h-2 rounded-full ${dotColor} ${status === "live" ? "shadow-sm shadow-status-ok/50" : ""}`} />
                         </Link>
                       </TableCell>
                       <TableCell className="text-xs font-medium text-blox-text">

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -9,7 +9,7 @@ import { SavedFiltersDropdown } from "@/components/SavedFiltersDropdown";
 import { demoMachines, MachineMetrics, AlertData } from "@/lib/demo-data";
 import { DEMO_MODE, HUB_URL } from "@/lib/session";
 import { MachineCard, MachineCardSkeleton } from "@/components/MachineCard";
-import { MachineStatus, classifyMachine, isProblem, STATUS_ORDER } from "@/components/StatusBadge";
+import { MachineStatus, classifyMachine, STATUS_ORDER } from "@/components/StatusBadge";
 import { Sparkline } from "@/components/Sparkline";
 import { AlertPanel } from "@/components/AlertPanel";
 import { AddMachineModal } from "@/components/AddMachineModal";
@@ -246,29 +246,25 @@ export default function Home() {
       }
     };
 
+    // Composite ordering — applied as a single comparator so each priority
+    // is strictly higher than the next:
+    //   1. status severity (critical → warning → offline → stale → live)
+    //   2. pinned before unpinned within the same status bucket
+    //   3. user's chosen sort key within the same status+pin bucket
+    //
+    // Done as one sort to avoid the bug from the prior two-phase impl,
+    // where a healthy-pinned machine could outrank a critical-unpinned
+    // one — directly contradicting the PR's "problem-first" promise.
+    const pinnedSet = new Set(preferences.pinned_machines);
     result = [...result].sort((a, b) => {
-      const statusA = getStatus(a);
-      const statusB = getStatus(b);
-      const problemA = isProblem(statusA);
-      const problemB = isProblem(statusB);
+      const statusDiff = STATUS_ORDER[getStatus(a)] - STATUS_ORDER[getStatus(b)];
+      if (statusDiff !== 0) return statusDiff;
 
-      if (problemA || problemB) {
-        const statusDiff = STATUS_ORDER[statusA] - STATUS_ORDER[statusB];
-        if (statusDiff !== 0) return statusDiff;
-      }
+      const pinDiff = Number(pinnedSet.has(b.machine_id)) - Number(pinnedSet.has(a.machine_id));
+      if (pinDiff !== 0) return pinDiff;
 
       return primaryCompare(a, b);
     });
-
-    // Phase 11 — pinned machines float to the top while preserving the
-    // primary sort order within each partition. Stable two-phase: pinned
-    // first (in their primary-sort order), then the rest.
-    if (preferences.pinned_machines.length > 0) {
-      const pinnedSet = new Set(preferences.pinned_machines);
-      const pinned = result.filter((m) => pinnedSet.has(m.machine_id));
-      const rest = result.filter((m) => !pinnedSet.has(m.machine_id));
-      result = [...pinned, ...rest];
-    }
 
     return result;
   }, [machines, search, statusFilter, sortBy, tagFilter, preferences.pinned_machines]);

--- a/dashboard/src/components/FleetPulse.tsx
+++ b/dashboard/src/components/FleetPulse.tsx
@@ -4,41 +4,48 @@ import { useMemo } from "react";
 import { motion } from "framer-motion";
 import { useSSE } from "@/contexts/SSEContext";
 import type { MachineMetrics } from "@/lib/demo-data";
-import { Cpu, MemoryStick, Thermometer, AlertTriangle, WifiOff } from "lucide-react";
+import { Cpu, MemoryStick, Thermometer, AlertTriangle, Activity, WifiOff } from "lucide-react";
+import { classifyMachine } from "@/components/StatusBadge";
 
-type Severity = "neutral" | "success" | "warning" | "danger";
+/* ============================================================================
+ * FleetPulse — top-of-page health strip.
+ *
+ * One hero cell (FLEET) + four supporting cells (CPU / RAM / GPU / ALERTS).
+ * Every cell uses the same locked anatomy via <StatCell>:
+ *
+ *     ┌───────────────────────────────────────┐
+ *     │ LABEL · ICON                          │  ← row 1 (xs uppercase muted)
+ *     │ <primary value><unit>                 │  ← row 2 (mono, scale-1.2 in hero)
+ *     │ <context line>                        │  ← row 3 (xs muted, tabular nums)
+ *     └───────────────────────────────────────┘
+ *
+ * State tinting (warning/critical) is applied as a subtle background tint,
+ * never as a colored left-border. Healthy cells stay neutral so problem
+ * cells pop without competing visual weight.
+ * ============================================================================ */
+
+type Severity = "neutral" | "ok" | "warning" | "critical";
 
 interface FleetStats {
   total: number;
-  online: number;
+  live: number;
   warning: number;
+  critical: number;
   offline: number;
-  activeMachines: number; // online + warning
+  stale: number;
+  activeMachines: number; // live + warning + critical + stale
   avgCpu: number;
   avgRamPct: number;
   maxGpuTemp: number;
   hasGpu: boolean;
 }
 
-function classifyMachine(m: MachineMetrics): "online" | "warning" | "offline" {
-  const age = Date.now() - (m.last_seen || 0);
-  if (age > 120_000) return "offline";
-  if (m.gpu_temp && m.gpu_temp > 80) return "warning";
-  const diskPct = (m.disk_total_bytes ?? 0) > 0
-    ? ((m.disk_used_bytes ?? 0) / m.disk_total_bytes) * 100
-    : 0;
-  if (diskPct > 90) return "warning";
-  const ramPct = (m.ram_total_bytes ?? 0) > 0
-    ? ((m.ram_used_bytes ?? 0) / m.ram_total_bytes) * 100
-    : 0;
-  if (ramPct > 95) return "warning";
-  return "online";
-}
-
 function computeStats(machines: MachineMetrics[]): FleetStats {
-  let online = 0;
+  let live = 0;
   let warning = 0;
+  let critical = 0;
   let offline = 0;
+  let stale = 0;
   let cpuSum = 0;
   let cpuCount = 0;
   let ramPctSum = 0;
@@ -47,12 +54,13 @@ function computeStats(machines: MachineMetrics[]): FleetStats {
   let hasGpu = false;
 
   for (const m of machines) {
-    const status = classifyMachine(m);
-    if (status === "online") online++;
+    const { status } = classifyMachine(m);
+    if (status === "live") live++;
     else if (status === "warning") warning++;
+    else if (status === "critical") critical++;
+    else if (status === "stale") stale++;
     else offline++;
 
-    // Only aggregate active machines into metric averages.
     if (status === "offline") continue;
 
     if ((m.cpu_percent ?? 0) > 0) {
@@ -71,10 +79,12 @@ function computeStats(machines: MachineMetrics[]): FleetStats {
 
   return {
     total: machines.length,
-    online,
+    live,
     warning,
+    critical,
     offline,
-    activeMachines: online + warning,
+    stale,
+    activeMachines: live + warning + critical + stale,
     avgCpu: cpuCount > 0 ? cpuSum / cpuCount : 0,
     avgRamPct: ramCount > 0 ? ramPctSum / ramCount : 0,
     maxGpuTemp,
@@ -90,35 +100,43 @@ export function FleetPulse({ onAlertsClick }: FleetPulseProps) {
   const { machines, alertCount, alerts, connected, hasReceivedData } = useSSE();
   const stats = useMemo(() => computeStats(machines), [machines]);
 
+  // Fleet severity = aggregate of the worst state present.
   const fleetSeverity: Severity =
-    stats.offline > 0 ? "danger" : stats.warning > 0 ? "warning" : stats.online > 0 ? "success" : "neutral";
+    stats.critical > 0 || stats.offline > 0
+      ? "critical"
+      : stats.warning > 0 || stats.stale > 0
+      ? "warning"
+      : stats.live > 0
+      ? "ok"
+      : "neutral";
 
-  const cpuSeverity: Severity =
-    stats.avgCpu > 90 ? "danger" : stats.avgCpu > 70 ? "warning" : "neutral";
-
-  const ramSeverity: Severity =
-    stats.avgRamPct > 95 ? "danger" : stats.avgRamPct > 80 ? "warning" : "neutral";
-
+  const cpuSeverity: Severity = stats.avgCpu >= 90 ? "critical" : stats.avgCpu >= 70 ? "warning" : "neutral";
+  const ramSeverity: Severity = stats.avgRamPct >= 95 ? "critical" : stats.avgRamPct >= 80 ? "warning" : "neutral";
   const gpuSeverity: Severity =
-    stats.maxGpuTemp > 80 ? "danger" : stats.maxGpuTemp > 60 ? "warning" : "success";
+    stats.maxGpuTemp >= 85 ? "critical" : stats.maxGpuTemp >= 70 ? "warning" : "neutral";
 
   const criticalAlerts = alerts.filter((a) => a.severity === "critical").length;
   const alertSeverity: Severity =
-    criticalAlerts > 0 ? "danger" : alertCount > 0 ? "warning" : "neutral";
+    criticalAlerts > 0 ? "critical" : alertCount > 0 ? "warning" : "neutral";
 
-  // Skeleton state during initial fetch.
+  // Skeleton: real layout shape, with subtle shimmer on the value rows so
+  // the loaded UI does not "pop" in. Never an empty card.
   if (!hasReceivedData && machines.length === 0) {
     return (
-      <div className="border-b border-blox-border bg-blox-bg/30">
+      <div className="border-b border-border-subtle bg-surface-base">
         <div className="max-w-[1600px] mx-auto px-4 sm:px-6 py-3">
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-px bg-blox-border rounded-lg overflow-hidden border border-blox-border">
+          <StatRow>
             {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="bg-blox-card p-3 h-[68px]">
-                <div className="h-2 bg-blox-border/60 rounded w-12 mb-2 animate-shimmer" />
-                <div className="h-5 bg-blox-border/60 rounded w-20 animate-shimmer" />
-              </div>
+              <StatCell
+                key={i}
+                label="…"
+                severity="neutral"
+                hero={i === 0}
+                primary={<span className="metric-value text-[1.1em] text-text-disabled">— —</span>}
+                context={<span className="h-2 w-24 rounded-sm bg-border-subtle animate-shimmer block" />}
+              />
             ))}
-          </div>
+          </StatRow>
         </div>
       </div>
     );
@@ -126,268 +144,289 @@ export function FleetPulse({ onAlertsClick }: FleetPulseProps) {
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: -8 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.25, delay: 0.05 }}
-      className="border-b border-blox-border bg-blox-bg/30"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.2 }}
+      className="border-b border-border-subtle bg-surface-base"
     >
       <div className="max-w-[1600px] mx-auto px-4 sm:px-6 py-3">
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-px bg-blox-border rounded-lg overflow-hidden border border-blox-border">
-
-          {/* 1. Fleet Status */}
-          <PulseCell label="Fleet" severity={fleetSeverity}>
-            <div className="flex items-baseline gap-1.5">
-              <span className="text-xl font-semibold text-blox-text tabular-nums">
-                {stats.online}
+        <StatRow>
+          {/* 1 · FLEET (hero) ─────────────────────────────────────────── */}
+          <StatCell
+            label="Fleet"
+            icon={<Activity className="h-3 w-3" />}
+            severity={fleetSeverity}
+            hero
+            primary={
+              <span className="inline-flex items-baseline gap-1.5">
+                <span className="metric-value text-3xl text-text-primary">{stats.live}</span>
+                <span className="metric-unit text-sm">/ {stats.total}</span>
               </span>
-              <span className="text-xs text-blox-muted tabular-nums">
-                / {stats.total} online
-              </span>
-            </div>
-            <FleetRatioBar
-              online={stats.online}
-              warning={stats.warning}
-              offline={stats.offline}
-              total={stats.total}
-            />
-          </PulseCell>
+            }
+            context={
+              <FleetMix
+                live={stats.live}
+                warning={stats.warning}
+                critical={stats.critical}
+                stale={stats.stale}
+                offline={stats.offline}
+                total={stats.total}
+              />
+            }
+          />
 
-          {/* 2. Avg CPU */}
-          <PulseCell label="Avg CPU" severity={cpuSeverity} icon={<Cpu className="w-3 h-3" />}>
-            <div className="flex items-baseline gap-1">
-              <span className={`text-xl font-semibold tabular-nums ${severityTextClass(cpuSeverity)}`}>
-                {stats.avgCpu.toFixed(1)}
-              </span>
-              <span className="text-xs text-blox-muted">%</span>
-            </div>
-            <div className="text-[10px] text-blox-muted mt-1.5 tabular-nums">
-              {stats.activeMachines > 0
-                ? `across ${stats.activeMachines} machine${stats.activeMachines === 1 ? "" : "s"}`
-                : "no active machines"}
-            </div>
-          </PulseCell>
-
-          {/* 3. Avg RAM */}
-          <PulseCell label="Avg RAM" severity={ramSeverity} icon={<MemoryStick className="w-3 h-3" />}>
-            <div className="flex items-baseline gap-1">
-              <span className={`text-xl font-semibold tabular-nums ${severityTextClass(ramSeverity)}`}>
-                {stats.avgRamPct.toFixed(0)}
-              </span>
-              <span className="text-xs text-blox-muted">%</span>
-            </div>
-            <SeverityBar pct={stats.avgRamPct} severity={ramSeverity} />
-          </PulseCell>
-
-          {/* 4. Max GPU Temp — only when at least one machine has a GPU */}
-          {stats.hasGpu ? (
-            <PulseCell label="Max GPU" severity={gpuSeverity} icon={<Thermometer className="w-3 h-3" />}>
-              <div className="flex items-baseline gap-1">
-                <span className={`text-xl font-semibold tabular-nums ${severityTextClass(gpuSeverity)}`}>
-                  {stats.maxGpuTemp.toFixed(0)}
+          {/* 2 · CPU ─────────────────────────────────────────────────── */}
+          <StatCell
+            label="Avg CPU"
+            icon={<Cpu className="h-3 w-3" />}
+            severity={cpuSeverity}
+            primary={
+              <span className="inline-flex items-baseline">
+                <span className={`metric-value text-2xl ${sevText(cpuSeverity)}`}>
+                  {stats.avgCpu.toFixed(1)}
                 </span>
-                <span className="text-xs text-blox-muted">°C</span>
-              </div>
-              <div className="text-[10px] text-blox-muted mt-1.5">
-                {gpuSeverity === "danger"
-                  ? "critical"
-                  : gpuSeverity === "warning"
-                  ? "warm"
-                  : "cool"}
-              </div>
-            </PulseCell>
+                <span className="metric-unit text-xs ml-1">%</span>
+              </span>
+            }
+            context={
+              <span className="metric-figure text-text-tertiary text-[11px]">
+                across {stats.activeMachines || 0} active
+              </span>
+            }
+          />
+
+          {/* 3 · RAM ─────────────────────────────────────────────────── */}
+          <StatCell
+            label="Avg RAM"
+            icon={<MemoryStick className="h-3 w-3" />}
+            severity={ramSeverity}
+            primary={
+              <span className="inline-flex items-baseline">
+                <span className={`metric-value text-2xl ${sevText(ramSeverity)}`}>
+                  {stats.avgRamPct.toFixed(0)}
+                </span>
+                <span className="metric-unit text-xs ml-1">%</span>
+              </span>
+            }
+            context={<SeverityRail pct={stats.avgRamPct} severity={ramSeverity} />}
+          />
+
+          {/* 4 · GPU ─────────────────────────────────────────────────── */}
+          {stats.hasGpu ? (
+            <StatCell
+              label="Max GPU"
+              icon={<Thermometer className="h-3 w-3" />}
+              severity={gpuSeverity}
+              primary={
+                <span className="inline-flex items-baseline">
+                  <span className={`metric-value text-2xl ${sevText(gpuSeverity)}`}>
+                    {stats.maxGpuTemp.toFixed(0)}
+                  </span>
+                  <span className="metric-unit text-xs ml-1">°C</span>
+                </span>
+              }
+              context={
+                <span className="metric-figure text-text-tertiary text-[11px] uppercase tracking-[0.08em]">
+                  {gpuSeverity === "critical" ? "thermal critical" : gpuSeverity === "warning" ? "warm" : "nominal"}
+                </span>
+              }
+            />
           ) : (
-            // Placeholder cell so the grid keeps 5 columns at lg.
-            // Hidden below lg so the grid wraps cleanly to 3 columns.
-            <PulseCell label="GPU" severity="neutral" className="hidden lg:flex">
-              <div className="flex items-baseline gap-1">
-                <span className="text-xl font-semibold tabular-nums text-blox-muted">—</span>
-              </div>
-              <div className="text-[10px] text-blox-muted mt-1.5">no GPU machines</div>
-            </PulseCell>
+            <StatCell
+              label="GPU"
+              icon={<Thermometer className="h-3 w-3" />}
+              severity="neutral"
+              className="hidden lg:flex"
+              primary={<span className="metric-value text-2xl text-text-disabled">—</span>}
+              context={<span className="metric-figure text-text-tertiary text-[11px]">no GPU machines</span>}
+            />
           )}
 
-          {/* 5. Alerts (clickable to open alert panel) + live status */}
-          <PulseCell
+          {/* 5 · ALERTS ─────────────────────────────────────────────── */}
+          <StatCell
             label="Alerts"
+            icon={<AlertTriangle className="h-3 w-3" />}
             severity={alertSeverity}
-            icon={<AlertTriangle className="w-3 h-3" />}
             onClick={alertCount > 0 ? onAlertsClick : undefined}
-          >
-            <div className="flex items-baseline gap-2">
-              <span className={`text-xl font-semibold tabular-nums ${severityTextClass(alertSeverity)}`}>
-                {alertCount}
-              </span>
-              {criticalAlerts > 0 && (
-                <span className="text-[10px] text-red-400 font-medium tabular-nums">
-                  {criticalAlerts} critical
-                </span>
-              )}
-            </div>
-            <div className="flex items-center gap-1.5 text-[10px] text-blox-muted mt-1.5">
-              {connected ? (
-                <>
-                  <span className="relative flex h-1.5 w-1.5">
-                    <span className="animate-status-pulse absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-                    <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
+            primary={
+              <span className="inline-flex items-baseline gap-2">
+                <span className={`metric-value text-2xl ${sevText(alertSeverity)}`}>{alertCount}</span>
+                {criticalAlerts > 0 && (
+                  <span className="metric-figure text-status-critical text-[10px] uppercase tracking-[0.08em]">
+                    {criticalAlerts} crit
                   </span>
-                  <span>live updates</span>
-                </>
-              ) : (
-                <>
-                  <WifiOff className="w-2.5 h-2.5 text-amber-400" />
-                  <span className="text-amber-400">reconnecting…</span>
-                </>
-              )}
-            </div>
-          </PulseCell>
-        </div>
+                )}
+              </span>
+            }
+            context={
+              <span className="flex items-center gap-1.5 text-[11px] text-text-tertiary">
+                {connected ? (
+                  <>
+                    <span className="relative inline-flex h-1.5 w-1.5">
+                      <span className="absolute inset-0 rounded-full bg-status-ok opacity-60 animate-status-pulse" />
+                      <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-status-ok" />
+                    </span>
+                    <span>live</span>
+                  </>
+                ) : (
+                  <>
+                    <WifiOff className="h-2.5 w-2.5 text-status-warning" />
+                    <span className="text-status-warning">reconnecting</span>
+                  </>
+                )}
+              </span>
+            }
+          />
+        </StatRow>
       </div>
     </motion.div>
   );
 }
 
 /* ============================================================================
- * Subcomponents
+ * Layout — asymmetric grid. Hero claims 5fr, four supporting cells share
+ * 4fr each (totaling 16fr → 21fr). On mobile the row collapses to 2-col.
  * ============================================================================ */
 
-function severityTextClass(severity: Severity): string {
-  switch (severity) {
-    case "danger":
-      return "text-red-400";
-    case "warning":
-      return "text-amber-400";
-    case "success":
-      return "text-emerald-400";
-    case "neutral":
-    default:
-      return "text-blox-text";
-  }
-}
-
-interface PulseCellProps {
-  label: string;
-  severity: Severity;
-  icon?: React.ReactNode;
-  onClick?: () => void;
-  className?: string;
-  children: React.ReactNode;
-}
-
-function PulseCell({ label, severity, icon, onClick, className, children }: PulseCellProps) {
-  const isInteractive = !!onClick;
-
-  // Subtle severity hint via a 2px left accent — only for warning/danger.
-  // Avoids painting healthy cells with color.
-  const accent =
-    severity === "danger"
-      ? "before:bg-red-500/70"
-      : severity === "warning"
-      ? "before:bg-amber-500/70"
-      : "before:bg-transparent";
-
-  if (isInteractive) {
-    return (
-      <button
-        type="button"
-        onClick={onClick}
-        className={[
-          "bg-blox-card p-3 text-left relative",
-          "before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-full",
-          accent,
-          "hover:bg-blox-border/30 cursor-pointer transition-colors duration-[var(--motion-fast)]",
-          className ?? "",
-        ].join(" ")}
-      >
-        <div className="flex items-center gap-1.5 mb-1">
-          {icon && <span className="text-blox-muted shrink-0">{icon}</span>}
-          <span className="text-[10px] uppercase tracking-wider font-medium text-blox-muted">
-            {label}
-          </span>
-        </div>
-        {children}
-      </button>
-    );
-  }
-
+function StatRow({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className={[
-        "bg-blox-card p-3 text-left relative",
-        "before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-full",
-        accent,
-        className ?? "",
-      ].join(" ")}
+      className="grid grid-cols-2 sm:grid-cols-[5fr_3fr_3fr_3fr_3fr] gap-px overflow-hidden rounded-lg bg-border-subtle ring-1 ring-border-subtle"
     >
-      <div className="flex items-center gap-1.5 mb-1">
-        {icon && <span className="text-blox-muted shrink-0">{icon}</span>}
-        <span className="text-[10px] uppercase tracking-wider font-medium text-blox-muted">
-          {label}
-        </span>
-      </div>
       {children}
     </div>
   );
 }
 
-interface FleetRatioBarProps {
-  online: number;
-  warning: number;
-  offline: number;
-  total: number;
+/* ============================================================================
+ * StatCell — locked anatomy. Every consumer of the strip uses this.
+ * ============================================================================ */
+
+function sevText(s: Severity): string {
+  return s === "critical"
+    ? "text-status-critical"
+    : s === "warning"
+    ? "text-status-warning"
+    : s === "ok"
+    ? "text-text-primary"
+    : "text-text-primary";
 }
 
-function FleetRatioBar({ online, warning, offline, total }: FleetRatioBarProps) {
-  if (total === 0) {
-    return <div className="h-1 mt-1.5 rounded-full bg-blox-border/30" />;
-  }
-  const onlinePct = (online / total) * 100;
-  const warningPct = (warning / total) * 100;
-  const offlinePct = (offline / total) * 100;
+function sevSurface(s: Severity): string {
+  return s === "critical"
+    ? "bg-status-critical-tint"
+    : s === "warning"
+    ? "bg-status-warning-tint"
+    : "bg-surface-raised";
+}
 
+interface StatCellProps {
+  label: string;
+  icon?: React.ReactNode;
+  severity: Severity;
+  hero?: boolean;
+  className?: string;
+  onClick?: () => void;
+  primary: React.ReactNode;
+  context: React.ReactNode;
+}
+
+function StatCell({ label, icon, severity, hero, className, onClick, primary, context }: StatCellProps) {
+  const interactive = !!onClick;
+  const body = (
+    <>
+      <div className="flex items-center gap-1.5 text-text-tertiary">
+        {icon && <span className="shrink-0">{icon}</span>}
+        <span className="text-[10px] font-medium uppercase tracking-[0.14em]">{label}</span>
+      </div>
+      <div className={`${hero ? "mt-1.5" : "mt-1"} leading-none`}>{primary}</div>
+      <div className="mt-2">{context}</div>
+    </>
+  );
+
+  const base = [
+    "relative flex flex-col px-3.5 py-3 text-left",
+    sevSurface(severity),
+    "transition-colors duration-[var(--motion-fast)]",
+    hero ? "min-h-[88px]" : "min-h-[82px]",
+    className ?? "",
+  ].join(" ");
+
+  if (interactive) {
+    return (
+      <button type="button" onClick={onClick} className={`${base} cursor-pointer hover:bg-surface-elevated`}>
+        {body}
+      </button>
+    );
+  }
+  return <div className={base}>{body}</div>;
+}
+
+/* ============================================================================
+ * FleetMix — segmented bar showing live / warn / critical / stale / offline
+ * ratio. Replaces the old 3-color bar so all 5 states are visible.
+ * ============================================================================ */
+
+function FleetMix({
+  live,
+  warning,
+  critical,
+  stale,
+  offline,
+  total,
+}: {
+  live: number;
+  warning: number;
+  critical: number;
+  stale: number;
+  offline: number;
+  total: number;
+}) {
+  if (total === 0) {
+    return (
+      <span className="metric-figure text-text-tertiary text-[11px]">no machines enrolled</span>
+    );
+  }
+  const seg = (n: number) => `${(n / total) * 100}%`;
   return (
-    <div className="flex h-1 mt-1.5 rounded-full overflow-hidden bg-blox-border/30">
-      {online > 0 && (
-        <div
-          className="bg-emerald-500 transition-all duration-[var(--motion-slow)]"
-          style={{ width: `${onlinePct}%` }}
-          title={`${online} online`}
-        />
-      )}
-      {warning > 0 && (
-        <div
-          className="bg-amber-500 transition-all duration-[var(--motion-slow)]"
-          style={{ width: `${warningPct}%` }}
-          title={`${warning} warning`}
-        />
-      )}
-      {offline > 0 && (
-        <div
-          className="bg-red-500/60 transition-all duration-[var(--motion-slow)]"
-          style={{ width: `${offlinePct}%` }}
-          title={`${offline} offline`}
-        />
-      )}
+    <div className="space-y-1.5">
+      <div className="flex h-[3px] overflow-hidden rounded-full bg-surface-sunken">
+        {critical > 0 && <div className="bg-status-critical transition-[width] duration-[var(--motion-slow)]" style={{ width: seg(critical) }} title={`${critical} critical`} />}
+        {warning > 0 && <div className="bg-status-warning transition-[width] duration-[var(--motion-slow)]" style={{ width: seg(warning) }} title={`${warning} warning`} />}
+        {stale > 0 && <div className="bg-status-stale transition-[width] duration-[var(--motion-slow)]" style={{ width: seg(stale) }} title={`${stale} stale`} />}
+        {offline > 0 && <div className="bg-status-offline transition-[width] duration-[var(--motion-slow)]" style={{ width: seg(offline) }} title={`${offline} offline`} />}
+        {live > 0 && <div className="bg-status-ok transition-[width] duration-[var(--motion-slow)]" style={{ width: seg(live) }} title={`${live} live`} />}
+      </div>
+      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-0.5 text-[10px] font-medium uppercase tracking-[0.06em]">
+        {critical > 0 && <MixLegend n={critical} label="crit" color="text-status-critical" />}
+        {warning > 0 && <MixLegend n={warning} label="warn" color="text-status-warning" />}
+        {offline > 0 && <MixLegend n={offline} label="off" color="text-status-offline" />}
+        {stale > 0 && <MixLegend n={stale} label="stale" color="text-status-stale" />}
+      </div>
     </div>
   );
 }
 
-interface SeverityBarProps {
-  pct: number;
-  severity: Severity;
+function MixLegend({ n, label, color }: { n: number; label: string; color: string }) {
+  return (
+    <span className={color}>
+      <span className="metric-figure">{n}</span>
+      <span className="ml-0.5 text-text-tertiary">{label}</span>
+    </span>
+  );
 }
 
-function SeverityBar({ pct, severity }: SeverityBarProps) {
-  const color =
-    severity === "danger"
-      ? "bg-red-500"
-      : severity === "warning"
-      ? "bg-amber-500"
-      : "bg-blox-blue/60";
+/* ============================================================================
+ * SeverityRail — single horizontal indicator used by RAM cell.
+ * ============================================================================ */
 
+function SeverityRail({ pct, severity }: { pct: number; severity: Severity }) {
+  const fill =
+    severity === "critical" ? "bg-status-critical" : severity === "warning" ? "bg-status-warning" : "bg-accent";
   return (
-    <div className="h-1 mt-1.5 rounded-full bg-blox-border/30 overflow-hidden">
+    <div className="h-[3px] overflow-hidden rounded-full bg-surface-sunken">
       <div
-        className={`h-full rounded-full transition-all duration-[var(--motion-slow)] ${color}`}
+        className={`h-full rounded-full ${fill} transition-[width] duration-[var(--motion-slow)] ease-out`}
         style={{ width: `${Math.min(100, Math.max(0, pct))}%` }}
       />
     </div>

--- a/dashboard/src/components/MachineCard.tsx
+++ b/dashboard/src/components/MachineCard.tsx
@@ -3,88 +3,88 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { Trash2, Pencil, Zap, RefreshCw, Star, Thermometer } from "lucide-react";
+import { Trash2, Pencil, RefreshCw, Star, ArrowUpFromLine } from "lucide-react";
 import type { MachineMetrics } from "@/lib/demo-data";
-import { ProgressBar, type ProgressVariant } from "./ProgressBar";
 import { Sparkline } from "./Sparkline";
 import { useVersions } from "@/contexts/VersionsContext";
 import { usePreferences } from "@/contexts/PreferencesContext";
+import {
+  classifyMachine,
+  StatusDot,
+  StatusBadge,
+  STATUS_VIS,
+} from "@/components/StatusBadge";
 
 /* ============================================================================
- * Helpers
+ * MachineCard — dense, operator-focused card.
+ *
+ * Layout (no left-border accent bar — state lives in the dot, the badge,
+ * and a subtle surface tint for warning/critical):
+ *
+ *     ┌─────────────────────────────────────────────────────────────┐
+ *     │ ● hostname           [Warn · CPU 84%]      ⭐ ⟳ ✎ ✕        │
+ *     │   192.168.1.45 · ubuntu 24.04 · proxmox · tagA, tagB       │
+ *     │                                                             │
+ *     │   CPU 73%   RAM 64%   DISK 41%   GPU 72°C  ▂▃▆▇█▇▆          │
+ *     │                                                             │
+ *     │   ↑ 14h · 23 ms · update pending                            │
+ *     └─────────────────────────────────────────────────────────────┘
+ *
+ * State map (single source of truth in StatusBadge.ts via classifyMachine):
+ *   live      surface-raised, dot pulses, no badge, full opacity
+ *   stale     surface-raised, "Stale" badge, no value tint
+ *   warning   surface-raised + status-warning-tint overlay, "Warn" badge
+ *   critical  surface-raised + status-critical-tint overlay + 1px ring
+ *   offline   surface-sunken, dimmed values, "Offline · last seen X ago"
+ *   loading   real layout, "…" figures with shimmer (NEVER an empty card)
+ *
+ * Action buttons fade in on hover/focus so the resting state stays calm.
  * ============================================================================ */
 
-function formatBytes(bytes: number | undefined | null): string {
-  if (!bytes || bytes === 0) return "0";
-  const tb = bytes / 1024 ** 4;
-  if (tb >= 1) return `${tb.toFixed(tb >= 100 ? 0 : 1)} TB`;
-  const gb = bytes / 1024 ** 3;
-  if (gb >= 1) return `${gb.toFixed(gb >= 100 ? 0 : 1)} GB`;
-  const mb = bytes / 1024 ** 2;
-  return `${mb.toFixed(0)} MB`;
-}
+const OFFLINE_TINT = "bg-surface-sunken";
+const STATE_RING = {
+  critical: "ring-1 ring-inset ring-status-critical/30",
+  warning: "",
+  stale: "",
+  offline: "",
+  live: "",
+} as const;
+
+const API_ADAPTERS = ["synology", "proxmox"];
 
 function timeSince(ms: number): string {
   const sec = Math.floor((Date.now() - ms) / 1000);
   if (sec < 5) return "just now";
-  if (sec < 60) return `${sec}s ago`;
+  if (sec < 60) return `${sec}s`;
   const min = Math.floor(sec / 60);
-  if (min < 60) return `${min}m ago`;
+  if (min < 60) return `${min}m`;
   const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}h ago`;
+  if (hr < 24) return `${hr}h`;
   const d = Math.floor(hr / 24);
-  return `${d}d ago`;
+  return `${d}d`;
 }
 
-type Status = "online" | "warning" | "offline";
+type Tone = "neutral" | "ok" | "warning" | "critical";
 
-function classifyMachine(m: MachineMetrics): { status: Status; reason?: string } {
-  const age = Date.now() - (m.last_seen || 0);
-  if (age > 120_000) return { status: "offline" };
-
-  if (m.gpu_temp && m.gpu_temp > 80) {
-    return { status: "warning", reason: `GPU ${m.gpu_temp.toFixed(0)}°C` };
-  }
-  const diskPct =
-    (m.disk_total_bytes ?? 0) > 0
-      ? ((m.disk_used_bytes ?? 0) / m.disk_total_bytes) * 100
-      : 0;
-  if (diskPct > 90) return { status: "warning", reason: `Disk ${diskPct.toFixed(0)}%` };
-
-  const ramPct =
-    (m.ram_total_bytes ?? 0) > 0
-      ? ((m.ram_used_bytes ?? 0) / m.ram_total_bytes) * 100
-      : 0;
-  if (ramPct > 95) return { status: "warning", reason: `RAM ${ramPct.toFixed(0)}%` };
-
-  return { status: "online" };
+function toneText(t: Tone): string {
+  if (t === "critical") return "text-status-critical";
+  if (t === "warning") return "text-status-warning";
+  if (t === "ok") return "text-status-ok";
+  return "text-text-primary";
 }
 
-function isAwaitingData(m: MachineMetrics): boolean {
-  return (
-    (m.cpu_percent ?? 0) === 0 &&
-    (m.ram_total_bytes ?? 0) === 0 &&
-    (m.disk_total_bytes ?? 0) === 0
-  );
-}
-
-const API_ADAPTERS = ["synology", "proxmox"];
-
-function deriveMetricVariant(pct: number, warningAt: number, dangerAt: number): ProgressVariant {
+function pctTone(pct: number, warn: number, crit: number): Tone {
   if (pct <= 0) return "neutral";
-  if (pct >= dangerAt) return "danger";
-  if (pct >= warningAt) return "warning";
-  return "active";
+  if (pct >= crit) return "critical";
+  if (pct >= warn) return "warning";
+  return "neutral";
 }
 
-// PHASE12-NOTE: shared thermal-color thresholds. The existing GPU row
-// uses a slightly different palette (emerald-400 below 60°C) so we
-// can't trivially reuse this there without changing GPU-row semantics
-// — kept as its own helper to avoid touching GPU rendering.
-function getTempColorClass(c: number): string {
-  if (c >= 80) return "text-red-400";
-  if (c >= 60) return "text-amber-400";
-  return "text-blox-text";
+function tempTone(c: number): Tone {
+  if (c <= 0) return "neutral";
+  if (c >= 86) return "critical";
+  if (c >= 75) return "warning";
+  return "neutral";
 }
 
 /* ============================================================================
@@ -99,33 +99,27 @@ interface MachineCardProps {
 }
 
 export function MachineCard({ machine, onDelete, onEdit, onRefresh }: MachineCardProps) {
-  // The footer's "12s ago" timer is owned by <LiveTimeSince/> below — it
-  // mounts its own 1Hz ticker, so the parent doesn't need to force re-renders.
-
-  // B9 — was previously wrapped in a <Link>, which produced invalid
-  // <a><button>...</button></a> nesting because the action buttons
-  // (pin / refresh / edit / delete) live inside the card body. Now the
-  // card is a div with role=link + programmatic navigation. Trade-off:
-  // loses middle-click-to-open-in-new-tab (no real <a href>). Worth it
-  // for valid HTML + working keyboard a11y.
   const router = useRouter();
   const detailPath = `/machine/${machine.machine_id}`;
   const navigateToDetail = () => router.push(detailPath);
 
-  // Phase 8 — version info from /api/versions for the update-pending badge.
   const { getMachineVersion } = useVersions();
   const versionInfo = getMachineVersion(machine.machine_id);
 
-  // Phase 11 — pin state. PHASE11-NOTE: every card subscribes to the full
-  // pinned_machines array, so pinning ONE machine triggers all cards to
-  // re-render. Acceptable for v1 (30-50 cards). Future: pass `pinned`
-  // boolean from parent, hoisted from a Set.
   const { isPinned, pinMachine, unpinMachine } = usePreferences();
   const pinned = isPinned(machine.machine_id);
 
   const { status, reason } = classifyMachine(machine);
-  const awaiting = isAwaitingData(machine);
-  const showPlaceholders = awaiting || status === "offline";
+
+  // Loading-vs-loaded distinction:
+  //   loading = heartbeat present but no metric values yet (just enrolled)
+  //   offline = no heartbeat in >120s
+  // Both render with reduced density, but with explicit context so the
+  // operator never mistakes them for a healthy card with empty bars.
+  const hasMetrics =
+    (machine.cpu_percent ?? 0) > 0 ||
+    (machine.ram_total_bytes ?? 0) > 0 ||
+    (machine.disk_total_bytes ?? 0) > 0;
 
   const ramPct =
     (machine.ram_total_bytes ?? 0) > 0
@@ -139,42 +133,20 @@ export function MachineCard({ machine, onDelete, onEdit, onRefresh }: MachineCar
   const gpu0 = machine.gpus && machine.gpus.length > 0 ? machine.gpus[0] : null;
   const hasGpu = (machine.gpu_temp ?? 0) > 0 || (gpu0 && gpu0.temp_c > 0);
   const gpuTemp = gpu0 ? gpu0.temp_c : machine.gpu_temp ?? 0;
-  const gpuUtil = gpu0 ? gpu0.util_percent : machine.gpu_util_percent ?? 0;
-  const gpuVramUsed = gpu0 ? gpu0.mem_used_bytes : machine.gpu_vram_used_bytes ?? 0;
-  const gpuVramTotal = gpu0 ? gpu0.mem_total_bytes : machine.gpu_vram_total_bytes ?? 0;
 
   const tags = machine.tags ? machine.tags.split(",").map((t) => t.trim()).filter(Boolean) : [];
   const adapterTag = tags.find((t) => API_ADAPTERS.includes(t.toLowerCase()));
   const otherTags = tags.filter((t) => !API_ADAPTERS.includes(t.toLowerCase()));
   const isAPIMachine = !!adapterTag;
 
-  const accentClass =
-    status === "online"
-      ? "before:bg-emerald-500"
-      : status === "warning"
-      ? "before:bg-amber-500"
-      : "before:bg-red-500/60";
-
-  const dotClass =
-    status === "online"
-      ? "bg-emerald-500"
-      : status === "warning"
-      ? "bg-amber-500"
-      : "bg-red-500/60";
-
-  const cpuTextColorClass =
-    (machine.cpu_percent ?? 0) > 90
-      ? "text-red-400"
-      : (machine.cpu_percent ?? 0) > 70
-      ? "text-amber-400"
-      : "text-blox-text";
-
-  const gpuTempColorClass =
-    gpuTemp > 80
-      ? "text-red-400"
-      : gpuTemp > 60
-      ? "text-amber-400"
-      : "text-emerald-400";
+  const stateVis = STATUS_VIS[status];
+  const isOffline = status === "offline";
+  const surfaceClass =
+    isOffline
+      ? OFFLINE_TINT
+      : stateVis.surfaceTintClass
+      ? `bg-surface-raised ${stateVis.surfaceTintClass}`
+      : "bg-surface-raised";
 
   return (
     <div
@@ -188,264 +160,151 @@ export function MachineCard({ machine, onDelete, onEdit, onRefresh }: MachineCar
         }
       }}
       aria-label={`Open ${machine.hostname} details`}
-      className="block h-full cursor-pointer"
+      className="group block h-full cursor-pointer"
     >
       <motion.div
-        whileHover={{ y: -2 }}
-        transition={{ type: "spring", stiffness: 420, damping: 28 }}
+        whileHover={{ y: -1 }}
+        transition={{ type: "spring", stiffness: 480, damping: 32 }}
         className={[
-          "group relative h-full flex flex-col cursor-pointer",
-          "bg-blox-card border border-blox-border rounded-xl",
-          "[padding:var(--card-padding)]",
-          "before:absolute before:left-0 before:top-3 before:bottom-3 before:w-[3px] before:rounded-full",
-          accentClass,
-          "hover:border-blox-muted/30 hover:shadow-lg",
-          "transition-[border-color,box-shadow] duration-[var(--motion-base)]",
+          "relative h-full flex flex-col",
+          surfaceClass,
+          "border border-border-default rounded-md",
+          STATE_RING[status],
+          "px-3.5 py-3",
+          "hover:border-border-strong",
+          "transition-[border-color,background-color] duration-[var(--motion-fast)]",
+          isOffline ? "opacity-75" : "",
         ].join(" ")}
       >
-        {/* row 1: hostname + actions */}
-        <div className="flex items-start justify-between gap-2 pl-2.5">
-          <div className="flex items-center gap-2 min-w-0 flex-1">
-            <span
-              className={[
-                "shrink-0 w-2 h-2 rounded-full",
-                dotClass,
-                status === "online" ? "animate-status-pulse" : "",
-              ].join(" ")}
-              aria-label={`Status: ${status}`}
-            />
-            <span className="font-semibold text-sm text-blox-text truncate">
-              {machine.hostname || machine.machine_id}
-            </span>
-            {reason && (
-              <span className="text-[10px] text-amber-400 font-medium shrink-0 tabular-nums">
-                {reason}
-              </span>
-            )}
-          </div>
-
-          <div className="flex items-center gap-0.5 shrink-0 -mr-1">
-            {/* Phase 11 — pin star, always first in the action group. */}
-            <button
-              type="button"
+        {/* ── row 1: dot · hostname · status badge · actions ── */}
+        <div className="flex items-center gap-2">
+          <StatusDot status={status} size="sm" pulse={status === "live"} />
+          <span className="font-semibold text-[13px] leading-tight text-text-primary truncate">
+            {machine.hostname || machine.machine_id}
+          </span>
+          {status !== "live" && (
+            <StatusBadge status={status} reason={reason} size="xs" />
+          )}
+          {pinned && (
+            <Star className="h-3 w-3 shrink-0 fill-status-warning text-status-warning" aria-label="Pinned" />
+          )}
+          <div className="ml-auto flex items-center gap-0.5 opacity-0 transition-opacity duration-[var(--motion-fast)] group-hover:opacity-100 focus-within:opacity-100">
+            <IconAction
+              title={pinned ? "Unpin from top" : "Pin to top"}
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                if (pinned) {
-                  void unpinMachine(machine.machine_id);
-                } else {
-                  void pinMachine(machine.machine_id);
-                }
+                if (pinned) void unpinMachine(machine.machine_id);
+                else void pinMachine(machine.machine_id);
               }}
-              className={`p-1 rounded transition-colors ${
-                pinned
-                  ? "text-amber-400 hover:text-amber-300"
-                  : "text-blox-muted/40 hover:text-amber-400 hover:bg-amber-500/10"
-              }`}
-              title={pinned ? "Unpin from top" : "Pin to top"}
-              aria-label={pinned ? "Unpin machine" : "Pin machine"}
-              aria-pressed={pinned}
+              tone={pinned ? "warn" : "default"}
             >
-              <Star className={`w-3 h-3 ${pinned ? "fill-amber-400" : ""}`} />
-            </button>
-            {onRefresh && status !== "offline" && (
-              <RefreshButton
-                onRefresh={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  onRefresh(machine.machine_id);
-                }}
-              />
+              <Star className={`h-3 w-3 ${pinned ? "fill-status-warning" : ""}`} />
+            </IconAction>
+            {onRefresh && !isOffline && (
+              <RefreshButton onRefresh={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(machine.machine_id); }} />
             )}
             {isAPIMachine && onEdit && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  onEdit(machine.machine_id);
-                }}
-                className="p-1 rounded text-blox-muted/40 hover:text-blox-blue hover:bg-blox-blue/10 transition-colors"
+              <IconAction
                 title="Edit API machine"
-                aria-label="Edit machine"
+                onClick={(e) => { e.preventDefault(); e.stopPropagation(); onEdit(machine.machine_id); }}
               >
-                <Pencil className="w-3 h-3" />
-              </button>
+                <Pencil className="h-3 w-3" />
+              </IconAction>
             )}
             {onDelete && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  onDelete(machine.machine_id, machine.hostname);
-                }}
-                className="p-1 rounded text-blox-muted/40 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+              <IconAction
                 title="Delete machine"
-                aria-label="Delete machine"
+                tone="danger"
+                onClick={(e) => { e.preventDefault(); e.stopPropagation(); onDelete(machine.machine_id, machine.hostname); }}
               >
-                <Trash2 className="w-3 h-3" />
-              </button>
+                <Trash2 className="h-3 w-3" />
+              </IconAction>
             )}
           </div>
         </div>
 
-        {/* row 2: ip + adapter / os */}
-        <div className="flex items-center gap-1.5 text-[11px] text-blox-muted pl-2.5 mt-0.5 truncate">
+        {/* ── row 2: meta (ip · os · adapter · tags) ── */}
+        <div className="mt-1 flex items-center gap-1.5 text-[11px] text-text-tertiary truncate metric-figure">
           {machine.ip ? (
-            <span className="font-mono tabular-nums truncate">{machine.ip}</span>
+            <span className="truncate">{machine.ip}</span>
           ) : (
-            <span className="text-blox-muted/50">no ip</span>
+            <span className="text-text-disabled">no ip</span>
           )}
-          {adapterTag ? (
+          {machine.os && (
             <>
-              <span aria-hidden>·</span>
-              <span className="uppercase text-[9px] tracking-[0.08em] text-violet-400 font-semibold">
+              <span className="text-border-strong" aria-hidden>·</span>
+              <span className="font-sans truncate">{machine.os}</span>
+            </>
+          )}
+          {adapterTag && (
+            <>
+              <span className="text-border-strong" aria-hidden>·</span>
+              <span className="font-sans font-medium uppercase tracking-[0.1em] text-[9px] text-accent">
                 {adapterTag}
-              </span>
-            </>
-          ) : machine.os ? (
-            <>
-              <span aria-hidden>·</span>
-              <span className="truncate">{machine.os}</span>
-            </>
-          ) : null}
-        </div>
-
-        {/* primary metric */}
-        <div className="pl-2.5 mt-3 mb-2">
-          {showPlaceholders ? (
-            <div className="flex items-baseline gap-2 py-1">
-              <span className="text-2xl font-semibold text-blox-muted/30 tabular-nums leading-none">
-                —
-              </span>
-              <span className="text-[11px] text-blox-muted">
-                {awaiting
-                  ? "Awaiting first metrics…"
-                  : `Last seen ${
-                      machine.last_seen ? timeSince(machine.last_seen) : "never"
-                    }`}
-              </span>
-            </div>
-          ) : (
-            <div className="flex items-end gap-3">
-              <div className="flex flex-col">
-                <div className="flex items-baseline gap-0.5 leading-none">
-                  <span className={`text-2xl font-semibold tabular-nums ${cpuTextColorClass}`}>
-                    {(machine.cpu_percent ?? 0).toFixed(0)}
-                  </span>
-                  <span className="text-xs text-blox-muted">%</span>
-                </div>
-                <span className="text-[9px] text-blox-muted uppercase tracking-[0.1em] mt-1">
-                  CPU
-                </span>
-              </div>
-              <div className="flex-1 self-end pb-0.5">
-                <Sparkline machineId={machine.machine_id} width={140} height={28} />
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* secondary metrics */}
-        <div className="space-y-1.5 pl-2.5 flex-1">
-          <CompactMetricRow
-            label="RAM"
-            pct={ramPct}
-            usedBytes={machine.ram_used_bytes}
-            totalBytes={machine.ram_total_bytes}
-            placeholder={showPlaceholders}
-            warningAt={80}
-            dangerAt={95}
-          />
-          <CompactMetricRow
-            label="DISK"
-            pct={diskPct}
-            usedBytes={machine.disk_used_bytes}
-            totalBytes={machine.disk_total_bytes}
-            placeholder={showPlaceholders}
-            warningAt={75}
-            dangerAt={90}
-          />
-
-          {/* PHASE12-NOTE: chose the *additive* thermal row (CPU + GPU temps
-              together) above the existing GPU row instead of pulling GPU
-              temp out of the GPU row. The GPU row's "72°C · 85% util · 18/24
-              GB" rhythm is load-bearing for visual scan; carving the temp
-              out of it would force a layout reflow we'd rather not ship in
-              this phase. */}
-          {!showPlaceholders && ((machine.cpu_temp_c ?? 0) > 0 || hasGpu) && (
-            <div className="flex items-center gap-2 px-0 py-1.5 text-[11px] text-blox-muted pt-1.5 mt-1.5 border-t border-blox-border/30">
-              <Thermometer className="w-3 h-3 shrink-0" />
-              {(machine.cpu_temp_c ?? 0) > 0 && (
-                <>
-                  <span className="uppercase tracking-[0.08em] text-[9px] font-medium">CPU</span>
-                  <span className={`tabular-nums font-mono ${getTempColorClass(machine.cpu_temp_c!)}`}>
-                    {machine.cpu_temp_c!.toFixed(0)}°C
-                  </span>
-                </>
-              )}
-              {(machine.cpu_temp_c ?? 0) > 0 && hasGpu && (
-                <span className="text-blox-muted/40">·</span>
-              )}
-              {hasGpu && (
-                <>
-                  <span className="uppercase tracking-[0.08em] text-[9px] font-medium">GPU</span>
-                  <span className={`tabular-nums font-mono ${getTempColorClass(gpuTemp)}`}>
-                    {gpuTemp.toFixed(0)}°C
-                  </span>
-                </>
-              )}
-            </div>
-          )}
-
-          {hasGpu && !showPlaceholders && (
-            <div className="flex items-center gap-2 text-[11px] pt-1.5 mt-1.5 border-t border-blox-border/30">
-              <Zap className="w-3 h-3 text-blox-muted shrink-0" />
-              <span className={`tabular-nums font-mono font-semibold ${gpuTempColorClass}`}>
-                {gpuTemp.toFixed(0)}°C
-              </span>
-              {gpuUtil > 0 && (
-                <span className="text-blox-muted tabular-nums">
-                  · {gpuUtil.toFixed(0)}% util
-                </span>
-              )}
-              {gpuVramTotal > 0 && (
-                <span className="text-blox-muted tabular-nums ml-auto font-mono">
-                  {formatBytes(gpuVramUsed)} / {formatBytes(gpuVramTotal)}
-                </span>
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* footer */}
-        <div className="flex items-center gap-1.5 text-[10px] text-blox-muted/70 mt-3 pt-2 border-t border-blox-border/40 pl-2.5 tabular-nums">
-          <span className="font-mono">
-            <LiveTimeSince since={machine.last_seen ?? null} />
-          </span>
-          {machine.latency_ms !== undefined && machine.latency_ms > 0 && (
-            <>
-              <span aria-hidden>·</span>
-              <span className="font-mono">{machine.latency_ms}ms</span>
-            </>
-          )}
-          {/* Phase 8 — version badge, only when an update is pending */}
-          {versionInfo && versionInfo.update_pending && (
-            <>
-              <span aria-hidden>·</span>
-              <span
-                className="inline-flex items-center gap-0.5 px-1 py-0 rounded bg-amber-500/10 text-amber-400 font-mono text-[9px]"
-                title={`Running ${versionInfo.running_sha?.slice(0, 8) ?? "unknown"}, update pending`}
-              >
-                update pending
               </span>
             </>
           )}
           {otherTags.length > 0 && (
             <>
-              <span aria-hidden>·</span>
-              <span className="truncate">{otherTags.join(", ")}</span>
+              <span className="text-border-strong" aria-hidden>·</span>
+              <span className="font-sans truncate">{otherTags.join(", ")}</span>
+            </>
+          )}
+        </div>
+
+        {/* ── row 3: metric figures + sparkline (or context for non-live) ── */}
+        <div className="mt-3 flex-1">
+          {hasMetrics && !isOffline ? (
+            <div className="flex items-end justify-between gap-3">
+              <div className="flex items-baseline gap-3.5">
+                <Figure label="CPU" value={(machine.cpu_percent ?? 0).toFixed(0)} unit="%" tone={pctTone(machine.cpu_percent ?? 0, 75, 92)} />
+                <Figure label="RAM" value={ramPct > 0 ? ramPct.toFixed(0) : "—"} unit={ramPct > 0 ? "%" : ""} tone={pctTone(ramPct, 82, 95)} />
+                <Figure label="DISK" value={diskPct > 0 ? diskPct.toFixed(0) : "—"} unit={diskPct > 0 ? "%" : ""} tone={pctTone(diskPct, 85, 95)} />
+                {hasGpu && (
+                  <Figure label="GPU" value={gpuTemp.toFixed(0)} unit="°C" tone={tempTone(gpuTemp)} />
+                )}
+              </div>
+              <div className="shrink-0">
+                <Sparkline machineId={machine.machine_id} width={92} height={26} />
+              </div>
+            </div>
+          ) : isOffline ? (
+            <div className="flex items-baseline gap-2 text-[11px] text-text-tertiary metric-figure">
+              <span className="text-text-disabled">last seen</span>
+              <span className="text-text-secondary">
+                <LiveTimeSince since={machine.last_seen ?? null} suffix=" ago" />
+              </span>
+            </div>
+          ) : (
+            <div className="flex items-baseline gap-2 text-[11px] text-text-tertiary metric-figure">
+              <span className="inline-flex h-1.5 w-1.5 rounded-full bg-status-stale animate-status-pulse" />
+              <span>awaiting first metrics</span>
+            </div>
+          )}
+        </div>
+
+        {/* ── row 4: footer (uptime · latency · update-pending) ── */}
+        <div className="mt-3 flex items-center gap-1.5 text-[10px] text-text-tertiary metric-figure">
+          <ArrowUpFromLine className="h-2.5 w-2.5 text-text-disabled shrink-0" />
+          <span className={isOffline ? "text-text-disabled" : ""}>
+            <LiveTimeSince since={machine.last_seen ?? null} />
+          </span>
+          {!isOffline && machine.latency_ms !== undefined && machine.latency_ms > 0 && (
+            <>
+              <span className="text-border-strong" aria-hidden>·</span>
+              <span>{machine.latency_ms} ms</span>
+            </>
+          )}
+          {versionInfo && versionInfo.update_pending && (
+            <>
+              <span className="text-border-strong" aria-hidden>·</span>
+              <span
+                className="inline-flex items-center gap-1 rounded-sm px-1 py-0 bg-status-warning-tint text-status-warning font-medium"
+                title={`Running ${versionInfo.running_sha?.slice(0, 8) ?? "unknown"}, update pending`}
+              >
+                update pending
+              </span>
             </>
           )}
         </div>
@@ -455,143 +314,121 @@ export function MachineCard({ machine, onDelete, onEdit, onRefresh }: MachineCar
 }
 
 /* ============================================================================
- * Compact metric row (RAM / Disk)
+ * Figure — the atom of a metric readout. Label small + uppercase, value in
+ * Geist Mono with tabular-nums. Tone-colored value when over threshold.
  * ============================================================================ */
 
-interface CompactMetricRowProps {
-  label: string;
-  pct: number;
-  usedBytes?: number | null;
-  totalBytes?: number | null;
-  placeholder: boolean;
-  warningAt: number;
-  dangerAt: number;
-}
-
-function CompactMetricRow({
+function Figure({
   label,
-  pct,
-  usedBytes,
-  totalBytes,
-  placeholder,
-  warningAt,
-  dangerAt,
-}: CompactMetricRowProps) {
-  const variant: ProgressVariant = placeholder
-    ? "neutral"
-    : (totalBytes ?? 0) === 0
-    ? "neutral"
-    : deriveMetricVariant(pct, warningAt, dangerAt);
-
-  const valueColorClass =
-    variant === "danger"
-      ? "text-red-400"
-      : variant === "warning"
-      ? "text-amber-400"
-      : "text-blox-text";
-
+  value,
+  unit,
+  tone,
+}: {
+  label: string;
+  value: string;
+  unit: string;
+  tone: Tone;
+}) {
   return (
-    <div className="grid grid-cols-[2.25rem_1fr_auto] items-center gap-2 text-[11px]">
-      <span className="text-blox-muted uppercase tracking-[0.08em] text-[9px] font-medium">
-        {label}
+    <div className="flex flex-col gap-0.5 leading-none">
+      <span className="text-[9px] font-medium uppercase tracking-[0.12em] text-text-tertiary">{label}</span>
+      <span className="inline-flex items-baseline gap-0.5">
+        <span className={`metric-value text-base ${toneText(tone)}`}>{value}</span>
+        {unit && <span className="metric-unit text-[10px]">{unit}</span>}
       </span>
-      <ProgressBar value={placeholder ? 0 : pct} variant={variant} />
-      <div className="flex items-center gap-1.5 tabular-nums shrink-0 min-w-0">
-        {placeholder ? (
-          <span className="text-blox-muted/40 font-mono">—</span>
-        ) : (
-          <>
-            <span className={`font-mono font-medium ${valueColorClass}`}>
-              {pct.toFixed(0)}%
-            </span>
-            {(totalBytes ?? 0) > 0 && (
-              <span className="text-blox-muted/70 font-mono text-[10px]">
-                {formatBytes(usedBytes)}/{formatBytes(totalBytes)}
-              </span>
-            )}
-          </>
-        )}
-      </div>
     </div>
   );
 }
 
 /* ============================================================================
- * LiveTimeSince — 1Hz ticking relative timestamp
- *
- * Each card mounts its own 1Hz interval so the footer "12s ago" advances
- * every second without waiting for a fresh SSE event to re-render the
- * parent. Lightweight: a single setInterval per card, no parent re-renders.
+ * IconAction — uniform 22px button slot.
  * ============================================================================ */
 
-function LiveTimeSince({ since, prefix = "" }: { since: number | null; prefix?: string }) {
+function IconAction({
+  children,
+  title,
+  onClick,
+  tone = "default",
+}: {
+  children: React.ReactNode;
+  title: string;
+  onClick: (e: React.MouseEvent) => void;
+  tone?: "default" | "danger" | "warn";
+}) {
+  const toneClass =
+    tone === "danger"
+      ? "text-text-disabled hover:text-status-critical hover:bg-status-critical-tint"
+      : tone === "warn"
+      ? "text-status-warning hover:bg-status-warning-tint"
+      : "text-text-disabled hover:text-text-primary hover:bg-surface-elevated";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex h-5 w-5 items-center justify-center rounded-sm transition-colors duration-[var(--motion-fast)] ${toneClass}`}
+      title={title}
+      aria-label={title}
+    >
+      {children}
+    </button>
+  );
+}
+
+/* ============================================================================
+ * LiveTimeSince — 1Hz ticking relative timestamp.
+ * ============================================================================ */
+
+function LiveTimeSince({ since, suffix = "" }: { since: number | null; suffix?: string }) {
   const [, force] = useState(0);
   useEffect(() => {
     if (!since) return;
     const id = setInterval(() => force((n) => n + 1), 1000);
     return () => clearInterval(id);
   }, [since]);
-  if (!since) return <span className="text-blox-muted/40">never</span>;
-  return <span>{prefix}{timeSince(since)}</span>;
+  if (!since) return <span className="text-text-disabled">never</span>;
+  return <span>{timeSince(since)}{suffix}</span>;
 }
 
 /* ============================================================================
- * RefreshButton — per-card refresh icon with self-contained spinner state
+ * RefreshButton — per-card refresh icon with self-contained spinner state.
  * ============================================================================ */
 
 function RefreshButton({ onRefresh }: { onRefresh: (e: React.MouseEvent) => void }) {
   const [refreshing, setRefreshing] = useState(false);
-
   const handleClick = (e: React.MouseEvent) => {
     if (refreshing) return;
     setRefreshing(true);
     onRefresh(e);
-    // Stop the spinner after 1.5s — fresh metrics typically arrive within
-    // ~500ms via SSE, but we don't get an explicit "refresh complete"
-    // signal so we time out the visual feedback.
     setTimeout(() => setRefreshing(false), 1500);
   };
-
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      disabled={refreshing}
-      className="p-1 rounded text-blox-muted/40 hover:text-blox-blue hover:bg-blox-blue/10 transition-colors disabled:opacity-50"
-      title="Refresh metrics"
-      aria-label="Refresh metrics for this machine"
-    >
-      <RefreshCw className={`w-3 h-3 ${refreshing ? "animate-spin" : ""}`} />
-    </button>
+    <IconAction onClick={handleClick} title="Refresh metrics">
+      <RefreshCw className={`h-3 w-3 ${refreshing ? "animate-spin" : ""}`} />
+    </IconAction>
   );
 }
 
 /* ============================================================================
- * Skeleton (initial load)
+ * MachineCardSkeleton — loading state, visually distinct from any loaded
+ * card so the operator never confuses "loading" with "machine has no data".
+ *
+ * Uses a single muted band with shimmer where the metrics would land —
+ * it does NOT mimic the row of figures.
  * ============================================================================ */
 
 export function MachineCardSkeleton() {
   return (
-    <div className="bg-blox-card border border-blox-border rounded-xl p-4 h-full flex flex-col relative before:absolute before:left-0 before:top-3 before:bottom-3 before:w-[3px] before:rounded-full before:bg-blox-border">
-      <div className="flex items-center gap-2 pl-2.5">
-        <div className="w-2 h-2 rounded-full bg-blox-border" />
-        <div className="h-3.5 bg-blox-border rounded w-28 animate-shimmer" />
+    <div className="bg-surface-raised border border-border-default rounded-md px-3.5 py-3 h-full flex flex-col">
+      <div className="flex items-center gap-2">
+        <span className="h-2 w-2 rounded-full bg-border-strong animate-status-pulse" />
+        <span className="h-3 w-32 rounded-sm bg-border-subtle animate-shimmer" />
       </div>
-      <div className="pl-2.5 mt-1.5">
-        <div className="h-2.5 bg-blox-border/60 rounded w-32 animate-shimmer" />
+      <span className="mt-2 h-2 w-44 rounded-sm bg-border-subtle/70 animate-shimmer" />
+      <div className="mt-4 flex items-center gap-2 text-[11px] text-text-tertiary">
+        <span className="inline-flex h-1.5 w-1.5 rounded-full bg-status-stale animate-status-pulse" />
+        <span className="metric-figure">connecting…</span>
       </div>
-      <div className="flex items-end gap-3 pl-2.5 mt-3 mb-2">
-        <div className="flex flex-col gap-1.5">
-          <div className="h-7 w-12 bg-blox-border rounded animate-shimmer" />
-          <div className="h-2 w-8 bg-blox-border/60 rounded animate-shimmer" />
-        </div>
-        <div className="flex-1 h-7 bg-blox-border/40 rounded animate-shimmer" />
-      </div>
-      <div className="space-y-1.5 pl-2.5 flex-1">
-        <div className="h-2.5 bg-blox-border/40 rounded animate-shimmer" />
-        <div className="h-2.5 bg-blox-border/40 rounded animate-shimmer" />
-      </div>
-      <div className="h-2 w-20 bg-blox-border/40 rounded mt-3 pl-2.5 animate-shimmer" />
+      <div className="mt-auto pt-3 h-2 w-20 rounded-sm bg-border-subtle/60 animate-shimmer" />
     </div>
   );
 }

--- a/dashboard/src/components/MachineCard.tsx
+++ b/dashboard/src/components/MachineCard.tsx
@@ -188,7 +188,7 @@ export function MachineCard({ machine, onDelete, onEdit, onRefresh }: MachineCar
           {pinned && (
             <Star className="h-3 w-3 shrink-0 fill-status-warning text-status-warning" aria-label="Pinned" />
           )}
-          <div className="ml-auto flex items-center gap-0.5 opacity-0 transition-opacity duration-[var(--motion-fast)] group-hover:opacity-100 focus-within:opacity-100">
+          <div className="ml-auto flex items-center gap-0.5 opacity-0 pointer-events-none transition-opacity duration-[var(--motion-fast)] group-hover:opacity-100 group-hover:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto">
             <IconAction
               title={pinned ? "Unpin from top" : "Pin to top"}
               onClick={(e) => {

--- a/dashboard/src/components/NeedsAttention.tsx
+++ b/dashboard/src/components/NeedsAttention.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useMemo } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { useRouter } from "next/navigation";
+import { AlertTriangle } from "lucide-react";
+import type { MachineMetrics } from "@/lib/demo-data";
+import {
+  classifyMachine,
+  isProblem,
+  STATUS_ORDER,
+  STATUS_VIS,
+  StatusDot,
+  type MachineStatus,
+} from "@/components/StatusBadge";
+
+/* ============================================================================
+ * NeedsAttention — pinned-to-top stripe showing problem machines.
+ *
+ * Only renders when there's at least one machine in {critical, warning,
+ * offline, stale}. Sorts by status severity (critical first) then alpha
+ * by hostname. Horizontally scrollable on narrow viewports; on desktop
+ * a flex-wrap grid lets all chips show at once.
+ *
+ * Each chip is a single-line summary that links to /machine/:id. The
+ * point: when something is wrong, the operator sees what and where in
+ * <2 seconds without scrolling the main grid.
+ * ============================================================================ */
+
+interface NeedsAttentionProps {
+  machines: MachineMetrics[];
+}
+
+interface ProblemEntry {
+  machine: MachineMetrics;
+  status: MachineStatus;
+  reason?: string;
+}
+
+function timeAgo(ms: number): string {
+  const sec = Math.floor((Date.now() - ms) / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const d = Math.floor(hr / 24);
+  return `${d}d ago`;
+}
+
+export function NeedsAttention({ machines }: NeedsAttentionProps) {
+  const router = useRouter();
+
+  const problems = useMemo<ProblemEntry[]>(() => {
+    const out: ProblemEntry[] = [];
+    for (const m of machines) {
+      const { status, reason } = classifyMachine(m);
+      if (isProblem(status)) out.push({ machine: m, status, reason });
+    }
+    out.sort((a, b) => {
+      const sd = STATUS_ORDER[a.status] - STATUS_ORDER[b.status];
+      if (sd !== 0) return sd;
+      return (a.machine.hostname ?? "").localeCompare(b.machine.hostname ?? "");
+    });
+    return out;
+  }, [machines]);
+
+  const counts = useMemo(() => {
+    let critical = 0, warning = 0, offline = 0, stale = 0;
+    for (const p of problems) {
+      if (p.status === "critical") critical++;
+      else if (p.status === "warning") warning++;
+      else if (p.status === "offline") offline++;
+      else if (p.status === "stale") stale++;
+    }
+    return { critical, warning, offline, stale, total: problems.length };
+  }, [problems]);
+
+  return (
+    <AnimatePresence>
+      {problems.length > 0 && (
+        <motion.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: "auto" }}
+          exit={{ opacity: 0, height: 0 }}
+          transition={{ duration: 0.2 }}
+          className="overflow-hidden border-y border-border-subtle bg-surface-sunken/60"
+        >
+          <div className="max-w-[1600px] mx-auto px-4 sm:px-6 py-2.5">
+            <div className="flex items-start gap-3">
+              <div className="flex items-center gap-2 pt-1.5 shrink-0">
+                <AlertTriangle className="h-3 w-3 text-status-critical" />
+                <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-text-tertiary">
+                  Needs Attention
+                </span>
+                <span className="metric-figure text-[10px] text-text-primary">
+                  {counts.total}
+                </span>
+                <span className="inline-flex items-center gap-1.5 ml-1">
+                  {counts.critical > 0 && <CountChip n={counts.critical} label="crit" color="text-status-critical" />}
+                  {counts.warning > 0 && <CountChip n={counts.warning} label="warn" color="text-status-warning" />}
+                  {counts.offline > 0 && <CountChip n={counts.offline} label="off" color="text-status-offline" />}
+                  {counts.stale > 0 && <CountChip n={counts.stale} label="stale" color="text-status-stale" />}
+                </span>
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex flex-wrap gap-1.5">
+                  {problems.map(({ machine, status, reason }) => (
+                    <ProblemChip
+                      key={machine.machine_id}
+                      machine={machine}
+                      status={status}
+                      reason={reason}
+                      onOpen={() => router.push(`/machine/${machine.machine_id}`)}
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+/* ============================================================================
+ * ProblemChip — single problem-machine summary.
+ * ============================================================================ */
+
+function ProblemChip({
+  machine,
+  status,
+  reason,
+  onOpen,
+}: {
+  machine: MachineMetrics;
+  status: MachineStatus;
+  reason?: string;
+  onOpen: () => void;
+}) {
+  const vis = STATUS_VIS[status];
+  // For offline, use "last seen Xm ago" instead of a metric reason.
+  const detail =
+    status === "offline"
+      ? machine.last_seen
+        ? timeAgo(machine.last_seen)
+        : "never seen"
+      : reason ?? vis.label.toLowerCase();
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className={[
+        "group inline-flex items-center gap-2 rounded-md px-2.5 py-1.5",
+        vis.surfaceTintClass || "bg-surface-raised",
+        "border border-border-subtle hover:border-border-strong",
+        "transition-colors duration-[var(--motion-fast)]",
+        "text-left",
+      ].join(" ")}
+      title={`${machine.hostname} — ${detail}`}
+    >
+      <StatusDot status={status} size="xs" />
+      <span className="font-semibold text-[12px] text-text-primary truncate max-w-[160px]">
+        {machine.hostname || machine.machine_id}
+      </span>
+      <span className={`metric-figure text-[10px] ${vis.textClass}`}>
+        {detail}
+      </span>
+    </button>
+  );
+}
+
+function CountChip({ n, label, color }: { n: number; label: string; color: string }) {
+  return (
+    <span className={`inline-flex items-baseline gap-0.5 text-[9px] ${color}`}>
+      <span className="metric-figure">{n}</span>
+      <span className="uppercase tracking-[0.08em]">{label}</span>
+    </span>
+  );
+}

--- a/dashboard/src/components/NeedsAttention.tsx
+++ b/dashboard/src/components/NeedsAttention.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useRouter } from "next/navigation";
 import { AlertTriangle } from "lucide-react";
@@ -51,6 +51,16 @@ function timeAgo(ms: number): string {
 export function NeedsAttention({ machines }: NeedsAttentionProps) {
   const router = useRouter();
 
+  // classifyMachine() reads Date.now() to decide stale/offline, so the memo
+  // must invalidate on time too — otherwise a silent fleet (no SSE updates,
+  // machines array reference unchanged) would leave the stripe stuck on its
+  // last classification. 5s tick is well below the 30s stale threshold.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 5_000);
+    return () => clearInterval(id);
+  }, []);
+
   const problems = useMemo<ProblemEntry[]>(() => {
     const out: ProblemEntry[] = [];
     for (const m of machines) {
@@ -63,7 +73,9 @@ export function NeedsAttention({ machines }: NeedsAttentionProps) {
       return (a.machine.hostname ?? "").localeCompare(b.machine.hostname ?? "");
     });
     return out;
-  }, [machines]);
+    // tick is the deliberate time-trigger — eslint can't see Date.now() inside classifyMachine
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [machines, tick]);
 
   const counts = useMemo(() => {
     let critical = 0, warning = 0, offline = 0, stale = 0;

--- a/dashboard/src/components/StatusBadge.tsx
+++ b/dashboard/src/components/StatusBadge.tsx
@@ -1,43 +1,187 @@
 "use client";
 
-import { Badge } from "@/components/ui/badge";
-import { AlertTriangle, Circle } from "lucide-react";
+import type { MachineMetrics } from "@/lib/demo-data";
 
-export type MachineStatus = "online" | "warning" | "offline";
+/* ============================================================================
+ * Fleet status — 5 intent states.
+ *
+ *   live      heartbeat + fresh metrics, all thresholds nominal
+ *   stale     heartbeat present but no metric update in 30–120s
+ *   warning   one or more metrics in warning zone
+ *   critical  one or more metrics in danger zone (urgent operator attention)
+ *   offline   no heartbeat in >120s
+ *
+ * `classifyMachine` is the single source of truth — used by the card, the
+ * stat strip, the filter dropdown, and the NeedsAttention stripe. Keep
+ * thresholds in sync with the hub-side `evaluateAlerts` rules.
+ * ============================================================================ */
 
-interface StatusBadgeProps {
+export type MachineStatus = "live" | "stale" | "warning" | "critical" | "offline";
+
+const OFFLINE_MS = 120_000;
+const STALE_MS = 30_000;
+
+const TH = {
+  cpuWarn: 75,
+  cpuCrit: 92,
+  ramWarn: 82,
+  ramCrit: 95,
+  diskWarn: 85,
+  diskCrit: 95,
+  gpuWarn: 78,
+  gpuCrit: 86,
+};
+
+export interface MachineClassification {
   status: MachineStatus;
   reason?: string;
 }
 
-export function StatusBadge({ status, reason }: StatusBadgeProps) {
-  if (status === "online") {
-    return (
-      <Badge variant="outline" className="gap-1.5 border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-[10px] px-2 py-0.5 h-auto">
-        <span className="relative flex h-2 w-2">
-          <span className="animate-status-pulse absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-          <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
-        </span>
-        Online
-        {reason && <span className="text-blox-muted ml-0.5">({reason})</span>}
-      </Badge>
-    );
-  }
+export function classifyMachine(m: MachineMetrics): MachineClassification {
+  const age = Date.now() - (m.last_seen || 0);
+  if (!m.last_seen || age > OFFLINE_MS) return { status: "offline" };
 
-  if (status === "warning") {
-    return (
-      <Badge variant="outline" className="gap-1 border-amber-500/30 bg-amber-500/10 text-amber-400 text-[10px] px-2 py-0.5 h-auto">
-        <AlertTriangle className="w-2.5 h-2.5" />
-        Warning
-        {reason && <span className="text-blox-muted ml-0.5">({reason})</span>}
-      </Badge>
-    );
-  }
+  const ramPct =
+    (m.ram_total_bytes ?? 0) > 0
+      ? ((m.ram_used_bytes ?? 0) / m.ram_total_bytes) * 100
+      : 0;
+  const diskPct =
+    (m.disk_total_bytes ?? 0) > 0
+      ? ((m.disk_used_bytes ?? 0) / m.disk_total_bytes) * 100
+      : 0;
+  const cpu = m.cpu_percent ?? 0;
+  const gpuT = m.gpu_temp ?? 0;
 
+  if (cpu >= TH.cpuCrit) return { status: "critical", reason: `CPU ${cpu.toFixed(0)}%` };
+  if (ramPct >= TH.ramCrit) return { status: "critical", reason: `RAM ${ramPct.toFixed(0)}%` };
+  if (diskPct >= TH.diskCrit) return { status: "critical", reason: `Disk ${diskPct.toFixed(0)}%` };
+  if (gpuT >= TH.gpuCrit) return { status: "critical", reason: `GPU ${gpuT.toFixed(0)}°C` };
+
+  if (cpu >= TH.cpuWarn) return { status: "warning", reason: `CPU ${cpu.toFixed(0)}%` };
+  if (ramPct >= TH.ramWarn) return { status: "warning", reason: `RAM ${ramPct.toFixed(0)}%` };
+  if (diskPct >= TH.diskWarn) return { status: "warning", reason: `Disk ${diskPct.toFixed(0)}%` };
+  if (gpuT >= TH.gpuWarn) return { status: "warning", reason: `GPU ${gpuT.toFixed(0)}°C` };
+
+  if (age > STALE_MS) return { status: "stale" };
+  return { status: "live" };
+}
+
+/** Ordering for sort-by-status — problem machines first. */
+export const STATUS_ORDER: Record<MachineStatus, number> = {
+  critical: 0,
+  warning: 1,
+  offline: 2,
+  stale: 3,
+  live: 4,
+};
+
+/** Operator-attention states surface at the top of the fleet. */
+export function isProblem(s: MachineStatus): boolean {
+  return s === "critical" || s === "warning" || s === "offline" || s === "stale";
+}
+
+/* ============================================================================
+ * Visual tokens — color + label for each state.
+ * Centralized so the StatCard, MachineCard, and NeedsAttention stripe
+ * never drift. Every consumer reads from `STATUS_VIS`.
+ * ============================================================================ */
+
+export interface StatusVisual {
+  label: string;
+  dotClass: string;
+  textClass: string;
+  surfaceTintClass: string;
+  ringClass: string;
+}
+
+export const STATUS_VIS: Record<MachineStatus, StatusVisual> = {
+  live: {
+    label: "Live",
+    dotClass: "bg-status-ok",
+    textClass: "text-status-ok",
+    surfaceTintClass: "",
+    ringClass: "ring-status-ok/30",
+  },
+  stale: {
+    label: "Stale",
+    dotClass: "bg-status-stale",
+    textClass: "text-status-stale",
+    surfaceTintClass: "bg-status-stale-tint",
+    ringClass: "ring-status-stale/30",
+  },
+  warning: {
+    label: "Warn",
+    dotClass: "bg-status-warning",
+    textClass: "text-status-warning",
+    surfaceTintClass: "bg-status-warning-tint",
+    ringClass: "ring-status-warning/35",
+  },
+  critical: {
+    label: "Critical",
+    dotClass: "bg-status-critical",
+    textClass: "text-status-critical",
+    surfaceTintClass: "bg-status-critical-tint",
+    ringClass: "ring-status-critical/40",
+  },
+  offline: {
+    label: "Offline",
+    dotClass: "bg-status-offline",
+    textClass: "text-status-offline",
+    surfaceTintClass: "bg-status-offline-tint",
+    ringClass: "ring-status-offline/30",
+  },
+};
+
+/* ============================================================================
+ * StatusDot — minimum-viable indicator.
+ * Used everywhere a colored dot is enough. Live state gets a soft outer ring
+ * pulse to convey "this is actively reporting" without animating its position.
+ * ============================================================================ */
+
+interface StatusDotProps {
+  status: MachineStatus;
+  size?: "xs" | "sm" | "md";
+  pulse?: boolean;
+}
+
+export function StatusDot({ status, size = "sm", pulse = false }: StatusDotProps) {
+  const dim = size === "xs" ? "h-1.5 w-1.5" : size === "md" ? "h-2.5 w-2.5" : "h-2 w-2";
+  const v = STATUS_VIS[status];
   return (
-    <Badge variant="outline" className="gap-1 border-red-500/30 bg-red-500/10 text-red-400 text-[10px] px-2 py-0.5 h-auto">
-      <Circle className="w-2.5 h-2.5" />
-      Offline
-    </Badge>
+    <span className={`relative inline-flex shrink-0 ${dim}`} aria-label={`Status: ${v.label.toLowerCase()}`}>
+      {pulse && status === "live" && (
+        <span className={`absolute inset-0 rounded-full ${v.dotClass} opacity-50 animate-status-pulse`} />
+      )}
+      <span className={`relative inline-flex rounded-full ${dim} ${v.dotClass}`} />
+    </span>
+  );
+}
+
+/* ============================================================================
+ * StatusBadge — dot + label, used in row contexts (NeedsAttention, machine
+ * detail header). Compact, never colored borders, just a tinted pill.
+ * ============================================================================ */
+
+interface StatusBadgeProps {
+  status: MachineStatus;
+  reason?: string;
+  size?: "xs" | "sm";
+}
+
+export function StatusBadge({ status, reason, size = "sm" }: StatusBadgeProps) {
+  const v = STATUS_VIS[status];
+  const pad = size === "xs" ? "px-1.5 py-0 text-[10px]" : "px-2 py-0.5 text-[11px]";
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-md ${pad} ${v.surfaceTintClass || "bg-surface-elevated"} ${v.textClass} font-medium tracking-tight`}
+    >
+      <StatusDot status={status} size="xs" pulse={status === "live"} />
+      <span>{v.label}</span>
+      {reason && (
+        <span className="text-text-tertiary font-mono tabular-nums lowercase font-normal">
+          · {reason}
+        </span>
+      )}
+    </span>
   );
 }


### PR DESCRIPTION
## Summary

Visual/product design pass on the fleet dashboard screen only. The goal: make the dashboard read as a serious commercial product instead of a default admin template, with fleet health legible in under 2 seconds. Keeps the existing dark theme, blue accent, and full stack (Next.js 16 / React 19 / Tailwind v4 / shadcn / Base UI / Tremor / Recharts / Framer Motion) — nothing added, nothing swapped.

## Scope

Fleet dashboard screen only:

- Stat row (FleetPulse)
- Search/filter toolbar
- Machine grid/list (MachineCard + list-view dots)
- New: Needs Attention stripe between FleetPulse and the toolbar

Design language locked here. Will be propagated to other screens in follow-up PRs only after sign-off.

Backend, API contracts, auth, routing, persistence: **untouched**.

## Confirmations (against the brief)

- [x] **No colored left-border card accents remain.** The `before:` pseudo-element bar is gone from MachineCard and every FleetPulse cell. State lives in the dot, the badge, the surface tint, and (for critical only) a 1px inset ring.
- [x] **Stat row is one FLEET hero cell + four consistent support cells.** Grid is `grid-cols-2 sm:grid-cols-[5fr_3fr_3fr_3fr_3fr]`. Earlier inline-style attempt was overridden by media CSS and pinned at 2 cols on desktop — fixed by moving to Tailwind arbitrary values.
- [x] **Machine cards handle live / stale / warning / critical / offline / loading explicitly.** See `STATUS_VIS` map in `StatusBadge.tsx` and the state branches in `MachineCard.tsx`. Loading uses a distinct shimmer layout with "connecting…" text — never an empty card with zero values.
- [x] **Needs Attention appears only when problem machines exist.** `NeedsAttention.tsx` short-circuits to null when `problems.length === 0`. Renders inside an `AnimatePresence` so it slides in/out cleanly when state flips.

## Design tokens (globals.css)

- Dark theme retuned to a cool-neutral OKLCH ramp (sunken / base / raised / elevated / overlay).
- Accent shifted from default Tailwind blue-500 to instrument-cyan `oklch(0.7 0.155 230)`.
- New 5-state status namespace: `--status-{ok,warning,critical,stale,offline}` + matching tints.
- Radius tightened from 10px to 8px.
- `.metric-value` / `.metric-figure` / `.metric-unit` helpers — Geist Mono + tabular-nums + slashed-zero + ss06/ss07 features for aligned numeric readouts.

## Behavior changes (intentional)

- **`MachineStatus` widened** from `online | warning | offline` to `live | stale | warning | critical | offline`. Stale = heartbeat present, no metric update in 30–120s. Critical = any metric in danger zone (CPU≥92%, RAM≥95%, disk≥95%, GPU≥86°C).
- **Problem-first sort.** Critical → warning → offline → stale always bubble above live machines regardless of the user's chosen sort (name/CPU/GPU), while preserving the chosen sort within each partition.
- **Saved-filter hydration** accepts both the new state names and the legacy `"online"` literal (auto-mapped to `"live"`) so existing saved filters keep working.
- **`machine/[id]/page.tsx`** — one-character compat change: the return literal `"online"` → `"live"` to match the widened type. No behavior change.

## Files

| File | Change |
|---|---|
| `dashboard/src/app/globals.css` | New token system, status namespace, metric typography helpers |
| `dashboard/src/components/StatusBadge.tsx` | Rewrite — 5-state primitive + `classifyMachine` + `STATUS_VIS` map |
| `dashboard/src/components/FleetPulse.tsx` | Rewrite — locked anatomy + asymmetric grid |
| `dashboard/src/components/MachineCard.tsx` | Rewrite — dense, no border bars, six explicit states |
| `dashboard/src/components/NeedsAttention.tsx` | **New** — problem-machine pinned stripe |
| `dashboard/src/app/page.tsx` | Status filter + problem-first sort + NeedsAttention mount |
| `dashboard/src/app/machine/[id]/page.tsx` | One-line type compat |

## Test plan

- [x] `pnpm tsc --noEmit` — clean (0 errors)
- [x] `pnpm eslint src` — clean (0 errors, 0 warnings)
- [x] `pnpm build` — production build succeeds
- [x] Deployed to live hub, https://192.168.16.113 returns 200, `bloxos-dashboard` service active, no errors in journal
- [ ] **Visual review required from someone with browser access** — this PR has no screenshots because the hub VM has no Playwright/browser installed. Please hard-refresh and walk the dashboard against the confirmations list above.

## What to look at on visual review

- FLEET cell is clearly wider than the other four (desktop, >640px)
- No colored stripe on the left edge of any machine card or stat cell
- Numeric values use mono font, percentage signs attached without a space ("73%" not "73 %")
- Critical machines have a subtle red surface tint + 1px inset ring (not a border bar)
- Offline cards are visibly dimmed and show "last seen Xm ago" prominently
- The Needs Attention stripe only appears when at least one machine is critical/warning/offline/stale
- Hover a machine card → action buttons (pin/refresh/edit/delete) fade in; resting state stays calm
- Skeleton state (initial load) shows "connecting…" — clearly not a loaded card with zero data

🤖 Generated with [Claude Code](https://claude.com/claude-code)