### PR TITLE
fix: bind agent identity, harden WS liveness, fix terminal goroutine leak

### DIFF
--- a/agent/backoff_test.go
+++ b/agent/backoff_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBackoffAfterConn covers the reconnect-backoff reset rule: a connection
+// that stayed up beyond stableConnThreshold is treated as healthy and resets
+// the backoff to its base delay, so a later brief blip does not inherit a long
+// backoff accumulated earlier in the agent's life.
+func TestBackoffAfterConn(t *testing.T) {
+	base := time.Second
+	cases := []struct {
+		name    string
+		current time.Duration
+		uptime  time.Duration
+		want    time.Duration
+	}{
+		{"stable connection resets to base", 60 * time.Second, stableConnThreshold + time.Second, base},
+		{"brief connection keeps current backoff", 60 * time.Second, time.Second, 60 * time.Second},
+		{"exactly at threshold keeps current backoff", 30 * time.Second, stableConnThreshold, 30 * time.Second},
+		{"already at base stays at base", base, time.Millisecond, base},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := backoffAfterConn(tc.current, base, tc.uptime); got != tc.want {
+				t.Fatalf("backoffAfterConn(%v, %v, %v) = %v, want %v",
+					tc.current, base, tc.uptime, got, tc.want)
+			}
+		})
+	}
+}

--- a/agent/main.go
+++ b/agent/main.go
@@ -320,6 +320,32 @@ func main() {
 	runPlatformAgent()
 }
 
+// WebSocket liveness tuning. pingPeriod must be shorter than pongWait so a
+// missed pong is noticed within one interval; writeWait bounds every write so
+// a stuck send fails fast and triggers reconnect instead of blocking forever.
+const (
+	agentPongWait   = 70 * time.Second
+	agentPingPeriod = 30 * time.Second
+	agentWriteWait  = 10 * time.Second
+)
+
+// stableConnThreshold is how long a connection must stay up before the agent
+// treats it as healthy and resets its reconnect backoff to the base delay.
+const stableConnThreshold = 2 * time.Minute
+
+// backoffAfterConn returns the backoff to carry into the next reconnect sleep.
+// A connection that stayed up longer than stableConnThreshold is considered
+// healthy, so the backoff resets to base; otherwise the current backoff is
+// preserved for the caller's exponential progression. Without this reset an
+// agent that accumulated a long backoff early keeps a ~60s reconnect delay for
+// the rest of its life, even after hours of stable uptime.
+func backoffAfterConn(current, base, uptime time.Duration) time.Duration {
+	if uptime > stableConnThreshold {
+		return base
+	}
+	return current
+}
+
 func connectLoop(machineID string) {
 	backoff := time.Second
 	maxBackoff := 60 * time.Second
@@ -330,10 +356,15 @@ func connectLoop(machineID string) {
 			agentSecret = stored
 		}
 
+		start := time.Now()
 		err := runAgent(machineID)
 		if err != nil {
 			log.Printf("connection error: %v", err)
 		}
+
+		// A connection that stayed up long enough to be "stable" resets the
+		// backoff so a later brief blip doesn't inherit a long delay.
+		backoff = backoffAfterConn(backoff, time.Second, time.Since(start))
 
 		jitter := time.Duration(rand.Int63n(int64(backoff) / 2))
 		wait := backoff + jitter
@@ -383,6 +414,15 @@ func runAgent(machineID string) error {
 	// Mutex for concurrent writes to WebSocket.
 	var writeMu sync.Mutex
 
+	// Liveness: require a hub frame (data or pong) within pongWait, and refresh
+	// the deadline whenever one arrives. A silently dead TCP connection now
+	// surfaces within ~pongWait instead of hanging on the OS keepalive (~2h).
+	conn.SetReadDeadline(time.Now().Add(agentPongWait))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(agentPongWait))
+		return nil
+	})
+
 	// Start a goroutine to read incoming commands from the hub.
 	errCh := make(chan error, 1)
 	go func() {
@@ -392,6 +432,7 @@ func runAgent(machineID string) error {
 				errCh <- fmt.Errorf("read error: %w", err)
 				return
 			}
+			conn.SetReadDeadline(time.Now().Add(agentPongWait))
 
 			// Decode the type field to dispatch.
 			var envelope struct {
@@ -439,6 +480,11 @@ func runAgent(machineID string) error {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
+	// Ping the hub on a fixed cadence so a half-open connection is detected via
+	// the pong deadline even during a lull in metrics traffic.
+	pingTicker := time.NewTicker(agentPingPeriod)
+	defer pingTicker.Stop()
+
 	// Send immediately on connect, then every 30s. Metrics MUST go first
 	// because the hub creates the machines row from the metric payload
 	// (hostname/IP/OS); any other persisted message that arrives before the
@@ -474,6 +520,14 @@ func runAgent(machineID string) error {
 			if err := sendAll(conn, &writeMu, machineID); err != nil {
 				return err
 			}
+		case <-pingTicker.C:
+			writeMu.Lock()
+			conn.SetWriteDeadline(time.Now().Add(agentWriteWait))
+			err := conn.WriteMessage(websocket.PingMessage, nil)
+			writeMu.Unlock()
+			if err != nil {
+				return fmt.Errorf("ping: %w", err)
+			}
 		}
 	}
 }
@@ -494,6 +548,7 @@ func writeJSON(conn *websocket.Conn, mu *sync.Mutex, v interface{}) error {
 	}
 	mu.Lock()
 	defer mu.Unlock()
+	conn.SetWriteDeadline(time.Now().Add(agentWriteWait))
 	return conn.WriteMessage(websocket.TextMessage, data)
 }
 

--- a/dashboard/src/components/Terminal.tsx
+++ b/dashboard/src/components/Terminal.tsx
@@ -5,6 +5,7 @@ import { Terminal as XTerm, ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { useTheme } from "@/contexts/ThemeContext";
+import { getHubWsBaseUrl } from "@/lib/session";
 import "@xterm/xterm/css/xterm.css";
 
 interface TerminalProps {
@@ -122,7 +123,10 @@ export function Terminal({ sessionId, browserToken, onDisconnect }: TerminalProp
 
     term.writeln("\x1b[36mConnecting to terminal session…\x1b[0m");
 
-    const baseUrl = window.location.origin.replace(/^http/, "ws");
+    // Use the hub base URL (HUB_URL when set), not the dashboard's own origin,
+    // so the terminal works in split-origin deployments where the dashboard
+    // and hub are served from different hosts.
+    const baseUrl = getHubWsBaseUrl();
     const wsUrl = `${baseUrl}/ws/terminal/${sessionId}?role=browser&browser_token=${encodeURIComponent(
       browserToken
     )}`;

--- a/dashboard/src/contexts/AuthContext.tsx
+++ b/dashboard/src/contexts/AuthContext.tsx
@@ -153,20 +153,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
     const res = await fetch(url, { ...init, headers });
     if (res.status === 401) {
-      try {
-        const payload = JSON.parse(atob((currentToken || "").split(".")[1]));
-        if (payload.exp * 1000 < Date.now()) {
-          localStorage.removeItem("bloxos_token");
-          setToken(null);
-          dispatchAuthChanged();
-          router.push("/login");
-        }
-      } catch {
-        localStorage.removeItem("bloxos_token");
-        setToken(null);
-        dispatchAuthChanged();
-        router.push("/login");
-      }
+      // Any 401 is authoritative: the hub rejected this token. That covers
+      // server-side revocation (deleted user, role change, rotated secret) as
+      // well as expiry — cases the old local `exp` check missed, leaving the
+      // client "logged in" while every request silently failed.
+      localStorage.removeItem("bloxos_token");
+      setToken(null);
+      dispatchAuthChanged();
+      router.push("/login");
     }
     return res;
   }, [router]);

--- a/dashboard/src/contexts/SSEContext.tsx
+++ b/dashboard/src/contexts/SSEContext.tsx
@@ -71,6 +71,8 @@ export function SSEProvider({ children }: { children: ReactNode }) {
   // Refresh SSE token before it expires (every 4 min for a 5-min token).
   const sseTokenRefreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const connectRef = useRef<() => void>(() => {});
+  // Generation counter to serialize overlapping async connect() calls.
+  const connectSeqRef = useRef(0);
 
   // Phase 7: localStorage-backed cache for instant rehydration on reload.
   const userIDRef = useRef<string | null>(null);
@@ -111,6 +113,13 @@ export function SSEProvider({ children }: { children: ReactNode }) {
   const connect = useCallback(async () => {
     if (!mountedRef.current) return;
 
+    // Serialize overlapping connects. Three triggers — the 4-min token refresh,
+    // the onerror backoff, and the auth/storage listeners — can call connect()
+    // concurrently. Each awaits fetchSSEToken(); without this generation guard
+    // two of them could both assign esRef.current, orphaning (never closing)
+    // the first EventSource and leaking a live connection.
+    const mySeq = ++connectSeqRef.current;
+
     disconnect();
     const token = getStoredToken();
 
@@ -119,6 +128,8 @@ export function SSEProvider({ children }: { children: ReactNode }) {
 
     // Get SSE-scoped token (Finding #8).
     const sseToken = await fetchSSEToken();
+    // A newer connect() superseded this one (or we unmounted) while awaiting.
+    if (mySeq !== connectSeqRef.current || !mountedRef.current) return;
     if (!sseToken) {
       reconnectTimer.current = setTimeout(() => {
         backoffRef.current = Math.min(backoffRef.current * 2, 30000);

--- a/hub/agent_identity_test.go
+++ b/hub/agent_identity_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// enrollAndCaptureSecret enrolls a fresh agent for machineID via a valid token
+// and returns the durable secret. It drains any agent_version frames the hub
+// sends on registration until it sees the "enrolled" frame.
+func enrollAndCaptureSecret(t *testing.T, server *httptest.Server, token, machineID string) string {
+	t.Helper()
+	conn, err := wsDialAgent(t, server, "token="+token)
+	if err != nil {
+		t.Fatalf("enroll dial: %v", err)
+	}
+	sendMetricsMsg(t, conn, machineID)
+
+	var secret string
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	for secret == "" {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read on enroll conn: %v", err)
+		}
+		var probe struct {
+			Type        string `json:"type"`
+			AgentSecret string `json:"agent_secret"`
+		}
+		if err := json.Unmarshal(msg, &probe); err != nil {
+			continue
+		}
+		if probe.Type == "enrolled" {
+			secret = probe.AgentSecret
+		}
+	}
+	conn.Close()
+	waitAgentDrain(t, machineID, 2*time.Second)
+	return secret
+}
+
+// TestAuthedAgentCannotWriteForeignMachineID locks in the identity-binding fix:
+// once a WebSocket is authenticated as machine A (via durable secret), any
+// later frame that claims a different machine_id must be ignored, for every
+// message type. Without the guard, one compromised fleet member can overwrite
+// another machine's row/metrics/inventory and suppress its alerts.
+func TestAuthedAgentCannotWriteForeignMachineID(t *testing.T) {
+	e := setupTestServer(t)
+	token := seedValidToken(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	secret := enrollAndCaptureSecret(t, server, token, "machine-A")
+
+	// Reconnect authenticated as machine-A.
+	conn, err := wsDialAgent(t, server, "secret="+secret)
+	if err != nil {
+		t.Fatalf("reconnect as A: %v", err)
+	}
+	defer conn.Close()
+
+	writeJSONFrame := func(v map[string]interface{}) {
+		data, _ := json.Marshal(v)
+		if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+			t.Fatalf("write frame: %v", err)
+		}
+	}
+
+	// Forge one frame per sink we changed, each claiming a foreign machine-B.
+	writeJSONFrame(map[string]interface{}{
+		"type": "metrics", "machine_id": "machine-B",
+		"hostname": "attacker", "ip": "10.9.9.9", "os": "linux",
+		"cpu_percent": 1.0, "ram_used_bytes": 1, "ram_total_bytes": 2,
+		"disk_used_bytes": 1, "disk_total_bytes": 2,
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	})
+	writeJSONFrame(map[string]interface{}{
+		"type": "hardware_info", "machine_id": "machine-B", "cpu": "forged",
+	})
+	writeJSONFrame(map[string]interface{}{
+		"type": "services", "machine_id": "machine-B",
+		"services": []map[string]interface{}{
+			{"name": "sshd", "status": "running", "description": "forged"},
+		},
+	})
+	writeJSONFrame(map[string]interface{}{
+		"type": "containers", "machine_id": "machine-B",
+		"containers": []map[string]interface{}{
+			{"id": "deadbeef", "name": "forged", "status": "up", "image": "evil:latest"},
+		},
+	})
+
+	// Send a legitimate metrics frame for machine-A with a sentinel hostname.
+	// Frames on one connection are processed in order, so once the sentinel is
+	// visible the forged frames have already been handled (and rejected).
+	writeJSONFrame(map[string]interface{}{
+		"type": "metrics", "machine_id": "machine-A",
+		"hostname": "sentinel-host", "ip": "10.0.0.1", "os": "linux",
+		"cpu_percent": 2.0, "ram_used_bytes": 1, "ram_total_bytes": 2,
+		"disk_used_bytes": 1, "disk_total_bytes": 2,
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	})
+
+	// Wait until the sentinel A-write lands.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		var hostname string
+		_ = db.QueryRow(`SELECT hostname FROM machines WHERE id = ?`, "machine-A").Scan(&hostname)
+		if hostname == "sentinel-host" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sentinel A-write never landed (hostname=%q)", hostname)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// machine-B must not exist and must have no metrics.
+	var machineCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM machines WHERE id = ?`, "machine-B").Scan(&machineCount); err != nil {
+		t.Fatalf("count machine-B: %v", err)
+	}
+	if machineCount != 0 {
+		t.Fatalf("machine-B row was created by a foreign-id frame (count=%d)", machineCount)
+	}
+	var metricCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM metrics WHERE machine_id = ?`, "machine-B").Scan(&metricCount); err != nil {
+		t.Fatalf("count machine-B metrics: %v", err)
+	}
+	if metricCount != 0 {
+		t.Fatalf("machine-B metrics were written by a foreign-id frame (count=%d)", metricCount)
+	}
+
+	// Every sink we changed must be locked down, not just metrics.
+	for _, tbl := range []string{"services", "containers"} {
+		var n int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM `+tbl+` WHERE machine_id = ?`, "machine-B").Scan(&n); err != nil {
+			t.Fatalf("count machine-B %s: %v", tbl, err)
+		}
+		if n != 0 {
+			t.Fatalf("machine-B %s rows were written by a foreign-id frame (count=%d)", tbl, n)
+		}
+	}
+}
+
+// TestAgentWSInvalidTokenRejectedBeforeUpgrade locks in the pre-upgrade
+// rejection: a caller with no durable secret and an invalid/expired/used token
+// must be refused at the HTTP layer (401) rather than being upgraded and then
+// held for the auth window. No token is seeded, so any token is invalid.
+func TestAgentWSInvalidTokenRejectedBeforeUpgrade(t *testing.T) {
+	e := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws/agent?token=bogus-invalid-token"
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected upgrade to be rejected for invalid token with no secret")
+	}
+	if resp == nil {
+		t.Fatalf("expected an HTTP response (401) before upgrade, got none (err=%v)", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected HTTP 401 before upgrade, got %d (err=%v)", resp.StatusCode, err)
+	}
+}
+
+// TestAgentWSIdleUpgradeIsDropped locks in the invalid-upgrade/idle fix: a
+// client that completes the WebSocket upgrade but never sends its first
+// authenticating frame must be dropped after the auth window rather than
+// holding a socket open indefinitely.
+func TestAgentWSIdleUpgradeIsDropped(t *testing.T) {
+	e := setupTestServer(t)
+	token := seedValidToken(t)
+
+	prev := agentAuthWindow
+	agentAuthWindow = 300 * time.Millisecond
+	t.Cleanup(func() { agentAuthWindow = prev })
+
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	// Upgrade succeeds (valid token) but we deliberately send no frame.
+	conn, err := wsDialAgent(t, server, "token="+token)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Give the client a generous read deadline. If the hub enforces the auth
+	// window it will close the socket at ~300ms; if it does not, the read
+	// blocks until this client-side deadline (~3s). Distinguish by elapsed time.
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	start := time.Now()
+	_, _, readErr := conn.ReadMessage()
+	elapsed := time.Since(start)
+
+	if readErr == nil {
+		t.Fatal("expected the hub to close the idle socket, but a frame was read")
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("hub did not drop idle socket within the auth window; read returned after %v (client-side timeout, not a server close)", elapsed)
+	}
+}
+
+// TestHandleCloseTerminalReleasesWaiter locks in the terminal-close lifecycle
+// fix: the close endpoint must route through cleanupTerminalSession (or
+// otherwise close session.Done) so a goroutine parked on the session's Done
+// channel is released. The old handler deleted the map entry and closed the
+// sockets but never closed Done, leaking the parked handleTerminalWS goroutine.
+func TestHandleCloseTerminalReleasesWaiter(t *testing.T) {
+	e := setupTestServer(t)
+
+	sid := "term-close-release"
+	session := &TerminalSession{
+		ID:           sid,
+		MachineID:    "machine-x",
+		UserID:       "test-admin-id",
+		CreatedAt:    time.Now(),
+		LastActivity: time.Now(),
+		Done:         make(chan struct{}),
+	}
+	termSessionsMu.Lock()
+	termSessions[sid] = session
+	termSessionsMu.Unlock()
+
+	released := make(chan struct{})
+	go func() {
+		<-waitForSessionEnd(sid)
+		close(released)
+	}()
+	// Let the waiter park.
+	time.Sleep(50 * time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/terminal/"+sid, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("session_id")
+	c.SetParamValues(sid)
+	if err := handleCloseTerminal(c); err != nil {
+		t.Fatalf("handleCloseTerminal: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from close, got %d", rec.Code)
+	}
+
+	select {
+	case <-released:
+		// good — Done was closed.
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter parked on session.Done was not released by handleCloseTerminal (goroutine would leak)")
+	}
+}

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -423,6 +423,18 @@ func handleDownloadCACert(c echo.Context) error {
 // scales fine because each agent gets its own bucket.
 const wsAgentRateLimit = 30
 
+// agentAuthWindow bounds how long an upgraded agent socket may stay open before
+// it sends its first authenticating frame. Without it, a client that completes
+// the WebSocket upgrade but never speaks would hold the socket (and its file
+// descriptor) open indefinitely. It is a var so tests can shorten it.
+var agentAuthWindow = 30 * time.Second
+
+// agentIdleTimeout bounds the gap between frames once an agent is established.
+// Agents push metrics every 30s and ping on the same cadence, so a silently
+// dead TCP connection is dropped within this window instead of lingering until
+// the OS keepalive notices (which can take ~2h).
+var agentIdleTimeout = 90 * time.Second
+
 func handleAgentWS(c echo.Context) error {
 	ip := getRealIP(c)
 	if !rateLimiter.Allow("ws_agent", ip, wsAgentRateLimit) {
@@ -468,11 +480,32 @@ func handleAgentWS(c echo.Context) error {
 		}
 	}
 
+	// Reject before upgrading when the caller has neither a valid durable
+	// secret nor a valid install token. Enrollment requires a VALID token; an
+	// invalid, expired, or already-used token must not obtain an upgraded
+	// socket. Valid-token enrollment still authenticates post-upgrade because
+	// machine_id is only learned from the first metrics frame — this guard only
+	// rejects the definitively-unauthenticated.
+	if secretMachineID == "" && !tokenValidated {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "valid agent secret or install token required"})
+	}
+
 	ws, wsErr := upgrader.Upgrade(c.Response(), c.Request(), nil)
 	if wsErr != nil {
 		return wsErr
 	}
 	defer ws.Close()
+
+	// Bound the socket lifetime. An upgraded client must send its first frame
+	// within the auth window; thereafter it must keep the connection live
+	// (metrics or a ping) within the idle timeout. A ping resets the deadline
+	// and is answered with a pong. This closes both the idle-hold DoS (upgrade
+	// then go silent) and the ~2h half-open detection gap.
+	ws.SetReadDeadline(time.Now().Add(agentAuthWindow))
+	ws.SetPingHandler(func(appData string) error {
+		ws.SetReadDeadline(time.Now().Add(agentIdleTimeout))
+		return ws.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(10*time.Second))
+	})
 
 	// If authenticated via secret, we already know the machine_id.
 	var machineID string
@@ -490,6 +523,8 @@ func handleAgentWS(c echo.Context) error {
 			unregisterAgentConnection(machineID, agent)
 			return nil
 		}
+		// A frame arrived — extend the deadline to the idle timeout.
+		ws.SetReadDeadline(time.Now().Add(agentIdleTimeout))
 
 		var envelope struct {
 			Type      string `json:"type"`
@@ -497,6 +532,16 @@ func handleAgentWS(c echo.Context) error {
 		}
 		if err := json.Unmarshal(msg, &envelope); err != nil {
 			log.Printf("invalid JSON from agent: %v", err)
+			continue
+		}
+
+		// Identity binding: once this socket is authenticated as machineID,
+		// reject any frame that claims a different machine_id. During token
+		// enrollment machineID is still "" until the first metrics frame
+		// establishes it, so this guard is a no-op on that first frame.
+		if machineID != "" && envelope.MachineID != "" && envelope.MachineID != machineID {
+			log.Printf("rejecting cross-machine frame: authed=%s claimed=%s type=%s",
+				machineID, envelope.MachineID, envelope.Type)
 			continue
 		}
 
@@ -555,6 +600,11 @@ func handleAgentWS(c echo.Context) error {
 				log.Printf("agent registered: %s (%s)", m.Hostname, machineID)
 			}
 
+			// The authenticated machineID is authoritative — bind this frame to
+			// it so all downstream writes (upsert, metrics, latency) use it
+			// regardless of what the payload claimed.
+			m.MachineID = machineID
+
 			// Calculate latency from sent_at.
 			if m.SentAt != "" {
 				sentTime, err := time.Parse(time.RFC3339Nano, m.SentAt)
@@ -599,9 +649,9 @@ func handleAgentWS(c echo.Context) error {
 				log.Printf("invalid services JSON: %v", err)
 				continue
 			}
-			mid := sm.MachineID
+			mid := machineID
 			if mid == "" {
-				mid = machineID
+				mid = sm.MachineID
 			}
 			upsertServices(mid, sm.Services)
 			framed := []byte(fmt.Sprintf("event: services\ndata: %s\n\n", msg))
@@ -613,9 +663,9 @@ func handleAgentWS(c echo.Context) error {
 				log.Printf("invalid containers JSON: %v", err)
 				continue
 			}
-			mid := cm.MachineID
+			mid := machineID
 			if mid == "" {
-				mid = machineID
+				mid = cm.MachineID
 			}
 			upsertContainers(mid, cm.Containers)
 			framed := []byte(fmt.Sprintf("event: containers\ndata: %s\n\n", msg))
@@ -638,9 +688,9 @@ func handleAgentWS(c echo.Context) error {
 				log.Printf("invalid hardware_info JSON: %v", err)
 				continue
 			}
-			mid := hw.MachineID
+			mid := machineID
 			if mid == "" {
-				mid = machineID
+				mid = hw.MachineID
 			}
 			if _, err := db.Exec(`
 				INSERT INTO machines (id, hostname, status, hardware_info)

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -1843,21 +1843,13 @@ func TestKnownMachineReconnectWithoutCredentialRejected(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
+	// A known machine presenting an invalid token and no durable secret is now
+	// rejected before the WebSocket upgrade (no valid credential of any kind),
+	// rather than being upgraded to receive a post-upgrade rejection message.
 	conn, err := wsDialAgent(t, server, "token=definitely-invalid")
-	if err != nil {
-		t.Fatalf("dial failed: %v", err)
-	}
-	defer conn.Close()
-
-	sendMetricsMsg(t, conn, "known-machine-without-secret")
-
-	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
-	_, msg, err := conn.ReadMessage()
-	if err != nil {
-		t.Fatalf("expected rejection message, got read error: %v", err)
-	}
-	if !strings.Contains(string(msg), "durable credential required") {
-		t.Fatalf("expected durable credential rejection, got %s", string(msg))
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected upgrade to be rejected for invalid token with no secret")
 	}
 }
 

--- a/hub/terminal.go
+++ b/hub/terminal.go
@@ -190,29 +190,21 @@ func handleStartTerminal(c echo.Context) error {
 func handleCloseTerminal(c echo.Context) error {
 	sessionID := c.Param("session_id")
 
-	termSessionsMu.Lock()
-	session, ok := termSessions[sessionID]
-	if ok {
-		delete(termSessions, sessionID)
-	}
-	termSessionsMu.Unlock()
-
+	termSessionsMu.RLock()
+	_, ok := termSessions[sessionID]
+	termSessionsMu.RUnlock()
 	if !ok {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "session not found"})
 	}
 
-	session.mu.Lock()
-	if session.AgentWS != nil {
-		session.AgentWS.Close()
-	}
-	if session.BrowserWS != nil {
-		session.BrowserWS.Close()
-	}
-	session.mu.Unlock()
+	// Route through the single teardown path so session.Done is closed via
+	// closeOnce (releasing any parked handleTerminalWS goroutine), the sockets
+	// are closed, and the DB row is finalized. The old inline teardown deleted
+	// the map entry and closed the sockets but never closed Done, leaking the
+	// waiter goroutine on every close.
+	cleanupTerminalSession(sessionID)
 
-	_, _ = db.Exec(`UPDATE terminal_sessions SET ended_at = CURRENT_TIMESTAMP, status = 'closed' WHERE id = ?`, sessionID)
-
-	log.Printf("terminal session %s closed", sessionID)
+	log.Printf("terminal session %s closed via API", sessionID)
 	return c.JSON(http.StatusOK, map[string]string{"status": "closed"})
 }
 


### PR DESCRIPTION
First remediation slice from the code review — one tight PR closing the immediate high-risk runtime issues. No Phase 2+ hardening, no signing, no cookie migration, no refactors.

## What & why

### Hub — agent identity binding
Once a `/ws/agent` socket is authenticated as machine A, every later frame is bound to A. Any `metrics`/`services`/`containers`/`hardware_info` frame claiming a different `machine_id` is rejected, and the authenticated id is authoritative for all sinks. Previously a compromised fleet member could overwrite another machine's row/metrics/inventory and suppress its alerts.

### Hub — invalid upgrade / idle sockets
`/ws/agent` now rejects **before** the WebSocket upgrade when there's no valid durable secret and no valid install token (invalid/expired/used). Valid-token enrollment still authenticates post-upgrade (machine_id is only known from the first metrics frame). Every agent socket is bounded by an auth-window + idle read deadline plus a ping handler, so invalid or silent clients can't hold a socket (and FD) open indefinitely.

### Hub — terminal close lifecycle
`handleCloseTerminal` now routes through `cleanupTerminalSession`, which closes `session.Done` via `closeOnce`. The old inline teardown closed the sockets but never closed `Done`, leaking the parked `handleTerminalWS` goroutine on every close.

### Agent — connection liveness
Added WebSocket ping/pong with read/write deadlines so a silently-dead TCP connection fails within ~pongWait and reconnects, instead of wedging up to ~2h on the OS keepalive. Reconnect backoff resets after a stable connection.

### Dashboard — small correctness fixes
- Terminal WS uses `getHubWsBaseUrl()`/`HUB_URL` (fixes split-origin deployments; also retires that dead helper).
- `authFetch` treats **any** 401 as logout — covers server-side revocation (deleted user, role change, rotated secret), not just locally-expired tokens.
- `connect()` in the SSE context is serialized with a generation guard so overlapping async reconnects can't orphan a live `EventSource`.

## Tests added
- `TestAuthedAgentCannotWriteForeignMachineID` — forged metrics/hardware/services/containers frames leave machine-B with zero rows in every sink.
- `TestAgentWSInvalidTokenRejectedBeforeUpgrade` — invalid token + no secret returns HTTP 401 before upgrade.
- `TestAgentWSIdleUpgradeIsDropped` — a valid-token client that upgrades then goes silent is dropped within the auth window.
- `TestHandleCloseTerminalReleasesWaiter` — a goroutine parked on `session.Done` is released by the close endpoint.
- `TestBackoffAfterConn` — the stable-connection backoff-reset rule.

## Checks (all green)
- `cd hub && go test ./...` + `go vet` + `-race` on agent-WS/terminal tests
- `cd agent && go test ./...` + `go vet`
- `cd dashboard && pnpm lint` + `pnpm build`

## Notes for reviewers
- Pre-upgrade rejection makes the read-loop's `durable credential required` / `invalid or used token` branches effectively unreachable; left in place as defensive belt-and-suspenders rather than refactored out (out of scope for this PR).
- Hub idle timeout assumes the ~30s agent metrics cadence; both are named constants in `agentws.go`.
- Deferred to later phases (not this PR): unsigned auto-update, credentials in the WS query string, the agent's unsynchronized `agentSecret`/`token` globals.