### PR TITLE
ci: re-evaluate Dependabot auto-merge on every revision

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,6 +11,15 @@ name: Dependabot auto-merge
 #
 # Runtime minors and any majors stay manual — they can ship subtle visual or
 # API changes that CI cannot catch.
+#
+# Every run re-evaluates from scratch: the disarm step below clears any
+# auto-merge armed by a previous revision before the enable steps re-arm it.
+# Without that, arming is sticky in a way the scope above does not survive.
+# GitHub keeps an armed auto-merge across a force-push, and Dependabot force-
+# pushes the same branch when it rebases — so a PR armed while it was a patch
+# stays armed after a rebase turns it into a major, and merges on the next
+# approval under a classification that no longer holds. That is how
+# @types/node 25.9.0 -> 25.9.1 landed on main as 25.9.0 -> 26.1.2 (#107).
 
 on:
   pull_request_target:
@@ -30,6 +39,16 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v2.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Unconditional, and ahead of both enable steps: this is what makes each
+      # revision stand on its own metadata rather than inheriting the previous
+      # revision's verdict. `|| true` because disarming a PR that was never
+      # armed exits non-zero, which is the common case and not a failure.
+      - name: Disarm auto-merge before re-evaluating
+        run: gh pr merge --disable-auto "$PR_URL" || true
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for patch updates
         if: steps.meta.outputs.update-type == 'version-update:semver-patch'


### PR DESCRIPTION
## Problem

`gh pr merge --auto` is sticky across force-pushes, and Dependabot force-pushes
the same branch on every rebase. The scope this workflow documents — patches, and
dev-dependency minors — is enforced only at arming time, so it does not survive a
rebase that changes the update type.

Observed on #107 today:

1. A `synchronize` event fired with metadata `@types/node 25.9.0 -> 25.9.1`,
   `version-update:semver-patch`. The workflow correctly armed auto-merge.
2. Dependabot then force-pushed the same branch, recreating the PR as
   `25.9.0 -> 26.1.2` (`^25` -> `^26` in `package.json`) — a major.
3. The arming persisted. The next approval merged a major under a patch verdict.

No CI gate catches this: branch protection was satisfied and `Dashboard Lint + Build`
passed on the merged SHA. The classification was simply stale.

## Fix

Disarm unconditionally before re-evaluating, so every revision stands on its own
metadata. `|| true` because disarming a never-armed PR exits non-zero — the common
case, and not a failure.

## Scope

No change to what qualifies for auto-merge. Patches and dev-dependency minors still
auto-merge; runtime minors and majors still stay manual. This only ensures the
verdict is recomputed per revision rather than inherited.

Follow-up, not in this PR: `@types/node` is now `^26` while CI runs `node-version: 22`.
That mismatch predates this incident (it was `^25` against Node 22 before) and is
tracked separately.