### PR TITLE
fix(agent): bound command execution, de-shell Windows restart (Phase 2C)

### DIFF
--- a/agent/command_exec_linux_test.go
+++ b/agent/command_exec_linux_test.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// TestConfigureCommandSetsProcessGroup locks in item 2: on Linux, commands run
+// in their own process group with a cancel hook, so a timeout kills the whole
+// tree (systemctl/docker may fork children) rather than just the direct child.
+func TestConfigureCommandSetsProcessGroup(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "true")
+	configureCommand(cmd)
+
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		t.Fatal("expected Setpgid=true so the command runs in its own process group")
+	}
+	if cmd.Cancel == nil {
+		t.Fatal("expected a Cancel hook to kill the process group on timeout")
+	}
+}

--- a/agent/command_exec_test.go
+++ b/agent/command_exec_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCommandPlanForWindowsRestartService locks in item 3: on Windows,
+// restart_service is two separate argv commands (sc.exe stop / sc.exe start)
+// with no cmd.exe and no shell metacharacters — injection-proof by
+// construction. This is pure argv logic, testable on any OS.
+func TestCommandPlanForWindowsRestartService(t *testing.T) {
+	plan, err := commandPlanFor("windows", "restart_service", "My-Svc.1")
+	if err != nil {
+		t.Fatalf("commandPlanFor: %v", err)
+	}
+	want := [][]string{
+		{"sc.exe", "stop", "My-Svc.1"},
+		{"sc.exe", "start", "My-Svc.1"},
+	}
+	if !equalPlan(plan, want) {
+		t.Fatalf("windows restart_service plan = %v, want %v", plan, want)
+	}
+	for _, step := range plan {
+		for _, arg := range step {
+			if strings.Contains(arg, "cmd.exe") || strings.Contains(arg, "&") {
+				t.Fatalf("windows plan must not use cmd.exe / shell chaining, got arg %q", arg)
+			}
+		}
+	}
+}
+
+// TestCommandPlanForLinuxRestartService locks in the Linux argv shape.
+func TestCommandPlanForLinuxRestartService(t *testing.T) {
+	plan, err := commandPlanFor("linux", "restart_service", "nginx")
+	if err != nil {
+		t.Fatalf("commandPlanFor: %v", err)
+	}
+	want := [][]string{{"sudo", "systemctl", "restart", "nginx"}}
+	if !equalPlan(plan, want) {
+		t.Fatalf("linux restart_service plan = %v, want %v", plan, want)
+	}
+}
+
+func TestCommandPlanForUnknown(t *testing.T) {
+	if _, err := commandPlanFor("linux", "definitely_not_a_command", "x"); err == nil {
+		t.Fatal("expected error for unknown command type")
+	}
+}
+
+// TestRunCommandPlanTimeout proves a long-running command is killed and the
+// call unwinds promptly instead of hanging forever.
+func TestRunCommandPlanTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses unix `sleep`")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := runCommandPlan(ctx, [][]string{{"sleep", "10"}})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	if ctx.Err() != context.DeadlineExceeded {
+		t.Fatalf("expected context deadline exceeded, got %v", ctx.Err())
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("command was not killed promptly: returned after %v", elapsed)
+	}
+}
+
+// TestRunCommandPlanRunsStepsInOrder proves a multi-step plan (e.g. the Windows
+// stop+start) runs every step and concatenates output.
+func TestRunCommandPlanRunsStepsInOrder(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses unix `echo`")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := runCommandPlan(ctx, [][]string{{"echo", "one"}, {"echo", "two"}})
+	if err != nil {
+		t.Fatalf("runCommandPlan: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "one") || !strings.Contains(s, "two") {
+		t.Fatalf("expected output from both steps, got %q", s)
+	}
+}
+
+// TestRunCommandPlanStopsOnError proves a failing step aborts the remaining
+// steps.
+func TestRunCommandPlanStopsOnError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses unix `false`/`echo`")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := runCommandPlan(ctx, [][]string{{"false"}, {"echo", "after"}})
+	if err == nil {
+		t.Fatal("expected error from failing first step")
+	}
+	if strings.Contains(string(out), "after") {
+		t.Fatalf("second step ran after a failing first step: %q", string(out))
+	}
+}
+
+func equalPlan(a, b [][]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if len(a[i]) != len(b[i]) {
+			return false
+		}
+		for j := range a[i] {
+			if a[i][j] != b[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/agent/command_plan.go
+++ b/agent/command_plan.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+// agentCommandTimeout bounds how long a single remote command may run before
+// it is killed. Without a bound, a wedged systemctl/docker call (stuck daemon)
+// would block its handler goroutine forever.
+const agentCommandTimeout = 30 * time.Second
+
+// commandPlan returns the argv steps to execute for a command on this host.
+func commandPlan(cmdType, target string) ([][]string, error) {
+	return commandPlanFor(runtime.GOOS, cmdType, target)
+}
+
+// commandPlanFor returns the argv steps for a command type on the given GOOS.
+// It is pure argv construction (no OS-specific calls), so it is unit-testable
+// on any platform. Every step is a discrete argv slice executed without a
+// shell, so a validated target can never be interpreted as shell syntax.
+//
+// Windows restart_service is two steps (sc.exe stop, then sc.exe start) run as
+// separate argv commands rather than a "cmd.exe /C stop & start" string — no
+// shell interpolation, injection-proof by construction.
+func commandPlanFor(goos, cmdType, target string) ([][]string, error) {
+	if goos == "windows" {
+		switch cmdType {
+		case "restart_service":
+			return [][]string{
+				{"sc.exe", "stop", target},
+				{"sc.exe", "start", target},
+			}, nil
+		case "stop_service":
+			return [][]string{{"sc.exe", "stop", target}}, nil
+		case "start_service":
+			return [][]string{{"sc.exe", "start", target}}, nil
+		case "restart_container":
+			return [][]string{{"docker.exe", "restart", target}}, nil
+		case "start_container":
+			return [][]string{{"docker.exe", "start", target}}, nil
+		case "reboot":
+			return [][]string{{"shutdown.exe", "/r", "/t", "0", "/f"}}, nil
+		case "shutdown":
+			return [][]string{{"shutdown.exe", "/s", "/t", "0", "/f"}}, nil
+		default:
+			return nil, fmt.Errorf("unknown command type: %s", cmdType)
+		}
+	}
+
+	switch cmdType {
+	case "restart_service":
+		return [][]string{{"sudo", "systemctl", "restart", target}}, nil
+	case "stop_service":
+		return [][]string{{"sudo", "systemctl", "stop", target}}, nil
+	case "start_service":
+		return [][]string{{"sudo", "systemctl", "start", target}}, nil
+	case "restart_container":
+		return [][]string{{"sudo", "docker", "restart", target}}, nil
+	case "start_container":
+		return [][]string{{"sudo", "docker", "start", target}}, nil
+	case "reboot":
+		return [][]string{{"sudo", "reboot"}}, nil
+	case "shutdown":
+		return [][]string{{"sudo", "shutdown", "-h", "now"}}, nil
+	default:
+		return nil, fmt.Errorf("unknown command type: %s", cmdType)
+	}
+}
+
+// runCommandPlan executes each step's argv in order under ctx, concatenating
+// combined stdout/stderr. It stops at the first failing step. Each command is
+// context-bounded and (on platforms where configureCommand sets it up) killed
+// as a process group when the context expires, so a hung child cannot outlive
+// the timeout.
+func runCommandPlan(ctx context.Context, plan [][]string) ([]byte, error) {
+	var combined []byte
+	for _, step := range plan {
+		if len(step) == 0 {
+			continue
+		}
+		cmd := exec.CommandContext(ctx, step[0], step[1:]...)
+		configureCommand(cmd)
+		out, err := cmd.CombinedOutput()
+		combined = append(combined, out...)
+		if err != nil {
+			return combined, err
+		}
+	}
+	return combined, nil
+}

--- a/agent/main.go
+++ b/agent/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -712,7 +713,7 @@ func handleCommand(conn *websocket.Conn, mu *sync.Mutex, msg []byte) {
 		}
 	}
 
-	execCmd, err := buildPlatformCommand(cmd.Type, cmd.Target)
+	plan, err := commandPlan(cmd.Type, cmd.Target)
 	if err != nil {
 		resp := CommandResponse{
 			Type:  "command_response",
@@ -723,7 +724,13 @@ func handleCommand(conn *websocket.Conn, mu *sync.Mutex, msg []byte) {
 		return
 	}
 
-	output, err := execCmd.CombinedOutput()
+	// Bound execution so a wedged systemctl/docker call can't hang this
+	// goroutine forever; on timeout the command (and its process group, on
+	// Linux) is killed and we report a clear timeout error.
+	ctx, cancel := context.WithTimeout(context.Background(), agentCommandTimeout)
+	defer cancel()
+
+	output, err := runCommandPlan(ctx, plan)
 	resp := CommandResponse{
 		Type:    "command_response",
 		ID:      cmd.ID,
@@ -731,7 +738,11 @@ func handleCommand(conn *websocket.Conn, mu *sync.Mutex, msg []byte) {
 		Output:  string(output),
 	}
 	if err != nil {
-		resp.Error = err.Error()
+		if ctx.Err() == context.DeadlineExceeded {
+			resp.Error = fmt.Sprintf("command timed out after %s", agentCommandTimeout)
+		} else {
+			resp.Error = err.Error()
+		}
 	}
 
 	log.Printf("command %s (id=%s target=%s): success=%v", cmd.Type, cmd.ID, cmd.Target, resp.Success)

--- a/agent/main_linux.go
+++ b/agent/main_linux.go
@@ -92,26 +92,19 @@ func applyTerminalCredentials(bashCmd *exec.Cmd, termUser *user.User) error {
 	return nil
 }
 
-// buildPlatformCommand returns the OS-specific *exec.Cmd for an incoming
-// hub command. Linux uses sudo+systemd+docker.
-func buildPlatformCommand(cmdType, target string) (*exec.Cmd, error) {
-	switch cmdType {
-	case "restart_service":
-		return exec.Command("sudo", "systemctl", "restart", target), nil
-	case "stop_service":
-		return exec.Command("sudo", "systemctl", "stop", target), nil
-	case "start_service":
-		return exec.Command("sudo", "systemctl", "start", target), nil
-	case "restart_container":
-		return exec.Command("sudo", "docker", "restart", target), nil
-	case "start_container":
-		return exec.Command("sudo", "docker", "start", target), nil
-	case "reboot":
-		return exec.Command("sudo", "reboot"), nil
-	case "shutdown":
-		return exec.Command("sudo", "shutdown", "-h", "now"), nil
-	default:
-		return nil, fmt.Errorf("unknown command type: %s", cmdType)
+// configureCommand prepares a to-be-run command for bounded execution on Linux.
+// It places the command in its own process group and installs a Cancel hook
+// that SIGKILLs the whole group when the context expires, so a command that
+// forks children (systemctl/docker) is fully torn down on timeout rather than
+// leaving orphans. The argv itself comes from commandPlanFor.
+func configureCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		// Negative PID targets the whole process group.
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 	}
 }
 

--- a/agent/main_windows.go
+++ b/agent/main_windows.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -11,30 +10,13 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-// buildPlatformCommand returns the OS-specific *exec.Cmd for an incoming
-// hub command. Windows uses sc.exe / docker.exe / shutdown.exe. There is
-// no `sudo` — the agent runs as a Windows service under LocalSystem.
-func buildPlatformCommand(cmdType, target string) (*exec.Cmd, error) {
-	switch cmdType {
-	case "restart_service":
-		// sc.exe doesn't have a built-in restart; chain stop+start in cmd.exe.
-		return exec.Command("cmd.exe", "/C", fmt.Sprintf("sc.exe stop %s & sc.exe start %s", target, target)), nil
-	case "stop_service":
-		return exec.Command("sc.exe", "stop", target), nil
-	case "start_service":
-		return exec.Command("sc.exe", "start", target), nil
-	case "restart_container":
-		return exec.Command("docker.exe", "restart", target), nil
-	case "start_container":
-		return exec.Command("docker.exe", "start", target), nil
-	case "reboot":
-		return exec.Command("shutdown.exe", "/r", "/t", "0", "/f"), nil
-	case "shutdown":
-		return exec.Command("shutdown.exe", "/s", "/t", "0", "/f"), nil
-	default:
-		return nil, fmt.Errorf("unknown command type: %s", cmdType)
-	}
-}
+// configureCommand is the Windows counterpart to the Linux process-group hook.
+// Windows commands (sc.exe / docker.exe / shutdown.exe) don't fork long-lived
+// child trees the way a Linux service manager can, and CommandContext already
+// kills the child on timeout, so no extra process-group handling is needed.
+// The argv (including restart_service as two discrete sc.exe calls — no cmd.exe
+// string interpolation) comes from commandPlanFor.
+func configureCommand(cmd *exec.Cmd) {}
 
 // platformSupportsTerminal reports whether the current platform supports
 // PTY-based terminal sessions. Windows: not yet implemented.


### PR DESCRIPTION
Phase 2C of the review remediation plan — agent command-execution hardening only. Scoped narrowly: **no** SSRF, JWT/login timing, TLS build-tag, signing, cookie, infra, or refactor work.

## Changes

### 1. Bounded timeout for remote commands
Remote commands ran via an unbounded `execCmd.CombinedOutput()`; a wedged `systemctl`/`docker` call (stuck daemon) would block its `go handleCommand` goroutine forever. Commands now run under a `context.WithTimeout(agentCommandTimeout)` (30s, named constant). On timeout the command is killed and `CommandResponse.Error` is a clear `"command timed out after 30s"`. `agent/main.go`.

### 2. Linux process-group cleanup
On Linux, each command runs in its own process group (`Setpgid`) with a `Cancel` hook that `SIGKILL`s the whole group when the context expires — so a command that forks children (systemctl/docker) is fully torn down on timeout, not left as orphans. The `sudo`/`systemctl`/`docker` argv shape is unchanged; no sudoers/permission changes. `agent/main_linux.go` (`configureCommand`).

### 3. Windows restart_service without cmd.exe
`restart_service` was `exec.Command("cmd.exe", "/C", fmt.Sprintf("sc.exe stop %s & sc.exe start %s", …))` — safe only because of the upstream target regex. It's now two discrete argv commands (`sc.exe stop`, then `sc.exe start`), injection-proof by construction. Existing `validTarget` validation is unchanged. `agent/main_windows.go` (no-op `configureCommand`; argv in the plan helper).

## Structure (for testability)
The per-command argv is built by a pure, OS-neutral `commandPlanFor(goos, cmdType, target) [][]string` (`agent/command_plan.go`) — so the plan logic, including the Windows two-step restart, is unit-testable on Linux CI without running Windows. Execution goes through `runCommandPlan(ctx, plan)` which applies the platform `configureCommand` hook and the context bound. This replaces the old per-platform `buildPlatformCommand`.

## Tests
- `command_exec_test.go` (neutral, runs in CI): Linux & Windows `restart_service` plan shapes (Windows asserted to contain no `cmd.exe`/`&`), unknown-type error, prompt timeout kill (`sleep` returns in ~200ms not 10s, `DeadlineExceeded`), multi-step ordering, stop-on-error.
- `command_exec_linux_test.go` (`//go:build linux`): `configureCommand` sets `Setpgid` and a `Cancel` hook.

## Checks
- `cd agent && go test ./...` ✓ · `go vet ./...` ✓ · `GOOS=windows go build/vet` ✓
- `cd hub && go test ./...` ✓
- `cd dashboard && pnpm lint` ✓ · `pnpm build` ✓ (untouched — runs clean)

## Notes for reviewers
- No hub command APIs changed, no new command types, target validation untouched.
- The Windows argv moved from `main_windows.go` into the neutral `commandPlanFor` so it's CI-testable on Linux; `main_windows.go` still owns the Windows execution hook (`configureCommand`). This is the "isolate the command-plan logic so it is unit-testable" ask from the slice brief.
- Uses `exec.Cmd.Cancel` (Go 1.20+); repo is on Go 1.25.
- Do not merge until reviewed.