### PR TITLE
fix(hub): SSRF-harden API-machine polling with resolved-IP guard (Phase 2D-2)

### DIFF
--- a/hub/main.go
+++ b/hub/main.go
@@ -1639,7 +1639,10 @@ func redactAPITLSConfig(raw string) json.RawMessage {
 }
 
 func apiHTTPClient(baseURL string, tlsConfigRaw json.RawMessage) (*http.Client, error) {
-	transport := &http.Transport{}
+	// SSRF guard: resolve and validate the target IP before every connection
+	// (initial request and redirects), so a public hostname that resolves to an
+	// internal address — or a DNS rebind — cannot reach blocked ranges.
+	transport := &http.Transport{DialContext: safeDialContext}
 	tlsConfig := &tls.Config{}
 	cfg, err := parseAPITLSConfig(tlsConfigRaw)
 	if err != nil {
@@ -1663,8 +1666,9 @@ func apiHTTPClient(baseURL string, tlsConfigRaw json.RawMessage) (*http.Client, 
 
 	transport.TLSClientConfig = tlsConfig
 	return &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: transport,
+		Timeout:       30 * time.Second,
+		Transport:     transport,
+		CheckRedirect: checkAPIRedirect,
 	}, nil
 }
 
@@ -1701,8 +1705,12 @@ func pollProxmox(baseURL string, authConfig json.RawMessage, tlsConfig json.RawM
 	}
 	defer nodesResp.Body.Close()
 	if nodesResp.StatusCode != 200 {
-		body, _ := io.ReadAll(nodesResp.Body)
-		return nil, fmt.Errorf("proxmox nodes: HTTP %d: %s", nodesResp.StatusCode, string(body))
+		// Log the upstream body server-side for debugging, but never fold it
+		// into the returned error — reflecting an upstream response body would
+		// leak the content of whatever endpoint an SSRF probe reached.
+		body, _ := io.ReadAll(io.LimitReader(nodesResp.Body, 4096))
+		log.Printf("proxmox nodes poll failed: HTTP %d, body=%q", nodesResp.StatusCode, string(body))
+		return nil, fmt.Errorf("proxmox nodes: HTTP %d", nodesResp.StatusCode)
 	}
 
 	var nodesData struct {
@@ -1965,6 +1973,95 @@ var rfc1918Networks = func() []*net.IPNet {
 	}
 	return out
 }()
+
+// lookupIPFunc resolves a host to its IP addresses. It is a package var so
+// tests can inject a fake resolver without external network access.
+var lookupIPFunc = net.DefaultResolver.LookupIPAddr
+
+// isBlockedIP reports whether an IP address must never be the target of an
+// API-machine poll. Loopback, unspecified, link-local, and multicast (which
+// covers the 169.254.169.254 cloud-metadata endpoint) are always blocked.
+// Private ranges (RFC 1918 + IPv6 ULA) are blocked unless the homelab opt-in
+// BLOXOS_ALLOW_PRIVATE_TARGETS=1 is set — preserving the existing behavior for
+// LAN fleets.
+func isBlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() || ip.IsMulticast() {
+		return true
+	}
+	if ip.IsPrivate() && os.Getenv("BLOXOS_ALLOW_PRIVATE_TARGETS") != "1" {
+		return true
+	}
+	return false
+}
+
+// resolveAndValidate resolves host and returns its IP addresses, failing closed
+// if the host cannot be resolved or ANY resolved address is blocked (so a DNS
+// answer mixing a public and an internal IP cannot be used to reach the
+// internal one).
+func resolveAndValidate(ctx context.Context, host string) ([]net.IP, error) {
+	// A bracketed IPv6 literal or plain IP still goes through the resolver,
+	// which returns it verbatim — so the block policy applies uniformly.
+	addrs, err := lookupIPFunc(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("resolve host: %w", err)
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("no addresses resolved for host")
+	}
+	ips := make([]net.IP, 0, len(addrs))
+	for _, a := range addrs {
+		if isBlockedIP(a.IP) {
+			return nil, fmt.Errorf("refusing to connect to blocked address %s (resolved from %s)", a.IP, host)
+		}
+		ips = append(ips, a.IP)
+	}
+	return ips, nil
+}
+
+// safeDialContext resolves and validates the target host, then dials only a
+// validated IP (pinning it, so there is no second resolution a rebind could
+// race). It is installed on every API-poll HTTP client, so it guards the
+// initial request and every redirect the client follows.
+func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := resolveAndValidate(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	d := &net.Dialer{Timeout: 10 * time.Second}
+	var dialErr error
+	for _, ip := range ips {
+		conn, err := d.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		dialErr = err
+	}
+	return nil, dialErr
+}
+
+// checkAPIRedirect validates every redirect an API poll would follow with the
+// same base-URL policy (scheme + host), and caps the redirect chain. The
+// resolved-IP guard in safeDialContext still applies to the redirect's actual
+// connection, so a redirect to a hostname that resolves internally is also
+// blocked at dial time.
+func checkAPIRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 5 {
+		return fmt.Errorf("stopped after too many redirects")
+	}
+	if err := validateBaseURL(req.URL.String()); err != nil {
+		return fmt.Errorf("redirect blocked: %w", err)
+	}
+	return nil
+}
 
 // validateBaseURL checks that a base URL is safe to poll (prevents SSRF).
 func validateBaseURL(rawURL string) error {
@@ -2322,8 +2419,12 @@ func handleForceAPIPoll(c echo.Context) error {
 
 	result, pollErr := doPoll(m.AdapterType, m.BaseURL, json.RawMessage(m.AuthConfig), json.RawMessage(m.TLSConfig))
 	if pollErr != nil {
-		db.Exec("UPDATE api_machines SET last_error = ?, last_poll_at = CURRENT_TIMESTAMP WHERE id = ?", pollErr.Error(), id)
-		return c.JSON(http.StatusBadGateway, map[string]string{"error": pollErr.Error()})
+		// Log the detailed error server-side, but return a generic message to
+		// the dashboard so upstream/network detail from a poll target isn't
+		// reflected to the client.
+		log.Printf("api machine %s (%s) poll failed: %v", id, m.Name, pollErr)
+		db.Exec("UPDATE api_machines SET last_error = ?, last_poll_at = CURRENT_TIMESTAMP WHERE id = ?", "poll failed", id)
+		return c.JSON(http.StatusBadGateway, map[string]string{"error": "poll failed"})
 	}
 
 	storeAPIPollResult(id, m.Name, m.AdapterType, m.BaseURL, result)

--- a/hub/ssrf_test.go
+++ b/hub/ssrf_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestIsBlockedIP(t *testing.T) {
+	cases := []struct {
+		name    string
+		ip      string
+		homelab bool
+		blocked bool
+	}{
+		{"ipv4 loopback", "127.0.0.1", true, true},   // never allowed, even with opt-in
+		{"ipv6 loopback", "::1", true, true},         // never allowed
+		{"unspecified v4", "0.0.0.0", true, true},    // never allowed
+		{"unspecified v6", "::", true, true},         // never allowed
+		{"cloud metadata", "169.254.169.254", true, true},
+		{"link-local v4", "169.254.1.1", true, true},
+		{"link-local v6", "fe80::1", true, true},
+		{"multicast", "224.0.0.1", true, true},
+		{"rfc1918 10/8 default", "10.20.30.40", false, true},
+		{"rfc1918 192.168 default", "192.168.1.50", false, true},
+		{"rfc1918 172.16 default", "172.20.5.10", false, true},
+		{"ula v6 default", "fc00::1", false, true},
+		{"rfc1918 10/8 homelab", "10.20.30.40", true, false},
+		{"rfc1918 192.168 homelab", "192.168.1.50", true, false},
+		{"ula v6 homelab", "fc00::1", true, false},
+		{"public v4", "8.8.8.8", false, false},
+		{"public v4 with homelab", "93.184.216.34", true, false},
+		{"public v6", "2606:4700:4700::1111", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.homelab {
+				t.Setenv("BLOXOS_ALLOW_PRIVATE_TARGETS", "1")
+			} else {
+				t.Setenv("BLOXOS_ALLOW_PRIVATE_TARGETS", "")
+			}
+			ip := net.ParseIP(tc.ip)
+			if ip == nil {
+				t.Fatalf("bad test IP %q", tc.ip)
+			}
+			if got := isBlockedIP(ip); got != tc.blocked {
+				t.Fatalf("isBlockedIP(%s) homelab=%v = %v, want %v", tc.ip, tc.homelab, got, tc.blocked)
+			}
+		})
+	}
+}
+
+// withFakeResolver swaps lookupIPFunc for a static map and restores it.
+func withFakeResolver(t *testing.T, m map[string][]string) {
+	t.Helper()
+	prev := lookupIPFunc
+	t.Cleanup(func() { lookupIPFunc = prev })
+	lookupIPFunc = func(_ context.Context, host string) ([]net.IPAddr, error) {
+		ips, ok := m[host]
+		if !ok {
+			return nil, &net.DNSError{Err: "not found", Name: host, IsNotFound: true}
+		}
+		out := make([]net.IPAddr, 0, len(ips))
+		for _, s := range ips {
+			out = append(out, net.IPAddr{IP: net.ParseIP(s)})
+		}
+		return out, nil
+	}
+}
+
+func TestResolveAndValidate(t *testing.T) {
+	withFakeResolver(t, map[string][]string{
+		"public.example":   {"93.184.216.34"},
+		"evil-loopback":    {"127.0.0.1"},
+		"evil-internal":    {"10.0.0.5"},
+		"evil-metadata":    {"169.254.169.254"},
+		"mixed":            {"93.184.216.34", "10.0.0.5"}, // one bad IP taints the set
+	})
+
+	t.Run("public host allowed", func(t *testing.T) {
+		t.Setenv("BLOXOS_ALLOW_PRIVATE_TARGETS", "")
+		ips, err := resolveAndValidate(context.Background(), "public.example")
+		if err != nil {
+			t.Fatalf("expected public host allowed, got %v", err)
+		}
+		if len(ips) != 1 || ips[0].String() != "93.184.216.34" {
+			t.Fatalf("unexpected ips: %v", ips)
+		}
+	})
+
+	t.Run("hostname resolving to loopback rejected", func(t *testing.T) {
+		t.Setenv("BLOXOS_ALLOW_PRIVATE_TARGETS", "1")
+		if _, err := resolveAndValidate(context.Background(), "evil-loopback"); err == nil {
+			t.Fatal("expected rejection for host resolving to loopback")
+		}
+	})
+
+	t.Run("hostname resolving to metadata rejected", func(t *testing.T) {
+		if _, err := resolveAndValidate(context.Background(), "evil-metadata"); err == nil {
+			t.Fatal("expected rejection for host resolving to metadata IP")
+		}
+	})
+
+	t.Run("hostname resolving to private rejected by default", func(t *testing.T) {
+		t.Setenv("BLOXOS_ALLOW_PRIVATE_TARGETS", "")
+		if _, err := resolveAndValidate(context.Background(), "evil-internal"); err == nil {
+			t.Fatal("expected rejection for host resolving to private IP by default")
+		}
+	})
+
+	t.Run("hostname resolving to private allowed with opt-in", func(t *testing.T) {
+		t.Setenv("BLOXOS_ALLOW_PRIVATE_TARGETS", "1")
+		if _, err := resolveAndValidate(context.Background(), "evil-internal"); err != nil {
+			t.Fatalf("expected private host allowed with opt-in, got %v", err)
+		}
+	})
+
+	t.Run("mixed public+private rejected fail-closed", func(t *testing.T) {
+		t.Setenv("BLOXOS_ALLOW_PRIVATE_TARGETS", "")
+		if _, err := resolveAndValidate(context.Background(), "mixed"); err == nil {
+			t.Fatal("expected rejection when any resolved IP is unsafe")
+		}
+	})
+}
+
+func TestCheckAPIRedirect(t *testing.T) {
+	mkReq := func(u string) *http.Request {
+		r, _ := http.NewRequest(http.MethodGet, u, nil)
+		return r
+	}
+
+	t.Run("redirect to loopback rejected", func(t *testing.T) {
+		t.Setenv("BLOXOS_ALLOW_PRIVATE_TARGETS", "1")
+		if err := checkAPIRedirect(mkReq("http://127.0.0.1/x"), nil); err == nil {
+			t.Fatal("expected redirect to loopback rejected")
+		}
+	})
+
+	t.Run("redirect to private literal rejected by default", func(t *testing.T) {
+		t.Setenv("BLOXOS_ALLOW_PRIVATE_TARGETS", "")
+		if err := checkAPIRedirect(mkReq("http://10.0.0.9/x"), nil); err == nil {
+			t.Fatal("expected redirect to private literal rejected")
+		}
+	})
+
+	t.Run("redirect to public allowed", func(t *testing.T) {
+		t.Setenv("BLOXOS_ALLOW_PRIVATE_TARGETS", "")
+		if err := checkAPIRedirect(mkReq("https://example.com/x"), nil); err != nil {
+			t.Fatalf("expected public redirect allowed, got %v", err)
+		}
+	})
+
+	t.Run("too many redirects rejected", func(t *testing.T) {
+		via := make([]*http.Request, 6)
+		if err := checkAPIRedirect(mkReq("https://example.com/x"), via); err == nil {
+			t.Fatal("expected too-many-redirects rejection")
+		}
+	})
+}
+
+// TestAPIHTTPClientUsesSafeDialer verifies the poll client is wired with the
+// SSRF-guarding dialer and redirect check.
+func TestAPIHTTPClientUsesSafeDialer(t *testing.T) {
+	client, err := apiHTTPClient("https://example.com", nil)
+	if err != nil {
+		t.Fatalf("apiHTTPClient: %v", err)
+	}
+	if client.CheckRedirect == nil {
+		t.Fatal("api poll client must set a CheckRedirect guard")
+	}
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok || tr.DialContext == nil {
+		t.Fatal("api poll client transport must set a DialContext guard")
+	}
+	// The dialer must reject a hostname that resolves to a blocked IP.
+	withFakeResolver(t, map[string][]string{"rebind.example": {"127.0.0.1"}})
+	if _, err := tr.DialContext(context.Background(), "tcp", "rebind.example:443"); err == nil {
+		t.Fatal("dialer should reject a host resolving to loopback")
+	} else if !strings.Contains(err.Error(), "blocked") {
+		t.Fatalf("expected a 'blocked address' error, got %v", err)
+	}
+}


### PR DESCRIPTION
Phase 2D-2 of the review remediation plan — SSRF hardening for API-polled machines (Proxmox/Synology). Hub-only, +108/−7 in `main.go` plus tests. **No** TLS-build-tag, signing, cookie, infra, updater, docs, or refactor work.

## Problem
`validateBaseURL` only inspects URL literals: `if ip := net.ParseIP(host); ip != nil { … }`. A public hostname that resolves to an internal IP — or a DNS rebind between config-time validation and the actual poll — was never re-checked, so the poll could reach loopback/metadata/private ranges.

## Changes (`hub/main.go`)

### 1. Resolve-and-validate dial guard
`safeDialContext` (installed on every API-poll client's `Transport.DialContext`) resolves the target host and refuses to connect if **any** resolved IP is blocked, then dials only the validated IP (pinned — no second resolution a rebind could race). Blocked set via `isBlockedIP`: loopback, unspecified, link-local unicast/multicast (covers `169.254.169.254`), and other multicast are always blocked; RFC 1918 + IPv6 ULA are blocked unless the existing `BLOXOS_ALLOW_PRIVATE_TARGETS=1` opt-in is set. Fails closed on a mixed public+private DNS answer. Because it's at the connection layer, it also guards redirects and DNS rebinding. IP-literal targets go through the resolver too, so they get the same check.

### 2. Redirect safety
`checkAPIRedirect` (the client's `CheckRedirect`) re-validates each redirect target with the base-URL policy and caps the chain at 5. The dialer additionally validates the redirect's resolved IP, so a redirect to a hostname that resolves internally is blocked at dial time.

### 3. Error hygiene
`pollProxmox` no longer folds the upstream response body into the returned error (it logs a 4KB-capped body server-side instead) — reflecting an upstream body would leak whatever an SSRF probe reached. `handleForceAPIPoll` returns a generic `"poll failed"` to the dashboard (and stores that in `last_error`) while logging the detailed error server-side.

## Homelab preserved
Private LAN API machines still work with `BLOXOS_ALLOW_PRIVATE_TARGETS=1` — the opt-in gates `isBlockedIP` exactly as it gated `validateBaseURL`. `validateBaseURL` and the `auth_config`/`tls_config` schema are unchanged.

## Tests (`hub/ssrf_test.go`, no external network — fake resolver / injected dialer)
- `TestIsBlockedIP` — matrix: v4/v6 loopback, unspecified, metadata, link-local, multicast always blocked; RFC1918 + ULA blocked by default and allowed with the opt-in; public v4/v6 allowed.
- `TestResolveAndValidate` — public host allowed; hostnames resolving to loopback/metadata/private rejected (private allowed with opt-in); fail-closed on a mixed public+private answer.
- `TestCheckAPIRedirect` — redirect to loopback / private-literal rejected, public allowed, too-many-redirects rejected.
- `TestAPIHTTPClientUsesSafeDialer` — the poll client wires both `DialContext` and `CheckRedirect`, and the dialer rejects a host resolving to loopback.

## Checks
- `cd hub && go test ./...` ✓ (incl. existing `TestValidateBaseURL`, unchanged) · `go vet ./...` ✓
- `cd agent && go test ./...` ✓ (untouched)
- `cd dashboard && pnpm lint` ✓ · `pnpm build` ✓ (untouched — runs clean)

## Notes for reviewers
- `validateBaseURL` intentionally left as-is (config-time literal check); the dialer is the new poll-time resolved-IP layer. They're complementary.
- `lookupIPFunc` is a package var solely so tests can inject a resolver — it defaults to `net.DefaultResolver.LookupIPAddr`.
- Scope stayed small (single reviewable PR); no split needed.
- Do not merge until reviewed.