### PR TITLE
feat(dashboard): add run-dashboard skill for browser-driven smoke testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,12 @@ Thumbs.db
 *.db-shm
 .bak
 
-# Local Claude Code / dev tool artifacts
+# Local Claude Code / dev tool artifacts. Skills are the one thing meant
+# to be shared and committed -- everything else under .claude/ (settings,
+# caches, session state) stays local.
 .backups/
-.claude/
+.claude/*
+!.claude/skills/
 .turbo/
 
 # Local-only audit / analysis drafts (not meant to live in git)

--- a/dashboard/.claude/skills/run-dashboard/SKILL.md
+++ b/dashboard/.claude/skills/run-dashboard/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: run-dashboard
+description: Build and run the BloxOS dashboard (Next.js) against a local hub backend, then drive it with a headless-browser script to take screenshots and smoke-test UI primitives (dropdowns, modals, command palette). Use when asked to run, start, launch, or screenshot the dashboard, or to smoke-test it after a dependency bump (especially @base-ui/react) or a UI change.
+---
+
+The dashboard is a Next.js app that talks to the Go hub over HTTP + a
+WebSocket, and has no meaningful standalone mode — driving it means
+building and running the hub too. An agent drives it via
+`.claude/skills/run-dashboard/driver.mjs`, a Playwright script with its
+own isolated dependency install (does not touch `dashboard/`'s own
+`package.json`/`pnpm-lock.yaml`).
+
+All paths below are relative to `dashboard/` (this skill's directory
+is `dashboard/.claude/skills/run-dashboard/`).
+
+## Prerequisites
+
+Go and Node/pnpm are already project requirements (see repo root
+`CONTRIBUTING.md`). Playwright's Chromium needs its OS deps once:
+
+```bash
+cd .claude/skills/run-dashboard
+npm install   # installs Playwright into this skill dir only
+npx playwright install --with-deps chromium
+```
+
+No extra `apt-get` was needed beyond what `playwright install --with-deps`
+pulls in itself (fontconfig/freetype/font packages — already present in
+this container).
+
+## Build
+
+```bash
+mkdir -p /tmp/bloxos-dashboard-smoke/hub-run
+( cd ../hub && go build -o /tmp/bloxos-dashboard-smoke/hub-run/bloxos-hub . )
+```
+
+The hub binary is built to a scratch dir on purpose — see Gotchas
+(relative-path SQLite file).
+
+## Run (agent path)
+
+Three steps: launch the hub, launch the dashboard dev server, run the
+driver. Each is a background process; the driver assumes both are
+already up.
+
+```bash
+# 1. Hub — from a scratch working directory, NOT hub/ (see Gotchas)
+cd /tmp/bloxos-dashboard-smoke/hub-run
+BLOXOS_SETUP_TOKEN=smoketest-setup-token-12345 \
+ALLOWED_ORIGINS=http://localhost:3000 \
+nohup ./bloxos-hub > hub.log 2>&1 &
+disown
+timeout 15 bash -c 'until curl -sf -o /dev/null -w "%{http_code}" \
+  http://127.0.0.1:4000/api/setup -X OPTIONS -H "Origin: http://localhost:3000" \
+  2>/dev/null | grep -q 204; do sleep 0.5; done'
+
+# 2. Dashboard dev server — from dashboard/
+NEXT_PUBLIC_HUB_URL=http://localhost:4000 nohup pnpm dev \
+  > /tmp/bloxos-dashboard-smoke/dashboard.log 2>&1 &
+disown
+timeout 30 bash -c 'until curl -sf http://localhost:3000 >/dev/null; do sleep 1; done'
+
+# 3. Drive it
+cd .claude/skills/run-dashboard
+node driver.mjs --shots-dir /tmp/bloxos-dashboard-smoke/screenshots
+```
+
+The driver: completes first-boot `/setup` (creates an admin user, falls
+back to a manual `/login` fill if setup doesn't auto-sign-in), then on
+the fleet page opens the status-filter **dropdown** and selects an item,
+opens the **Add Machine modal** and closes it, and opens the **command
+palette** (⌘K) — the three most common `@base-ui/react`-backed surfaces.
+It asserts zero browser console errors and zero page errors across the
+whole run, not just that screenshots exist. Exits non-zero (with a
+`FAIL:` line) if either check fails.
+
+Screenshots land in `/tmp/bloxos-dashboard-smoke/screenshots/`,
+numbered in the order they were taken (`01-setup-page.png` …
+`09-command-palette-open.png`). **Look at them** — a blank or
+half-rendered frame is a failure even if the driver's own DOM
+assertions pass.
+
+Teardown:
+
+```bash
+lsof -ti:3000 -sTCP:LISTEN | xargs -r kill -9
+lsof -ti:4000 -sTCP:LISTEN | xargs -r kill -9
+```
+
+(`-9` because the wrapper processes don't reliably forward a plain
+`kill` to the child — see Gotchas.)
+
+## Run (human path)
+
+```bash
+( cd ../hub && go run . )                        # separate terminal, from a scratch cwd
+NEXT_PUBLIC_HUB_URL=http://localhost:4000 pnpm dev         # from dashboard/
+```
+
+Open `http://localhost:3000/setup`, paste whatever setup token the hub
+printed to its own stdout (or set `BLOXOS_SETUP_TOKEN` before starting
+it, as above, to skip hunting for it in the logs).
+
+## Test
+
+```bash
+pnpm lint && pnpm build
+```
+
+Both must pass with zero errors/warnings for a change to be mergeable
+(`Dashboard Lint + Build` is a required CI check on `main`). This is
+static verification only — it does not replace actually running the
+app; a change can lint- and build-clean while still being visually
+broken (a bad Tailwind class, a `@base-ui/react` API drift) or throwing
+at runtime.
+
+---
+
+## Gotchas
+
+- **Hub writes `bloxos.db` as a relative path.** Running it from
+  `hub/` creates a stray SQLite file in the repo checkout. Always run
+  the built binary from a scratch directory.
+- **Hub fails closed on CORS by design.** With neither `ALLOWED_ORIGINS`
+  nor `PUBLIC_URL` set, it refuses to start at all rather than fall
+  back to a wildcard origin (`refusing to start with wildcard origin`).
+  This is intentional hardening, not a bug — always set
+  `ALLOWED_ORIGINS=http://localhost:3000` for local dev against the
+  Next.js dev server.
+- **Dashboard defaults to same-origin API calls.** Without
+  `NEXT_PUBLIC_HUB_URL`, `getHubWsBaseUrl()` in `src/lib/session.ts`
+  falls back to `window.location.origin` — silently wrong once the
+  dashboard (port 3000) and hub (port 4000) are on different ports.
+  Always set it explicitly.
+- **`pnpm dev &`'s `$!` is the wrapper, not the server.** Killing that
+  PID leaves the actual `next-server` process running and the port
+  still bound. Kill by port (`lsof -ti:3000 -sTCP:LISTEN`) instead of
+  trusting `$!`. Verified in this container: `kill $!` left `next-server`
+  alive; `lsof -ti:3000 | xargs kill -9` was needed.
+- **Ambiguous Playwright locators silently hit the wrong element.**
+  `text=Live` on the fleet page matches both the dropdown's menu item
+  *and* the "live" text in the ALERTS summary card, and Playwright's
+  auto-retry means the failure mode is a 30s timeout fighting an inert
+  overlay (`data-base-ui-inert`), not an immediate clear error. Scope
+  menu clicks to `[role="menuitem"]:has-text(...)`, not bare text
+  matches, on any page with repeated status words.
+- **A dismissed/duplicate-key lockfile is not a dropdown/modal
+  problem.** If `Dashboard Lint + Build` fails on `pnpm install`
+  (`ERR_PNPM_BROKEN_LOCKFILE`), that's unrelated to anything this
+  driver tests — it's usually a `git merge`-produced duplicate YAML key
+  in `pnpm-lock.yaml`. Don't debug it by re-running this skill; fix the
+  lockfile first (see recent history around PR #140 for the exact
+  fix pattern: remove the duplicate block, don't blindly
+  `pnpm install --lockfile-only`, which can silently upgrade an
+  unrelated package past what was actually reviewed).
+
+## Troubleshooting
+
+- **`refusing to start with wildcard origin`** (hub log, exits
+  immediately): `ALLOWED_ORIGINS` (or `PUBLIC_URL`) wasn't set. Add
+  `ALLOWED_ORIGINS=http://localhost:3000`.
+- **Driver hangs / times out on `input[placeholder="Paste the
+  one-time setup token"]`**: the dashboard is pointed at the wrong hub,
+  or the hub isn't actually reachable yet. Confirm
+  `NEXT_PUBLIC_HUB_URL=http://localhost:4000` was set *before* `pnpm dev`
+  started (Next.js inlines `NEXT_PUBLIC_*` at build/start time — setting
+  it after the server is already running has no effect).
+- **`page.click` times out with `<div role="presentation"
+  data-base-ui-inert=""> ... subtree intercepts pointer events`**: an
+  ambiguous locator resolved to an element behind the dropdown/dialog's
+  own overlay, not a real regression. Make the locator more specific
+  (see Gotchas).
+- **Setup form submits but the driver ends up back on `/setup`**: the
+  setup token didn't match. `BLOXOS_SETUP_TOKEN` must be set on the hub
+  process *before* it boots (it only reads the token at first-boot when
+  the users table is empty) and must exactly match what the driver
+  fills in (`smoketest-setup-token-12345` by default — override both
+  sides together, not just one).

--- a/dashboard/.claude/skills/run-dashboard/driver.mjs
+++ b/dashboard/.claude/skills/run-dashboard/driver.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Drives a running BloxOS dashboard (localhost:3000) + hub (localhost:4000)
+// through first-boot setup and three representative @base-ui/react-backed
+// interactions: a dropdown, a modal, and the command palette.
+//
+// Assumes the hub and dashboard dev server are already running — see
+// SKILL.md "Run (agent path)" for the exact launch commands. This script
+// only drives the browser; it does not manage the app processes.
+//
+// Usage: node driver.mjs [--shots-dir <path>]
+
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+
+const BASE = process.env.DASHBOARD_URL || "http://localhost:3000";
+const SETUP_TOKEN = process.env.BLOXOS_SETUP_TOKEN || "smoketest-setup-token-12345";
+const ADMIN_USER = "smokeadmin";
+const ADMIN_PASS = "SmokeTest12345!";
+
+const shotsArgIdx = process.argv.indexOf("--shots-dir");
+const SHOTDIR =
+  shotsArgIdx !== -1 ? process.argv[shotsArgIdx + 1] : "/tmp/bloxos-dashboard-smoke/screenshots";
+mkdirSync(SHOTDIR, { recursive: true });
+
+const consoleErrors = [];
+let stepNum = 0;
+
+function log(...args) {
+  console.log(...args);
+}
+
+async function shot(page, name) {
+  stepNum += 1;
+  const file = path.join(SHOTDIR, `${String(stepNum).padStart(2, "0")}-${name}.png`);
+  await page.screenshot({ path: file });
+  log("screenshot:", file);
+}
+
+async function main() {
+  const browser = await chromium.launch({ args: ["--no-sandbox"] });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push("PAGEERROR: " + err.message));
+
+  // --- First-boot setup ---
+  await page.goto(BASE + "/setup", { waitUntil: "networkidle" });
+  await shot(page, "setup-page");
+  await page.fill('input[placeholder="Paste the one-time setup token"]', SETUP_TOKEN);
+  await page.fill('input[placeholder="admin"]', ADMIN_USER);
+  await page.fill('input[placeholder="Minimum 8 characters"]', ADMIN_PASS);
+  await page.fill('input[placeholder="Repeat password"]', ADMIN_PASS);
+  await page.fill('input[placeholder="At least 4 digits"]', "123456");
+  await page.fill('input[placeholder="Repeat PIN"]', "123456");
+  await shot(page, "setup-filled");
+  await page.click('button[type="submit"]');
+  await page.waitForTimeout(2000);
+  await shot(page, "after-setup-submit");
+  log("URL after setup:", page.url());
+
+  // Setup usually auto-signs-in and redirects to /. If instead it lands on
+  // /login (e.g. a session cookie didn't take), sign in explicitly.
+  if (page.url().includes("/login")) {
+    log("landed on /login, signing in manually");
+    await page.locator("input").first().fill(ADMIN_USER);
+    await page.locator('input[type="password"]').fill(ADMIN_PASS);
+    await shot(page, "login-filled");
+    await page.click('button[type="submit"]');
+    await page.waitForTimeout(2000);
+    await shot(page, "after-login");
+    log("URL after login:", page.url());
+  }
+
+  // --- Fleet page (root) ---
+  await page.goto(BASE + "/", { waitUntil: "networkidle" });
+  await page.waitForTimeout(1000);
+  await shot(page, "fleet-page");
+
+  // --- Dropdown: status filter (base-ui DropdownMenu) ---
+  // IMPORTANT: scope the item click to [role="menuitem"], not a bare
+  // text= locator. "Live" also appears in the ALERTS summary card on this
+  // same page, so text=Live resolves to 2 elements and click() times out
+  // fighting the wrong (inert, overlay-covered) one.
+  await page.click('button:has-text("All Status")');
+  await page.waitForTimeout(300);
+  await shot(page, "dropdown-open");
+  await page.click('[role="menuitem"]:has-text("Live")');
+  await page.waitForTimeout(400);
+  await shot(page, "dropdown-selected");
+  const filterTrigger = await page.textContent('button:has-text("Live")');
+  log("dropdown applied, trigger now reads:", filterTrigger?.trim());
+
+  // --- Modal: Add Machine (base-ui Dialog) ---
+  await page.click('button:has-text("Add Machine")');
+  await page.waitForTimeout(400);
+  await shot(page, "modal-open");
+  const modalTitleVisible = await page.isVisible('text="Add Machine"');
+  log("modal opened, title visible:", modalTitleVisible);
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(300);
+  await shot(page, "modal-closed");
+
+  // --- Command palette (⌘K / Ctrl+K) ---
+  await page.click('button[aria-label="Open command palette"]');
+  await page.waitForTimeout(400);
+  await shot(page, "command-palette-open");
+  const navigateVisible = await page.isVisible("text=NAVIGATE");
+  log("command palette opened, NAVIGATE section visible:", navigateVisible);
+  await page.keyboard.press("Escape");
+
+  await browser.close();
+
+  log("");
+  log(`=== CONSOLE ERRORS: ${consoleErrors.length} ===`);
+  consoleErrors.forEach((e) => log(" -", e));
+
+  if (consoleErrors.length > 0) {
+    log("FAIL: console errors were captured during the run");
+    process.exit(1);
+  }
+  if (!modalTitleVisible || !navigateVisible) {
+    log("FAIL: an expected element did not render");
+    process.exit(1);
+  }
+  log("PASS: dashboard smoke test clean");
+}
+
+main().catch((err) => {
+  console.error("DRIVER FAILED:", err);
+  process.exit(1);
+});

--- a/dashboard/.claude/skills/run-dashboard/package-lock.json
+++ b/dashboard/.claude/skills/run-dashboard/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "run-dashboard-driver",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "run-dashboard-driver",
+      "dependencies": {
+        "playwright": "^1.55.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/dashboard/.claude/skills/run-dashboard/package.json
+++ b/dashboard/.claude/skills/run-dashboard/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "run-dashboard-driver",
+  "private": true,
+  "description": "Isolated Playwright install for the run-dashboard skill's driver. Deliberately not part of dashboard/'s own package.json/pnpm-lock.yaml.",
+  "dependencies": {
+    "playwright": "^1.55.0"
+  }
+}


### PR DESCRIPTION
Captures the base-ui bump (#140) smoke test as a repeatable project skill instead of one-off manual commands.

## What
- `dashboard/.claude/skills/run-dashboard/SKILL.md` + `driver.mjs`: build/launch the hub with a known setup token and explicit CORS origin, launch the dashboard dev server pointed at it, drive headless Chromium through first-boot setup and three `@base-ui/react`-backed surfaces (dropdown, modal, command palette), screenshot each step, assert zero console errors.
- Driver has its own isolated Playwright install (`package.json`/`package-lock.json` inside the skill dir) — does not touch `dashboard/`'s own `package.json`/`pnpm-lock.yaml`.
- `.gitignore`: narrowed the repo-wide `.claude/` exclusion (line 37, never exempted before) to carve out `.claude/skills/` specifically, since skills are meant to be shared/committed — everything else under `.claude/` stays local as before.

## Verification
Ran the documented Build / Run (agent path) sections line-by-line from a fresh shell, exactly as written in SKILL.md, before committing. Driver exits 0, zero console errors, all 9 screenshots render correctly (not blank frames).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-tooling and gitignore carve-out only; no production dashboard, hub, or auth runtime changes.
> 
> **Overview**
> Adds a **repeatable agent/human workflow** to run the dashboard against a local hub and smoke-test key `@base-ui/react` UI (dropdown, modal, command palette), with screenshots and console-error checks.
> 
> **`.gitignore`** no longer ignores all of `.claude/`; it ignores `.claude/*` but **keeps `.claude/skills/` committable** so shared skills can live in the repo.
> 
> **New `dashboard/.claude/skills/run-dashboard/`** includes `SKILL.md` (build hub from scratch cwd, CORS/`NEXT_PUBLIC_HUB_URL`, teardown gotchas), **`driver.mjs`** (Playwright: first-boot setup → fleet interactions, scoped menu locators, non-zero exit on console/page errors), and an **isolated** `package.json` / `package-lock.json` for Playwright so the main dashboard `pnpm-lock.yaml` is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63966a53142c30b739b92d3851da6f71b7518ed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->