### PR TITLE
fix(hub): install/enrollment hardening (Phase 2A)

### DIFF
--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -74,6 +74,16 @@ func handleCreateToken(c echo.Context) error {
 		return c.JSON(http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 	}
 
+	// The generated install one-liner points agents at the hub. Deriving that
+	// URL from the request Host header lets a crafted Host / DNS-rebind produce
+	// a command that installs the agent pointed at an attacker host. Refuse to
+	// mint a token+command unless the operator has set an explicit PUBLIC_URL.
+	if strings.TrimSpace(os.Getenv("PUBLIC_URL")) == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "PUBLIC_URL is not set on the hub; set PUBLIC_URL to the hub's public URL and restart before generating install tokens",
+		})
+	}
+
 	token := uuid.New().String()
 	h := sha256.Sum256([]byte(token))
 	tokenHash := hex.EncodeToString(h[:])
@@ -84,7 +94,7 @@ func handleCreateToken(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 
-	httpBase, wsBase := publicAndWebsocketBase(c)
+	httpBase, wsBase := publicAndWebsocketBase()
 	command, caURL, caSHA256 := buildInstallCommand(httpBase, wsBase, token)
 
 	resp := map[string]interface{}{
@@ -176,6 +186,23 @@ fi
 echo "Downloading agent binary..."
 curl_fetch "${HUB_HTTP}/download/agent?arch=${ARCH}" "${CA_CURL_ARGS[@]}" -o /tmp/bloxos-agent
 chmod +x /tmp/bloxos-agent
+
+# Verify the downloaded binary against the SHA-256 the hub computed for the
+# binary it serves. Provides integrity even over a plain-HTTP LAN download.
+EXPECTED_AGENT_SHA256="__EXPECTED_AGENT_SHA256__"
+if [[ -n "$EXPECTED_AGENT_SHA256" ]]; then
+  ACTUAL_AGENT_SHA=$(sha256sum /tmp/bloxos-agent | awk '{print $1}')
+  if [[ "$ACTUAL_AGENT_SHA" != "$EXPECTED_AGENT_SHA256" ]]; then
+    echo "Agent binary fingerprint mismatch"
+    echo "Expected: $EXPECTED_AGENT_SHA256"
+    echo "Actual:   $ACTUAL_AGENT_SHA"
+    rm -f /tmp/bloxos-agent
+    exit 1
+  fi
+  echo "Agent binary verified ($EXPECTED_AGENT_SHA256)"
+else
+  echo "WARNING: hub did not provide an agent binary hash; skipping integrity check"
+fi
 
 # Create system user (if not exists).
 if ! id -u bloxos &>/dev/null; then
@@ -274,26 +301,26 @@ sudo systemctl restart bloxos-agent
 echo "=== BloxOS Agent installed and running ==="
 echo "Check status: systemctl status bloxos-agent"
 `
+	// Pin the hash of the binary the hub actually serves. recompute is
+	// mtime-cached, so this is cheap on the hot path.
+	recomputeAgentBinarySHA()
+	script = strings.ReplaceAll(script, "__EXPECTED_AGENT_SHA256__", announcedSHAFor("linux"))
 	return c.String(http.StatusOK, script)
 }
 
-func publicAndWebsocketBase(c echo.Context) (string, string) {
-	publicURL := os.Getenv("PUBLIC_URL")
-	if publicURL != "" {
-		httpBase := publicURL
-		wsBase := strings.Replace(publicURL, "https://", "wss://", 1)
-		wsBase = strings.Replace(wsBase, "http://", "ws://", 1)
-		return httpBase, wsBase
+// publicAndWebsocketBase derives the hub's HTTP and WebSocket base URLs from
+// PUBLIC_URL. It never falls back to the request Host header, which is
+// attacker-influenced — callers (handleCreateToken) guarantee PUBLIC_URL is set
+// before reaching here and return "" otherwise.
+func publicAndWebsocketBase() (string, string) {
+	publicURL := strings.TrimSpace(os.Getenv("PUBLIC_URL"))
+	if publicURL == "" {
+		return "", ""
 	}
-
-	host := c.Request().Host
-	proto := "ws"
-	httpProto := "http"
-	if c.Request().TLS != nil {
-		proto = "wss"
-		httpProto = "https"
-	}
-	return fmt.Sprintf("%s://%s", httpProto, host), fmt.Sprintf("%s://%s", proto, host)
+	httpBase := publicURL
+	wsBase := strings.Replace(publicURL, "https://", "wss://", 1)
+	wsBase = strings.Replace(wsBase, "http://", "ws://", 1)
+	return httpBase, wsBase
 }
 
 func bootstrapCACertCandidates() []string {
@@ -567,7 +594,7 @@ func handleAgentWS(c echo.Context) error {
 
 				if knownMachine && secretMachineID == machineID {
 					log.Printf("known agent reconnecting with durable credential: %s (%s)", m.Hostname, machineID)
-				} else if tokenValidated {
+				} else if tokenValidated && !hasCredential {
 					// New enrollment with valid token - consume it and issue durable secret.
 					rawSecret, secretHash, err := generateAgentSecret()
 					if err != nil {
@@ -586,7 +613,17 @@ func handleAgentWS(c echo.Context) error {
 					})
 					ws.WriteMessage(websocket.TextMessage, enrolledMsg)
 					log.Printf("new agent enrolled with durable secret: %s (%s)", m.Hostname, machineID)
-				} else if knownMachine || hasCredential {
+				} else if hasCredential {
+					// A durable credential already exists for this machine_id. A
+					// fresh install token must NOT silently replace it (that would
+					// let any valid token hijack an enrolled machine and lock out
+					// the legitimate agent). Require an explicit revoke first. The
+					// token is deliberately left unconsumed so a legitimate
+					// re-enroll can proceed after revocation.
+					log.Printf("rejecting enrollment for %s (%s): machine already has a durable credential; revoke before re-enrolling", m.Hostname, machineID)
+					ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"machine already enrolled; revoke its credential before re-enrolling"}`))
+					return nil
+				} else if knownMachine {
 					log.Printf("rejecting known agent %s (%s): durable credential required", m.Hostname, machineID)
 					ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"durable credential required"}`))
 					return nil
@@ -830,10 +867,29 @@ $DownloadUrl = "$HubHttp/download/agent?os=windows"
 # (NewSessionTicket) and HTTP/2 ALPN against self-signed Caddy certs and bails
 # with "underlying connection was closed". curl.exe uses Schannel for TLS but
 # its own HTTP stack, which handles both cleanly.
-& curl.exe -ksfL -o $AgentExe $DownloadUrl
+#
+# The CA was bootstrapped above, so verify TLS against it (--cacert) instead of
+# using -k. Only the initial CA fetch remains insecure; the agent binary is
+# both TLS-verified here and SHA-256-pinned below.
+& curl.exe --cacert $CaPath -sfL -o $AgentExe $DownloadUrl
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Agent binary download failed (curl exit code $LASTEXITCODE)"
     exit 1
+}
+
+# Verify the downloaded binary against the SHA-256 the hub computed for the
+# binary it serves.
+$ExpectedSha = "__EXPECTED_AGENT_SHA256__"
+if ($ExpectedSha) {
+    $ActualSha = (Get-FileHash -Algorithm SHA256 -Path $AgentExe).Hash.ToLower()
+    if ($ActualSha -ne $ExpectedSha.ToLower()) {
+        Remove-Item -Path $AgentExe -Force -ErrorAction SilentlyContinue
+        Write-Error "Agent binary fingerprint mismatch. Expected $ExpectedSha, got $ActualSha"
+        exit 1
+    }
+    Write-Host "Agent binary verified ($ExpectedSha)"
+} else {
+    Write-Warning "Hub did not provide an agent binary hash; skipping integrity check"
 }
 
 # Persist HUB + TOKEN for the service to pick up at next start.
@@ -859,6 +915,8 @@ if ($svc -and $svc.Status -eq 'Running') {
     Write-Warning "BloxOSAgent service is not running. Check Event Viewer or services.msc."
 }
 `
+	recomputeAgentBinarySHA()
+	script = strings.ReplaceAll(script, "__EXPECTED_AGENT_SHA256__", announcedSHAFor("windows"))
 	return c.String(http.StatusOK, script)
 }
 

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -810,8 +810,10 @@ Write-Host "Hub:    $HubHttp"
 Write-Host "WS hub: $Hub"
 
 # install.ps1 is invoked via 'powershell.exe -ExecutionPolicy Bypass -File'.
-# All HTTP downloads use curl.exe with -k for self-signed cert tolerance, so
-# no PowerShell-side cert callback or SecurityProtocol pinning is needed.
+# HTTP downloads use curl.exe rather than a PowerShell cert callback or
+# SecurityProtocol pinning. Only the initial CA bootstrap fetch uses -k; the
+# agent binary fetch verifies TLS against the bootstrapped CA (--cacert) and is
+# additionally SHA-256-pinned.
 
 # Stop + remove existing service if present.
 $svc = Get-Service -Name BloxOSAgent -ErrorAction SilentlyContinue

--- a/hub/install_enrollment_test.go
+++ b/hub/install_enrollment_test.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// seedTokenValue inserts a valid (unused, unexpired) install token with the
+// given raw value and returns it. Complements seedValidToken, which always
+// inserts the same fixed token.
+func seedTokenValue(t *testing.T, raw string) string {
+	t.Helper()
+	h := sha256.Sum256([]byte(raw))
+	tokenHash := hex.EncodeToString(h[:])
+	expiresAt := time.Now().Add(1 * time.Hour).Format("2006-01-02 15:04:05")
+	if _, err := db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, FALSE)`, tokenHash, expiresAt); err != nil {
+		t.Fatalf("seed token %q: %v", raw, err)
+	}
+	return raw
+}
+
+// TestInstallTokenCannotTakeOverEnrolledMachine locks in item 1: a fresh valid
+// install token must not be able to claim a machine_id that already has a
+// durable credential. Re-enrollment requires an explicit revoke first.
+func TestInstallTokenCannotTakeOverEnrolledMachine(t *testing.T) {
+	e := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	// Enroll machine-A and capture its durable secret.
+	token1 := seedValidToken(t)
+	secret := enrollAndCaptureSecret(t, server, token1, "machine-A")
+	if secret == "" {
+		t.Fatal("enrollment did not yield a secret")
+	}
+
+	var before string
+	if err := db.QueryRow(`SELECT secret_hash FROM agent_credentials WHERE machine_id = ?`, "machine-A").Scan(&before); err != nil {
+		t.Fatalf("read machine-A credential: %v", err)
+	}
+
+	// Attacker holds a fresh, valid token and tries to claim machine-A.
+	seedTokenValue(t, "attacker-token-xyz")
+	conn, err := wsDialAgent(t, server, "token=attacker-token-xyz")
+	if err != nil {
+		t.Fatalf("attacker dial: %v", err)
+	}
+	defer conn.Close()
+	sendMetricsMsg(t, conn, "machine-A")
+
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("expected a rejection frame, got read error: %v", err)
+	}
+	if strings.Contains(string(msg), "agent_secret") {
+		t.Fatalf("takeover succeeded — hub issued a new secret: %s", string(msg))
+	}
+	if !strings.Contains(string(msg), "revoke") {
+		t.Fatalf("expected a revoke-required rejection, got %s", string(msg))
+	}
+
+	// machine-A's credential must be unchanged, and unique.
+	var after string
+	if err := db.QueryRow(`SELECT secret_hash FROM agent_credentials WHERE machine_id = ?`, "machine-A").Scan(&after); err != nil {
+		t.Fatalf("read machine-A credential after: %v", err)
+	}
+	if after != before {
+		t.Fatal("machine-A credential was replaced by a takeover enrollment")
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, "machine-A").Scan(&n); err != nil {
+		t.Fatalf("count machine-A credentials: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected exactly 1 credential for machine-A, got %d", n)
+	}
+
+	// The attacker token must NOT be consumed, so a legitimate re-enroll can
+	// still use it after an explicit revoke.
+	h := sha256.Sum256([]byte("attacker-token-xyz"))
+	var used bool
+	if err := db.QueryRow(`SELECT used FROM tokens WHERE token_hash = ?`, hex.EncodeToString(h[:])).Scan(&used); err != nil {
+		t.Fatalf("read attacker token: %v", err)
+	}
+	if used {
+		t.Fatal("attacker token was consumed by a rejected takeover attempt")
+	}
+}
+
+// TestCreateTokenRequiresPublicURL locks in item 2: with PUBLIC_URL unset,
+// /api/tokens must refuse rather than emit a Host-header-derived install
+// command, and must not mint a token.
+func TestCreateTokenRequiresPublicURL(t *testing.T) {
+	e := setupTestServer(t)
+	token := loginAndGetToken(t, e)
+	markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when PUBLIC_URL unset, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "PUBLIC_URL") {
+		t.Fatalf("expected error to mention PUBLIC_URL, got %s", rec.Body.String())
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM tokens`).Scan(&n); err != nil {
+		t.Fatalf("count tokens: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected no token minted on refusal, got %d", n)
+	}
+}
+
+// TestCreateTokenUsesPublicURL locks in item 2's happy path: with PUBLIC_URL
+// set, the generated command is derived from PUBLIC_URL.
+func TestCreateTokenUsesPublicURL(t *testing.T) {
+	e := setupTestServer(t)
+	token := loginAndGetToken(t, e)
+	markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "https://hub.public.example")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	// A hostile Host header must not influence the emitted command.
+	req.Host = "attacker.evil.example"
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	command, _ := resp["command"].(string)
+	if !strings.Contains(command, "hub.public.example") {
+		t.Fatalf("command should use PUBLIC_URL host, got %q", command)
+	}
+	if strings.Contains(command, "attacker.evil.example") {
+		t.Fatalf("command leaked the request Host header: %q", command)
+	}
+}
+
+// TestInstallScriptPinsAgentBinaryHash locks in item 3 (Linux): the generated
+// install.sh must verify the downloaded agent binary's SHA-256 against the hash
+// of the binary the hub actually serves.
+func TestInstallScriptPinsAgentBinaryHash(t *testing.T) {
+	e := setupTestServer(t)
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bloxos-agent")
+	content := []byte("fake-linux-agent-binary-v1")
+	if err := os.WriteFile(bin, content, 0o755); err != nil {
+		t.Fatalf("write agent binary: %v", err)
+	}
+	t.Setenv("BLOXOS_AGENT_BINARY", bin)
+
+	hubAgentBinaryMu.Lock()
+	prevSHA, prevMtime := hubAgentBinarySHA, hubAgentBinaryMtime
+	hubAgentBinarySHA = ""
+	hubAgentBinaryMtime = time.Time{}
+	hubAgentBinaryMu.Unlock()
+	t.Cleanup(func() {
+		hubAgentBinaryMu.Lock()
+		hubAgentBinarySHA, hubAgentBinaryMtime = prevSHA, prevMtime
+		hubAgentBinaryMu.Unlock()
+	})
+
+	sum := sha256.Sum256(content)
+	want := hex.EncodeToString(sum[:])
+
+	req := httptest.NewRequest(http.MethodGet, "/install.sh", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, want) {
+		t.Fatalf("install.sh does not pin the expected agent SHA %s", want)
+	}
+	if !strings.Contains(body, "fingerprint mismatch") {
+		t.Fatalf("install.sh missing the hash-verification failure path")
+	}
+}
+
+// TestWindowsInstallScriptPinsHashAndVerifiesBinaryDownload locks in item 3
+// (Windows): install.ps1 must pin the agent .exe SHA-256 and must download the
+// binary with TLS verification (via the bootstrapped CA), not curl -k. The
+// initial CA fetch may remain insecure.
+func TestWindowsInstallScriptPinsHashAndVerifiesBinaryDownload(t *testing.T) {
+	e := setupTestServer(t)
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bloxos-agent.exe")
+	content := []byte("fake-windows-agent-binary-v1")
+	if err := os.WriteFile(bin, content, 0o755); err != nil {
+		t.Fatalf("write agent binary: %v", err)
+	}
+	t.Setenv("BLOXOS_AGENT_BINARY_WINDOWS", bin)
+
+	hubAgentBinaryMu.Lock()
+	prevSHA, prevMtime := hubWindowsAgentBinarySHA, hubWindowsAgentBinaryMtime
+	hubWindowsAgentBinarySHA = ""
+	hubWindowsAgentBinaryMtime = time.Time{}
+	hubAgentBinaryMu.Unlock()
+	t.Cleanup(func() {
+		hubAgentBinaryMu.Lock()
+		hubWindowsAgentBinarySHA, hubWindowsAgentBinaryMtime = prevSHA, prevMtime
+		hubAgentBinaryMu.Unlock()
+	})
+
+	sum := sha256.Sum256(content)
+	want := hex.EncodeToString(sum[:])
+
+	req := httptest.NewRequest(http.MethodGet, "/install.ps1", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, want) {
+		t.Fatalf("install.ps1 does not pin the expected agent SHA %s", want)
+	}
+	if strings.Contains(body, "curl.exe -ksfL -o $AgentExe") {
+		t.Fatal("install.ps1 still downloads the agent binary with insecure curl -k")
+	}
+	if !strings.Contains(body, "--cacert $CaPath") {
+		t.Fatal("install.ps1 agent download should verify TLS via the bootstrapped CA (--cacert)")
+	}
+	if !strings.Contains(body, "curl.exe -ksfL -o $CaPath") {
+		t.Fatal("expected the initial CA bootstrap fetch to remain (curl -k to $CaPath)")
+	}
+}

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -779,6 +779,9 @@ func TestCreateTokenWithValidJWT(t *testing.T) {
 	e := setupTestServer(t)
 	token := loginAndGetToken(t, e)
 	markCredentialsRotated(t)
+	// Install-command generation now requires PUBLIC_URL (Host-header fallback
+	// removed) — set it so the happy path still yields a command.
+	t.Setenv("PUBLIC_URL", "https://hub.example")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
 	req.Header.Set("Authorization", "Bearer "+token)


### PR DESCRIPTION
Phase 2A of the review remediation plan — install/enrollment hardening only. Scoped deliberately narrow: **no** credentials-out-of-query-string, SSRF, command-timeout, TLS-insecure-build-tag, signing, cookie-auth, or refactor work (those are later phases).

## Changes

### 1. Prevent install-token takeover of an enrolled machine
A fresh valid install token could previously claim a `machine_id` that already had a durable credential — the enrollment path used `INSERT OR REPLACE`, silently overwriting the secret and locking out the legitimate agent. Enrollment is now gated on `!hasCredential`: a takeover attempt is rejected with a "revoke before re-enrolling" message, and the token is **left unconsumed** so a legitimate re-enroll works after an explicit revoke. Secret-based reconnect is unchanged.

`hub/agentws.go` (enrollment branch in `handleAgentWS`).

### 2. Require PUBLIC_URL for generated install commands
`/api/tokens` now returns a clear `400` when `PUBLIC_URL` is unset, instead of deriving the install one-liner's hub URL from the request `Host` header (a crafted `Host` / DNS-rebind could hand an admin a command that points the agent at an attacker host). `publicAndWebsocketBase` no longer falls back to `Host` at all.

`hub/agentws.go` (`handleCreateToken`, `publicAndWebsocketBase`).

### 3. Pin the downloaded agent binary hash in generated installers
`install.sh` and `install.ps1` now verify the downloaded binary's SHA-256 against the hash of the binary the hub actually serves (`announcedSHAFor`), before installing — integrity even over a plain-HTTP LAN download. The Windows agent-binary download **drops `curl -k`** and verifies TLS against the bootstrapped CA (`--cacert $CaPath`); only the initial CA fetch stays insecure (unavoidable bootstrap).

`hub/agentws.go` (`handleInstallScript`, `handleWindowsInstallScript`).

## Tests added (`hub/install_enrollment_test.go`)
- `TestInstallTokenCannotTakeOverEnrolledMachine` — enroll A, then a fresh valid token claiming A is rejected; A's credential is byte-for-byte unchanged and unique, and the attacker token stays unconsumed.
- `TestCreateTokenRequiresPublicURL` — unset → 400 mentioning `PUBLIC_URL`, and no token minted.
- `TestCreateTokenUsesPublicURL` — set → command uses the PUBLIC_URL host; a hostile `Host` header does not leak into the command.
- `TestInstallScriptPinsAgentBinaryHash` / `TestWindowsInstallScriptPinsHashAndVerifiesBinaryDownload` — generated scripts pin the served binary's SHA; Windows binary fetch uses `--cacert` (not `-k`) while the CA fetch keeps `-k`.
- Updated `TestCreateTokenWithValidJWT` to set `PUBLIC_URL` (Host fallback removed).

## Checks
- `cd hub && go test ./...` ✓ · `go vet` ✓
- `cd agent && go test ./...` ✓ (agent untouched)
- `cd dashboard && pnpm lint` ✓ · `pnpm build` ✓ (dashboard untouched — run clean, reported per request)

## Notes for reviewers
- The takeover rejection leaves the token valid on purpose; revoke-then-reenroll is the intended flow. There's no revoke UI change in this PR (revoke already exists via `revokeAgentCredential`).
- Installers inject the hash via a `__EXPECTED_AGENT_SHA256__` placeholder replaced at serve time; if the hub can't determine a hash (no binary present, in which case `/download/agent` 404s anyway) the script warns and continues rather than hard-failing.
- Do not merge until reviewed.