### PR TITLE
ci: auto-merge Dependabot patch + dev-minor bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,48 @@
+name: Dependabot auto-merge
+
+# Auto-queue merges for low-risk Dependabot PRs once branch-protection gates
+# pass. The workflow does NOT bypass protection — it sets the PR to auto-merge
+# (via `gh pr merge --auto`), so GitHub waits for required CI checks before
+# completing the merge.
+#
+# Scope of "low-risk":
+#   - any patch (semver-patch)
+#   - dev-dependency minor bumps (semver-minor + direct:development)
+#
+# Runtime minors and any majors stay manual — they can ship subtle visual or
+# API changes that CI cannot catch.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7  # v2.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --squash --auto "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for dev-dependency minor updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-minor' &&
+          steps.meta.outputs.dependency-type == 'direct:development'
+        run: gh pr merge --squash --auto "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependabot-auto-merge.yml` that auto-queues merges for low-risk Dependabot PRs once branch-protection gates pass.

**Scope (auto-merge):**
- any `semver-patch` (regardless of dep type)
- `semver-minor` where `dependency-type == direct:development`

**Stays manual:**
- runtime minor bumps (can ship subtle visual/API changes CI doesn't catch)
- any major bump

## How it works

The workflow uses `dependabot/fetch-metadata` (pinned to its v2.2.0 commit SHA, matching the supply-chain pinning pattern used in `InContext/deploy.yml`'s `appleboy/ssh-action` pin) to read the bump scope, then calls `gh pr merge --auto --squash` on qualifying PRs. The `--auto` flag **queues** the merge — GitHub waits until all branch-protection requirements pass before actually merging.

## ⚠️ Important: review-requirement compatibility

This is the trade-off you need to think about. `main` is currently protected with `required_approving_review_count: 1`. Until that gate is satisfied, `--auto` will queue forever and nothing merges. There are three ways to make this fully autonomous:

1. **Drop review-count to 0** for `main` (still keeps no-force-push, no-deletion, linear history, required CI). Solo maintainer + CI is the gate.
2. **Add Dependabot as a bypass** in branch protection rules (requires migrating to GitHub rulesets — more setup).
3. **Manually approve each PR** via web UI — defeats the auto-merge purpose, just rubber-stamps.

My recommendation: **option 1** for `main` on this repo. Your real protection against unreviewed merges is who has write access (just you), not the review-count rule.

If you go with option 1, the command is:
```bash
gh api -X PUT repos/bokiko/bloxos/branches/main/protection -H "Accept: application/vnd.github+json" --input - <<'EOF2'
{"required_status_checks":{"strict":true,"contexts":["Hub Tests","Agent Tests","Dashboard Lint + Build"]},"enforce_admins":false,"required_pull_request_reviews":null,"restrictions":null,"required_linear_history":true,"allow_force_pushes":false,"allow_deletions":false,"required_conversation_resolution":true}
EOF2
```

## Security audit

Reviewed against the workflow-injection patterns from https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/:

- No user-controlled inputs (`pull_request.title`, `pull_request.body`, `head.ref`, etc.) are interpolated into `run:` blocks.
- The only `\${{ ... }}` expression in a `run:` context is `github.event.pull_request.html_url`, which is GitHub-generated, not user-controllable.
- That URL is passed via `env: PR_URL: \${{ ... }}` and consumed as `"\$PR_URL"` in the shell — the documented safe pattern.
- Action pinned to commit SHA, not floating tag.

## Test plan

- [ ] Merge this PR
- [ ] (Optional) apply the protection relaxation in the snippet above
- [ ] Wait for next Dependabot PR
- [ ] Verify: workflow runs, finds patch/dev-minor, calls `pr merge --auto`
- [ ] Verify: PR auto-merges once CI is green
- [ ] Verify: a hypothetical major or runtime-minor bump does NOT auto-merge

## For the 5 currently-open Dependabot PRs

This workflow does NOT retroactively process them — workflows only trigger on new `pull_request_target` events. To clear those, either:
```bash
for n in 97 98 99 100 101; do gh pr merge \$n -R bokiko/bloxos --squash --admin; done
```
or close + reopen each PR to retrigger the new workflow.