### PR TITLE
fix(agent): gate BLOXOS_TLS_INSECURE behind an explicit insecure build (Phase 2E)

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/xml"
@@ -237,26 +236,18 @@ func websocketDialerFor(rawURL string) (*websocket.Dialer, error) {
 	dialer := *websocket.DefaultDialer
 	// Phase 8 update flow reuses this for HTTPS downloads (`/download/agent`),
 	// not just the WS dial. Both wss:// and https:// need the same TLS config
-	// (custom CA, optional InsecureSkipVerify); without this, the auto-update
+	// (system roots + optional BLOXOS_CA_CERT); without this, the auto-update
 	// HTTP fetch failed with "x509: certificate signed by unknown authority"
-	// and the rollout circuit breaker tripped.
+	// and the rollout circuit breaker tripped. The config is built by
+	// buildAgentTLSConfig, whose release build always verifies (see
+	// tls_secure.go / tls_insecure.go).
 	if u.Scheme != "wss" && u.Scheme != "https" {
 		return &dialer, nil
 	}
 
-	tlsConfig := &tls.Config{}
-	if os.Getenv("BLOXOS_TLS_INSECURE") == "1" {
-		tlsConfig.InsecureSkipVerify = true
-		log.Printf("WARNING: BLOXOS_TLS_INSECURE=1 disables TLS verification for %s", u.Host)
-	} else {
-		rootCAs, caPath, err := loadRootCAs()
-		if err != nil {
-			return nil, err
-		}
-		tlsConfig.RootCAs = rootCAs
-		if caPath != "" {
-			log.Printf("agent TLS: trusting additional CA from %s", caPath)
-		}
+	tlsConfig, err := buildAgentTLSConfig(u.Host)
+	if err != nil {
+		return nil, err
 	}
 
 	dialer.TLSClientConfig = tlsConfig

--- a/agent/tls_insecure.go
+++ b/agent/tls_insecure.go
@@ -1,0 +1,28 @@
+//go:build insecure
+
+package main
+
+import (
+	"crypto/tls"
+	"log"
+	"os"
+)
+
+// buildAgentTLSConfig (insecure dev build) honors BLOXOS_TLS_INSECURE=1 to skip
+// TLS verification entirely, with a loud warning. This file only compiles under
+// `-tags insecure`; release/default builds use tls_secure.go, which can never
+// disable verification. Do NOT ship binaries built with this tag.
+func buildAgentTLSConfig(host string) (*tls.Config, error) {
+	if os.Getenv("BLOXOS_TLS_INSECURE") == "1" {
+		log.Printf("WARNING: BLOXOS_TLS_INSECURE=1 disables TLS verification for %s (insecure dev build)", host)
+		return &tls.Config{InsecureSkipVerify: true}, nil
+	}
+	rootCAs, caPath, err := loadRootCAs()
+	if err != nil {
+		return nil, err
+	}
+	if caPath != "" {
+		log.Printf("agent TLS: trusting additional CA from %s", caPath)
+	}
+	return &tls.Config{RootCAs: rootCAs}, nil
+}

--- a/agent/tls_insecure_test.go
+++ b/agent/tls_insecure_test.go
@@ -1,0 +1,28 @@
+//go:build insecure
+
+package main
+
+import "testing"
+
+// TestBuildAgentTLSConfigInsecureBypass runs only under `-tags insecure`. It
+// proves the dev build honors BLOXOS_TLS_INSECURE=1 (skip verification) and
+// still verifies when the env is unset.
+func TestBuildAgentTLSConfigInsecureBypass(t *testing.T) {
+	t.Setenv("BLOXOS_TLS_INSECURE", "1")
+	cfg, err := buildAgentTLSConfig("hub.example")
+	if err != nil {
+		t.Fatalf("buildAgentTLSConfig: %v", err)
+	}
+	if !cfg.InsecureSkipVerify {
+		t.Fatal("insecure build with BLOXOS_TLS_INSECURE=1 must set InsecureSkipVerify")
+	}
+
+	t.Setenv("BLOXOS_TLS_INSECURE", "")
+	cfg2, err := buildAgentTLSConfig("hub.example")
+	if err != nil {
+		t.Fatalf("buildAgentTLSConfig (no env): %v", err)
+	}
+	if cfg2.InsecureSkipVerify {
+		t.Fatal("insecure build without BLOXOS_TLS_INSECURE must still verify")
+	}
+}

--- a/agent/tls_secure.go
+++ b/agent/tls_secure.go
@@ -1,0 +1,24 @@
+//go:build !insecure
+
+package main
+
+import (
+	"crypto/tls"
+	"log"
+)
+
+// buildAgentTLSConfig returns the agent's TLS client config for wss:// and
+// https:// connections. Release/default builds ALWAYS verify the server
+// certificate using the system roots plus the optional BLOXOS_CA_CERT.
+// BLOXOS_TLS_INSECURE is intentionally not honored here — the verification
+// bypass only exists in `-tags insecure` dev builds (see tls_insecure.go).
+func buildAgentTLSConfig(host string) (*tls.Config, error) {
+	rootCAs, caPath, err := loadRootCAs()
+	if err != nil {
+		return nil, err
+	}
+	if caPath != "" {
+		log.Printf("agent TLS: trusting additional CA from %s", caPath)
+	}
+	return &tls.Config{RootCAs: rootCAs}, nil
+}

--- a/agent/tls_secure_test.go
+++ b/agent/tls_secure_test.go
@@ -1,0 +1,23 @@
+//go:build !insecure
+
+package main
+
+import "testing"
+
+// TestBuildAgentTLSConfigDefaultVerifies proves that a default/release build
+// never disables TLS verification, even if BLOXOS_TLS_INSECURE=1 is set — the
+// insecure bypass must not exist outside an explicit `-tags insecure` build.
+func TestBuildAgentTLSConfigDefaultVerifies(t *testing.T) {
+	t.Setenv("BLOXOS_TLS_INSECURE", "1")
+
+	cfg, err := buildAgentTLSConfig("hub.example")
+	if err != nil {
+		t.Fatalf("buildAgentTLSConfig: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected a non-nil tls.Config")
+	}
+	if cfg.InsecureSkipVerify {
+		t.Fatal("default build must not set InsecureSkipVerify even with BLOXOS_TLS_INSECURE=1")
+	}
+}


### PR DESCRIPTION
Phase 2E of the review remediation plan — remove the TLS-verification bypass from shipped agent builds. Agent-only. **No** signing, cookie, updater-resilience, infra, docs, or refactor work. This finishes the small Phase 2 hardening items.

## Problem
`websocketDialerFor` honored `BLOXOS_TLS_INSECURE=1` by setting `InsecureSkipVerify = true` in the **release** binary — a full TLS-bypass switch shipped to the fleet, enabling trivial MITM (including of the auto-update HTTPS fetch).

## Changes (`agent/`)
- **Default/release builds never disable verification.** `buildAgentTLSConfig` is split into two build-tagged implementations:
  - `tls_secure.go` (`//go:build !insecure`) — always verifies using system roots + optional `BLOXOS_CA_CERT`; `BLOXOS_TLS_INSECURE` is not referenced.
  - `tls_insecure.go` (`//go:build insecure`) — dev-only; honors `BLOXOS_TLS_INSECURE=1` (`InsecureSkipVerify`) with the existing loud warning, else verifies. Carries a "do NOT ship" note.
- `websocketDialerFor` now calls `buildAgentTLSConfig(u.Host)` instead of inlining the insecure branch; the adjacent comment was updated (it previously said "optional InsecureSkipVerify").
- Normal builds compile with **no** insecure code path.

## Unchanged (per scope)
CA bootstrap/install behavior, hub TLS, WebSocket credential transport, and the updater are all untouched.

## Tests
- `tls_secure_test.go` (`//go:build !insecure`) — proves a default build ignores `BLOXOS_TLS_INSECURE=1` and keeps `InsecureSkipVerify=false`. Runs in normal CI.
- `tls_insecure_test.go` (`//go:build insecure`) — proves the dev build honors the env only under the tag (and still verifies without it). Not run by default CI; run with `-tags insecure`.

## Checks
- `cd agent && go build/test ./...` ✓ · `go vet ./...` ✓
- `cd agent && go build -tags insecure ./... && go test -tags insecure ./... && go vet -tags insecure ./...` ✓
- `GOOS=windows go build ./...` ✓ and `GOOS=windows go build -tags insecure ./...` ✓ (agent targets Windows too)
- `cd hub && go test ./...` ✓ (untouched)
- `cd dashboard && pnpm lint` ✓ · `pnpm build` ✓ (untouched — runs clean)

## Notes for reviewers
- CI's default `go test ./...` exercises the secure path and confirms the bypass is absent; the insecure-tag test is verified locally and documented above (kept out of required CI per the slice brief).
- After this lands you wanted to pause and reassess before the big architecture items (signed updates, httpOnly cookie auth).
- Do not merge until reviewed.