### PR TITLE
fix(hub,agent): move WS credentials from query strings to headers (Phase 2B)

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"math/rand"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -384,27 +385,28 @@ func runAgent(machineID string) error {
 		return fmt.Errorf("invalid hub URL: %w", err)
 	}
 
-	q := u.Query()
-	// Send whichever credentials we have. The hub will try the secret first
-	// (if present) and fall back to the token (if also present) when the secret
-	// fails validation. This handles credential drift cleanly: stale agent-secret
-	// + fresh enrollment token re-enrolls instead of looping with an invalid
-	// secret. See hub/agentws.go::handleAgentWS for the fallback contract:
-	// secret error → agentSecret = "" → drop into the token-mode branch.
+	// Send whichever credentials we have via handshake headers rather than the
+	// URL query string, so they don't land in reverse-proxy access logs. The
+	// hub tries the secret first (if present) and falls back to the token (if
+	// also present) when the secret fails validation. This handles credential
+	// drift cleanly: a stale agent-secret + fresh enrollment token re-enrolls
+	// instead of looping with an invalid secret. See hub/agentws.go::
+	// handleAgentWS for the fallback contract: secret error → agentSecret = ""
+	// → drop into the token-mode branch.
+	header := http.Header{}
 	if agentSecret != "" {
-		q.Set("secret", agentSecret)
+		header.Set("Authorization", "Bearer "+agentSecret)
 	}
 	if token != "" {
-		q.Set("token", token)
+		header.Set("X-Bloxos-Enroll-Token", token)
 	}
-	u.RawQuery = q.Encode()
 
 	log.Printf("connecting to %s", hubURL)
 	dialer, err := websocketDialerFor(u.String())
 	if err != nil {
 		return fmt.Errorf("build websocket dialer: %w", err)
 	}
-	conn, _, err := dialer.Dial(u.String(), nil)
+	conn, _, err := dialer.Dial(u.String(), header)
 	if err != nil {
 		return fmt.Errorf("dial failed: %w", err)
 	}

--- a/agent/main_linux.go
+++ b/agent/main_linux.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -194,13 +195,15 @@ func handleStartTerminal(cmd Command, rawMsg []byte) {
 		log.Printf("terminal: invalid hub URL: %v", err)
 		return
 	}
-	// Build terminal relay URL with terminal_token for auth (Finding #4).
-	// Derive scheme from hubURL so terminal connections go through Caddy too.
+	// Build terminal relay URL. The terminal token goes in a handshake header
+	// (below) rather than the query string so it doesn't leak into proxy access
+	// logs (Finding #4). Derive scheme from hubURL so terminal connections go
+	// through Caddy too.
 	wsScheme := "ws"
 	if u.Scheme == "wss" {
 		wsScheme = "wss"
 	}
-	termURL := fmt.Sprintf("%s://%s/ws/terminal/%s?role=agent&terminal_token=%s", wsScheme, u.Host, sessionID, url.QueryEscape(terminalToken))
+	termURL := fmt.Sprintf("%s://%s/ws/terminal/%s?role=agent", wsScheme, u.Host, sessionID)
 
 	// Spawn bash PTY as non-root user for security.
 	// Uses BLOXOS_TERMINAL_USER env var, or falls back to the owner of the
@@ -246,7 +249,9 @@ func handleStartTerminal(cmd Command, rawMsg []byte) {
 		log.Printf("terminal: build websocket dialer failed: %v", err)
 		return
 	}
-	ws, _, err := dialer.Dial(termURL, nil)
+	termHeader := http.Header{}
+	termHeader.Set("X-Bloxos-Terminal-Token", terminalToken)
+	ws, _, err := dialer.Dial(termURL, termHeader)
 	if err != nil {
 		log.Printf("terminal: dial hub failed: %v", err)
 		return

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -450,6 +450,21 @@ func handleDownloadCACert(c echo.Context) error {
 // scales fine because each agent gets its own bucket.
 const wsAgentRateLimit = 30
 
+// agentEnrollTokenHeader carries the install token on the /ws/agent handshake.
+// Preferred over the deprecated ?token= query param, which leaks into
+// reverse-proxy access logs.
+const agentEnrollTokenHeader = "X-Bloxos-Enroll-Token"
+
+// bearerToken extracts the credential from an "Authorization: Bearer <x>"
+// header value. Returns "" when the header is absent or not a bearer scheme.
+func bearerToken(header string) string {
+	const prefix = "Bearer "
+	if len(header) >= len(prefix) && strings.EqualFold(header[:len(prefix)], prefix) {
+		return strings.TrimSpace(header[len(prefix):])
+	}
+	return ""
+}
+
 // agentAuthWindow bounds how long an upgraded agent socket may stay open before
 // it sends its first authenticating frame. Without it, a client that completes
 // the WebSocket upgrade but never speaks would hold the socket (and its file
@@ -469,8 +484,17 @@ func handleAgentWS(c echo.Context) error {
 		return c.JSON(http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 	}
 
-	token := c.QueryParam("token")
-	agentSecret := c.QueryParam("secret")
+	// Prefer credentials from handshake headers — unlike query strings, they
+	// are not written to reverse-proxy access logs. Fall back to the deprecated
+	// query params so agents predating this change keep working.
+	agentSecret := bearerToken(c.Request().Header.Get("Authorization"))
+	if agentSecret == "" {
+		agentSecret = c.QueryParam("secret") // deprecated: use Authorization: Bearer
+	}
+	token := c.Request().Header.Get(agentEnrollTokenHeader)
+	if token == "" {
+		token = c.QueryParam("token") // deprecated: use the X-Bloxos-Enroll-Token header
+	}
 
 	// Auth priority: secret > token. If neither, reject.
 	if token == "" && agentSecret == "" {

--- a/hub/terminal.go
+++ b/hub/terminal.go
@@ -36,6 +36,11 @@ type TerminalSession struct {
 // TODO: make this per-user when multi-user support is added.
 const maxTerminalSessions = 3
 
+// terminalTokenHeader carries the agent-side terminal token on the
+// /ws/terminal handshake. Preferred over the deprecated ?terminal_token= query
+// param, which leaks into reverse-proxy access logs.
+const terminalTokenHeader = "X-Bloxos-Terminal-Token"
+
 func configuredAllowedOrigins() []string {
 	if ao := os.Getenv("ALLOWED_ORIGINS"); ao != "" {
 		parts := strings.Split(ao, ",")
@@ -220,7 +225,12 @@ func handleTerminalWS(c echo.Context) error {
 	// Auth check (Finding #4).
 	if role == "agent" {
 		// Agent must present a valid terminal_token matching the session.
-		termToken := c.QueryParam("terminal_token")
+		// Prefer the header (kept out of proxy access logs); fall back to the
+		// deprecated query param for agents predating this change.
+		termToken := c.Request().Header.Get(terminalTokenHeader)
+		if termToken == "" {
+			termToken = c.QueryParam("terminal_token") // deprecated
+		}
 		if termToken == "" {
 			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "terminal_token required for agent role"})
 		}

--- a/hub/ws_credential_headers_test.go
+++ b/hub/ws_credential_headers_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// dialWSWithHeader dials an arbitrary hub WebSocket path with custom handshake
+// headers. A successful dial (101 Switching Protocols) means the hub accepted
+// the credentials before upgrade; a rejected dial returns an error plus the
+// HTTP response.
+func dialWSWithHeader(t *testing.T, server *httptest.Server, path string, h http.Header) (*websocket.Conn, *http.Response, error) {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + path
+	return websocket.DefaultDialer.Dial(wsURL, h)
+}
+
+// TestAgentWSAuthViaSecretHeader proves /ws/agent authenticates a durable
+// secret presented in the Authorization header, with no query credentials.
+func TestAgentWSAuthViaSecretHeader(t *testing.T) {
+	e := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	token := seedValidToken(t)
+	secret := enrollAndCaptureSecret(t, server, token, "machine-hdr-secret")
+	if secret == "" {
+		t.Fatal("enrollment did not yield a secret")
+	}
+
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+secret)
+	conn, resp, err := dialWSWithHeader(t, server, "/ws/agent", h)
+	if err != nil {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Fatalf("dial with Authorization header failed: %v (status=%d)", err, status)
+	}
+	defer conn.Close()
+
+	// A secret-authenticated connection is registered at upgrade time.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		agentsMu.RLock()
+		_, ok := agents["machine-hdr-secret"]
+		agentsMu.RUnlock()
+		if ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("agent authenticated via secret header was never registered")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestAgentWSEnrollViaTokenHeader proves /ws/agent performs token enrollment
+// when the install token is presented in the X-Bloxos-Enroll-Token header.
+func TestAgentWSEnrollViaTokenHeader(t *testing.T) {
+	e := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	token := seedValidToken(t)
+	h := http.Header{}
+	h.Set("X-Bloxos-Enroll-Token", token)
+	conn, resp, err := dialWSWithHeader(t, server, "/ws/agent", h)
+	if err != nil {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Fatalf("dial with enroll-token header failed: %v (status=%d)", err, status)
+	}
+	defer conn.Close()
+
+	sendMetricsMsg(t, conn, "machine-hdr-enroll")
+
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	var secret string
+	for secret == "" {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read enrolled frame: %v", err)
+		}
+		var p struct {
+			Type        string `json:"type"`
+			AgentSecret string `json:"agent_secret"`
+		}
+		if err := json.Unmarshal(msg, &p); err != nil {
+			continue
+		}
+		if p.Type == "enrolled" {
+			secret = p.AgentSecret
+		}
+	}
+	if secret == "" {
+		t.Fatal("header-based enrollment did not issue a secret")
+	}
+}
+
+// TestAgentWSSecretQueryFallback proves the deprecated query-param credential
+// path still authenticates, so agents predating the header change keep working.
+func TestAgentWSSecretQueryFallback(t *testing.T) {
+	e := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	token := seedValidToken(t)
+	secret := enrollAndCaptureSecret(t, server, token, "machine-qp-secret")
+
+	conn, resp, err := dialWSWithHeader(t, server, "/ws/agent?secret="+secret, nil)
+	if err != nil {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Fatalf("query-param secret fallback failed: %v (status=%d)", err, status)
+	}
+	defer conn.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		agentsMu.RLock()
+		_, ok := agents["machine-qp-secret"]
+		agentsMu.RUnlock()
+		if ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("agent authenticated via query-param secret was never registered")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestTerminalAgentTokenViaHeader proves /ws/terminal role=agent accepts the
+// terminal token in the X-Bloxos-Terminal-Token header.
+func TestTerminalAgentTokenViaHeader(t *testing.T) {
+	e := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	sid := "term-hdr-session"
+	now := time.Now()
+	termSessionsMu.Lock()
+	termSessions[sid] = &TerminalSession{
+		ID:            sid,
+		MachineID:     "machine-term",
+		TerminalToken: "tok-header-abc",
+		CreatedAt:     now,
+		LastActivity:  now,
+		Done:          make(chan struct{}),
+	}
+	termSessionsMu.Unlock()
+	t.Cleanup(func() { cleanupTerminalSession(sid) })
+
+	h := http.Header{}
+	h.Set("X-Bloxos-Terminal-Token", "tok-header-abc")
+	conn, resp, err := dialWSWithHeader(t, server, "/ws/terminal/"+sid+"?role=agent", h)
+	if err != nil {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Fatalf("terminal agent dial with token header failed: %v (status=%d)", err, status)
+	}
+	conn.Close()
+}
+
+// TestTerminalAgentTokenQueryFallback proves the deprecated query-param
+// terminal_token still authenticates the agent role.
+func TestTerminalAgentTokenQueryFallback(t *testing.T) {
+	e := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	sid := "term-qp-session"
+	now := time.Now()
+	termSessionsMu.Lock()
+	termSessions[sid] = &TerminalSession{
+		ID:            sid,
+		MachineID:     "machine-term",
+		TerminalToken: "tok-qp-abc",
+		CreatedAt:     now,
+		LastActivity:  now,
+		Done:          make(chan struct{}),
+	}
+	termSessionsMu.Unlock()
+	t.Cleanup(func() { cleanupTerminalSession(sid) })
+
+	conn, resp, err := dialWSWithHeader(t, server, "/ws/terminal/"+sid+"?role=agent&terminal_token=tok-qp-abc", nil)
+	if err != nil {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Fatalf("terminal agent query-param fallback failed: %v (status=%d)", err, status)
+	}
+	conn.Close()
+}
+
+// TestTerminalAgentInvalidTokenHeaderRejected proves a wrong header token is
+// rejected before upgrade.
+func TestTerminalAgentInvalidTokenHeaderRejected(t *testing.T) {
+	e := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	sid := "term-bad-session"
+	now := time.Now()
+	termSessionsMu.Lock()
+	termSessions[sid] = &TerminalSession{
+		ID:            sid,
+		TerminalToken: "tok-real",
+		CreatedAt:     now,
+		LastActivity:  now,
+		Done:          make(chan struct{}),
+	}
+	termSessionsMu.Unlock()
+	t.Cleanup(func() { cleanupTerminalSession(sid) })
+
+	h := http.Header{}
+	h.Set("X-Bloxos-Terminal-Token", "tok-wrong")
+	conn, resp, err := dialWSWithHeader(t, server, "/ws/terminal/"+sid+"?role=agent", h)
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected rejection for wrong terminal token, dial succeeded")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		got := 0
+		if resp != nil {
+			got = resp.StatusCode
+		}
+		t.Fatalf("expected 401 for wrong terminal token, got %d", got)
+	}
+}


### PR DESCRIPTION
Phase 2B of the review remediation plan — reduce credential leakage through proxy access logs by moving sensitive WebSocket credentials out of URL query strings into handshake headers. Scoped narrowly: **no** SSRF, command-timeout, Windows cmd.exe, TLS build-tag, signing, cookie, or refactor work.

## Why
Credentials in a WebSocket URL query string (`?secret=…`, `?token=…`, `?terminal_token=…`) are logged by reverse proxies (Caddy et al.) by default, shipped to log aggregators, and persist — even over `wss://`, because the proxy sees the full request line. Headers are not logged that way.

## Changes

### 1. `/ws/agent` main auth via headers
- **Agent** (`agent/main.go`): sends the durable secret as `Authorization: Bearer <secret>` and the install token as `X-Bloxos-Enroll-Token`, instead of `?secret=`/`?token=`.
- **Hub** (`hub/agentws.go`): reads those headers first, then falls back to the deprecated query params (marked deprecated in comments) so agents predating this change keep working. Secret > token priority and the enrollment fallback contract are unchanged.

### 2. Terminal agent token via header
- **Agent** (`agent/main_linux.go`): sends the terminal token as `X-Bloxos-Terminal-Token` on the `/ws/terminal` handshake instead of `?terminal_token=`.
- **Hub** (`hub/terminal.go`): reads the header first for `role=agent`, falls back to the deprecated query param.

### 3. Browser terminal token unchanged (by design)
The browser side still uses `?browser_token=` — the native `WebSocket` API can't set handshake headers, and moving it belongs with the later httpOnly-cookie auth work. Not touched here.

## Tests (`hub/ws_credential_headers_test.go`)
- `TestAgentWSAuthViaSecretHeader` — durable secret in `Authorization` header authenticates and registers the agent.
- `TestAgentWSEnrollViaTokenHeader` — install token in `X-Bloxos-Enroll-Token` header completes enrollment and issues a secret.
- `TestAgentWSSecretQueryFallback` — deprecated `?secret=` still authenticates.
- `TestTerminalAgentTokenViaHeader` / `…QueryFallback` — `role=agent` accepts the token via header and via the deprecated query param.
- `TestTerminalAgentInvalidTokenHeaderRejected` — a wrong header token is rejected with 401 before upgrade.

## Checks
- `cd hub && go test ./...` ✓ · `go vet` ✓
- `cd agent && go test ./...` ✓ · `go vet` ✓
- `cd dashboard && pnpm lint` ✓ · `pnpm build` ✓ (dashboard untouched — runs clean)

## Notes for reviewers
- No enrollment-semantics change from Phase 2A; only the credential transport moved.
- Query-param support is intentionally retained (deprecated) — a follow-up can remove it once the fleet is confirmed upgraded.
- The Windows terminal path (`main_windows.go`) wasn't in scope (item 2 named `main_linux.go`); Windows agents continue to work via the hub's query-param fallback.
- Do not merge until reviewed.