### PR TITLE
ci: add race, vet, windows, and insecure-tag coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,36 @@ jobs:
           go-version: "1.25.9"
           cache-dependency-path: hub/go.sum
 
+      - name: Vet hub
+        run: go vet ./...
+
       - name: Run hub tests
         run: go test -count=1 ./...
+
+  # Reports only; does not block merges yet. The hub keeps its DB handle and ten
+  # other pieces of state in package globals (hub/main.go), so main_test.go
+  # reassigns them between tests while leaked agent-WS goroutines still write
+  # through them -- that is issue #60, and it is an architecture fix, not a test
+  # fix. Flip continue-on-error off once #60 lands so this becomes a real gate.
+  hub-race:
+    name: Hub Tests (race, non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: hub
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.9"
+          cache-dependency-path: hub/go.sum
+
+      - name: Run hub tests with the race detector
+        run: go test -race -count=1 ./...
 
   agent:
     name: Agent Tests
@@ -46,6 +74,39 @@ jobs:
         with:
           go-version: "1.25.9"
           cache-dependency-path: agent/go.sum
+
+      - name: Vet agent
+        run: go vet ./...
+
+      # tls_insecure.go and tls_insecure_test.go are both behind //go:build
+      # insecure, so a bare `go test ./...` never builds either one. Without
+      # this step that file compiles nowhere in CI.
+      - name: Vet agent with the insecure build tag
+        run: go vet -tags insecure ./...
+
+      - name: Run agent tests
+        run: go test -count=1 ./...
+
+  # ~1,600 lines of *_windows.go were never compiled by CI. A windows-latest
+  # runner costs the same as a GOOS=windows cross-build and also runs the tests.
+  agent-windows:
+    name: Agent Tests (windows)
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: agent
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.9"
+          cache-dependency-path: agent/go.sum
+
+      - name: Vet agent
+        run: go vet ./...
 
       - name: Run agent tests
         run: go test -count=1 ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
     name: Hub Tests (race, non-blocking)
     runs-on: ubuntu-latest
     continue-on-error: true
+    # continue-on-error only applies once the process exits, so a hung race run
+    # would sit pending indefinitely without these. The Go timeout is the lower
+    # of the two on purpose -- it dumps goroutine stacks, the Actions kill does not.
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: hub
@@ -57,7 +61,7 @@ jobs:
           cache-dependency-path: hub/go.sum
 
       - name: Run hub tests with the race detector
-        run: go test -race -count=1 ./...
+        run: go test -race -count=1 -timeout=10m ./...
 
   agent:
     name: Agent Tests
@@ -79,10 +83,14 @@ jobs:
         run: go vet ./...
 
       # tls_insecure.go and tls_insecure_test.go are both behind //go:build
-      # insecure, so a bare `go test ./...` never builds either one. Without
-      # this step that file compiles nowhere in CI.
+      # insecure, so a bare `go test ./...` never builds either one. Vet gets
+      # the compile coverage; the test run is what actually exercises
+      # tls_insecure_test.go, which has never executed in CI.
       - name: Vet agent with the insecure build tag
         run: go vet -tags insecure ./...
+
+      - name: Run agent tests with the insecure build tag
+        run: go test -tags insecure -count=1 ./...
 
       - name: Run agent tests
         run: go test -count=1 ./...


### PR DESCRIPTION
## Why

CI cannot currently observe several bug classes this repo already has open. It runs a bare `go test -count=1 ./...` on two Linux jobs and lint+build on the dashboard — no race detector, no `go vet`, no Windows target, and no build with the `insecure` tag.

This lands the net before the fixes, so the P0 work in flight has something to fall into.

## What changed

| Job | Change |
|---|---|
| `hub` | added `go vet ./...` |
| `hub-race` | **new** — `go test -race -count=1 ./...`, `continue-on-error: true` |
| `agent` | added `go vet ./...` and `go vet -tags insecure ./...` |
| `agent-windows` | **new** — `windows-latest`, vet + `go test ./...` in `agent/` |
| `dashboard` | untouched |

### `hub-race` is non-blocking on purpose

It fails today, and that failure is [#60](https://github.com/bokiko/bloxos/issues/60), not a flake. Reproduced locally at `78608e9`:

```
--- FAIL: TestAgentWSSecretQueryFallback (1.31s)
WARNING: DATA RACE
Write at 0x0001022b41c0 by goroutine 2156:
  hub.setupTestServer()      hub/main_test.go:131
  hub.TestAgentWSSecretQueryFallback()  hub/ws_credential_headers_test.go:113

Previous read at 0x0001022b41c0 by goroutine 2152:
  hub.storeMetrics()         hub/main.go:840
  hub.handleAgentWS()        hub/agentws.go:684
```

`hub/main.go` keeps the `*sql.DB` handle and ten other pieces of state in package globals. `setupTestServer` reassigns them per test while the previous test's leaked agent-WS goroutine is still writing metrics through them. That is an architecture fix (a server struct), not a test fix — so making this a required check today would block every unrelated PR.

**`continue-on-error: true` comes off the moment #60 lands.** There's a comment in the workflow saying exactly that.

### The `insecure` tag built nowhere

`agent/tls_insecure.go` and `agent/tls_insecure_test.go` are both `//go:build insecure`. A bare `go test ./...` builds neither. That file and its test have never been compiled by CI — including in #129, the Phase 2E change that introduced them. One `go vet -tags insecure` step closes it.

### Windows

~1,600 lines of `agent/*_windows.go` were never compiled here. A `windows-latest` runner costs about the same as a `GOOS=windows` cross-build and additionally runs the tests. Worth being explicit: a compile gate would **not** have caught the known Windows updater defects (service never restarts after update, `applyPendingUpdate` skips SHA re-verification, the helper batch deletes before it moves, `restart_service` doesn't wait for STOPPED). Those need real tests and one manual run on hardware. This is the floor, not the ceiling.

### Not included: `GOOS=darwin`

`GOOS=darwin go build ./...` fails in `agent/` with 10+ undefined symbols — there are no `*_darwin.go` files at all. macOS agent support is a product decision, not a CI line, so no darwin gate here.

## Verification at `78608e9`

- `go vet ./...` — clean in `hub/`, and in `agent/` for both `GOOS=linux` and `GOOS=windows`
- `go vet -tags insecure ./...` — clean in `agent/`
- `go test -race -count=1 ./...` in `hub/` — 1 data race, 1 test failure, as quoted above
- workflow parses as YAML; jobs resolve to `hub, hub-race, agent, agent-windows, dashboard`

`agent/` cannot be built or tested natively on macOS, so no local test-pass claim is made for it — that's what the new Linux/Windows jobs are for.

Co-authored-by: bokiko <bokiko@users.noreply.github.com>