### PR TITLE
docs: document the two-lane merge policy for main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,25 @@ For agent changes that affect the Windows build, also run:
 ( cd agent && GOOS=windows go vet ./... )
 ```
 
+## Merge policy
+
+`main` requires green CI, linear history (squash merges only — no merge
+commits), and 1 approving review. Two lanes, depending on who authored the
+PR:
+
+- **Dependabot PRs** — approve the diff, then let `dependabot-auto-merge.yml`
+  complete the merge once required checks pass. The workflow never bypasses
+  protection; it only arms `gh pr merge --auto`.
+- **Self-authored PRs** — GitHub blocks approving your own PR, so the review
+  requirement has no valid path here. Merge with `gh pr merge --admin
+  --squash`. Each use is a deliberate, explicit exception — call it out in the
+  PR or session notes, never merge silently past it.
+
+If self-authored PRs start needing `--admin` more than a couple of times a
+month, that's the signal to revisit the rule itself (a bot/GitHub App as a
+second approver is the fix — not dropping the review requirement, which is
+still doing real work gating the Dependabot lane).
+
 ## Commit messages
 
 This repo uses Conventional Commits with a multi-target scope when changes


### PR DESCRIPTION
Documents the branch protection posture on `main` (green CI, linear history/squash-only, 1 approving review) and the two lanes for satisfying the review requirement: Dependabot PRs (approve normally, auto-merge completes) vs. self-authored PRs (GitHub blocks self-approval, so `gh pr merge --admin --squash` is the explicit, called-out exception).

Prompted by merging #135: investigated whether the review requirement was being silently bypassed. It wasn't -- #107/#120/#121 all show a real approving review seconds before merge. The rule just has no valid path for self-authored PRs specifically. This documents that so it doesn't need re-deriving next time.

No config change -- branch protection is audited and unchanged from before this investigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or configuration impact.
> 
> **Overview**
> Adds a **Merge policy** section to `CONTRIBUTING.md` that spells out what `main` branch protection expects (green CI, squash-only linear history, one approving review) and how to merge in practice.
> 
> It defines two lanes: **Dependabot** PRs are approved normally and `dependabot-auto-merge.yml` arms `gh pr merge --auto` after checks pass without bypassing protection; **self-authored** PRs cannot be self-approved on GitHub, so the documented exception is an explicit `gh pr merge --admin --squash` with the exception called out in the PR or notes. The section also notes when to revisit the rule (frequent `--admin` use) and points to a bot/GitHub App as the long-term fix rather than dropping the review gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e7f35b58224dbc659e5f566a61d0ef26fd1066e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->