### PR TITLE
fix(hub): auth hardening — JWT extraction, login timing, secret length (Phase 2D-1)

### DIFF
--- a/hub/auth.go
+++ b/hub/auth.go
@@ -193,6 +193,20 @@ func handleSetup(c echo.Context) error {
 	})
 }
 
+// dummyPasswordHash is a valid bcrypt hash at DefaultCost used to spend
+// roughly the same time on an unknown username as on a real one, reducing the
+// username-enumeration timing oracle. Computed once at startup.
+var dummyPasswordHash = mustDummyPasswordHash()
+
+func mustDummyPasswordHash() []byte {
+	h, err := bcrypt.GenerateFromPassword([]byte("bloxos-timing-equalizer"), bcrypt.DefaultCost)
+	if err != nil {
+		// bcrypt only errors on an invalid cost, which is impossible here.
+		log.Fatalf("failed to compute dummy password hash: %v", err)
+	}
+	return h
+}
+
 func handleLogin(c echo.Context) error {
 	ip := getRealIP(c)
 	if !rateLimiter.Allow("login", ip, 5) {
@@ -212,6 +226,10 @@ func handleLogin(c echo.Context) error {
 	err := db.QueryRow(`SELECT id, username, password_hash, COALESCE(role, 'admin') FROM users WHERE username = ?`, body.Username).
 		Scan(&userID, &storedUsername, &passwordHash, &rawRole)
 	if err == sql.ErrNoRows {
+		// Spend a comparable amount of time as the valid-username path so the
+		// response time doesn't reveal whether the username exists. Result is
+		// intentionally discarded.
+		_ = bcrypt.CompareHashAndPassword(dummyPasswordHash, []byte(body.Password))
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "invalid credentials"})
 	}
 	if err != nil {
@@ -367,10 +385,17 @@ func extractUserIDFromRequest(c echo.Context) string {
 	if tokenStr == "" {
 		return ""
 	}
-	tkn, _ := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
+	// Validate the token the same way jwtMiddleware does: honor the parse
+	// error, require a valid token, and assert the HMAC signing method (so an
+	// alg=none / algorithm-confusion token is rejected). Any invalid state
+	// yields an empty userID.
+	tkn, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method")
+		}
 		return jwtSecret, nil
 	})
-	if tkn == nil {
+	if err != nil || tkn == nil || !tkn.Valid {
 		return ""
 	}
 	claims, ok := tkn.Claims.(jwt.MapClaims)
@@ -381,12 +406,30 @@ func extractUserIDFromRequest(c echo.Context) string {
 	return userID
 }
 
+// minJWTSecretLen is the minimum accepted length for a JWT signing secret,
+// applied to both the file-backed and env-provided secret.
+const minJWTSecretLen = 32
+
+// validateEnvJWTSecret enforces the minimum length on an env-provided JWT
+// secret, so a weak signing key can't be silently accepted (the file-backed
+// secret already requires >= 32 bytes).
+func validateEnvJWTSecret(envSecret string) ([]byte, error) {
+	if len(envSecret) < minJWTSecretLen {
+		return nil, fmt.Errorf("BLOXOS_JWT_SECRET must be at least %d bytes, got %d", minJWTSecretLen, len(envSecret))
+	}
+	return []byte(envSecret), nil
+}
+
 // loadOrGenerateJWTSecret loads from file or generates a new secret (Finding #2).
 func loadOrGenerateJWTSecret() []byte {
 	// Check env var first (explicit override).
 	if envSecret := os.Getenv("BLOXOS_JWT_SECRET"); envSecret != "" {
+		secret, err := validateEnvJWTSecret(envSecret)
+		if err != nil {
+			log.Fatalf("invalid BLOXOS_JWT_SECRET: %v", err)
+		}
 		log.Println("JWT secret loaded from BLOXOS_JWT_SECRET env var")
-		return []byte(envSecret)
+		return secret
 	}
 
 	homeDir, err := os.UserHomeDir()
@@ -400,7 +443,7 @@ func loadOrGenerateJWTSecret() []byte {
 
 	// Try to read existing secret.
 	data, err := os.ReadFile(secretFile)
-	if err == nil && len(data) >= 32 {
+	if err == nil && len(data) >= minJWTSecretLen {
 		log.Printf("JWT secret loaded from %s", secretFile)
 		return data
 	}

--- a/hub/auth_hardening_test.go
+++ b/hub/auth_hardening_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
+)
+
+func signHS256(t *testing.T, claims jwt.MapClaims, secret []byte) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := tok.SignedString(secret)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return s
+}
+
+func ctxWithBearer(e *echo.Echo, token string) echo.Context {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec)
+}
+
+// TestExtractUserIDValidToken: a properly signed, unexpired token yields its
+// user_id.
+func TestExtractUserIDValidToken(t *testing.T) {
+	e := setupTestServer(t)
+	tok := signHS256(t, jwt.MapClaims{"user_id": "user-123", "exp": time.Now().Add(time.Hour).Unix()}, jwtSecret)
+	if got := extractUserIDFromRequest(ctxWithBearer(e, tok)); got != "user-123" {
+		t.Fatalf("extractUserIDFromRequest = %q, want user-123", got)
+	}
+}
+
+// TestExtractUserIDRejectsBadSignature: a token signed with the wrong key must
+// not be trusted.
+func TestExtractUserIDRejectsBadSignature(t *testing.T) {
+	e := setupTestServer(t)
+	tok := signHS256(t, jwt.MapClaims{"user_id": "user-123", "exp": time.Now().Add(time.Hour).Unix()}, []byte("a-totally-different-signing-key-32b!"))
+	if got := extractUserIDFromRequest(ctxWithBearer(e, tok)); got != "" {
+		t.Fatalf("expected empty userID for bad signature, got %q", got)
+	}
+}
+
+// TestExtractUserIDRejectsNoneAlg: an alg=none token must be rejected (the
+// keyfunc must require HMAC).
+func TestExtractUserIDRejectsNoneAlg(t *testing.T) {
+	e := setupTestServer(t)
+	tok, err := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
+		"user_id": "user-123", "exp": time.Now().Add(time.Hour).Unix(),
+	}).SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("sign none-alg token: %v", err)
+	}
+	if got := extractUserIDFromRequest(ctxWithBearer(e, tok)); got != "" {
+		t.Fatalf("expected empty userID for alg=none token, got %q", got)
+	}
+}
+
+// TestExtractUserIDRejectsExpired: an expired token must not be trusted.
+func TestExtractUserIDRejectsExpired(t *testing.T) {
+	e := setupTestServer(t)
+	tok := signHS256(t, jwt.MapClaims{"user_id": "user-123", "exp": time.Now().Add(-time.Hour).Unix()}, jwtSecret)
+	if got := extractUserIDFromRequest(ctxWithBearer(e, tok)); got != "" {
+		t.Fatalf("expected empty userID for expired token, got %q", got)
+	}
+}
+
+// TestLoginUnknownUsernameRunsDummyCompare: an unknown username still returns
+// 401 and pays a bcrypt comparison (dummy hash), so its response time is
+// comparable to a real user's — closing the username-enumeration timing oracle.
+// Before the fix the unknown-username path returned in well under a millisecond.
+func TestLoginUnknownUsernameRunsDummyCompare(t *testing.T) {
+	e := setupTestServer(t)
+
+	body := `{"username":"definitely-not-a-real-user","password":"whatever-password"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	start := time.Now()
+	e.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for unknown username, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid credentials") {
+		t.Fatalf("expected 'invalid credentials', got %s", rec.Body.String())
+	}
+	// bcrypt at DefaultCost reliably takes tens of milliseconds; a no-bcrypt
+	// fast path is sub-millisecond. Generous 15ms threshold avoids CI flake.
+	if elapsed < 15*time.Millisecond {
+		t.Fatalf("unknown-username login returned in %v; dummy bcrypt compare appears to be skipped", elapsed)
+	}
+}
+
+// TestValidateEnvJWTSecret: the env-provided JWT secret must meet the same
+// minimum length as the file-backed secret.
+func TestValidateEnvJWTSecret(t *testing.T) {
+	if _, err := validateEnvJWTSecret(strings.Repeat("a", 32)); err != nil {
+		t.Fatalf("32-byte secret should be accepted: %v", err)
+	}
+	if _, err := validateEnvJWTSecret(strings.Repeat("a", 64)); err != nil {
+		t.Fatalf("64-byte secret should be accepted: %v", err)
+	}
+	if _, err := validateEnvJWTSecret(strings.Repeat("a", 31)); err == nil {
+		t.Fatal("31-byte secret should be rejected")
+	}
+	if _, err := validateEnvJWTSecret(""); err == nil {
+		t.Fatal("empty secret should be rejected")
+	}
+}


### PR DESCRIPTION
Phase 2D-1 of the review remediation plan — hub auth hardening only. Split out from the rest of 2D deliberately: SSRF resolved-IP guarding is subtle (redirects, DNS rebinding, private homelab targets, adapter behavior) and gets its own PR. This one is small and low-risk. **No** SSRF, TLS build-tag, signing, cookie, infra, updater, or refactor work.

## Changes (all in `hub/auth.go`)

### 1. Harden `extractUserIDFromRequest`
It parsed the JWT while ignoring the parse error, `token.Valid`, and the signing method — so a bad-signature, expired, or `alg=none`/algorithm-confusion token would still yield a `user_id`. It now mirrors `jwtMiddleware`: honors the error, checks `token.Valid`, and asserts `*jwt.SigningMethodHMAC` in the keyfunc. Any invalid state returns an empty userID. Not reachable today (all callers sit behind the middleware, which checks context first) but a live footgun for the next caller — now closed.

### 2. Constant-time-ish login for unknown usernames
On `sql.ErrNoRows` the handler returned immediately without hashing, so a valid username paid the ~tens-of-ms bcrypt cost while an unknown one returned sub-millisecond — a username-enumeration timing oracle. It now runs `bcrypt.CompareHashAndPassword` against a fixed dummy hash (DefaultCost, computed once at startup) before returning the same `401 invalid credentials`. No account lockout added (per-IP rate limit already exists); external response unchanged.

### 3. JWT secret env length guard
`loadOrGenerateJWTSecret` accepted any-length `BLOXOS_JWT_SECRET` while the file-backed secret required >= 32 bytes. It now validates the env secret via a small `validateEnvJWTSecret` helper (shared `minJWTSecretLen = 32`) and `log.Fatal`s on a too-short secret instead of silently signing with a weak key. The file check now uses the same named constant.

## Tests (`hub/auth_hardening_test.go`)
- `TestExtractUserIDValidToken` — valid HS256 token yields its userID.
- `TestExtractUserIDRejectsBadSignature` / `…RejectsNoneAlg` / `…RejectsExpired` — each yields empty.
- `TestLoginUnknownUsernameRunsDummyCompare` — unknown username returns 401 and takes bcrypt-comparable time (>15 ms; the pre-fix fast path was sub-ms), so the fix is behaviorally verified without a flaky micro-timing assertion.
- `TestValidateEnvJWTSecret` — accepts >= 32 bytes, rejects shorter and empty.

## Checks
- `cd hub && go test ./...` ✓ · `go vet ./...` ✓
- `cd agent && go test ./...` ✓ (untouched)
- `cd dashboard && pnpm lint` ✓ · `pnpm build` ✓ (untouched — runs clean)

## Notes for reviewers
- The env-secret guard `log.Fatal`s (startup-time, clear message); extracted into `validateEnvJWTSecret` so the length rule is unit-tested without making `main` startup harder to test. No existing test uses the env path.
- No dashboard auth-storage, cookie, RBAC/route, or SSRF changes.
- Do not merge until reviewed.