### PR TITLE
refactor(hub): own db and the agent registry on a Server struct (closes #60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,18 +34,20 @@ jobs:
       - name: Run hub tests
         run: go test -count=1 ./...
 
-  # Reports only; does not block merges yet. The hub keeps its DB handle and ten
-  # other pieces of state in package globals (hub/main.go), so main_test.go
-  # reassigns them between tests while leaked agent-WS goroutines still write
-  # through them -- that is issue #60, and it is an architecture fix, not a test
-  # fix. Flip continue-on-error off once #60 lands so this becomes a real gate.
+  # A real gate as of issue #60: the hub's DB handle and agent registry now live
+  # on a Server instance, so tests build isolated servers instead of reassigning
+  # package globals under leaked agent-WS goroutines. Verified stable across four
+  # consecutive full runs before this was made blocking.
+  #
+  # If this job starts failing, treat it as a real finding. It is no longer the
+  # known-red job it used to be, and the whole point of flipping it was that a
+  # permanently-red gate trains everyone to ignore red CI.
   hub-race:
-    name: Hub Tests (race, non-blocking)
+    name: Hub Tests (race)
     runs-on: ubuntu-latest
-    continue-on-error: true
-    # continue-on-error only applies once the process exits, so a hung race run
-    # would sit pending indefinitely without these. The Go timeout is the lower
-    # of the two on purpose -- it dumps goroutine stacks, the Actions kill does not.
+    # A hung race run would otherwise sit pending indefinitely rather than
+    # failing. The Go timeout is the lower of the two on purpose -- it dumps
+    # goroutine stacks, the Actions kill does not.
     timeout-minutes: 15
     defaults:
       run:

--- a/hub/agent_identity_test.go
+++ b/hub/agent_identity_test.go
@@ -14,7 +14,7 @@ import (
 // enrollAndCaptureSecret enrolls a fresh agent for machineID via a valid token
 // and returns the durable secret. It drains any agent_version frames the hub
 // sends on registration until it sees the "enrolled" frame.
-func enrollAndCaptureSecret(t *testing.T, server *httptest.Server, token, machineID string) string {
+func (s *Server) enrollAndCaptureSecret(t *testing.T, server *httptest.Server, token, machineID string) string {
 	t.Helper()
 	conn, err := wsDialAgent(t, server, "token="+token)
 	if err != nil {
@@ -41,7 +41,7 @@ func enrollAndCaptureSecret(t *testing.T, server *httptest.Server, token, machin
 		}
 	}
 	conn.Close()
-	waitAgentDrain(t, machineID, 2*time.Second)
+	s.waitAgentDrain(t, machineID, 2*time.Second)
 	return secret
 }
 
@@ -51,12 +51,12 @@ func enrollAndCaptureSecret(t *testing.T, server *httptest.Server, token, machin
 // message type. Without the guard, one compromised fleet member can overwrite
 // another machine's row/metrics/inventory and suppress its alerts.
 func TestAuthedAgentCannotWriteForeignMachineID(t *testing.T) {
-	e := setupTestServer(t)
-	token := seedValidToken(t)
+	e, s := setupTestServer(t)
+	token := s.seedValidToken(t)
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	secret := enrollAndCaptureSecret(t, server, token, "machine-A")
+	secret := s.enrollAndCaptureSecret(t, server, token, "machine-A")
 
 	// Reconnect authenticated as machine-A.
 	conn, err := wsDialAgent(t, server, "secret="+secret)
@@ -111,7 +111,7 @@ func TestAuthedAgentCannotWriteForeignMachineID(t *testing.T) {
 	deadline := time.Now().Add(3 * time.Second)
 	for {
 		var hostname string
-		_ = db.QueryRow(`SELECT hostname FROM machines WHERE id = ?`, "machine-A").Scan(&hostname)
+		_ = s.db.QueryRow(`SELECT hostname FROM machines WHERE id = ?`, "machine-A").Scan(&hostname)
 		if hostname == "sentinel-host" {
 			break
 		}
@@ -123,14 +123,14 @@ func TestAuthedAgentCannotWriteForeignMachineID(t *testing.T) {
 
 	// machine-B must not exist and must have no metrics.
 	var machineCount int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM machines WHERE id = ?`, "machine-B").Scan(&machineCount); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM machines WHERE id = ?`, "machine-B").Scan(&machineCount); err != nil {
 		t.Fatalf("count machine-B: %v", err)
 	}
 	if machineCount != 0 {
 		t.Fatalf("machine-B row was created by a foreign-id frame (count=%d)", machineCount)
 	}
 	var metricCount int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM metrics WHERE machine_id = ?`, "machine-B").Scan(&metricCount); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM metrics WHERE machine_id = ?`, "machine-B").Scan(&metricCount); err != nil {
 		t.Fatalf("count machine-B metrics: %v", err)
 	}
 	if metricCount != 0 {
@@ -140,7 +140,7 @@ func TestAuthedAgentCannotWriteForeignMachineID(t *testing.T) {
 	// Every sink we changed must be locked down, not just metrics.
 	for _, tbl := range []string{"services", "containers"} {
 		var n int
-		if err := db.QueryRow(`SELECT COUNT(*) FROM `+tbl+` WHERE machine_id = ?`, "machine-B").Scan(&n); err != nil {
+		if err := s.db.QueryRow(`SELECT COUNT(*) FROM `+tbl+` WHERE machine_id = ?`, "machine-B").Scan(&n); err != nil {
 			t.Fatalf("count machine-B %s: %v", tbl, err)
 		}
 		if n != 0 {
@@ -154,7 +154,7 @@ func TestAuthedAgentCannotWriteForeignMachineID(t *testing.T) {
 // must be refused at the HTTP layer (401) rather than being upgraded and then
 // held for the auth window. No token is seeded, so any token is invalid.
 func TestAgentWSInvalidTokenRejectedBeforeUpgrade(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 	server := httptest.NewServer(e)
 	defer server.Close()
 
@@ -177,8 +177,8 @@ func TestAgentWSInvalidTokenRejectedBeforeUpgrade(t *testing.T) {
 // authenticating frame must be dropped after the auth window rather than
 // holding a socket open indefinitely.
 func TestAgentWSIdleUpgradeIsDropped(t *testing.T) {
-	e := setupTestServer(t)
-	token := seedValidToken(t)
+	e, s := setupTestServer(t)
+	token := s.seedValidToken(t)
 
 	prev := agentAuthWindow
 	agentAuthWindow = 300 * time.Millisecond
@@ -216,7 +216,7 @@ func TestAgentWSIdleUpgradeIsDropped(t *testing.T) {
 // channel is released. The old handler deleted the map entry and closed the
 // sockets but never closed Done, leaking the parked handleTerminalWS goroutine.
 func TestHandleCloseTerminalReleasesWaiter(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 
 	sid := "term-close-release"
 	session := &TerminalSession{
@@ -244,7 +244,7 @@ func TestHandleCloseTerminalReleasesWaiter(t *testing.T) {
 	c := e.NewContext(req, rec)
 	c.SetParamNames("session_id")
 	c.SetParamValues(sid)
-	if err := handleCloseTerminal(c); err != nil {
+	if err := s.handleCloseTerminal(c); err != nil {
 		t.Fatalf("handleCloseTerminal: %v", err)
 	}
 	if rec.Code != http.StatusOK {

--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -627,7 +627,7 @@ func (s *Server) recordAgentRunningVersion(machineID string, report agentVersion
 		agent, online := s.agents[machineID]
 		s.agentsMu.RUnlock()
 		if online {
-			go s.announceVersionToAgent(machineID, agent)
+			s.goTracked(func() { s.announceVersionToAgent(machineID, agent) })
 		}
 	}
 }
@@ -773,7 +773,8 @@ func (s *Server) handleResumeRollout(c echo.Context) error {
 	s.agentsMu.RUnlock()
 
 	for i := range conns {
-		go s.announceVersionToAgent(ids[i], conns[i])
+		mid, conn := ids[i], conns[i]
+		s.goTracked(func() { s.announceVersionToAgent(mid, conn) })
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"status": "resumed"})

--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -282,7 +282,7 @@ func agentBinaryPathFor(osName string) string {
 // unless rollout is paused or announceDecision withholds it. The SHA
 // announced is platform-specific: Windows agents get the Windows binary SHA,
 // Linux/unknown agents get the Linux SHA.
-func announceVersionToAgent(machineID string, agent *ConnectedAgent) {
+func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent) {
 	rolloutPausedMu.RLock()
 	paused := rolloutPaused
 	rolloutPausedMu.RUnlock()
@@ -291,7 +291,7 @@ func announceVersionToAgent(machineID string, agent *ConnectedAgent) {
 		return
 	}
 
-	osName := lookupAgentOS(machineID)
+	osName := s.lookupAgentOS(machineID)
 	sha := announcedSHAFor(osName)
 	if sha == "" {
 		return
@@ -483,7 +483,7 @@ func announcedSHAFor(osName string) string {
 
 // lookupAgentOS returns the recorded OS for a machine ("linux",
 // "windows", or "" if unknown / pre-Phase-9 agent).
-func lookupAgentOS(machineID string) string {
+func (s *Server) lookupAgentOS(machineID string) string {
 	agentRunningVersionsMu.RLock()
 	v, ok := agentRunningVersions[machineID]
 	agentRunningVersionsMu.RUnlock()
@@ -500,7 +500,7 @@ func lookupAgentOS(machineID string) string {
 	// expects. Returning the un-normalised string would cause the default
 	// switch arm to fire and suppress the announce — exactly the
 	// regression that surfaced after the Phase-9 unknown-OS protection.
-	osStr := lookupMetricsOS(machineID)
+	osStr := s.lookupMetricsOS(machineID)
 	if osStr == "" {
 		return ""
 	}
@@ -539,9 +539,9 @@ func indexByte(s string, c byte) int {
 // lookupMetricsOS returns the most recently reported `os` string from
 // the metrics table for a given machine, e.g. "linux/amd64". Returns
 // empty if not found.
-func lookupMetricsOS(machineID string) string {
+func (s *Server) lookupMetricsOS(machineID string) string {
 	var osStr string
-	if err := db.QueryRow(`SELECT COALESCE(os, '') FROM machines WHERE id = ?`, machineID).Scan(&osStr); err != nil {
+	if err := s.db.QueryRow(`SELECT COALESCE(os, '') FROM machines WHERE id = ?`, machineID).Scan(&osStr); err != nil {
 		return ""
 	}
 	return osStr
@@ -566,18 +566,18 @@ func clearReconnectExpectation(machineID string) {
 //
 // The report carries the agent's capability level and its own answer on
 // whether its transport permits self-update. See announceDecision.
-func recordAgentRunningVersion(machineID string, report agentVersionReport) {
+func (s *Server) recordAgentRunningVersion(machineID string, report agentVersionReport) {
 	runningSHA, osName := report.RunningSHA, report.OS
 	// Resolve the per-OS expected SHA. If we don't yet know the agent's
 	// OS, lookupAgentOS will check the DB metrics for it. New-on-this-hub
 	// agents return "" here and that's fine — we'll announce after we
 	// learn the OS below.
 	if osName == "" {
-		osName = lookupAgentOS(machineID)
+		osName = s.lookupAgentOS(machineID)
 	}
 	expectedSHA := announcedSHAFor(osName)
 
-	hostname := lookupVersionHostname(machineID)
+	hostname := s.lookupVersionHostname(machineID)
 
 	agentRunningVersionsMu.Lock()
 	prev, hadPrev := agentRunningVersions[machineID]
@@ -623,11 +623,11 @@ func recordAgentRunningVersion(machineID string, report agentVersionReport) {
 		prev.UpdateTransportOK != report.TransportOK ||
 		prev.UpdateKeyPinned != report.KeyPinned) &&
 		expectedSHA != "" && runningSHA != expectedSHA {
-		agentsMu.RLock()
-		agent, online := agents[machineID]
-		agentsMu.RUnlock()
+		s.agentsMu.RLock()
+		agent, online := s.agents[machineID]
+		s.agentsMu.RUnlock()
 		if online {
-			go announceVersionToAgent(machineID, agent)
+			go s.announceVersionToAgent(machineID, agent)
 		}
 	}
 }
@@ -675,9 +675,9 @@ func recordRolloutSuccess(machineID string) {
 	rolloutFailures = fresh
 }
 
-func lookupVersionHostname(machineID string) string {
+func (s *Server) lookupVersionHostname(machineID string) string {
 	var hostname string
-	if err := db.QueryRow(`SELECT hostname FROM machines WHERE id = ?`, machineID).Scan(&hostname); err != nil {
+	if err := s.db.QueryRow(`SELECT hostname FROM machines WHERE id = ?`, machineID).Scan(&hostname); err != nil {
 		return machineID
 	}
 	return hostname
@@ -687,7 +687,7 @@ func lookupVersionHostname(machineID string) string {
  * REST endpoints
  * ============================================================================ */
 
-func handleListVersions(c echo.Context) error {
+func (s *Server) handleListVersions(c echo.Context) error {
 	hubAgentBinaryMu.RLock()
 	hubSHA := hubAgentBinarySHA
 	hubMtime := hubAgentBinaryMtime
@@ -709,7 +709,7 @@ func handleListVersions(c echo.Context) error {
 
 	for i := range versions {
 		v := &versions[i]
-		v.Hostname = lookupVersionHostname(v.MachineID)
+		v.Hostname = s.lookupVersionHostname(v.MachineID)
 		expected := announcedSHAFor(v.OS)
 		v.UpdatePending = expected != "" && v.RunningSHA != expected
 		if v.UpdatePending {
@@ -750,7 +750,7 @@ func handlePauseRollout(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"status": "paused"})
 }
 
-func handleResumeRollout(c echo.Context) error {
+func (s *Server) handleResumeRollout(c echo.Context) error {
 	rolloutPausedMu.Lock()
 	rolloutPaused = false
 	rolloutPauseReason = ""
@@ -763,17 +763,17 @@ func handleResumeRollout(c echo.Context) error {
 	log.Printf("rollout: RESUMED by operator")
 
 	// Re-announce to all currently connected agents.
-	agentsMu.RLock()
-	conns := make([]*ConnectedAgent, 0, len(agents))
-	ids := make([]string, 0, len(agents))
-	for id, a := range agents {
+	s.agentsMu.RLock()
+	conns := make([]*ConnectedAgent, 0, len(s.agents))
+	ids := make([]string, 0, len(s.agents))
+	for id, a := range s.agents {
 		ids = append(ids, id)
 		conns = append(conns, a)
 	}
-	agentsMu.RUnlock()
+	s.agentsMu.RUnlock()
 
 	for i := range conns {
-		go announceVersionToAgent(ids[i], conns[i])
+		go s.announceVersionToAgent(ids[i], conns[i])
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"status": "resumed"})

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -36,12 +36,12 @@ type ConnectedAgent struct {
 // and token-based fresh enrolment — call this exactly once per connection,
 // which guarantees Phase-8 auto-update propagates on reconnect (the bug
 // that originally motivated extracting this helper).
-func registerAgentConnection(machineID string, agent *ConnectedAgent) {
+func (s *Server) registerAgentConnection(machineID string, agent *ConnectedAgent) {
 	agent.MachineID = machineID
-	agentsMu.Lock()
-	agents[machineID] = agent
-	agentsMu.Unlock()
-	go announceVersionToAgent(machineID, agent)
+	s.agentsMu.Lock()
+	s.agents[machineID] = agent
+	s.agentsMu.Unlock()
+	go s.announceVersionToAgent(machineID, agent)
 }
 
 // unregisterAgentConnection is the symmetric cleanup for
@@ -51,23 +51,23 @@ func registerAgentConnection(machineID string, agent *ConnectedAgent) {
 // — otherwise we'd false-offline a fast-reconnecting agent whose new
 // handler already overwrote the entry. Empty machineID (auth never
 // succeeded) is a no-op.
-func unregisterAgentConnection(machineID string, agent *ConnectedAgent) {
+func (s *Server) unregisterAgentConnection(machineID string, agent *ConnectedAgent) {
 	if machineID == "" {
 		return
 	}
-	agentsMu.Lock()
-	current, ok := agents[machineID]
+	s.agentsMu.Lock()
+	current, ok := s.agents[machineID]
 	stillOurs := ok && current == agent
 	if stillOurs {
-		delete(agents, machineID)
+		delete(s.agents, machineID)
 	}
-	agentsMu.Unlock()
+	s.agentsMu.Unlock()
 	if stillOurs {
-		markOffline(machineID)
+		s.markOffline(machineID)
 	}
 }
 
-func handleCreateToken(c echo.Context) error {
+func (s *Server) handleCreateToken(c echo.Context) error {
 	ip := getRealIP(c)
 	if !rateLimiter.Allow("token_create", ip, 3) {
 		log.Printf("rate limit exceeded: token_create from %s", ip)
@@ -89,7 +89,7 @@ func handleCreateToken(c echo.Context) error {
 	tokenHash := hex.EncodeToString(h[:])
 	expiresAt := time.Now().Add(15 * time.Minute)
 
-	_, err := db.Exec(`INSERT INTO tokens (token_hash, expires_at) VALUES (?, ?)`, tokenHash, expiresAt)
+	_, err := s.db.Exec(`INSERT INTO tokens (token_hash, expires_at) VALUES (?, ?)`, tokenHash, expiresAt)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
@@ -499,7 +499,7 @@ var agentAuthWindow = 30 * time.Second
 // the OS keepalive notices (which can take ~2h).
 var agentIdleTimeout = 90 * time.Second
 
-func handleAgentWS(c echo.Context) error {
+func (s *Server) handleAgentWS(c echo.Context) error {
 	ip := getRealIP(c)
 	if !rateLimiter.Allow("ws_agent", ip, wsAgentRateLimit) {
 		log.Printf("rate limit exceeded: ws_agent from %s", ip)
@@ -527,7 +527,7 @@ func handleAgentWS(c echo.Context) error {
 	var secretMachineID string
 	if agentSecret != "" {
 		var err error
-		secretMachineID, err = validateAgentSecret(agentSecret)
+		secretMachineID, err = s.validateAgentSecret(agentSecret)
 		if err != nil {
 			log.Printf("agent secret validation failed: %v", err)
 			// If secret was provided but invalid, and no token fallback, reject.
@@ -544,7 +544,7 @@ func handleAgentWS(c echo.Context) error {
 	tokenValidated := false
 	if agentSecret == "" && token != "" {
 		var err error
-		tokenHash, err = validateAgentToken(token)
+		tokenHash, err = s.validateAgentToken(token)
 		if err != nil {
 			tokenHash = ""
 			log.Printf("agent token validation deferred (may be reconnecting agent): %v", err)
@@ -585,7 +585,7 @@ func handleAgentWS(c echo.Context) error {
 	agent := &ConnectedAgent{Conn: ws}
 	if secretMachineID != "" {
 		machineID = secretMachineID
-		registerAgentConnection(machineID, agent)
+		s.registerAgentConnection(machineID, agent)
 		log.Printf("agent authenticated via secret: machine_id=%s", machineID)
 	}
 
@@ -593,7 +593,7 @@ func handleAgentWS(c echo.Context) error {
 		_, msg, err := ws.ReadMessage()
 		if err != nil {
 			log.Printf("agent disconnected: %v", err)
-			unregisterAgentConnection(machineID, agent)
+			s.unregisterAgentConnection(machineID, agent)
 			return nil
 		}
 		// A frame arrived — extend the deadline to the idle timeout.
@@ -635,8 +635,8 @@ func handleAgentWS(c echo.Context) error {
 
 				// Check if this machine_id already exists (reconnecting agent).
 				var existingID string
-				knownMachine := db.QueryRow(`SELECT id FROM machines WHERE id = ?`, machineID).Scan(&existingID) == nil
-				hasCredential := machineHasCredential(machineID)
+				knownMachine := s.db.QueryRow(`SELECT id FROM machines WHERE id = ?`, machineID).Scan(&existingID) == nil
+				hasCredential := s.machineHasCredential(machineID)
 
 				if knownMachine && secretMachineID == machineID {
 					log.Printf("known agent reconnecting with durable credential: %s (%s)", m.Hostname, machineID)
@@ -648,7 +648,7 @@ func handleAgentWS(c echo.Context) error {
 						ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"enrollment failed"}`))
 						return nil
 					}
-					if err := consumeTokenAndStoreCredential(tokenHash, machineID, secretHash); err != nil {
+					if err := s.consumeTokenAndStoreCredential(tokenHash, machineID, secretHash); err != nil {
 						log.Printf("failed to store agent credential: %v", err)
 						ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"enrollment failed"}`))
 						return nil
@@ -679,7 +679,7 @@ func handleAgentWS(c echo.Context) error {
 					return nil
 				}
 
-				registerAgentConnection(machineID, agent)
+				s.registerAgentConnection(machineID, agent)
 				log.Printf("agent registered: %s (%s)", m.Hostname, machineID)
 			}
 
@@ -702,8 +702,8 @@ func handleAgentWS(c echo.Context) error {
 				}
 			}
 
-			upsertMachine(m)
-			storeMetrics(m)
+			s.upsertMachine(m)
+			s.storeMetrics(m)
 
 			// Enrich the metrics broadcast with latency.
 			machineLatencyMu.RLock()
@@ -736,7 +736,7 @@ func handleAgentWS(c echo.Context) error {
 			if mid == "" {
 				mid = sm.MachineID
 			}
-			upsertServices(mid, sm.Services)
+			s.upsertServices(mid, sm.Services)
 			framed := []byte(fmt.Sprintf("event: services\ndata: %s\n\n", msg))
 			broadcastSSE(framed)
 
@@ -750,7 +750,7 @@ func handleAgentWS(c echo.Context) error {
 			if mid == "" {
 				mid = cm.MachineID
 			}
-			upsertContainers(mid, cm.Containers)
+			s.upsertContainers(mid, cm.Containers)
 			framed := []byte(fmt.Sprintf("event: containers\ndata: %s\n\n", msg))
 			broadcastSSE(framed)
 
@@ -775,7 +775,7 @@ func handleAgentWS(c echo.Context) error {
 			if mid == "" {
 				mid = hw.MachineID
 			}
-			if _, err := db.Exec(`
+			if _, err := s.db.Exec(`
 				INSERT INTO machines (id, hostname, status, hardware_info)
 				VALUES (?, '', 'offline', ?)
 				ON CONFLICT(id) DO UPDATE SET hardware_info = excluded.hardware_info
@@ -811,7 +811,7 @@ func handleAgentWS(c echo.Context) error {
 				continue
 			}
 			if versionMsg.SHA256 != "" && machineID != "" {
-				recordAgentRunningVersion(machineID, agentVersionReport{
+				s.recordAgentRunningVersion(machineID, agentVersionReport{
 					RunningSHA:     versionMsg.SHA256,
 					OS:             versionMsg.OS,
 					UpdateProtocol: versionMsg.UpdateProtocol,
@@ -1006,13 +1006,13 @@ if ($svc -and $svc.Status -eq 'Running') {
 
 // validateAgentToken checks a token against the DB (Finding #1).
 // Returns the token hash so the caller can mark it as used after enrollment.
-func validateAgentToken(token string) (string, error) {
+func (s *Server) validateAgentToken(token string) (string, error) {
 	h := sha256.Sum256([]byte(token))
 	tokenHash := hex.EncodeToString(h[:])
 
 	var expiresAt string
 	var used bool
-	err := db.QueryRow(`SELECT expires_at, used FROM tokens WHERE token_hash = ?`, tokenHash).Scan(&expiresAt, &used)
+	err := s.db.QueryRow(`SELECT expires_at, used FROM tokens WHERE token_hash = ?`, tokenHash).Scan(&expiresAt, &used)
 	if err == sql.ErrNoRows {
 		return "", fmt.Errorf("invalid token")
 	}
@@ -1038,8 +1038,8 @@ func validateAgentToken(token string) (string, error) {
 }
 
 // consumeToken marks a token as used after successful enrollment.
-func consumeToken(tokenHash string) {
-	_, err := db.Exec(`UPDATE tokens SET used = TRUE WHERE token_hash = ?`, tokenHash)
+func (s *Server) consumeToken(tokenHash string) {
+	_, err := s.db.Exec(`UPDATE tokens SET used = TRUE WHERE token_hash = ?`, tokenHash)
 	if err != nil {
 		log.Printf("failed to mark token as used: %v", err)
 	} else {
@@ -1047,8 +1047,8 @@ func consumeToken(tokenHash string) {
 	}
 }
 
-func consumeTokenAndStoreCredential(tokenHash, machineID, secretHash string) error {
-	tx, err := db.Begin()
+func (s *Server) consumeTokenAndStoreCredential(tokenHash, machineID, secretHash string) error {
+	tx, err := s.db.Begin()
 	if err != nil {
 		return err
 	}
@@ -1087,15 +1087,15 @@ func generateAgentSecret() (raw string, hash string, err error) {
 }
 
 // storeAgentCredential saves (or replaces) the hashed secret for a machine.
-func storeAgentCredential(machineID, secretHash string) error {
-	_, err := db.Exec(`INSERT OR REPLACE INTO agent_credentials (machine_id, secret_hash, created_at, last_used_at)
+func (s *Server) storeAgentCredential(machineID, secretHash string) error {
+	_, err := s.db.Exec(`INSERT OR REPLACE INTO agent_credentials (machine_id, secret_hash, created_at, last_used_at)
 		VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, machineID, secretHash)
 	return err
 }
 
-func machineHasCredential(machineID string) bool {
+func (s *Server) machineHasCredential(machineID string) bool {
 	var count int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, machineID).Scan(&count); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, machineID).Scan(&count); err != nil {
 		log.Printf("failed checking agent credential for %s: %v", machineID, err)
 		return false
 	}
@@ -1104,12 +1104,12 @@ func machineHasCredential(machineID string) bool {
 
 // validateAgentSecret looks up a credential by the SHA-256 hash of the provided secret.
 // Returns the associated machine_id if found.
-func validateAgentSecret(secret string) (string, error) {
+func (s *Server) validateAgentSecret(secret string) (string, error) {
 	h := sha256.Sum256([]byte(secret))
 	secretHash := hex.EncodeToString(h[:])
 
 	var machineID string
-	err := db.QueryRow(`SELECT machine_id FROM agent_credentials WHERE secret_hash = ?`, secretHash).Scan(&machineID)
+	err := s.db.QueryRow(`SELECT machine_id FROM agent_credentials WHERE secret_hash = ?`, secretHash).Scan(&machineID)
 	if err == sql.ErrNoRows {
 		return "", fmt.Errorf("invalid agent secret")
 	}
@@ -1118,21 +1118,21 @@ func validateAgentSecret(secret string) (string, error) {
 	}
 
 	// Update last_used_at.
-	_, _ = db.Exec(`UPDATE agent_credentials SET last_used_at = CURRENT_TIMESTAMP WHERE secret_hash = ?`, secretHash)
+	_, _ = s.db.Exec(`UPDATE agent_credentials SET last_used_at = CURRENT_TIMESTAMP WHERE secret_hash = ?`, secretHash)
 
 	return machineID, nil
 }
 
 // revokeAgentCredential removes the stored credential for a machine.
-func revokeAgentCredential(machineID string) error {
-	_, err := db.Exec(`DELETE FROM agent_credentials WHERE machine_id = ?`, machineID)
+func (s *Server) revokeAgentCredential(machineID string) error {
+	_, err := s.db.Exec(`DELETE FROM agent_credentials WHERE machine_id = ?`, machineID)
 	return err
 }
 
 // generateFirstRunToken creates a one-time token on first startup when no tokens and no machines exist.
-func generateFirstRunToken() {
+func (s *Server) generateFirstRunToken() {
 	var tokenCount int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM tokens`).Scan(&tokenCount); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM tokens`).Scan(&tokenCount); err != nil {
 		log.Printf("first-run check: token count error: %v", err)
 		return
 	}
@@ -1141,7 +1141,7 @@ func generateFirstRunToken() {
 	}
 
 	var machineCount int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM machines`).Scan(&machineCount); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM machines`).Scan(&machineCount); err != nil {
 		log.Printf("first-run check: machine count error: %v", err)
 		return
 	}
@@ -1155,7 +1155,7 @@ func generateFirstRunToken() {
 	tokenHash := hex.EncodeToString(h[:])
 	expiresAt := time.Now().Add(1 * time.Hour)
 
-	_, err := db.Exec(`INSERT INTO tokens (token_hash, expires_at) VALUES (?, ?)`, tokenHash, expiresAt)
+	_, err := s.db.Exec(`INSERT INTO tokens (token_hash, expires_at) VALUES (?, ?)`, tokenHash, expiresAt)
 	if err != nil {
 		log.Printf("first-run: failed to insert token: %v", err)
 		return

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -41,7 +41,7 @@ func (s *Server) registerAgentConnection(machineID string, agent *ConnectedAgent
 	s.agentsMu.Lock()
 	s.agents[machineID] = agent
 	s.agentsMu.Unlock()
-	go s.announceVersionToAgent(machineID, agent)
+	s.goTracked(func() { s.announceVersionToAgent(machineID, agent) })
 }
 
 // unregisterAgentConnection is the symmetric cleanup for

--- a/hub/alerts.go
+++ b/hub/alerts.go
@@ -40,9 +40,9 @@ type Alert struct {
 }
 
 // seedAlertRules inserts default alert rules if the table is empty.
-func seedAlertRules() {
+func (s *Server) seedAlertRules() {
 	var count int
-	err := db.QueryRow(`SELECT COUNT(*) FROM alert_rules`).Scan(&count)
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM alert_rules`).Scan(&count)
 	if err != nil {
 		log.Printf("error checking alert_rules count: %v", err)
 		return
@@ -69,7 +69,7 @@ func seedAlertRules() {
 
 	for _, d := range defaults {
 		id := uuid.New().String()
-		_, err := db.Exec(`INSERT INTO alert_rules (id, name, metric, operator, threshold, duration_secs, severity) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		_, err := s.db.Exec(`INSERT INTO alert_rules (id, name, metric, operator, threshold, duration_secs, severity) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 			id, d.name, d.metric, d.operator, d.threshold, d.duration, d.severity)
 		if err != nil {
 			log.Printf("error seeding alert rule %s: %v", d.name, err)
@@ -79,25 +79,25 @@ func seedAlertRules() {
 }
 
 // alertEvalLoop runs every 30 seconds to evaluate alert rules.
-func alertEvalLoop() {
+func (s *Server) alertEvalLoop() {
 	time.Sleep(5 * time.Second) // Wait for startup.
 	log.Println("alert evaluation loop started")
 	for {
-		evaluateAlerts()
+		s.evaluateAlerts()
 		time.Sleep(30 * time.Second)
 	}
 }
 
-func evaluateAlerts() {
+func (s *Server) evaluateAlerts() {
 	// Get all enabled rules.
-	rules, err := getAlertRules(true)
+	rules, err := s.getAlertRules(true)
 	if err != nil {
 		log.Printf("alert eval: error getting rules: %v", err)
 		return
 	}
 
 	// Get all machines with latest metrics.
-	rows, err := db.Query(`
+	rows, err := s.db.Query(`
 		SELECT m.id, m.hostname, m.last_seen,
 			COALESCE(met.cpu_percent, 0),
 			COALESCE(met.ram_used_bytes, 0), COALESCE(met.ram_total_bytes, 0),
@@ -142,7 +142,7 @@ func evaluateAlerts() {
 	// Pre-fetch all active alerts once to avoid one SELECT per (rule×machine)
 	// in the inner loop. Active alerts are a small set; the cross product is not.
 	active := map[string]string{} // key: ruleID+"|"+machineID → alertID
-	if alertRows, err := db.Query(`SELECT rule_id, machine_id, id FROM alerts WHERE status = 'active'`); err == nil {
+	if alertRows, err := s.db.Query(`SELECT rule_id, machine_id, id FROM alerts WHERE status = 'active'`); err == nil {
 		for alertRows.Next() {
 			var ruleID, machineID, alertID string
 			if alertRows.Scan(&ruleID, &machineID, &alertID) == nil {
@@ -209,7 +209,7 @@ func evaluateAlerts() {
 			if triggered && !hasActive {
 				// Create new alert.
 				alertID := uuid.New().String()
-				_, err := db.Exec(`INSERT INTO alerts (id, rule_id, machine_id, message, severity) VALUES (?, ?, ?, ?, ?)`,
+				_, err := s.db.Exec(`INSERT INTO alerts (id, rule_id, machine_id, message, severity) VALUES (?, ?, ?, ?, ?)`,
 					alertID, rule.ID, m.id, msg, rule.Severity)
 				if err != nil {
 					log.Printf("alert eval: error creating alert: %v", err)
@@ -242,7 +242,7 @@ func evaluateAlerts() {
 				// dashboard with one alert event per machine per 30s. The
 				// dashboard picks up the refreshed message on next reload
 				// or fetch of /api/alerts.
-				_, err := db.Exec(`UPDATE alerts SET message = ? WHERE id = ?`, msg, existingID)
+				_, err := s.db.Exec(`UPDATE alerts SET message = ? WHERE id = ?`, msg, existingID)
 				if err != nil {
 					log.Printf("alert eval: error refreshing alert message: %v", err)
 					continue
@@ -250,7 +250,7 @@ func evaluateAlerts() {
 
 			} else if !triggered && hasActive {
 				// Resolve the alert.
-				_, err := db.Exec(`UPDATE alerts SET status = 'resolved', resolved_at = CURRENT_TIMESTAMP WHERE id = ?`, existingID)
+				_, err := s.db.Exec(`UPDATE alerts SET status = 'resolved', resolved_at = CURRENT_TIMESTAMP WHERE id = ?`, existingID)
 				if err != nil {
 					log.Printf("alert eval: error resolving alert: %v", err)
 					continue
@@ -287,14 +287,14 @@ func compareValue(value float64, operator string, threshold float64) bool {
 	}
 }
 
-func getAlertRules(enabledOnly bool) ([]AlertRule, error) {
+func (s *Server) getAlertRules(enabledOnly bool) ([]AlertRule, error) {
 	query := `SELECT id, name, metric, operator, threshold, duration_secs, severity, enabled, created_at FROM alert_rules`
 	if enabledOnly {
 		query += ` WHERE enabled = TRUE`
 	}
 	query += ` ORDER BY created_at`
 
-	rows, err := db.Query(query)
+	rows, err := s.db.Query(query)
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +370,7 @@ func sendTelegram(text string) {
 
 // --- Alert REST API ---
 
-func handleListAlerts(c echo.Context) error {
+func (s *Server) handleListAlerts(c echo.Context) error {
 	status := c.QueryParam("status")
 	query := `SELECT a.id, a.rule_id, a.machine_id, a.message, a.severity, a.status, a.triggered_at, a.resolved_at,
 		COALESCE(m.hostname, a.machine_id) as hostname
@@ -380,7 +380,7 @@ func handleListAlerts(c echo.Context) error {
 	}
 	query += ` ORDER BY a.triggered_at DESC LIMIT 200`
 
-	rows, err := db.Query(query)
+	rows, err := s.db.Query(query)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
@@ -401,18 +401,18 @@ func handleListAlerts(c echo.Context) error {
 	return c.JSON(http.StatusOK, alerts)
 }
 
-func handleAlertCount(c echo.Context) error {
+func (s *Server) handleAlertCount(c echo.Context) error {
 	var count int
-	err := db.QueryRow(`SELECT COUNT(*) FROM alerts WHERE status = 'active'`).Scan(&count)
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM alerts WHERE status = 'active'`).Scan(&count)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 	return c.JSON(http.StatusOK, map[string]int{"count": count})
 }
 
-func handleAcknowledgeAlert(c echo.Context) error {
+func (s *Server) handleAcknowledgeAlert(c echo.Context) error {
 	id := c.Param("id")
-	res, err := db.Exec(`UPDATE alerts SET status = 'acknowledged' WHERE id = ? AND status = 'active'`, id)
+	res, err := s.db.Exec(`UPDATE alerts SET status = 'acknowledged' WHERE id = ? AND status = 'active'`, id)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
@@ -423,15 +423,15 @@ func handleAcknowledgeAlert(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"status": "acknowledged"})
 }
 
-func handleListAlertRules(c echo.Context) error {
-	rules, err := getAlertRules(false)
+func (s *Server) handleListAlertRules(c echo.Context) error {
+	rules, err := s.getAlertRules(false)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 	return c.JSON(http.StatusOK, rules)
 }
 
-func handleUpdateAlertRule(c echo.Context) error {
+func (s *Server) handleUpdateAlertRule(c echo.Context) error {
 	id := c.Param("id")
 	var body struct {
 		Enabled   *bool    `json:"enabled"`
@@ -443,19 +443,19 @@ func handleUpdateAlertRule(c echo.Context) error {
 	}
 
 	if body.Enabled != nil {
-		_, err := db.Exec(`UPDATE alert_rules SET enabled = ? WHERE id = ?`, *body.Enabled, id)
+		_, err := s.db.Exec(`UPDATE alert_rules SET enabled = ? WHERE id = ?`, *body.Enabled, id)
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		}
 	}
 	if body.Threshold != nil {
-		_, err := db.Exec(`UPDATE alert_rules SET threshold = ? WHERE id = ?`, *body.Threshold, id)
+		_, err := s.db.Exec(`UPDATE alert_rules SET threshold = ? WHERE id = ?`, *body.Threshold, id)
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		}
 	}
 	if body.Name != nil {
-		_, err := db.Exec(`UPDATE alert_rules SET name = ? WHERE id = ?`, *body.Name, id)
+		_, err := s.db.Exec(`UPDATE alert_rules SET name = ? WHERE id = ?`, *body.Name, id)
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		}

--- a/hub/alerts_test.go
+++ b/hub/alerts_test.go
@@ -25,7 +25,10 @@ func setupAlertsDB(t *testing.T) *Server {
 	sseClientsMu.Lock()
 	sseClients = make(map[chan []byte]struct{})
 	sseClientsMu.Unlock()
-	return newServer(db)
+	s := newServer(db)
+	// See setupTestServer: LIFO cleanup, drain before the db closes.
+	t.Cleanup(func() { s.Shutdown(2 * time.Second) })
+	return s
 }
 
 func (s *Server) insertAlertRule(t *testing.T, metric, operator string, threshold float64) string {

--- a/hub/alerts_test.go
+++ b/hub/alerts_test.go
@@ -10,10 +10,9 @@ import (
 )
 
 // setupAlertsDB opens a fresh in-memory SQLite DB with migrations applied.
-func setupAlertsDB(t *testing.T) {
+func setupAlertsDB(t *testing.T) *Server {
 	t.Helper()
-	var err error
-	db, err = sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("open alerts test db: %v", err)
 	}
@@ -26,12 +25,13 @@ func setupAlertsDB(t *testing.T) {
 	sseClientsMu.Lock()
 	sseClients = make(map[chan []byte]struct{})
 	sseClientsMu.Unlock()
+	return newServer(db)
 }
 
-func insertAlertRule(t *testing.T, metric, operator string, threshold float64) string {
+func (s *Server) insertAlertRule(t *testing.T, metric, operator string, threshold float64) string {
 	t.Helper()
 	id := uuid.New().String()
-	_, err := db.Exec(
+	_, err := s.db.Exec(
 		`INSERT INTO alert_rules (id, name, metric, operator, threshold, duration_secs, severity, enabled)
 		 VALUES (?, ?, ?, ?, ?, 0, 'warning', TRUE)`,
 		id, metric+"-rule", metric, operator, threshold,
@@ -42,16 +42,16 @@ func insertAlertRule(t *testing.T, metric, operator string, threshold float64) s
 	return id
 }
 
-func insertMachineWithMetrics(t *testing.T, machineID string, cpu float64, ramUsed, ramTotal, diskUsed, diskTotal int64) {
+func (s *Server) insertMachineWithMetrics(t *testing.T, machineID string, cpu float64, ramUsed, ramTotal, diskUsed, diskTotal int64) {
 	t.Helper()
-	_, err := db.Exec(
+	_, err := s.db.Exec(
 		`INSERT INTO machines (id, hostname, status, last_seen) VALUES (?, ?, 'online', ?)`,
 		machineID, "host-"+machineID, time.Now().UTC().Format("2006-01-02 15:04:05"),
 	)
 	if err != nil {
 		t.Fatalf("insert machine: %v", err)
 	}
-	_, err = db.Exec(
+	_, err = s.db.Exec(
 		`INSERT INTO metrics (machine_id, cpu_percent, ram_used_bytes, ram_total_bytes,
 		 disk_used_bytes, disk_total_bytes) VALUES (?, ?, ?, ?, ?, ?)`,
 		machineID, cpu, ramUsed, ramTotal, diskUsed, diskTotal,
@@ -61,19 +61,19 @@ func insertMachineWithMetrics(t *testing.T, machineID string, cpu float64, ramUs
 	}
 }
 
-func alertCount(t *testing.T, machineID string) int {
+func (s *Server) alertCount(t *testing.T, machineID string) int {
 	t.Helper()
 	var n int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM alerts WHERE machine_id = ?`, machineID).Scan(&n); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM alerts WHERE machine_id = ?`, machineID).Scan(&n); err != nil {
 		t.Fatalf("alert count: %v", err)
 	}
 	return n
 }
 
-func activeAlertCount(t *testing.T, machineID string) int {
+func (s *Server) activeAlertCount(t *testing.T, machineID string) int {
 	t.Helper()
 	var n int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM alerts WHERE machine_id = ? AND status = 'active'`, machineID).Scan(&n); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM alerts WHERE machine_id = ? AND status = 'active'`, machineID).Scan(&n); err != nil {
 		t.Fatalf("active alert count: %v", err)
 	}
 	return n
@@ -82,49 +82,49 @@ func activeAlertCount(t *testing.T, machineID string) int {
 // TestEvaluateAlerts_GTRuleTriggersAndRefreshes verifies that a 'gt' rule
 // fires a new alert and then refreshes its message on subsequent evaluations.
 func TestEvaluateAlerts_GTRuleTriggersAndRefreshes(t *testing.T) {
-	setupAlertsDB(t)
+	s := setupAlertsDB(t)
 	mID := "machine-gt-test"
-	insertMachineWithMetrics(t, mID, 95.0, 800, 1000, 500, 1000)
-	insertAlertRule(t, "cpu", "gt", 90.0)
+	s.insertMachineWithMetrics(t, mID, 95.0, 800, 1000, 500, 1000)
+	s.insertAlertRule(t, "cpu", "gt", 90.0)
 
-	evaluateAlerts()
-	if got := activeAlertCount(t, mID); got != 1 {
+	s.evaluateAlerts()
+	if got := s.activeAlertCount(t, mID); got != 1 {
 		t.Fatalf("want 1 active alert after trigger, got %d", got)
 	}
 
 	// Second evaluation — already active, should refresh message, not create another.
-	evaluateAlerts()
-	if got := activeAlertCount(t, mID); got != 1 {
+	s.evaluateAlerts()
+	if got := s.activeAlertCount(t, mID); got != 1 {
 		t.Fatalf("want still 1 active alert after refresh, got %d", got)
 	}
 }
 
 // TestEvaluateAlerts_Recovery verifies that a resolved condition clears the alert.
 func TestEvaluateAlerts_Recovery(t *testing.T) {
-	setupAlertsDB(t)
+	s := setupAlertsDB(t)
 	mID := "machine-recover-test"
-	insertMachineWithMetrics(t, mID, 95.0, 800, 1000, 500, 1000)
-	ruleID := insertAlertRule(t, "cpu", "gt", 90.0)
+	s.insertMachineWithMetrics(t, mID, 95.0, 800, 1000, 500, 1000)
+	ruleID := s.insertAlertRule(t, "cpu", "gt", 90.0)
 
-	evaluateAlerts()
-	if got := activeAlertCount(t, mID); got != 1 {
+	s.evaluateAlerts()
+	if got := s.activeAlertCount(t, mID); got != 1 {
 		t.Fatalf("want 1 active alert after trigger, got %d", got)
 	}
 
 	// Drop CPU below threshold by updating the existing row so the window
 	// function still sees exactly one row with the latest timestamp.
-	if _, err := db.Exec(`UPDATE metrics SET cpu_percent = 50.0 WHERE machine_id = ?`, mID); err != nil {
+	if _, err := s.db.Exec(`UPDATE metrics SET cpu_percent = 50.0 WHERE machine_id = ?`, mID); err != nil {
 		t.Fatalf("update recovery metric: %v", err)
 	}
 
-	evaluateAlerts()
-	if got := activeAlertCount(t, mID); got != 0 {
+	s.evaluateAlerts()
+	if got := s.activeAlertCount(t, mID); got != 0 {
 		t.Fatalf("want 0 active alerts after recovery, got %d", got)
 	}
 	// Row still exists but resolved.
 	_ = ruleID
 	var status string
-	if err := db.QueryRow(`SELECT status FROM alerts WHERE machine_id = ?`, mID).Scan(&status); err != nil {
+	if err := s.db.QueryRow(`SELECT status FROM alerts WHERE machine_id = ?`, mID).Scan(&status); err != nil {
 		t.Fatalf("query alert status: %v", err)
 	}
 	if status != "resolved" {
@@ -135,39 +135,39 @@ func TestEvaluateAlerts_Recovery(t *testing.T) {
 // TestEvaluateAlerts_ZeroRAMNoFalseTrigger verifies that a machine with no RAM
 // data (ramTotalBytes=0) does NOT fire a 'lt' RAM alert.
 func TestEvaluateAlerts_ZeroRAMNoFalseTrigger(t *testing.T) {
-	setupAlertsDB(t)
+	s := setupAlertsDB(t)
 	mID := "machine-zero-ram"
-	insertMachineWithMetrics(t, mID, 0, 0, 0, 0, 1000) // ramTotal = 0
-	insertAlertRule(t, "ram", "lt", 10.0)               // would fire if metricValue=0
+	s.insertMachineWithMetrics(t, mID, 0, 0, 0, 0, 1000) // ramTotal = 0
+	s.insertAlertRule(t, "ram", "lt", 10.0)               // would fire if metricValue=0
 
-	evaluateAlerts()
-	if got := alertCount(t, mID); got != 0 {
+	s.evaluateAlerts()
+	if got := s.alertCount(t, mID); got != 0 {
 		t.Fatalf("want 0 alerts for zero-RAM machine, got %d (false trigger bug)", got)
 	}
 }
 
 // TestEvaluateAlerts_ZeroDiskNoFalseTrigger mirrors the RAM test for disk.
 func TestEvaluateAlerts_ZeroDiskNoFalseTrigger(t *testing.T) {
-	setupAlertsDB(t)
+	s := setupAlertsDB(t)
 	mID := "machine-zero-disk"
-	insertMachineWithMetrics(t, mID, 0, 800, 1000, 0, 0) // diskTotal = 0
-	insertAlertRule(t, "disk", "lt", 10.0)
+	s.insertMachineWithMetrics(t, mID, 0, 800, 1000, 0, 0) // diskTotal = 0
+	s.insertAlertRule(t, "disk", "lt", 10.0)
 
-	evaluateAlerts()
-	if got := alertCount(t, mID); got != 0 {
+	s.evaluateAlerts()
+	if got := s.alertCount(t, mID); got != 0 {
 		t.Fatalf("want 0 alerts for zero-disk machine, got %d (false trigger bug)", got)
 	}
 }
 
 // TestEvaluateAlerts_ZeroGPUTempSkipped verifies gpu_temp=0 is not evaluated.
 func TestEvaluateAlerts_ZeroGPUTempSkipped(t *testing.T) {
-	setupAlertsDB(t)
+	s := setupAlertsDB(t)
 	mID := "machine-no-gpu"
-	insertMachineWithMetrics(t, mID, 50, 500, 1000, 200, 1000)
-	insertAlertRule(t, "gpu_temp", "gt", 80.0)
+	s.insertMachineWithMetrics(t, mID, 50, 500, 1000, 200, 1000)
+	s.insertAlertRule(t, "gpu_temp", "gt", 80.0)
 
-	evaluateAlerts()
-	if got := alertCount(t, mID); got != 0 {
+	s.evaluateAlerts()
+	if got := s.alertCount(t, mID); got != 0 {
 		t.Fatalf("want 0 alerts when gpu_temp=0, got %d", got)
 	}
 }
@@ -175,18 +175,18 @@ func TestEvaluateAlerts_ZeroGPUTempSkipped(t *testing.T) {
 // TestEvaluateAlerts_MachineOffline verifies the offline rule fires when
 // last_seen exceeds the threshold (using the SQLite timestamp format).
 func TestEvaluateAlerts_MachineOffline(t *testing.T) {
-	setupAlertsDB(t)
+	s := setupAlertsDB(t)
 	mID := "machine-offline-test"
 	staleTime := time.Now().Add(-5 * time.Minute).UTC().Format("2006-01-02 15:04:05")
-	_, err := db.Exec(`INSERT INTO machines (id, hostname, status, last_seen) VALUES (?, 'stale', 'offline', ?)`,
+	_, err := s.db.Exec(`INSERT INTO machines (id, hostname, status, last_seen) VALUES (?, 'stale', 'offline', ?)`,
 		mID, staleTime)
 	if err != nil {
 		t.Fatalf("insert stale machine: %v", err)
 	}
-	insertAlertRule(t, "machine_offline", "gt", 120.0)
+	s.insertAlertRule(t, "machine_offline", "gt", 120.0)
 
-	evaluateAlerts()
-	if got := activeAlertCount(t, mID); got != 1 {
+	s.evaluateAlerts()
+	if got := s.activeAlertCount(t, mID); got != 1 {
 		t.Fatalf("want 1 active offline alert, got %d", got)
 	}
 }

--- a/hub/auth.go
+++ b/hub/auth.go
@@ -31,9 +31,9 @@ var (
 
 // generateSetupToken creates a one-time setup token if no users exist.
 // Token source priority: BLOXOS_SETUP_TOKEN env var > file > auto-generate.
-func generateSetupToken() {
+func (s *Server) generateSetupToken() {
 	var count int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&count); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&count); err != nil {
 		log.Printf("setup: error checking user count: %v", err)
 		return
 	}
@@ -99,9 +99,9 @@ func generateSetupToken() {
 }
 
 // handleSetupStatus returns whether the system needs first-boot setup.
-func handleSetupStatus(c echo.Context) error {
+func (s *Server) handleSetupStatus(c echo.Context) error {
 	var count int
-	err := db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&count)
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&count)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
@@ -109,10 +109,10 @@ func handleSetupStatus(c echo.Context) error {
 }
 
 // handleSetup processes the first-boot setup request.
-func handleSetup(c echo.Context) error {
+func (s *Server) handleSetup(c echo.Context) error {
 	// Check if setup is still needed.
 	var count int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&count); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&count); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
 	if count > 0 {
@@ -173,7 +173,7 @@ func handleSetup(c echo.Context) error {
 
 	// Create admin user with credentials already rotated.
 	id := uuid.New().String()
-	_, err = db.Exec(`INSERT INTO users (id, username, password_hash, terminal_pin_hash, password_changed, pin_changed, role) VALUES (?, ?, ?, ?, TRUE, TRUE, ?)`,
+	_, err = s.db.Exec(`INSERT INTO users (id, username, password_hash, terminal_pin_hash, password_changed, pin_changed, role) VALUES (?, ?, ?, ?, TRUE, TRUE, ?)`,
 		id, body.Username, string(passwordHash), string(pinHash), RoleAdmin)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create user"})
@@ -207,7 +207,7 @@ func mustDummyPasswordHash() []byte {
 	return h
 }
 
-func handleLogin(c echo.Context) error {
+func (s *Server) handleLogin(c echo.Context) error {
 	ip := getRealIP(c)
 	if !rateLimiter.Allow("login", ip, 5) {
 		log.Printf("rate limit exceeded: login from %s", ip)
@@ -223,7 +223,7 @@ func handleLogin(c echo.Context) error {
 	}
 
 	var userID, storedUsername, passwordHash, rawRole string
-	err := db.QueryRow(`SELECT id, username, password_hash, COALESCE(role, 'admin') FROM users WHERE username = ?`, body.Username).
+	err := s.db.QueryRow(`SELECT id, username, password_hash, COALESCE(role, 'admin') FROM users WHERE username = ?`, body.Username).
 		Scan(&userID, &storedUsername, &passwordHash, &rawRole)
 	if err == sql.ErrNoRows {
 		// Spend a comparable amount of time as the valid-username path so the
@@ -258,12 +258,12 @@ func handleLogin(c echo.Context) error {
 
 	// Check if password change is required (Finding #2).
 	var passwordChanged sql.NullBool
-	db.QueryRow(`SELECT password_changed FROM users WHERE username = ?`, storedUsername).Scan(&passwordChanged)
+	s.db.QueryRow(`SELECT password_changed FROM users WHERE username = ?`, storedUsername).Scan(&passwordChanged)
 	pwChangeRequired := !passwordChanged.Valid || !passwordChanged.Bool
 
 	// Check if PIN change is required (Finding #2).
 	var pinChanged sql.NullBool
-	db.QueryRow(`SELECT pin_changed FROM users WHERE username = ?`, storedUsername).Scan(&pinChanged)
+	s.db.QueryRow(`SELECT pin_changed FROM users WHERE username = ?`, storedUsername).Scan(&pinChanged)
 	pinChangeRequired := !pinChanged.Valid || !pinChanged.Bool
 
 	return c.JSON(http.StatusOK, map[string]interface{}{
@@ -330,7 +330,7 @@ var rotationAllowlist = map[string]bool{
 
 // credentialRotationMiddleware blocks access to protected endpoints until the user
 // has changed both the default password and PIN (Finding #10).
-func credentialRotationMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+func (s *Server) credentialRotationMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		// Skip allowlisted paths.
 		path := c.Request().URL.Path
@@ -348,7 +348,7 @@ func credentialRotationMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 
 		var passwordChanged, pinChanged sql.NullBool
-		err := db.QueryRow(`SELECT password_changed, pin_changed FROM users WHERE id = ?`, userID).Scan(&passwordChanged, &pinChanged)
+		err := s.db.QueryRow(`SELECT password_changed, pin_changed FROM users WHERE id = ?`, userID).Scan(&passwordChanged, &pinChanged)
 		if err != nil {
 			// User not found or DB error — let the request proceed (handler will fail on its own).
 			return next(c)
@@ -471,7 +471,7 @@ func generateRandomSecret() []byte {
 }
 
 // handleChangePassword allows authenticated users to change their password (Finding #2).
-func handleChangePassword(c echo.Context) error {
+func (s *Server) handleChangePassword(c echo.Context) error {
 	var body struct {
 		CurrentPassword string `json:"current_password"`
 		NewPassword     string `json:"new_password"`
@@ -490,7 +490,7 @@ func handleChangePassword(c echo.Context) error {
 	}
 
 	var passwordHash string
-	err := db.QueryRow(`SELECT password_hash FROM users WHERE id = ?`, userID).Scan(&passwordHash)
+	err := s.db.QueryRow(`SELECT password_hash FROM users WHERE id = ?`, userID).Scan(&passwordHash)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "user not found"})
 	}
@@ -502,7 +502,7 @@ func handleChangePassword(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to hash password"})
 	}
-	_, err = db.Exec(`UPDATE users SET password_hash = ?, password_changed = TRUE WHERE id = ?`, string(newHash), userID)
+	_, err = s.db.Exec(`UPDATE users SET password_hash = ?, password_changed = TRUE WHERE id = ?`, string(newHash), userID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update password"})
 	}
@@ -512,12 +512,12 @@ func handleChangePassword(c echo.Context) error {
 }
 
 // verifyTerminalPIN checks a PIN against the stored hash (Finding #3).
-func verifyTerminalPIN(userID, pin string) error {
+func (s *Server) verifyTerminalPIN(userID, pin string) error {
 	if userID == "" {
 		return fmt.Errorf("missing user context")
 	}
 	var pinHash sql.NullString
-	err := db.QueryRow(`SELECT terminal_pin_hash FROM users WHERE id = ?`, userID).Scan(&pinHash)
+	err := s.db.QueryRow(`SELECT terminal_pin_hash FROM users WHERE id = ?`, userID).Scan(&pinHash)
 	if err != nil || !pinHash.Valid || pinHash.String == "" {
 		return fmt.Errorf("invalid PIN")
 	}
@@ -528,7 +528,7 @@ func verifyTerminalPIN(userID, pin string) error {
 }
 
 // handleChangePIN allows authenticated users to change the terminal PIN (Finding #3).
-func handleChangePIN(c echo.Context) error {
+func (s *Server) handleChangePIN(c echo.Context) error {
 	var body struct {
 		CurrentPIN string `json:"current_pin"`
 		NewPIN     string `json:"new_pin"`
@@ -544,7 +544,7 @@ func handleChangePIN(c echo.Context) error {
 	if userID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
 	}
-	if err := verifyTerminalPIN(userID, body.CurrentPIN); err != nil {
+	if err := s.verifyTerminalPIN(userID, body.CurrentPIN); err != nil {
 		return c.JSON(http.StatusForbidden, map[string]string{"error": "current PIN is incorrect"})
 	}
 
@@ -552,7 +552,7 @@ func handleChangePIN(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to hash PIN"})
 	}
-	_, err = db.Exec(`UPDATE users SET terminal_pin_hash = ?, pin_changed = TRUE WHERE id = ?`, string(newHash), userID)
+	_, err = s.db.Exec(`UPDATE users SET terminal_pin_hash = ?, pin_changed = TRUE WHERE id = ?`, string(newHash), userID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update PIN"})
 	}

--- a/hub/auth_hardening_test.go
+++ b/hub/auth_hardening_test.go
@@ -33,7 +33,7 @@ func ctxWithBearer(e *echo.Echo, token string) echo.Context {
 // TestExtractUserIDValidToken: a properly signed, unexpired token yields its
 // user_id.
 func TestExtractUserIDValidToken(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 	tok := signHS256(t, jwt.MapClaims{"user_id": "user-123", "exp": time.Now().Add(time.Hour).Unix()}, jwtSecret)
 	if got := extractUserIDFromRequest(ctxWithBearer(e, tok)); got != "user-123" {
 		t.Fatalf("extractUserIDFromRequest = %q, want user-123", got)
@@ -43,7 +43,7 @@ func TestExtractUserIDValidToken(t *testing.T) {
 // TestExtractUserIDRejectsBadSignature: a token signed with the wrong key must
 // not be trusted.
 func TestExtractUserIDRejectsBadSignature(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 	tok := signHS256(t, jwt.MapClaims{"user_id": "user-123", "exp": time.Now().Add(time.Hour).Unix()}, []byte("a-totally-different-signing-key-32b!"))
 	if got := extractUserIDFromRequest(ctxWithBearer(e, tok)); got != "" {
 		t.Fatalf("expected empty userID for bad signature, got %q", got)
@@ -53,7 +53,7 @@ func TestExtractUserIDRejectsBadSignature(t *testing.T) {
 // TestExtractUserIDRejectsNoneAlg: an alg=none token must be rejected (the
 // keyfunc must require HMAC).
 func TestExtractUserIDRejectsNoneAlg(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 	tok, err := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
 		"user_id": "user-123", "exp": time.Now().Add(time.Hour).Unix(),
 	}).SignedString(jwt.UnsafeAllowNoneSignatureType)
@@ -67,7 +67,7 @@ func TestExtractUserIDRejectsNoneAlg(t *testing.T) {
 
 // TestExtractUserIDRejectsExpired: an expired token must not be trusted.
 func TestExtractUserIDRejectsExpired(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 	tok := signHS256(t, jwt.MapClaims{"user_id": "user-123", "exp": time.Now().Add(-time.Hour).Unix()}, jwtSecret)
 	if got := extractUserIDFromRequest(ctxWithBearer(e, tok)); got != "" {
 		t.Fatalf("expected empty userID for expired token, got %q", got)
@@ -79,7 +79,7 @@ func TestExtractUserIDRejectsExpired(t *testing.T) {
 // comparable to a real user's — closing the username-enumeration timing oracle.
 // Before the fix the unknown-username path returned in well under a millisecond.
 func TestLoginUnknownUsernameRunsDummyCompare(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	body := `{"username":"definitely-not-a-real-user","password":"whatever-password"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(body))

--- a/hub/branding.go
+++ b/hub/branding.go
@@ -61,13 +61,13 @@ func validatePNG(data []byte, maxBytes int, label string) (sha string, err error
 }
 
 // handleGetBranding returns the public branding metadata. No auth.
-func handleGetBranding(c echo.Context) error {
+func (s *Server) handleGetBranding(c echo.Context) error {
 	var (
 		title, subtitle, welcome string
 		logoSHA, faviconSHA      sql.NullString
 		logoMime, faviconMime    sql.NullString
 	)
-	err := db.QueryRow(`
+	err := s.db.QueryRow(`
 		SELECT title, subtitle, COALESCE(welcome_message, ''), logo_sha, logo_mime, favicon_sha, favicon_mime
 		FROM branding_config WHERE id = 1
 	`).Scan(&title, &subtitle, &welcome, &logoSHA, &logoMime, &faviconSHA, &faviconMime)
@@ -110,7 +110,7 @@ var (
 	brandingFaviconImage = brandingImage{dataCol: "favicon_data", mimeCol: "favicon_mime", shaCol: "favicon_sha"}
 )
 
-func serveBrandingImage(c echo.Context, img brandingImage) error {
+func (s *Server) serveBrandingImage(c echo.Context, img brandingImage) error {
 	query := fmt.Sprintf(`SELECT %s, %s, %s FROM branding_config WHERE id = 1`,
 		img.dataCol, img.mimeCol, img.shaCol)
 	var (
@@ -118,7 +118,7 @@ func serveBrandingImage(c echo.Context, img brandingImage) error {
 		mime     sql.NullString
 		shaStore sql.NullString
 	)
-	err := db.QueryRow(query).Scan(&data, &mime, &shaStore)
+	err := s.db.QueryRow(query).Scan(&data, &mime, &shaStore)
 	if err == sql.ErrNoRows || len(data) == 0 || !mime.Valid || mime.String == "" {
 		return c.NoContent(http.StatusNotFound)
 	}
@@ -135,16 +135,16 @@ func serveBrandingImage(c echo.Context, img brandingImage) error {
 	return c.Blob(http.StatusOK, mime.String, data)
 }
 
-func handleGetLogo(c echo.Context) error {
-	return serveBrandingImage(c, brandingLogoImage)
+func (s *Server) handleGetLogo(c echo.Context) error {
+	return s.serveBrandingImage(c, brandingLogoImage)
 }
 
-func handleGetFavicon(c echo.Context) error {
-	return serveBrandingImage(c, brandingFaviconImage)
+func (s *Server) handleGetFavicon(c echo.Context) error {
+	return s.serveBrandingImage(c, brandingFaviconImage)
 }
 
 // handleUpdateBrandingText accepts PATCH {title?, subtitle?}.
-func handleUpdateBrandingText(c echo.Context) error {
+func (s *Server) handleUpdateBrandingText(c echo.Context) error {
 	var body struct {
 		Title          *string `json:"title,omitempty"`
 		Subtitle       *string `json:"subtitle,omitempty"`
@@ -187,13 +187,13 @@ func handleUpdateBrandingText(c echo.Context) error {
 
 	sets = append(sets, "updated_at = CURRENT_TIMESTAMP")
 	query := fmt.Sprintf(`UPDATE branding_config SET %s WHERE id = 1`, strings.Join(sets, ", "))
-	if _, err := db.Exec(query, args...); err != nil {
+	if _, err := s.db.Exec(query, args...); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
-	return handleGetBranding(c)
+	return s.handleGetBranding(c)
 }
 
-func handleUploadBrandingImage(c echo.Context, img brandingImage, maxBytes int, label string) error {
+func (s *Server) handleUploadBrandingImage(c echo.Context, img brandingImage, maxBytes int, label string) error {
 	fh, err := c.FormFile("file")
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "missing file field"})
@@ -224,22 +224,22 @@ func handleUploadBrandingImage(c echo.Context, img brandingImage, maxBytes int, 
 
 	query := fmt.Sprintf(`UPDATE branding_config SET %s = ?, %s = ?, %s = ?, updated_at = CURRENT_TIMESTAMP WHERE id = 1`,
 		img.dataCol, img.mimeCol, img.shaCol)
-	if _, err := db.Exec(query, data, "image/png", sha); err != nil {
+	if _, err := s.db.Exec(query, data, "image/png", sha); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
-	return handleGetBranding(c)
+	return s.handleGetBranding(c)
 }
 
-func handleUploadLogo(c echo.Context) error {
-	return handleUploadBrandingImage(c, brandingLogoImage, maxLogoBytes, "logo")
+func (s *Server) handleUploadLogo(c echo.Context) error {
+	return s.handleUploadBrandingImage(c, brandingLogoImage, maxLogoBytes, "logo")
 }
 
-func handleUploadFavicon(c echo.Context) error {
-	return handleUploadBrandingImage(c, brandingFaviconImage, maxFaviconBytes, "favicon")
+func (s *Server) handleUploadFavicon(c echo.Context) error {
+	return s.handleUploadBrandingImage(c, brandingFaviconImage, maxFaviconBytes, "favicon")
 }
 
 // handleClearBrandingImage removes a previously uploaded logo or favicon.
-func handleClearBrandingImage(c echo.Context) error {
+func (s *Server) handleClearBrandingImage(c echo.Context) error {
 	kind := c.Param("kind")
 	var img brandingImage
 	switch kind {
@@ -252,8 +252,8 @@ func handleClearBrandingImage(c echo.Context) error {
 	}
 	query := fmt.Sprintf(`UPDATE branding_config SET %s = NULL, %s = NULL, %s = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = 1`,
 		img.dataCol, img.mimeCol, img.shaCol)
-	if _, err := db.Exec(query); err != nil {
+	if _, err := s.db.Exec(query); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
-	return handleGetBranding(c)
+	return s.handleGetBranding(c)
 }

--- a/hub/install_enrollment_test.go
+++ b/hub/install_enrollment_test.go
@@ -16,12 +16,12 @@ import (
 // seedTokenValue inserts a valid (unused, unexpired) install token with the
 // given raw value and returns it. Complements seedValidToken, which always
 // inserts the same fixed token.
-func seedTokenValue(t *testing.T, raw string) string {
+func (s *Server) seedTokenValue(t *testing.T, raw string) string {
 	t.Helper()
 	h := sha256.Sum256([]byte(raw))
 	tokenHash := hex.EncodeToString(h[:])
 	expiresAt := time.Now().Add(1 * time.Hour).Format("2006-01-02 15:04:05")
-	if _, err := db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, FALSE)`, tokenHash, expiresAt); err != nil {
+	if _, err := s.db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, FALSE)`, tokenHash, expiresAt); err != nil {
 		t.Fatalf("seed token %q: %v", raw, err)
 	}
 	return raw
@@ -31,24 +31,24 @@ func seedTokenValue(t *testing.T, raw string) string {
 // install token must not be able to claim a machine_id that already has a
 // durable credential. Re-enrollment requires an explicit revoke first.
 func TestInstallTokenCannotTakeOverEnrolledMachine(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	server := httptest.NewServer(e)
 	defer server.Close()
 
 	// Enroll machine-A and capture its durable secret.
-	token1 := seedValidToken(t)
-	secret := enrollAndCaptureSecret(t, server, token1, "machine-A")
+	token1 := s.seedValidToken(t)
+	secret := s.enrollAndCaptureSecret(t, server, token1, "machine-A")
 	if secret == "" {
 		t.Fatal("enrollment did not yield a secret")
 	}
 
 	var before string
-	if err := db.QueryRow(`SELECT secret_hash FROM agent_credentials WHERE machine_id = ?`, "machine-A").Scan(&before); err != nil {
+	if err := s.db.QueryRow(`SELECT secret_hash FROM agent_credentials WHERE machine_id = ?`, "machine-A").Scan(&before); err != nil {
 		t.Fatalf("read machine-A credential: %v", err)
 	}
 
 	// Attacker holds a fresh, valid token and tries to claim machine-A.
-	seedTokenValue(t, "attacker-token-xyz")
+	s.seedTokenValue(t, "attacker-token-xyz")
 	conn, err := wsDialAgent(t, server, "token=attacker-token-xyz")
 	if err != nil {
 		t.Fatalf("attacker dial: %v", err)
@@ -70,14 +70,14 @@ func TestInstallTokenCannotTakeOverEnrolledMachine(t *testing.T) {
 
 	// machine-A's credential must be unchanged, and unique.
 	var after string
-	if err := db.QueryRow(`SELECT secret_hash FROM agent_credentials WHERE machine_id = ?`, "machine-A").Scan(&after); err != nil {
+	if err := s.db.QueryRow(`SELECT secret_hash FROM agent_credentials WHERE machine_id = ?`, "machine-A").Scan(&after); err != nil {
 		t.Fatalf("read machine-A credential after: %v", err)
 	}
 	if after != before {
 		t.Fatal("machine-A credential was replaced by a takeover enrollment")
 	}
 	var n int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, "machine-A").Scan(&n); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, "machine-A").Scan(&n); err != nil {
 		t.Fatalf("count machine-A credentials: %v", err)
 	}
 	if n != 1 {
@@ -88,7 +88,7 @@ func TestInstallTokenCannotTakeOverEnrolledMachine(t *testing.T) {
 	// still use it after an explicit revoke.
 	h := sha256.Sum256([]byte("attacker-token-xyz"))
 	var used bool
-	if err := db.QueryRow(`SELECT used FROM tokens WHERE token_hash = ?`, hex.EncodeToString(h[:])).Scan(&used); err != nil {
+	if err := s.db.QueryRow(`SELECT used FROM tokens WHERE token_hash = ?`, hex.EncodeToString(h[:])).Scan(&used); err != nil {
 		t.Fatalf("read attacker token: %v", err)
 	}
 	if used {
@@ -100,9 +100,9 @@ func TestInstallTokenCannotTakeOverEnrolledMachine(t *testing.T) {
 // /api/tokens must refuse rather than emit a Host-header-derived install
 // command, and must not mint a token.
 func TestCreateTokenRequiresPublicURL(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	token := loginAndGetToken(t, e)
-	markCredentialsRotated(t)
+	s.markCredentialsRotated(t)
 	t.Setenv("PUBLIC_URL", "")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
@@ -117,7 +117,7 @@ func TestCreateTokenRequiresPublicURL(t *testing.T) {
 		t.Fatalf("expected error to mention PUBLIC_URL, got %s", rec.Body.String())
 	}
 	var n int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM tokens`).Scan(&n); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM tokens`).Scan(&n); err != nil {
 		t.Fatalf("count tokens: %v", err)
 	}
 	if n != 0 {
@@ -128,9 +128,9 @@ func TestCreateTokenRequiresPublicURL(t *testing.T) {
 // TestCreateTokenUsesPublicURL locks in item 2's happy path: with PUBLIC_URL
 // set, the generated command is derived from PUBLIC_URL.
 func TestCreateTokenUsesPublicURL(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	token := loginAndGetToken(t, e)
-	markCredentialsRotated(t)
+	s.markCredentialsRotated(t)
 	t.Setenv("PUBLIC_URL", "https://hub.public.example")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
@@ -160,7 +160,7 @@ func TestCreateTokenUsesPublicURL(t *testing.T) {
 // install.sh must verify the downloaded agent binary's SHA-256 against the hash
 // of the binary the hub actually serves.
 func TestInstallScriptPinsAgentBinaryHash(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "bloxos-agent")
@@ -204,7 +204,7 @@ func TestInstallScriptPinsAgentBinaryHash(t *testing.T) {
 // binary with TLS verification (via the bootstrapped CA), not curl -k. The
 // initial CA fetch may remain insecure.
 func TestWindowsInstallScriptPinsHashAndVerifiesBinaryDownload(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "bloxos-agent.exe")

--- a/hub/inventory.go
+++ b/hub/inventory.go
@@ -180,8 +180,8 @@ type agentSnapshotNIC struct {
 	SpeedMbps int64  `json:"speed_mbps"`
 }
 
-func handleInventory(c echo.Context) error {
-	rows, err := db.Query(`
+func (s *Server) handleInventory(c echo.Context) error {
+	rows, err := s.db.Query(`
 		SELECT id, hostname, ip, os, status, COALESCE(hardware_info, '')
 		FROM machines
 		ORDER BY hostname

--- a/hub/main.go
+++ b/hub/main.go
@@ -112,14 +112,9 @@ type CommandResponse struct {
 
 // TerminalSession tracks an active terminal relay session.
 var (
-	db       *sql.DB
 	upgrader = websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool { return true },
 	}
-
-	// Connected agents keyed by machine ID.
-	agents   = make(map[string]*ConnectedAgent)
-	agentsMu sync.RWMutex
 
 	// SSE subscribers.
 	sseClients   = make(map[chan []byte]struct{})
@@ -153,24 +148,25 @@ func main() {
 	// Phase 11 — `foreign_keys=on` is load-bearing: ON DELETE CASCADE on
 	// user_pinned_machines / user_saved_filters relies on it being set per
 	// connection. Without this pragma SQLite silently ignores cascade clauses.
-	db, err = sql.Open("sqlite", "bloxos.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)")
+	db, err := sql.Open("sqlite", "bloxos.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)")
 	if err != nil {
 		log.Fatalf("failed to open database: %v", err)
 	}
 	defer db.Close()
+	s := newServer(db)
 
 	// Set DB file permissions to 0600 (owner read/write only).
 	if err := os.Chmod("bloxos.db", 0600); err != nil && !os.IsNotExist(err) {
 		log.Printf("WARNING: failed to set DB permissions: %v", err)
 	}
 
-	if err := initDB(); err != nil {
+	if err := s.initDB(); err != nil {
 		log.Fatalf("failed to init database: %v", err)
 	}
 	log.Println("database initialized")
 
 	// Seed default alert rules.
-	seedAlertRules()
+	s.seedAlertRules()
 
 	// Load or generate the agent-update signing key. Must run before
 	// initAgentVersionTracking so the first announce can be signed, and
@@ -182,10 +178,10 @@ func main() {
 	initAgentVersionTracking()
 
 	// Generate setup token if no users exist (Finding #11 — first-boot setup).
-	generateSetupToken()
+	s.generateSetupToken()
 
 	// Generate first-run token if needed (Finding #1).
-	generateFirstRunToken()
+	s.generateFirstRunToken()
 
 	// Load or generate JWT secret (Finding #2).
 	jwtSecret = loadOrGenerateJWTSecret()
@@ -204,11 +200,11 @@ func main() {
 	}
 
 	// Start alert evaluation loop.
-	goSafelyForever("alertEvalLoop", alertEvalLoop)
+	goSafelyForever("alertEvalLoop", s.alertEvalLoop)
 
 	// Start cleanup goroutine.
-	goSafelyForever("cleanupLoop", cleanupLoop)
-	startAPIPollers()
+	goSafelyForever("cleanupLoop", s.cleanupLoop)
+	s.startAPIPollers()
 
 	e := echo.New()
 	e.HideBanner = true
@@ -232,7 +228,7 @@ func main() {
 		AllowHeaders: []string{"Accept", "Content-Type", "Cache-Control", "Authorization"},
 	}))
 
-	registerRoutes(e)
+	s.registerRoutes(e)
 
 	if err := auditRBACRouteCoverage(e, routeScopeRequirements); err != nil {
 		log.Fatalf("RBAC route audit failed: %v", err)
@@ -251,94 +247,94 @@ func main() {
 // registerRoutes wires every public and RBAC-protected handler onto e.
 // Shared between main() and tests so the production route set and the audit
 // can never drift.
-func registerRoutes(e *echo.Echo) {
+func (s *Server) registerRoutes(e *echo.Echo) {
 	// Public endpoints (no auth).
 	e.GET("/health", handleHealth)
-	e.GET("/ws/agent", handleAgentWS)
-	e.POST("/api/auth/login", handleLogin)
+	e.GET("/ws/agent", s.handleAgentWS)
+	e.POST("/api/auth/login", s.handleLogin)
 	e.GET("/install.sh", handleInstallScript)
 	e.GET("/install.ps1", handleWindowsInstallScript)
 	e.GET("/download/agent", handleDownloadAgent)
 	e.GET("/download/ca.crt", handleDownloadCACert)
-	e.GET("/api/setup/status", handleSetupStatus)
-	e.POST("/api/setup", handleSetup)
+	e.GET("/api/setup/status", s.handleSetupStatus)
+	e.POST("/api/setup", s.handleSetup)
 
 	// Phase 10 — branding reads are public (dashboard fetches before auth).
-	e.GET("/api/branding", handleGetBranding)
-	e.GET("/api/branding/logo", handleGetLogo)
-	e.GET("/api/branding/favicon", handleGetFavicon)
+	e.GET("/api/branding", s.handleGetBranding)
+	e.GET("/api/branding/logo", s.handleGetLogo)
+	e.GET("/api/branding/favicon", s.handleGetFavicon)
 
 	// Protected endpoints.
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware, permissionMiddleware)
-	api.GET("/api/events", handleSSE)
-	api.GET("/api/machines", handleListMachines)
-	api.GET("/api/machines/:id", handleGetMachine)
-	api.GET("/api/machines/:id/services", handleGetServices)
-	api.GET("/api/machines/:id/containers", handleGetContainers)
-	api.POST("/api/machines/:id/command", handleCommand)
-	api.POST("/api/machines/:id/refresh", handleMachineRefresh)
-	api.POST("/api/refresh", handleFleetRefresh)
+	api := e.Group("", jwtMiddleware, s.credentialRotationMiddleware, s.permissionMiddleware)
+	api.GET("/api/events", s.handleSSE)
+	api.GET("/api/machines", s.handleListMachines)
+	api.GET("/api/machines/:id", s.handleGetMachine)
+	api.GET("/api/machines/:id/services", s.handleGetServices)
+	api.GET("/api/machines/:id/containers", s.handleGetContainers)
+	api.POST("/api/machines/:id/command", s.handleCommand)
+	api.POST("/api/machines/:id/refresh", s.handleMachineRefresh)
+	api.POST("/api/refresh", s.handleFleetRefresh)
 
 	// Phase 8 — agent version tracking and rollout control
-	api.GET("/api/versions", handleListVersions)
+	api.GET("/api/versions", s.handleListVersions)
 	api.POST("/api/versions/pause", handlePauseRollout)
-	api.POST("/api/versions/resume", handleResumeRollout)
-	api.PUT("/api/machines/:id/tags", handleSetTags)
-	api.GET("/api/machines/:id/notes", handleGetMachineNotes)
-	api.PUT("/api/machines/:id/notes", handleSetMachineNotes)
-	api.GET("/api/machines/:id/metrics/history", handleMetricsHistory)
-	api.DELETE("/api/machines/:id", handleDeleteMachine)
+	api.POST("/api/versions/resume", s.handleResumeRollout)
+	api.PUT("/api/machines/:id/tags", s.handleSetTags)
+	api.GET("/api/machines/:id/notes", s.handleGetMachineNotes)
+	api.PUT("/api/machines/:id/notes", s.handleSetMachineNotes)
+	api.GET("/api/machines/:id/metrics/history", s.handleMetricsHistory)
+	api.DELETE("/api/machines/:id", s.handleDeleteMachine)
 
-	api.POST("/api/machines/:id/terminal", handleStartTerminal)
-	api.DELETE("/api/machines/:id/terminal/:session_id", handleCloseTerminal)
-	e.GET("/ws/terminal/:session_id", handleTerminalWS)
+	api.POST("/api/machines/:id/terminal", s.handleStartTerminal)
+	api.DELETE("/api/machines/:id/terminal/:session_id", s.handleCloseTerminal)
+	e.GET("/ws/terminal/:session_id", s.handleTerminalWS)
 
-	api.GET("/api/alerts", handleListAlerts)
-	api.GET("/api/alerts/active/count", handleAlertCount)
-	api.POST("/api/alerts/:id/acknowledge", handleAcknowledgeAlert)
-	api.GET("/api/alert-rules", handleListAlertRules)
-	api.PUT("/api/alert-rules/:id", handleUpdateAlertRule)
+	api.GET("/api/alerts", s.handleListAlerts)
+	api.GET("/api/alerts/active/count", s.handleAlertCount)
+	api.POST("/api/alerts/:id/acknowledge", s.handleAcknowledgeAlert)
+	api.GET("/api/alert-rules", s.handleListAlertRules)
+	api.PUT("/api/alert-rules/:id", s.handleUpdateAlertRule)
 
-	api.POST("/api/auth/change-password", handleChangePassword)
-	api.POST("/api/auth/change-pin", handleChangePIN)
+	api.POST("/api/auth/change-password", s.handleChangePassword)
+	api.POST("/api/auth/change-pin", s.handleChangePIN)
 	api.POST("/api/auth/sse-token", handleSSEToken)
 
-	api.POST("/api/tokens", handleCreateToken)
+	api.POST("/api/tokens", s.handleCreateToken)
 
-	api.POST("/api/bulk/command", handleBulkCommand)
+	api.POST("/api/bulk/command", s.handleBulkCommand)
 
-	api.GET("/api/inventory", handleInventory)
+	api.GET("/api/inventory", s.handleInventory)
 
-	api.GET("/api/api-machines", handleListAPIMachines)
-	api.POST("/api/api-machines", handleCreateAPIMachine)
-	api.PATCH("/api/api-machines/:id", handleUpdateAPIMachine)
-	api.DELETE("/api/api-machines/:id", handleDeleteAPIMachine)
-	api.POST("/api/api-machines/:id/poll", handleForceAPIPoll)
+	api.GET("/api/api-machines", s.handleListAPIMachines)
+	api.POST("/api/api-machines", s.handleCreateAPIMachine)
+	api.PATCH("/api/api-machines/:id", s.handleUpdateAPIMachine)
+	api.DELETE("/api/api-machines/:id", s.handleDeleteAPIMachine)
+	api.POST("/api/api-machines/:id/poll", s.handleForceAPIPoll)
 
-	api.GET("/api/users", handleListUsers)
-	api.POST("/api/users", handleCreateUser)
-	api.PATCH("/api/users/:id", handleUpdateUser)
-	api.DELETE("/api/users/:id", handleDeleteUser)
+	api.GET("/api/users", s.handleListUsers)
+	api.POST("/api/users", s.handleCreateUser)
+	api.PATCH("/api/users/:id", s.handleUpdateUser)
+	api.DELETE("/api/users/:id", s.handleDeleteUser)
 
 	// Phase 10 — per-user theme prefs and admin branding writes.
-	api.GET("/api/me/theme", handleGetMyThemePrefs)
-	api.PATCH("/api/me/theme", handleUpdateMyThemePrefs)
-	api.PATCH("/api/branding", handleUpdateBrandingText)
-	api.POST("/api/branding/logo", handleUploadLogo)
-	api.POST("/api/branding/favicon", handleUploadFavicon)
-	api.DELETE("/api/branding/:kind", handleClearBrandingImage)
+	api.GET("/api/me/theme", s.handleGetMyThemePrefs)
+	api.PATCH("/api/me/theme", s.handleUpdateMyThemePrefs)
+	api.PATCH("/api/branding", s.handleUpdateBrandingText)
+	api.POST("/api/branding/logo", s.handleUploadLogo)
+	api.POST("/api/branding/favicon", s.handleUploadFavicon)
+	api.DELETE("/api/branding/:kind", s.handleClearBrandingImage)
 
 	// Phase 11 — per-user workflow personalization.
-	api.GET("/api/me/preferences", handleGetMyPreferences)
-	api.PATCH("/api/me/preferences", handlePatchMyPreferences)
-	api.POST("/api/me/avatar", handleUploadAvatar)
-	api.DELETE("/api/me/avatar", handleDeleteAvatar)
-	api.GET("/api/users/:user_id/avatar", handleGetAvatar)
-	api.POST("/api/me/pinned/:machine_id", handlePinMachine)
-	api.DELETE("/api/me/pinned/:machine_id", handleUnpinMachine)
-	api.GET("/api/me/filters", handleListSavedFilters)
-	api.POST("/api/me/filters", handleCreateSavedFilter)
-	api.DELETE("/api/me/filters/:id", handleDeleteSavedFilter)
+	api.GET("/api/me/preferences", s.handleGetMyPreferences)
+	api.PATCH("/api/me/preferences", s.handlePatchMyPreferences)
+	api.POST("/api/me/avatar", s.handleUploadAvatar)
+	api.DELETE("/api/me/avatar", s.handleDeleteAvatar)
+	api.GET("/api/users/:user_id/avatar", s.handleGetAvatar)
+	api.POST("/api/me/pinned/:machine_id", s.handlePinMachine)
+	api.DELETE("/api/me/pinned/:machine_id", s.handleUnpinMachine)
+	api.GET("/api/me/filters", s.handleListSavedFilters)
+	api.POST("/api/me/filters", s.handleCreateSavedFilter)
+	api.DELETE("/api/me/filters/:id", s.handleDeleteSavedFilter)
 }
 
 func getEnvOrDefault(key, def string) string {
@@ -349,31 +345,31 @@ func getEnvOrDefault(key, def string) string {
 	return v
 }
 
-func initDB() error {
-	return runMigrations(db)
+func (s *Server) initDB() error {
+	return runMigrations(s.db)
 }
 
 // --- Auth ---
 
 // --- Cleanup ---
 
-func cleanupLoop() {
+func (s *Server) cleanupLoop() {
 	log.Println("cleanup goroutine started (runs hourly)")
 	// Run once on startup after a short delay.
 	time.Sleep(10 * time.Second)
-	runCleanup()
+	s.runCleanup()
 	for {
 		time.Sleep(1 * time.Hour)
-		runCleanup()
+		s.runCleanup()
 	}
 }
 
-func runCleanup() {
+func (s *Server) runCleanup() {
 	log.Println("running cleanup...")
 	total := int64(0)
 
 	// Delete metrics older than 7 days.
-	res, err := db.Exec(`DELETE FROM metrics WHERE timestamp < datetime('now', '-7 days')`)
+	res, err := s.db.Exec(`DELETE FROM metrics WHERE timestamp < datetime('now', '-7 days')`)
 	if err == nil {
 		n, _ := res.RowsAffected()
 		total += n
@@ -383,7 +379,7 @@ func runCleanup() {
 	}
 
 	// Delete GPU metrics older than 7 days.
-	res, err = db.Exec(`DELETE FROM gpu_metrics WHERE timestamp < datetime('now', '-7 days')`)
+	res, err = s.db.Exec(`DELETE FROM gpu_metrics WHERE timestamp < datetime('now', '-7 days')`)
 	if err == nil {
 		n, _ := res.RowsAffected()
 		total += n
@@ -393,7 +389,7 @@ func runCleanup() {
 	}
 
 	// Delete resolved alerts older than 30 days.
-	res, err = db.Exec(`DELETE FROM alerts WHERE status != 'active' AND triggered_at < datetime('now', '-30 days')`)
+	res, err = s.db.Exec(`DELETE FROM alerts WHERE status != 'active' AND triggered_at < datetime('now', '-30 days')`)
 	if err == nil {
 		n, _ := res.RowsAffected()
 		total += n
@@ -403,7 +399,7 @@ func runCleanup() {
 	}
 
 	// Delete expired tokens.
-	res, err = db.Exec(`DELETE FROM tokens WHERE expires_at < datetime('now')`)
+	res, err = s.db.Exec(`DELETE FROM tokens WHERE expires_at < datetime('now')`)
 	if err == nil {
 		n, _ := res.RowsAffected()
 		total += n
@@ -413,7 +409,7 @@ func runCleanup() {
 	}
 
 	// Delete closed terminal sessions older than 30 days.
-	res, err = db.Exec(`DELETE FROM terminal_sessions WHERE status = 'closed' AND ended_at < datetime('now', '-30 days')`)
+	res, err = s.db.Exec(`DELETE FROM terminal_sessions WHERE status = 'closed' AND ended_at < datetime('now', '-30 days')`)
 	if err == nil {
 		n, _ := res.RowsAffected()
 		total += n
@@ -427,7 +423,7 @@ func runCleanup() {
 
 // --- Metrics History ---
 
-func handleMetricsHistory(c echo.Context) error {
+func (s *Server) handleMetricsHistory(c echo.Context) error {
 	machineID := c.Param("id")
 	period := c.QueryParam("period")
 	if period == "" {
@@ -457,7 +453,7 @@ func handleMetricsHistory(c echo.Context) error {
 		limit = 120
 	}
 
-	rows, err := db.Query(`
+	rows, err := s.db.Query(`
 		SELECT timestamp,
 			COALESCE(cpu_percent, 0),
 			COALESCE(ram_used_bytes, 0),
@@ -525,7 +521,7 @@ const maxBulkCommandTargets = 100
 // throughput on the common case (most targets reply in <1s).
 const bulkCommandConcurrency = 20
 
-func handleBulkCommand(c echo.Context) error {
+func (s *Server) handleBulkCommand(c echo.Context) error {
 	var body struct {
 		MachineIDs []string `json:"machine_ids"`
 		Type       string   `json:"type"`
@@ -563,9 +559,9 @@ func handleBulkCommand(c echo.Context) error {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			agentsMu.RLock()
-			agent, ok := agents[machineID]
-			agentsMu.RUnlock()
+			s.agentsMu.RLock()
+			agent, ok := s.agents[machineID]
+			s.agentsMu.RUnlock()
 
 			result := BulkResult{MachineID: machineID}
 			if !ok {
@@ -636,10 +632,10 @@ func handleBulkCommand(c echo.Context) error {
 // the SQLite row.
 const notesMaxLen = 10000
 
-func handleGetMachineNotes(c echo.Context) error {
+func (s *Server) handleGetMachineNotes(c echo.Context) error {
 	id := c.Param("id")
 	var notes string
-	err := db.QueryRow(`SELECT COALESCE(notes, '') FROM machines WHERE id = ?`, id).Scan(&notes)
+	err := s.db.QueryRow(`SELECT COALESCE(notes, '') FROM machines WHERE id = ?`, id).Scan(&notes)
 	if err == sql.ErrNoRows {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "machine not found"})
 	}
@@ -649,7 +645,7 @@ func handleGetMachineNotes(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"notes": notes})
 }
 
-func handleSetMachineNotes(c echo.Context) error {
+func (s *Server) handleSetMachineNotes(c echo.Context) error {
 	id := c.Param("id")
 	var body struct {
 		Notes string `json:"notes"`
@@ -663,7 +659,7 @@ func handleSetMachineNotes(c echo.Context) error {
 		})
 	}
 
-	res, err := db.Exec(`UPDATE machines SET notes = ? WHERE id = ?`, body.Notes, id)
+	res, err := s.db.Exec(`UPDATE machines SET notes = ? WHERE id = ?`, body.Notes, id)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
@@ -679,7 +675,7 @@ func handleSetMachineNotes(c echo.Context) error {
 
 // --- Tags ---
 
-func handleSetTags(c echo.Context) error {
+func (s *Server) handleSetTags(c echo.Context) error {
 	id := c.Param("id")
 	var body struct {
 		Tags []string `json:"tags"`
@@ -688,7 +684,7 @@ func handleSetTags(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid body"})
 	}
 	tagsStr := strings.Join(body.Tags, ",")
-	_, err := db.Exec(`UPDATE machines SET tags = ? WHERE id = ?`, tagsStr, id)
+	_, err := s.db.Exec(`UPDATE machines SET tags = ? WHERE id = ?`, tagsStr, id)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
@@ -699,18 +695,18 @@ func handleSetTags(c echo.Context) error {
 
 // --- Existing Handlers ---
 
-func handleDeleteMachine(c echo.Context) error {
+func (s *Server) handleDeleteMachine(c echo.Context) error {
 	id := c.Param("id")
 
 	// Check machine exists and get hostname
 	var hostname string
-	err := db.QueryRow("SELECT hostname FROM machines WHERE id = ?", id).Scan(&hostname)
+	err := s.db.QueryRow("SELECT hostname FROM machines WHERE id = ?", id).Scan(&hostname)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "machine not found"})
 	}
 
 	// Delete all related data in a transaction
-	tx, err := db.Begin()
+	tx, err := s.db.Begin()
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to start transaction"})
 	}
@@ -730,9 +726,9 @@ func handleDeleteMachine(c echo.Context) error {
 	}
 
 	// Remove from live cache
-	agentsMu.Lock()
-	delete(agents, id)
-	agentsMu.Unlock()
+	s.agentsMu.Lock()
+	delete(s.agents, id)
+	s.agentsMu.Unlock()
 	machineLatencyMu.Lock()
 	delete(machineLatency, id)
 	machineLatencyMu.Unlock()
@@ -745,8 +741,8 @@ func handleHealth(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 }
 
-func upsertServices(machineID string, services []ServiceInfo) {
-	tx, err := db.Begin()
+func (s *Server) upsertServices(machineID string, services []ServiceInfo) {
+	tx, err := s.db.Begin()
 	if err != nil {
 		log.Printf("begin tx error: %v", err)
 		return
@@ -775,8 +771,8 @@ func upsertServices(machineID string, services []ServiceInfo) {
 	log.Printf("stored %d services for %s", len(services), machineID)
 }
 
-func upsertContainers(machineID string, containers []ContainerInfo) {
-	tx, err := db.Begin()
+func (s *Server) upsertContainers(machineID string, containers []ContainerInfo) {
+	tx, err := s.db.Begin()
 	if err != nil {
 		log.Printf("begin tx error: %v", err)
 		return
@@ -805,8 +801,8 @@ func upsertContainers(machineID string, containers []ContainerInfo) {
 	log.Printf("stored %d containers for %s", len(containers), machineID)
 }
 
-func upsertMachine(m AgentMetrics) {
-	_, err := db.Exec(`
+func (s *Server) upsertMachine(m AgentMetrics) {
+	_, err := s.db.Exec(`
 		INSERT INTO machines (id, hostname, ip, os, status, last_seen)
 		VALUES (?, ?, ?, ?, 'online', ?)
 		ON CONFLICT(id) DO UPDATE SET
@@ -832,7 +828,7 @@ func nullableFloat(v float64) sql.NullFloat64 {
 	return sql.NullFloat64{Float64: v, Valid: true}
 }
 
-func storeMetrics(m AgentMetrics) {
+func (s *Server) storeMetrics(m AgentMetrics) {
 	var gpuTemp, gpuUtil float64
 	var gpuVRAMUsed, gpuVRAMTotal int64
 	if len(m.GPUs) > 0 {
@@ -842,7 +838,7 @@ func storeMetrics(m AgentMetrics) {
 		gpuVRAMTotal = m.GPUs[0].MemTotalBytes
 	}
 
-	tx, err := db.Begin()
+	tx, err := s.db.Begin()
 	if err != nil {
 		log.Printf("store metrics tx error: %v", err)
 		return
@@ -892,16 +888,16 @@ func storeMetrics(m AgentMetrics) {
 // (if any) so the caller can log it — the prior call site swallowed errors,
 // which masked a SQL syntax bug for the entire lifetime of the API-machines
 // feature.
-func markAPIMachineError(machineID, hostname, adapterType string) error {
-	_, err := db.Exec(`INSERT INTO machines (id, hostname, status, tags, last_seen)
+func (s *Server) markAPIMachineError(machineID, hostname, adapterType string) error {
+	_, err := s.db.Exec(`INSERT INTO machines (id, hostname, status, tags, last_seen)
 		VALUES (?, ?, 'error', ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET status = 'error', last_seen = CURRENT_TIMESTAMP`,
 		machineID, hostname, adapterType)
 	return err
 }
 
-func markOffline(machineID string) {
-	_, err := db.Exec(`UPDATE machines SET status = 'offline' WHERE id = ?`, machineID)
+func (s *Server) markOffline(machineID string) {
+	_, err := s.db.Exec(`UPDATE machines SET status = 'offline' WHERE id = ?`, machineID)
 	if err != nil {
 		log.Printf("mark offline error: %v", err)
 	}
@@ -919,7 +915,7 @@ func broadcastSSE(data []byte) {
 	}
 }
 
-func handleSSE(c echo.Context) error {
+func (s *Server) handleSSE(c echo.Context) error {
 	c.Response().Header().Set("Content-Type", "text/event-stream")
 	c.Response().Header().Set("Cache-Control", "no-cache")
 	c.Response().Header().Set("Connection", "keep-alive")
@@ -942,13 +938,13 @@ func handleSSE(c echo.Context) error {
 	}
 
 	// Send snapshot with alert count.
-	snapshot, _ := getEnrichedMachinesJSON()
+	snapshot, _ := s.getEnrichedMachinesJSON()
 	fmt.Fprintf(c.Response(), "event: snapshot\ndata: %s\n\n", snapshot)
 	flusher.Flush()
 
 	// Send initial alert count.
 	var alertCount int
-	db.QueryRow(`SELECT COUNT(*) FROM alerts WHERE status = 'active'`).Scan(&alertCount)
+	s.db.QueryRow(`SELECT COUNT(*) FROM alerts WHERE status = 'active'`).Scan(&alertCount)
 	alertCountJSON, _ := json.Marshal(map[string]int{"count": alertCount})
 	fmt.Fprintf(c.Response(), "event: alert_count\ndata: %s\n\n", alertCountJSON)
 	flusher.Flush()
@@ -975,15 +971,15 @@ func handleSSE(c echo.Context) error {
 
 }
 
-func handleListMachines(c echo.Context) error {
-	data, err := getMachinesJSON()
+func (s *Server) handleListMachines(c echo.Context) error {
+	data, err := s.getMachinesJSON()
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 	return c.JSONBlob(http.StatusOK, data)
 }
 
-func handleGetMachine(c echo.Context) error {
+func (s *Server) handleGetMachine(c echo.Context) error {
 	id := c.Param("id")
 
 	var m struct {
@@ -997,7 +993,7 @@ func handleGetMachine(c echo.Context) error {
 		Notes        string  `json:"notes"`
 		HardwareInfo *string `json:"-"`
 	}
-	err := db.QueryRow(`SELECT id, hostname, ip, os, status, tags, last_seen, COALESCE(notes, ''), hardware_info FROM machines WHERE id = ?`, id).
+	err := s.db.QueryRow(`SELECT id, hostname, ip, os, status, tags, last_seen, COALESCE(notes, ''), hardware_info FROM machines WHERE id = ?`, id).
 		Scan(&m.ID, &m.Hostname, &m.IP, &m.OS, &m.Status, &m.Tags, &m.LastSeen, &m.Notes, &m.HardwareInfo)
 	if err == sql.ErrNoRows {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "machine not found"})
@@ -1029,7 +1025,7 @@ func handleGetMachine(c echo.Context) error {
 	// COALESCE every column because API-polled machines (and agents that
 	// haven't reported GPU yet) store NULLs here, and Scan of NULL into
 	// float64/int64 fails with a 500.
-	err = db.QueryRow(`
+	err = s.db.QueryRow(`
 		SELECT
 			COALESCE(cpu_percent, 0),
 			COALESCE(ram_used_bytes, 0),
@@ -1049,7 +1045,7 @@ func handleGetMachine(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 
-	gpus := getLatestGPUMetrics(id)
+	gpus := s.getLatestGPUMetrics(id)
 
 	// Get latency.
 	machineLatencyMu.RLock()
@@ -1065,8 +1061,8 @@ func handleGetMachine(c echo.Context) error {
 	})
 }
 
-func getLatestGPUMetrics(machineID string) []GPUInfo {
-	rows, err := db.Query(`
+func (s *Server) getLatestGPUMetrics(machineID string) []GPUInfo {
+	rows, err := s.db.Query(`
 		SELECT gpu_index, gpu_name, temp_c, util_percent, mem_used_bytes, mem_total_bytes, power_watts, fan_percent
 		FROM gpu_metrics
 		WHERE machine_id = ? AND timestamp = (
@@ -1098,9 +1094,9 @@ func getLatestGPUMetrics(machineID string) []GPUInfo {
 	return gpus
 }
 
-func handleGetServices(c echo.Context) error {
+func (s *Server) handleGetServices(c echo.Context) error {
 	id := c.Param("id")
-	rows, err := db.Query(`SELECT name, status, description FROM services WHERE machine_id = ? ORDER BY name`, id)
+	rows, err := s.db.Query(`SELECT name, status, description FROM services WHERE machine_id = ? ORDER BY name`, id)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
@@ -1120,9 +1116,9 @@ func handleGetServices(c echo.Context) error {
 	return c.JSON(http.StatusOK, services)
 }
 
-func handleGetContainers(c echo.Context) error {
+func (s *Server) handleGetContainers(c echo.Context) error {
 	id := c.Param("id")
-	rows, err := db.Query(`SELECT container_id, name, status, image FROM containers WHERE machine_id = ? ORDER BY name`, id)
+	rows, err := s.db.Query(`SELECT container_id, name, status, image FROM containers WHERE machine_id = ? ORDER BY name`, id)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
@@ -1142,12 +1138,12 @@ func handleGetContainers(c echo.Context) error {
 	return c.JSON(http.StatusOK, containers)
 }
 
-func handleCommand(c echo.Context) error {
+func (s *Server) handleCommand(c echo.Context) error {
 	machineID := c.Param("id")
 
-	agentsMu.RLock()
-	agent, ok := agents[machineID]
-	agentsMu.RUnlock()
+	s.agentsMu.RLock()
+	agent, ok := s.agents[machineID]
+	s.agentsMu.RUnlock()
 	if !ok {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "agent not connected"})
 	}
@@ -1194,11 +1190,11 @@ func handleCommand(c echo.Context) error {
 	}
 }
 
-func getEnrichedMachinesJSON() ([]byte, error) {
+func (s *Server) getEnrichedMachinesJSON() ([]byte, error) {
 	// Bulk-fetch services for all machines (avoids 1+N per-machine queries).
 	servicesByMachine := map[string][]ServiceInfo{}
 	{
-		svcRows, err := db.Query(`SELECT machine_id, name, status, description FROM services ORDER BY machine_id, name`)
+		svcRows, err := s.db.Query(`SELECT machine_id, name, status, description FROM services ORDER BY machine_id, name`)
 		if err == nil {
 			for svcRows.Next() {
 				var machineID string
@@ -1214,7 +1210,7 @@ func getEnrichedMachinesJSON() ([]byte, error) {
 	// Bulk-fetch containers for all machines (avoids 1+N per-machine queries).
 	containersByMachine := map[string][]ContainerInfo{}
 	{
-		ctRows, err := db.Query(`SELECT machine_id, container_id, name, status, image FROM containers ORDER BY machine_id, name`)
+		ctRows, err := s.db.Query(`SELECT machine_id, container_id, name, status, image FROM containers ORDER BY machine_id, name`)
 		if err == nil {
 			for ctRows.Next() {
 				var machineID string
@@ -1231,7 +1227,7 @@ func getEnrichedMachinesJSON() ([]byte, error) {
 	// pattern as the metrics JOIN above (avoids 1+N per-machine queries).
 	gpusByMachine := map[string][]GPUInfo{}
 	{
-		gpuRows, err := db.Query(`
+		gpuRows, err := s.db.Query(`
 			SELECT machine_id, gpu_index, gpu_name, temp_c, util_percent,
 				mem_used_bytes, mem_total_bytes, power_watts, fan_percent
 			FROM (
@@ -1259,7 +1255,7 @@ func getEnrichedMachinesJSON() ([]byte, error) {
 		}
 	}
 
-	rows, err := db.Query(`
+	rows, err := s.db.Query(`
 		SELECT m.id, m.hostname, m.ip, m.os, m.status, m.last_seen, COALESCE(m.tags, ''),
 			COALESCE(met.cpu_percent, 0),
 			COALESCE(met.ram_used_bytes, 0), COALESCE(met.ram_total_bytes, 0),
@@ -1345,8 +1341,8 @@ func getEnrichedMachinesJSON() ([]byte, error) {
 	return json.Marshal(machines)
 }
 
-func getServicesForMachine(machineID string) []ServiceInfo {
-	rows, err := db.Query(`SELECT name, status, description FROM services WHERE machine_id = ? ORDER BY name`, machineID)
+func (s *Server) getServicesForMachine(machineID string) []ServiceInfo {
+	rows, err := s.db.Query(`SELECT name, status, description FROM services WHERE machine_id = ? ORDER BY name`, machineID)
 	if err != nil {
 		return []ServiceInfo{}
 	}
@@ -1365,8 +1361,8 @@ func getServicesForMachine(machineID string) []ServiceInfo {
 	return services
 }
 
-func getContainersForMachine(machineID string) []ContainerInfo {
-	rows, err := db.Query(`SELECT container_id, name, status, image FROM containers WHERE machine_id = ? ORDER BY name`, machineID)
+func (s *Server) getContainersForMachine(machineID string) []ContainerInfo {
+	rows, err := s.db.Query(`SELECT container_id, name, status, image FROM containers WHERE machine_id = ? ORDER BY name`, machineID)
 	if err != nil {
 		return []ContainerInfo{}
 	}
@@ -1385,8 +1381,8 @@ func getContainersForMachine(machineID string) []ContainerInfo {
 	return containers
 }
 
-func getMachinesJSON() ([]byte, error) {
-	rows, err := db.Query(`SELECT id, hostname, ip, os, status, COALESCE(tags, ''), last_seen, created_at FROM machines ORDER BY hostname`)
+func (s *Server) getMachinesJSON() ([]byte, error) {
+	rows, err := s.db.Query(`SELECT id, hostname, ip, os, status, COALESCE(tags, ''), last_seen, created_at FROM machines ORDER BY hostname`)
 	if err != nil {
 		return nil, err
 	}
@@ -2147,8 +2143,8 @@ func validateAPIAuthConfig(adapterType string, authConfig json.RawMessage) error
 
 // --- API Machine Handlers ---
 
-func handleListAPIMachines(c echo.Context) error {
-	rows, err := db.Query(`SELECT id, name, adapter_type, base_url, auth_config, tls_config, poll_interval_secs, enabled, last_poll_at, last_error, created_at FROM api_machines ORDER BY name`)
+func (s *Server) handleListAPIMachines(c echo.Context) error {
+	rows, err := s.db.Query(`SELECT id, name, adapter_type, base_url, auth_config, tls_config, poll_interval_secs, enabled, last_poll_at, last_error, created_at FROM api_machines ORDER BY name`)
 	if err != nil {
 		log.Printf("api machines: list query error: %v", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
@@ -2174,7 +2170,7 @@ func handleListAPIMachines(c echo.Context) error {
 	return c.JSON(http.StatusOK, machines)
 }
 
-func handleCreateAPIMachine(c echo.Context) error {
+func (s *Server) handleCreateAPIMachine(c echo.Context) error {
 	ip := getRealIP(c)
 	if !rateLimiter.Allow("api-machines-create", ip, 3) {
 		return c.JSON(http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
@@ -2220,7 +2216,7 @@ func handleCreateAPIMachine(c echo.Context) error {
 
 	// Enforce max API machines limit
 	var machineCount int
-	if err := db.QueryRow("SELECT COUNT(*) FROM api_machines").Scan(&machineCount); err != nil {
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM api_machines").Scan(&machineCount); err != nil {
 		log.Printf("api machines: count query error: %v", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
 	}
@@ -2234,7 +2230,7 @@ func handleCreateAPIMachine(c echo.Context) error {
 		log.Printf("api machines: tls config marshal error: %v", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
 	}
-	_, err = db.Exec(`INSERT INTO api_machines (id, name, adapter_type, base_url, auth_config, tls_config, poll_interval_secs) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	_, err = s.db.Exec(`INSERT INTO api_machines (id, name, adapter_type, base_url, auth_config, tls_config, poll_interval_secs) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		id, body.Name, body.AdapterType, body.BaseURL, string(body.AuthConfig), storedTLSCfg, body.PollIntervalSecs)
 	if err != nil {
 		log.Printf("api machines: create insert error: %v", err)
@@ -2244,7 +2240,7 @@ func handleCreateAPIMachine(c echo.Context) error {
 	log.Printf("api machine created: %s (%s, %s)", body.Name, body.AdapterType, id)
 
 	// Start poller for the new machine.
-	startAPIPoller(id, body.Name, body.AdapterType, body.BaseURL, body.AuthConfig, json.RawMessage(storedTLSCfg), body.PollIntervalSecs)
+	s.startAPIPoller(id, body.Name, body.AdapterType, body.BaseURL, body.AuthConfig, json.RawMessage(storedTLSCfg), body.PollIntervalSecs)
 
 	return c.JSON(http.StatusCreated, map[string]interface{}{
 		"id":                 id,
@@ -2256,7 +2252,7 @@ func handleCreateAPIMachine(c echo.Context) error {
 	})
 }
 
-func handleUpdateAPIMachine(c echo.Context) error {
+func (s *Server) handleUpdateAPIMachine(c echo.Context) error {
 	id := c.Param("id")
 
 	var current struct {
@@ -2267,7 +2263,7 @@ func handleUpdateAPIMachine(c echo.Context) error {
 		TLSConfig        string
 		PollIntervalSecs int
 	}
-	err := db.QueryRow(`SELECT name, adapter_type, base_url, auth_config, tls_config, poll_interval_secs
+	err := s.db.QueryRow(`SELECT name, adapter_type, base_url, auth_config, tls_config, poll_interval_secs
 		FROM api_machines WHERE id = ?`, id).
 		Scan(&current.Name, &current.AdapterType, &current.BaseURL, &current.AuthConfig, &current.TLSConfig, &current.PollIntervalSecs)
 	if err != nil {
@@ -2350,7 +2346,7 @@ func handleUpdateAPIMachine(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
 	}
 
-	_, err = db.Exec(`UPDATE api_machines
+	_, err = s.db.Exec(`UPDATE api_machines
 		SET name = ?, adapter_type = ?, base_url = ?, auth_config = ?, tls_config = ?, poll_interval_secs = ?
 		WHERE id = ?`,
 		name, adapterType, baseURL, string(authConfig), storedTLSCfg, pollIntervalSecs, id)
@@ -2359,7 +2355,7 @@ func handleUpdateAPIMachine(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
 	}
 
-	startAPIPoller(id, name, adapterType, baseURL, authConfig, json.RawMessage(storedTLSCfg), pollIntervalSecs)
+	s.startAPIPoller(id, name, adapterType, baseURL, authConfig, json.RawMessage(storedTLSCfg), pollIntervalSecs)
 
 	log.Printf("api machine updated: %s (%s, %s)", name, adapterType, id)
 	return c.JSON(http.StatusOK, map[string]interface{}{
@@ -2372,11 +2368,11 @@ func handleUpdateAPIMachine(c echo.Context) error {
 	})
 }
 
-func handleDeleteAPIMachine(c echo.Context) error {
+func (s *Server) handleDeleteAPIMachine(c echo.Context) error {
 	id := c.Param("id")
 
 	var name string
-	err := db.QueryRow("SELECT name FROM api_machines WHERE id = ?", id).Scan(&name)
+	err := s.db.QueryRow("SELECT name FROM api_machines WHERE id = ?", id).Scan(&name)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "api machine not found"})
 	}
@@ -2385,14 +2381,14 @@ func handleDeleteAPIMachine(c echo.Context) error {
 	stopAPIPoller(id)
 
 	// Delete api_machine row.
-	if _, err := db.Exec("DELETE FROM api_machines WHERE id = ?", id); err != nil {
+	if _, err := s.db.Exec("DELETE FROM api_machines WHERE id = ?", id); err != nil {
 		log.Printf("api machines: delete error: %v", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal error"})
 	}
 
 	// Delete associated machine and metrics.
 	machineID := "api-" + id
-	tx, err := db.Begin()
+	tx, err := s.db.Begin()
 	if err == nil {
 		// Note: table names are hardcoded constants, not user input — safe from SQL injection
 		for _, table := range []string{"metrics", "gpu_metrics", "services", "containers", "alerts"} {
@@ -2406,7 +2402,7 @@ func handleDeleteAPIMachine(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"status": "deleted", "name": name})
 }
 
-func handleForceAPIPoll(c echo.Context) error {
+func (s *Server) handleForceAPIPoll(c echo.Context) error {
 	id := c.Param("id")
 
 	var m struct {
@@ -2416,7 +2412,7 @@ func handleForceAPIPoll(c echo.Context) error {
 		AuthConfig  string `json:"auth_config"`
 		TLSConfig   string `json:"tls_config"`
 	}
-	err := db.QueryRow("SELECT name, adapter_type, base_url, auth_config, tls_config FROM api_machines WHERE id = ?", id).
+	err := s.db.QueryRow("SELECT name, adapter_type, base_url, auth_config, tls_config FROM api_machines WHERE id = ?", id).
 		Scan(&m.Name, &m.AdapterType, &m.BaseURL, &m.AuthConfig, &m.TLSConfig)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "api machine not found"})
@@ -2428,12 +2424,12 @@ func handleForceAPIPoll(c echo.Context) error {
 		// the dashboard so upstream/network detail from a poll target isn't
 		// reflected to the client.
 		log.Printf("api machine %s (%s) poll failed: %v", id, m.Name, pollErr)
-		db.Exec("UPDATE api_machines SET last_error = ?, last_poll_at = CURRENT_TIMESTAMP WHERE id = ?", "poll failed", id)
+		s.db.Exec("UPDATE api_machines SET last_error = ?, last_poll_at = CURRENT_TIMESTAMP WHERE id = ?", "poll failed", id)
 		return c.JSON(http.StatusBadGateway, map[string]string{"error": "poll failed"})
 	}
 
-	storeAPIPollResult(id, m.Name, m.AdapterType, m.BaseURL, result)
-	db.Exec("UPDATE api_machines SET last_poll_at = CURRENT_TIMESTAMP, last_error = NULL WHERE id = ?", id)
+	s.storeAPIPollResult(id, m.Name, m.AdapterType, m.BaseURL, result)
+	s.db.Exec("UPDATE api_machines SET last_poll_at = CURRENT_TIMESTAMP, last_error = NULL WHERE id = ?", id)
 
 	return c.JSON(http.StatusOK, map[string]interface{}{
 		"hostname":    result.Hostname,
@@ -2490,7 +2486,7 @@ func extractAPIMachineIP(baseURL, resultIP string) string {
 }
 
 // storeAPIPollResult upserts the machine and inserts metrics.
-func storeAPIPollResult(apiMachineID, name, adapterType, baseURL string, result *APIPollResult) {
+func (s *Server) storeAPIPollResult(apiMachineID, name, adapterType, baseURL string, result *APIPollResult) {
 	machineID := "api-" + apiMachineID
 	hostname := result.Hostname
 	if hostname == "" {
@@ -2500,7 +2496,7 @@ func storeAPIPollResult(apiMachineID, name, adapterType, baseURL string, result 
 	ip := extractAPIMachineIP(baseURL, result.IP)
 
 	// Upsert machine.
-	_, err := db.Exec(`INSERT INTO machines (id, hostname, ip, os, status, tags, last_seen)
+	_, err := s.db.Exec(`INSERT INTO machines (id, hostname, ip, os, status, tags, last_seen)
 		VALUES (?, ?, ?, ?, 'online', ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
 			hostname = excluded.hostname,
@@ -2515,7 +2511,7 @@ func storeAPIPollResult(apiMachineID, name, adapterType, baseURL string, result 
 	}
 
 	// Insert metrics.
-	_, err = db.Exec(`INSERT INTO metrics (machine_id, cpu_percent, ram_used_bytes, ram_total_bytes, disk_used_bytes, disk_total_bytes)
+	_, err = s.db.Exec(`INSERT INTO metrics (machine_id, cpu_percent, ram_used_bytes, ram_total_bytes, disk_used_bytes, disk_total_bytes)
 		VALUES (?, ?, ?, ?, ?, ?)`,
 		machineID, result.CPUPercent, result.RAMUsed, result.RAMTotal, result.DiskUsed, result.DiskTotal)
 	if err != nil {
@@ -2525,14 +2521,14 @@ func storeAPIPollResult(apiMachineID, name, adapterType, baseURL string, result 
 	// Update services.
 	if len(result.Services) > 0 {
 		for _, svc := range result.Services {
-			db.Exec(`INSERT OR REPLACE INTO services (machine_id, name, status, description, updated_at)
+			s.db.Exec(`INSERT OR REPLACE INTO services (machine_id, name, status, description, updated_at)
 				VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)`, machineID, svc.Name, svc.Status, svc.Description)
 		}
 	}
 
 	// Update containers atomically via the shared upsertContainers helper.
 	if len(result.Containers) > 0 {
-		upsertContainers(machineID, result.Containers)
+		s.upsertContainers(machineID, result.Containers)
 	}
 
 	log.Printf("api poll: %s (%s) cpu=%.1f%% ram=%d/%dMB",
@@ -2541,7 +2537,7 @@ func storeAPIPollResult(apiMachineID, name, adapterType, baseURL string, result 
 		result.RAMUsed/1024/1024, result.RAMTotal/1024/1024)
 
 	// Broadcast SSE update.
-	data, _ := getMachinesJSON()
+	data, _ := s.getMachinesJSON()
 	sseMsg, _ := json.Marshal(map[string]interface{}{
 		"type": "machines",
 		"data": json.RawMessage(data),
@@ -2551,8 +2547,8 @@ func storeAPIPollResult(apiMachineID, name, adapterType, baseURL string, result 
 
 // --- Background Poller ---
 
-func startAPIPollers() {
-	rows, err := db.Query("SELECT id, name, adapter_type, base_url, auth_config, tls_config, poll_interval_secs FROM api_machines WHERE enabled = TRUE")
+func (s *Server) startAPIPollers() {
+	rows, err := s.db.Query("SELECT id, name, adapter_type, base_url, auth_config, tls_config, poll_interval_secs FROM api_machines WHERE enabled = TRUE")
 	if err != nil {
 		log.Printf("failed to load api_machines: %v", err)
 		return
@@ -2567,7 +2563,7 @@ func startAPIPollers() {
 			log.Printf("failed to scan api_machine: %v", err)
 			continue
 		}
-		startAPIPoller(id, name, adapterType, baseURL, json.RawMessage(authConfig), json.RawMessage(tlsConfig), pollInterval)
+		s.startAPIPoller(id, name, adapterType, baseURL, json.RawMessage(authConfig), json.RawMessage(tlsConfig), pollInterval)
 		count++
 	}
 	if count > 0 {
@@ -2575,7 +2571,7 @@ func startAPIPollers() {
 	}
 }
 
-func startAPIPoller(id, name, adapterType, baseURL string, authConfig json.RawMessage, tlsConfig json.RawMessage, intervalSecs int) {
+func (s *Server) startAPIPoller(id, name, adapterType, baseURL string, authConfig json.RawMessage, tlsConfig json.RawMessage, intervalSecs int) {
 	apiPollersMu.Lock()
 	defer apiPollersMu.Unlock()
 
@@ -2601,13 +2597,13 @@ func startAPIPoller(id, name, adapterType, baseURL string, authConfig json.RawMe
 			result, err := doPoll(adapterType, baseURL, authConfig, tlsConfig)
 			if err != nil {
 				log.Printf("api poll error: %s (%s): %v", name, adapterType, err)
-				db.Exec("UPDATE api_machines SET last_error = ?, last_poll_at = CURRENT_TIMESTAMP WHERE id = ?", err.Error(), id)
-				if mErr := markAPIMachineError("api-"+id, name, adapterType); mErr != nil {
+				s.db.Exec("UPDATE api_machines SET last_error = ?, last_poll_at = CURRENT_TIMESTAMP WHERE id = ?", err.Error(), id)
+				if mErr := s.markAPIMachineError("api-"+id, name, adapterType); mErr != nil {
 					log.Printf("api poll: error-status upsert failed for %s: %v", name, mErr)
 				}
 			} else {
-				storeAPIPollResult(id, name, adapterType, baseURL, result)
-				db.Exec("UPDATE api_machines SET last_poll_at = CURRENT_TIMESTAMP, last_error = NULL WHERE id = ?", id)
+				s.storeAPIPollResult(id, name, adapterType, baseURL, result)
+				s.db.Exec("UPDATE api_machines SET last_poll_at = CURRENT_TIMESTAMP, last_error = NULL WHERE id = ?", id)
 			}
 
 			select {

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -31,7 +31,7 @@ import (
 
 // seedTestAdmin creates a test admin user directly in the DB (bypasses setup flow).
 // Uses the legacy default credentials (admin/bloxos, PIN 1234) for test compatibility.
-func seedTestAdmin(t *testing.T) {
+func (s *Server) seedTestAdmin(t *testing.T) {
 	t.Helper()
 	hash, err := bcrypt.GenerateFromPassword([]byte("bloxos"), bcrypt.DefaultCost)
 	if err != nil {
@@ -42,14 +42,14 @@ func seedTestAdmin(t *testing.T) {
 		t.Fatalf("hash pin: %v", err)
 	}
 	id := "test-admin-id"
-	_, err = db.Exec(`INSERT INTO users (id, username, password_hash, terminal_pin_hash) VALUES (?, ?, ?, ?)`,
+	_, err = s.db.Exec(`INSERT INTO users (id, username, password_hash, terminal_pin_hash) VALUES (?, ?, ?, ?)`,
 		id, "admin", string(hash), string(pinHash))
 	if err != nil {
 		t.Fatalf("seed test admin: %v", err)
 	}
 }
 
-func seedTestUser(t *testing.T, username, password, pin string, role UserRole, passwordChanged, pinChanged bool) string {
+func (s *Server) seedTestUser(t *testing.T, username, password, pin string, role UserRole, passwordChanged, pinChanged bool) string {
 	t.Helper()
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
@@ -60,7 +60,7 @@ func seedTestUser(t *testing.T, username, password, pin string, role UserRole, p
 		t.Fatalf("hash pin: %v", err)
 	}
 	id := "test-user-" + username
-	_, err = db.Exec(
+	_, err = s.db.Exec(
 		`INSERT INTO users (id, username, password_hash, terminal_pin_hash, password_changed, pin_changed, role) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		id, username, string(hash), string(pinHash), passwordChanged, pinChanged, role,
 	)
@@ -70,9 +70,9 @@ func seedTestUser(t *testing.T, username, password, pin string, role UserRole, p
 	return id
 }
 
-func seedTestMachine(t *testing.T, id string) {
+func (s *Server) seedTestMachine(t *testing.T, id string) {
 	t.Helper()
-	_, err := db.Exec(`INSERT INTO machines (id, hostname, status) VALUES (?, ?, 'online')`, id, "machine-"+id)
+	_, err := s.db.Exec(`INSERT INTO machines (id, hostname, status) VALUES (?, ?, 'online')`, id, "machine-"+id)
 	if err != nil {
 		t.Fatalf("seed test machine: %v", err)
 	}
@@ -105,8 +105,9 @@ func generateTestCertPEM(t *testing.T) string {
 
 // setupTestServer creates a fresh in-memory DB, seeds a test admin user,
 // sets a deterministic JWT secret, resets the rate limiter, and returns
-// an Echo instance with all routes registered.
-func setupTestServer(t *testing.T) *echo.Echo {
+// an Echo instance with all routes registered plus the isolated *Server
+// backing it.
+func setupTestServer(t *testing.T) (*echo.Echo, *Server) {
 	t.Helper()
 
 	// Default the homelab opt-in to ON for the test suite. Bloxos is a
@@ -123,17 +124,13 @@ func setupTestServer(t *testing.T) *echo.Echo {
 	ensureTestUpdateSigningKey(t)
 
 	// Drain stale goroutines from prior tests that may still reference
-	// the old db via the global agents map or markOffline calls.
-	agentsMu.Lock()
-	agents = make(map[string]*ConnectedAgent)
-	agentsMu.Unlock()
+	// the global terminal session map.
 	termSessionsMu.Lock()
 	termSessions = make(map[string]*TerminalSession)
 	termSessionsMu.Unlock()
 	time.Sleep(100 * time.Millisecond)
 
-	var err error
-	db, err = sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("open in-memory db: %v", err)
 	}
@@ -156,31 +153,28 @@ func setupTestServer(t *testing.T) *echo.Echo {
 		t.Fatalf("run migrations: %v", err)
 	}
 
-	seedTestAdmin(t)
+	s := newServer(db)
+	s.seedTestAdmin(t)
 	jwtSecret = []byte("test-secret-key-for-smoke-tests")
 	rateLimiter = NewRateLimiter()
 
 	e := echo.New()
 	e.HideBanner = true
-	registerRoutes(e)
+	s.registerRoutes(e)
 
-	return e
+	return e, s
 }
 
 // setupEmptyTestServer creates a server with NO users (for testing setup flow).
-func setupEmptyTestServer(t *testing.T) *echo.Echo {
+func setupEmptyTestServer(t *testing.T) (*echo.Echo, *Server) {
 	t.Helper()
 
-	agentsMu.Lock()
-	agents = make(map[string]*ConnectedAgent)
-	agentsMu.Unlock()
 	termSessionsMu.Lock()
 	termSessions = make(map[string]*TerminalSession)
 	termSessionsMu.Unlock()
 	time.Sleep(100 * time.Millisecond)
 
-	var err error
-	db, err = sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("open in-memory db: %v", err)
 	}
@@ -207,11 +201,13 @@ func setupEmptyTestServer(t *testing.T) *echo.Echo {
 	rateLimiter = NewRateLimiter()
 	setupTokenValue = "test-setup-token-abc123"
 
+	s := newServer(db)
+
 	e := echo.New()
 	e.HideBanner = true
-	registerRoutes(e)
+	s.registerRoutes(e)
 
-	return e
+	return e, s
 }
 
 // loginAndGetToken performs a login with the default admin credentials and
@@ -248,17 +244,17 @@ func loginAndGetTokenForCredentials(t *testing.T, e *echo.Echo, username, passwo
 
 // markCredentialsRotated sets password_changed and pin_changed to TRUE for the
 // default admin so that existing tests pass through the rotation middleware.
-func markCredentialsRotated(t *testing.T) {
+func (s *Server) markCredentialsRotated(t *testing.T) {
 	t.Helper()
-	_, err := db.Exec(`UPDATE users SET password_changed = TRUE, pin_changed = TRUE WHERE username = 'admin'`)
+	_, err := s.db.Exec(`UPDATE users SET password_changed = TRUE, pin_changed = TRUE WHERE username = 'admin'`)
 	if err != nil {
 		t.Fatalf("mark credentials rotated: %v", err)
 	}
 }
 
 func TestAdminCanCreateAndListUsers(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	adminToken := loginAndGetToken(t, e)
 
 	createBody := `{"username":"alice","password":"alicepass123","pin":"1234","role":"operator"}`
@@ -300,8 +296,8 @@ func TestAdminCanCreateAndListUsers(t *testing.T) {
 }
 
 func TestCreateUserRejectsDuplicateUsername(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	adminToken := loginAndGetToken(t, e)
 
 	body := `{"username":"admin","password":"anotherpass123","pin":"1234","role":"viewer"}`
@@ -317,8 +313,8 @@ func TestCreateUserRejectsDuplicateUsername(t *testing.T) {
 }
 
 func TestCreateUserRejectsInvalidRole(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	adminToken := loginAndGetToken(t, e)
 
 	body := `{"username":"bob","password":"bobpass123","pin":"1234","role":"superuser"}`
@@ -334,9 +330,9 @@ func TestCreateUserRejectsInvalidRole(t *testing.T) {
 }
 
 func TestOperatorCannotManageUsers(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
-	seedTestUser(t, "op1", "operatorpass123", "1234", RoleOperator, true, true)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	s.seedTestUser(t, "op1", "operatorpass123", "1234", RoleOperator, true, true)
 	opToken := loginAndGetTokenForCredentials(t, e, "op1", "operatorpass123")
 
 	body := `{"username":"charlie","password":"charliepass123","pin":"1234","role":"viewer"}`
@@ -352,10 +348,10 @@ func TestOperatorCannotManageUsers(t *testing.T) {
 }
 
 func TestAdminCanPromoteAndDemoteOthers(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
-	seedTestUser(t, "admin2", "admin2pass123", "1234", RoleAdmin, true, true)
-	targetID := seedTestUser(t, "target", "targetpass123", "1234", RoleViewer, true, true)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	s.seedTestUser(t, "admin2", "admin2pass123", "1234", RoleAdmin, true, true)
+	targetID := s.seedTestUser(t, "target", "targetpass123", "1234", RoleViewer, true, true)
 	adminToken := loginAndGetToken(t, e)
 
 	body := `{"role":"operator"}`
@@ -369,7 +365,7 @@ func TestAdminCanPromoteAndDemoteOthers(t *testing.T) {
 		t.Fatalf("expected 200 on role patch, got %d: %s", rec.Code, rec.Body.String())
 	}
 	var role string
-	if err := db.QueryRow(`SELECT role FROM users WHERE id = ?`, targetID).Scan(&role); err != nil {
+	if err := s.db.QueryRow(`SELECT role FROM users WHERE id = ?`, targetID).Scan(&role); err != nil {
 		t.Fatalf("fetch target role: %v", err)
 	}
 	if role != string(RoleOperator) {
@@ -378,9 +374,9 @@ func TestAdminCanPromoteAndDemoteOthers(t *testing.T) {
 }
 
 func TestAdminCannotChangeOwnRole(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
-	seedTestUser(t, "admin2", "admin2pass123", "1234", RoleAdmin, true, true)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	s.seedTestUser(t, "admin2", "admin2pass123", "1234", RoleAdmin, true, true)
 	adminToken := loginAndGetToken(t, e)
 
 	body := `{"role":"operator"}`
@@ -396,9 +392,9 @@ func TestAdminCannotChangeOwnRole(t *testing.T) {
 }
 
 func TestAdminCanDemoteAnotherAdmin(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
-	otherID := seedTestUser(t, "other", "otherpass123", "1234", RoleAdmin, true, true)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	otherID := s.seedTestUser(t, "other", "otherpass123", "1234", RoleAdmin, true, true)
 	adminToken := loginAndGetToken(t, e)
 
 	body := `{"role":"operator"}`
@@ -411,7 +407,7 @@ func TestAdminCanDemoteAnotherAdmin(t *testing.T) {
 		t.Fatalf("expected demote of other admin to succeed, got %d: %s", rec.Code, rec.Body.String())
 	}
 	var role string
-	if err := db.QueryRow(`SELECT role FROM users WHERE id = ?`, otherID).Scan(&role); err != nil {
+	if err := s.db.QueryRow(`SELECT role FROM users WHERE id = ?`, otherID).Scan(&role); err != nil {
 		t.Fatalf("fetch role: %v", err)
 	}
 	if role != string(RoleOperator) {
@@ -420,9 +416,9 @@ func TestAdminCanDemoteAnotherAdmin(t *testing.T) {
 }
 
 func TestAdminCanDeleteOtherUser(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
-	targetID := seedTestUser(t, "victim", "victimpass123", "1234", RoleViewer, true, true)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	targetID := s.seedTestUser(t, "victim", "victimpass123", "1234", RoleViewer, true, true)
 	adminToken := loginAndGetToken(t, e)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/users/"+targetID, nil)
@@ -434,7 +430,7 @@ func TestAdminCanDeleteOtherUser(t *testing.T) {
 		t.Fatalf("expected 200 on delete, got %d: %s", rec.Code, rec.Body.String())
 	}
 	var count int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM users WHERE id = ?`, targetID).Scan(&count); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM users WHERE id = ?`, targetID).Scan(&count); err != nil {
 		t.Fatalf("count: %v", err)
 	}
 	if count != 0 {
@@ -443,8 +439,8 @@ func TestAdminCanDeleteOtherUser(t *testing.T) {
 }
 
 func TestAdminCannotDeleteSelf(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	adminToken := loginAndGetToken(t, e)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/users/test-admin-id", nil)
@@ -458,9 +454,9 @@ func TestAdminCannotDeleteSelf(t *testing.T) {
 }
 
 func TestAdminCanDeleteAnotherAdmin(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
-	otherID := seedTestUser(t, "other", "otherpass123", "1234", RoleAdmin, true, true)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	otherID := s.seedTestUser(t, "other", "otherpass123", "1234", RoleAdmin, true, true)
 	adminToken := loginAndGetToken(t, e)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/users/"+otherID, nil)
@@ -473,9 +469,10 @@ func TestAdminCanDeleteAnotherAdmin(t *testing.T) {
 }
 
 func TestRBACRouteAuditPassesForProductionRoutes(t *testing.T) {
+	s := newServer(nil)
 	e := echo.New()
 	e.HideBanner = true
-	registerRoutes(e)
+	s.registerRoutes(e)
 
 	if err := auditRBACRouteCoverage(e, routeScopeRequirements); err != nil {
 		t.Fatalf("production route set failed RBAC audit: %v", err)
@@ -483,11 +480,12 @@ func TestRBACRouteAuditPassesForProductionRoutes(t *testing.T) {
 }
 
 func TestRBACRouteAuditDetectsMissingMapping(t *testing.T) {
+	s := newServer(nil)
 	e := echo.New()
 	e.HideBanner = true
-	registerRoutes(e)
+	s.registerRoutes(e)
 	// Add an extra protected route that has no scope mapping.
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware, permissionMiddleware)
+	api := e.Group("", jwtMiddleware, s.credentialRotationMiddleware, s.permissionMiddleware)
 	api.GET("/api/ghost", func(c echo.Context) error { return nil })
 
 	err := auditRBACRouteCoverage(e, routeScopeRequirements)
@@ -500,9 +498,10 @@ func TestRBACRouteAuditDetectsMissingMapping(t *testing.T) {
 }
 
 func TestRBACRouteAuditDetectsOrphanMapping(t *testing.T) {
+	s := newServer(nil)
 	e := echo.New()
 	e.HideBanner = true
-	registerRoutes(e)
+	s.registerRoutes(e)
 
 	// Clone production requirements and add an entry for a route that isn't registered.
 	requirements := make(map[string]string, len(routeScopeRequirements)+1)
@@ -521,9 +520,9 @@ func TestRBACRouteAuditDetectsOrphanMapping(t *testing.T) {
 }
 
 func TestLoginIncludesRoleAndScopes(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
-	seedTestUser(t, "viewer1", "viewerpass123", "1234", RoleViewer, true, true)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	s.seedTestUser(t, "viewer1", "viewerpass123", "1234", RoleViewer, true, true)
 
 	body := `{"username":"viewer1","password":"viewerpass123"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(body))
@@ -554,9 +553,9 @@ func TestLoginIncludesRoleAndScopes(t *testing.T) {
 }
 
 func TestViewerCanReadMachinesButCannotCreateInstallToken(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
-	seedTestUser(t, "viewer2", "viewerpass123", "1234", RoleViewer, true, true)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	s.seedTestUser(t, "viewer2", "viewerpass123", "1234", RoleViewer, true, true)
 	viewerToken := loginAndGetTokenForCredentials(t, e, "viewer2", "viewerpass123")
 
 	readReq := httptest.NewRequest(http.MethodGet, "/api/machines", nil)
@@ -582,10 +581,10 @@ func TestViewerCanReadMachinesButCannotCreateInstallToken(t *testing.T) {
 }
 
 func TestOperatorCanUpdateTagsButCannotDeleteMachine(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
-	seedTestUser(t, "operator1", "operatorpass123", "1234", RoleOperator, true, true)
-	seedTestMachine(t, "machine-1")
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	s.seedTestUser(t, "operator1", "operatorpass123", "1234", RoleOperator, true, true)
+	s.seedTestMachine(t, "machine-1")
 	operatorToken := loginAndGetTokenForCredentials(t, e, "operator1", "operatorpass123")
 
 	updateReq := httptest.NewRequest(http.MethodPut, "/api/machines/machine-1/tags", strings.NewReader(`{"tags":["gpu","lab"]}`))
@@ -612,12 +611,12 @@ func TestOperatorCanUpdateTagsButCannotDeleteMachine(t *testing.T) {
 }
 
 func TestDeleteMachineRemovesAgentCredential(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
-	seedTestMachine(t, "machine-delete-credential")
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	s.seedTestMachine(t, "machine-delete-credential")
 	adminToken := loginAndGetToken(t, e)
 
-	if _, err := db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`,
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`,
 		"machine-delete-credential", "test-secret-hash"); err != nil {
 		t.Fatalf("seed agent credential: %v", err)
 	}
@@ -632,7 +631,7 @@ func TestDeleteMachineRemovesAgentCredential(t *testing.T) {
 	}
 
 	var count int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, "machine-delete-credential").Scan(&count); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, "machine-delete-credential").Scan(&count); err != nil {
 		t.Fatalf("query agent credential count: %v", err)
 	}
 	if count != 0 {
@@ -644,7 +643,7 @@ func TestDeleteMachineRemovesAgentCredential(t *testing.T) {
 
 // 1. Login with valid credentials -> 200 + JWT
 func TestLoginValidCredentials(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	body := `{"username":"admin","password":"bloxos"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(body))
@@ -673,7 +672,7 @@ func TestLoginValidCredentials(t *testing.T) {
 
 // 2. Login with invalid credentials -> 401
 func TestLoginInvalidCredentials(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	body := `{"username":"admin","password":"wrongpassword"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(body))
@@ -688,7 +687,7 @@ func TestLoginInvalidCredentials(t *testing.T) {
 
 // 2b. Login with nonexistent username -> 401
 func TestLoginInvalidUsername(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	body := `{"username":"nonexistent","password":"bloxos"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(body))
@@ -703,7 +702,7 @@ func TestLoginInvalidUsername(t *testing.T) {
 
 // 3. Login rate limiting -> 6th attempt -> 429
 func TestLoginRateLimiting(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	body := `{"username":"admin","password":"wrongpassword"}`
 
@@ -726,7 +725,7 @@ func TestLoginRateLimiting(t *testing.T) {
 
 // 4. Password change with valid JWT -> 200
 func TestChangePasswordWithValidJWT(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 	token := loginAndGetToken(t, e)
 
 	body := `{"current_password":"bloxos","new_password":"newpassword123"}`
@@ -763,7 +762,7 @@ func TestChangePasswordWithValidJWT(t *testing.T) {
 
 // 5. PIN change with valid JWT -> 200
 func TestChangePINWithValidJWT(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 	token := loginAndGetToken(t, e)
 
 	// Default PIN is "1234" - change it.
@@ -781,9 +780,9 @@ func TestChangePINWithValidJWT(t *testing.T) {
 
 // 6. Token creation (install token) with valid JWT -> 200 + token returned
 func TestCreateTokenWithValidJWT(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	token := loginAndGetToken(t, e)
-	markCredentialsRotated(t)
+	s.markCredentialsRotated(t)
 	// Install-command generation now requires PUBLIC_URL (Host-header fallback
 	// removed) — set it so the happy path still yields a command.
 	t.Setenv("PUBLIC_URL", "https://hub.example")
@@ -813,9 +812,9 @@ func TestCreateTokenWithValidJWT(t *testing.T) {
 }
 
 func TestCreateTokenIncludesCABootstrapForHTTPS(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	token := loginAndGetToken(t, e)
-	markCredentialsRotated(t)
+	s.markCredentialsRotated(t)
 
 	caDir := t.TempDir()
 	caPath := filepath.Join(caDir, "root.crt")
@@ -860,7 +859,7 @@ func TestCreateTokenIncludesCABootstrapForHTTPS(t *testing.T) {
 }
 
 func TestDownloadCACert(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	caDir := t.TempDir()
 	caPath := filepath.Join(caDir, "root.crt")
@@ -884,20 +883,20 @@ func TestDownloadCACert(t *testing.T) {
 
 // 7. Agent enrollment with valid token - tested via validateAgentToken
 func TestValidateAgentTokenValid(t *testing.T) {
-	_ = setupTestServer(t)
+	_, s := setupTestServer(t)
 
 	rawToken := "test-token-valid-enrollment"
 	h := sha256.Sum256([]byte(rawToken))
 	tokenHash := hex.EncodeToString(h[:])
 	expiresAt := time.Now().Add(15 * time.Minute).Format(time.RFC3339)
 
-	_, err := db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, FALSE)`,
+	_, err := s.db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, FALSE)`,
 		tokenHash, expiresAt)
 	if err != nil {
 		t.Fatalf("insert token: %v", err)
 	}
 
-	gotHash, valErr := validateAgentToken(rawToken)
+	gotHash, valErr := s.validateAgentToken(rawToken)
 	if valErr != nil {
 		t.Fatalf("expected valid token, got error: %v", valErr)
 	}
@@ -908,20 +907,20 @@ func TestValidateAgentTokenValid(t *testing.T) {
 
 // 8. Agent enrollment with used token -> rejected
 func TestValidateAgentTokenUsed(t *testing.T) {
-	_ = setupTestServer(t)
+	_, s := setupTestServer(t)
 
 	rawToken := "test-token-used-12345"
 	h := sha256.Sum256([]byte(rawToken))
 	tokenHash := hex.EncodeToString(h[:])
 	expiresAt := time.Now().Add(15 * time.Minute).Format(time.RFC3339)
 
-	_, err := db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, TRUE)`,
+	_, err := s.db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, TRUE)`,
 		tokenHash, expiresAt)
 	if err != nil {
 		t.Fatalf("insert token: %v", err)
 	}
 
-	_, valErr := validateAgentToken(rawToken)
+	_, valErr := s.validateAgentToken(rawToken)
 	if valErr == nil {
 		t.Fatal("expected error for used token, got nil")
 	}
@@ -932,20 +931,20 @@ func TestValidateAgentTokenUsed(t *testing.T) {
 
 // 9. Agent enrollment with expired token -> rejected
 func TestValidateAgentTokenExpired(t *testing.T) {
-	_ = setupTestServer(t)
+	_, s := setupTestServer(t)
 
 	rawToken := "test-token-expired-12345"
 	h := sha256.Sum256([]byte(rawToken))
 	tokenHash := hex.EncodeToString(h[:])
 	expiresAt := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
 
-	_, err := db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, FALSE)`,
+	_, err := s.db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, FALSE)`,
 		tokenHash, expiresAt)
 	if err != nil {
 		t.Fatalf("insert token: %v", err)
 	}
 
-	_, valErr := validateAgentToken(rawToken)
+	_, valErr := s.validateAgentToken(rawToken)
 	if valErr == nil {
 		t.Fatal("expected error for expired token, got nil")
 	}
@@ -958,9 +957,9 @@ func TestValidateAgentTokenExpired(t *testing.T) {
 // (Without a real WebSocket agent, the handler returns 404 "agent not connected"
 // after PIN validation succeeds. We verify it does NOT return 403.)
 func TestTerminalSessionValidPIN(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	token := loginAndGetToken(t, e)
-	markCredentialsRotated(t)
+	s.markCredentialsRotated(t)
 
 	body := fmt.Sprintf(`{"pin":"1234"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/machines/nonexistent-machine/terminal", strings.NewReader(body))
@@ -981,9 +980,9 @@ func TestTerminalSessionValidPIN(t *testing.T) {
 
 // 11. Terminal session with invalid PIN -> 403
 func TestTerminalSessionInvalidPIN(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	token := loginAndGetToken(t, e)
-	markCredentialsRotated(t)
+	s.markCredentialsRotated(t)
 
 	body := `{"pin":"0000"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/machines/some-machine/terminal", strings.NewReader(body))
@@ -999,7 +998,7 @@ func TestTerminalSessionInvalidPIN(t *testing.T) {
 
 // 12. Unauthenticated request to protected endpoint -> 401
 func TestUnauthenticatedProtectedEndpoint(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	endpoints := []struct {
 		method string
@@ -1027,7 +1026,7 @@ func TestUnauthenticatedProtectedEndpoint(t *testing.T) {
 
 // Bonus: Health endpoint is public (no auth required)
 func TestHealthEndpointPublic(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()
@@ -1042,7 +1041,7 @@ func TestHealthEndpointPublic(t *testing.T) {
 
 // 13. Default admin (password_changed=false, pin_changed=false) gets 403 on protected endpoint
 func TestRotationEnforcement_DefaultAdminBlocked(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 	token := loginAndGetToken(t, e)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/machines", nil)
@@ -1071,9 +1070,9 @@ func TestRotationEnforcement_DefaultAdminBlocked(t *testing.T) {
 
 // 14. After changing password AND pin, protected endpoints return 200
 func TestRotationEnforcement_FullyRotatedAllowed(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	token := loginAndGetToken(t, e)
-	markCredentialsRotated(t)
+	s.markCredentialsRotated(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/machines", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -1087,7 +1086,7 @@ func TestRotationEnforcement_FullyRotatedAllowed(t *testing.T) {
 
 // 15. Allowlisted endpoints work even when rotation is incomplete
 func TestRotationEnforcement_AllowlistBypass(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 	token := loginAndGetToken(t, e)
 
 	// change-password should work (allowlisted)
@@ -1120,11 +1119,11 @@ func TestRotationEnforcement_AllowlistBypass(t *testing.T) {
 
 // 16. Partial rotation (only password changed, not PIN) still blocks
 func TestRotationEnforcement_PartialRotationBlocked(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	token := loginAndGetToken(t, e)
 
 	// Only mark password as changed
-	_, err := db.Exec(`UPDATE users SET password_changed = TRUE WHERE username = 'admin'`)
+	_, err := s.db.Exec(`UPDATE users SET password_changed = TRUE WHERE username = 'admin'`)
 	if err != nil {
 		t.Fatalf("update password_changed: %v", err)
 	}
@@ -1154,7 +1153,7 @@ func TestRotationEnforcement_PartialRotationBlocked(t *testing.T) {
 
 // 17. Setup status returns needs_setup=true when no users exist
 func TestSetupStatusNeedsSetup(t *testing.T) {
-	e := setupEmptyTestServer(t)
+	e, _ := setupEmptyTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/setup/status", nil)
 	rec := httptest.NewRecorder()
@@ -1175,7 +1174,7 @@ func TestSetupStatusNeedsSetup(t *testing.T) {
 
 // 18. Setup status returns needs_setup=false when users exist
 func TestSetupStatusAlreadySetup(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/setup/status", nil)
 	rec := httptest.NewRecorder()
@@ -1196,7 +1195,7 @@ func TestSetupStatusAlreadySetup(t *testing.T) {
 
 // 19. Setup with valid token creates admin user
 func TestSetupWithValidToken(t *testing.T) {
-	e := setupEmptyTestServer(t)
+	e, s := setupEmptyTestServer(t)
 
 	body := `{"setup_token":"test-setup-token-abc123","username":"myadmin","password":"securepass123","pin":"5678"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
@@ -1221,7 +1220,7 @@ func TestSetupWithValidToken(t *testing.T) {
 
 	// Verify the user was created with correct flags.
 	var passwordChanged, pinChanged bool
-	err := db.QueryRow(`SELECT password_changed, pin_changed FROM users WHERE username = 'myadmin'`).Scan(&passwordChanged, &pinChanged)
+	err := s.db.QueryRow(`SELECT password_changed, pin_changed FROM users WHERE username = 'myadmin'`).Scan(&passwordChanged, &pinChanged)
 	if err != nil {
 		t.Fatalf("query user: %v", err)
 	}
@@ -1255,7 +1254,7 @@ func TestSetupWithValidToken(t *testing.T) {
 
 // 20. Setup with invalid token returns 403
 func TestSetupWithInvalidToken(t *testing.T) {
-	e := setupEmptyTestServer(t)
+	e, _ := setupEmptyTestServer(t)
 
 	body := `{"setup_token":"wrong-token","username":"admin","password":"securepass123","pin":"5678"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
@@ -1270,7 +1269,7 @@ func TestSetupWithInvalidToken(t *testing.T) {
 
 // 21. Setup after admin already exists returns 404
 func TestSetupAfterAlreadySetup(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	body := `{"setup_token":"anything","username":"admin2","password":"securepass123","pin":"5678"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
@@ -1285,7 +1284,7 @@ func TestSetupAfterAlreadySetup(t *testing.T) {
 
 // 22. Setup rate limiting - 6th attempt returns 429
 func TestSetupRateLimiting(t *testing.T) {
-	e := setupEmptyTestServer(t)
+	e, _ := setupEmptyTestServer(t)
 
 	body := `{"setup_token":"wrong-token","username":"admin","password":"securepass123","pin":"5678"}`
 
@@ -1306,7 +1305,7 @@ func TestSetupRateLimiting(t *testing.T) {
 
 // 23. Setup validation - password too short
 func TestSetupValidation_ShortPassword(t *testing.T) {
-	e := setupEmptyTestServer(t)
+	e, _ := setupEmptyTestServer(t)
 
 	body := `{"setup_token":"test-setup-token-abc123","username":"admin","password":"short","pin":"5678"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
@@ -1321,7 +1320,7 @@ func TestSetupValidation_ShortPassword(t *testing.T) {
 
 // 24. Setup validation - invalid PIN (non-numeric)
 func TestSetupValidation_InvalidPIN(t *testing.T) {
-	e := setupEmptyTestServer(t)
+	e, _ := setupEmptyTestServer(t)
 
 	body := `{"setup_token":"test-setup-token-abc123","username":"admin","password":"securepass123","pin":"abcd"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
@@ -1336,7 +1335,7 @@ func TestSetupValidation_InvalidPIN(t *testing.T) {
 
 // 25. Setup validation - empty username
 func TestSetupValidation_EmptyUsername(t *testing.T) {
-	e := setupEmptyTestServer(t)
+	e, _ := setupEmptyTestServer(t)
 
 	body := `{"setup_token":"test-setup-token-abc123","username":"","password":"securepass123","pin":"5678"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
@@ -1365,13 +1364,13 @@ func wsDialAgent(t *testing.T, server *httptest.Server, queryParams string) (*we
 // waitAgentDrain waits until the handleAgentWS goroutine has fully exited for
 // the given machine_id. This prevents race conditions where the background
 // goroutine calls markOffline on a stale or closed db.
-func waitAgentDrain(t *testing.T, machineID string, timeout time.Duration) {
+func (s *Server) waitAgentDrain(t *testing.T, machineID string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		agentsMu.RLock()
-		_, exists := agents[machineID]
-		agentsMu.RUnlock()
+		s.agentsMu.RLock()
+		_, exists := s.agents[machineID]
+		s.agentsMu.RUnlock()
 		if !exists {
 			return
 		}
@@ -1381,13 +1380,13 @@ func waitAgentDrain(t *testing.T, machineID string, timeout time.Duration) {
 	t.Logf("waitAgentDrain: %s still in agents map after %v (may not have registered)", machineID, timeout)
 }
 
-func seedValidToken(t *testing.T) string {
+func (s *Server) seedValidToken(t *testing.T) string {
 	t.Helper()
 	rawToken := "test-enrollment-token-abc123"
 	h := sha256.Sum256([]byte(rawToken))
 	tokenHash := hex.EncodeToString(h[:])
 	expiresAt := time.Now().Add(1 * time.Hour).Format("2006-01-02 15:04:05")
-	_, err := db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, FALSE)`, tokenHash, expiresAt)
+	_, err := s.db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, FALSE)`, tokenHash, expiresAt)
 	if err != nil {
 		t.Fatalf("seed valid token: %v", err)
 	}
@@ -1417,8 +1416,8 @@ func sendMetricsMsg(t *testing.T, conn *websocket.Conn, machineID string) {
 }
 
 func TestAgentEnrollmentWithToken(t *testing.T) {
-	e := setupTestServer(t)
-	token := seedValidToken(t)
+	e, s := setupTestServer(t)
+	token := s.seedValidToken(t)
 
 	// Start real HTTP server for WebSocket upgrade.
 	server := httptest.NewServer(e)
@@ -1458,14 +1457,14 @@ func TestAgentEnrollmentWithToken(t *testing.T) {
 
 	// Close connection and wait for handler goroutine to finish.
 	conn.Close()
-	waitAgentDrain(t, "test-machine-enroll-001", 2*time.Second)
+	s.waitAgentDrain(t, "test-machine-enroll-001", 2*time.Second)
 	server.Close()
 
 	// Verify token was consumed.
 	h := sha256.Sum256([]byte(token))
 	tokenHash := hex.EncodeToString(h[:])
 	var used bool
-	err = db.QueryRow(`SELECT used FROM tokens WHERE token_hash = ?`, tokenHash).Scan(&used)
+	err = s.db.QueryRow(`SELECT used FROM tokens WHERE token_hash = ?`, tokenHash).Scan(&used)
 	if err != nil {
 		t.Fatalf("query token: %v", err)
 	}
@@ -1475,7 +1474,7 @@ func TestAgentEnrollmentWithToken(t *testing.T) {
 
 	// Verify credential was stored in DB.
 	var storedMachineID string
-	err = db.QueryRow(`SELECT machine_id FROM agent_credentials LIMIT 1`).Scan(&storedMachineID)
+	err = s.db.QueryRow(`SELECT machine_id FROM agent_credentials LIMIT 1`).Scan(&storedMachineID)
 	if err != nil {
 		t.Fatalf("query agent_credentials: %v", err)
 	}
@@ -1487,8 +1486,8 @@ func TestAgentEnrollmentWithToken(t *testing.T) {
 }
 
 func TestAgentReconnectWithSecret(t *testing.T) {
-	e := setupTestServer(t)
-	token := seedValidToken(t)
+	e, s := setupTestServer(t)
+	token := s.seedValidToken(t)
 
 	server := httptest.NewServer(e)
 
@@ -1533,7 +1532,7 @@ func TestAgentReconnectWithSecret(t *testing.T) {
 	t.Log("reconnection with secret successful")
 
 	conn2.Close()
-	waitAgentDrain(t, "test-machine-reconnect-001", 2*time.Second)
+	s.waitAgentDrain(t, "test-machine-reconnect-001", 2*time.Second)
 	server.Close()
 }
 
@@ -1543,8 +1542,8 @@ func TestAgentReconnectWithSecret(t *testing.T) {
 // Phase 8 wired the announce only into the new-enrolment branch, leaving
 // every existing fleet member stuck on the old binary across hub redeploys.
 func TestAgentVersionAnnouncedOnReconnect(t *testing.T) {
-	e := setupTestServer(t)
-	token := seedValidToken(t)
+	e, s := setupTestServer(t)
+	token := s.seedValidToken(t)
 
 	// The hub no longer announces to an agent it has heard nothing from —
 	// at WS-upgrade time it knows neither the agent's capability nor its
@@ -1599,7 +1598,7 @@ func TestAgentVersionAnnouncedOnReconnect(t *testing.T) {
 		t.Fatal("enrolment did not yield a secret")
 	}
 	conn1.Close()
-	waitAgentDrain(t, "test-machine-version-announce", 2*time.Second)
+	s.waitAgentDrain(t, "test-machine-version-announce", 2*time.Second)
 
 	// Step 2: reconnect via secret. The fix under test: the hub MUST send
 	// an agent_version frame off the back of registerAgentConnection.
@@ -1690,7 +1689,7 @@ func TestAnnouncedSHAIsPerPlatform(t *testing.T) {
 // right binary.
 func TestRecordAgentRunningVersionTracksOS(t *testing.T) {
 	// Use the test setup so the in-memory DB exists for lookupVersionHostname.
-	_ = setupTestServer(t)
+	_, s := setupTestServer(t)
 
 	const linuxSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	const windowsSHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -1717,7 +1716,7 @@ func TestRecordAgentRunningVersionTracksOS(t *testing.T) {
 	})
 
 	// A Windows agent reporting the Windows SHA is up-to-date.
-	recordAgentRunningVersion("test-machine-windows", agentVersionReport{RunningSHA: windowsSHA, OS: "windows", UpdateProtocol: minSignatureCapableProtocol, TransportOK: true})
+	s.recordAgentRunningVersion("test-machine-windows", agentVersionReport{RunningSHA: windowsSHA, OS: "windows", UpdateProtocol: minSignatureCapableProtocol, TransportOK: true})
 	agentRunningVersionsMu.RLock()
 	winInfo := agentRunningVersions["test-machine-windows"]
 	agentRunningVersionsMu.RUnlock()
@@ -1730,7 +1729,7 @@ func TestRecordAgentRunningVersionTracksOS(t *testing.T) {
 
 	// A Windows agent reporting the LINUX SHA must be flagged as pending —
 	// otherwise the symptom (perpetual update loop) cannot be detected.
-	recordAgentRunningVersion("test-machine-windows", agentVersionReport{RunningSHA: linuxSHA, OS: "windows", UpdateProtocol: minSignatureCapableProtocol, TransportOK: true})
+	s.recordAgentRunningVersion("test-machine-windows", agentVersionReport{RunningSHA: linuxSHA, OS: "windows", UpdateProtocol: minSignatureCapableProtocol, TransportOK: true})
 	agentRunningVersionsMu.RLock()
 	winInfo = agentRunningVersions["test-machine-windows"]
 	agentRunningVersionsMu.RUnlock()
@@ -1739,7 +1738,7 @@ func TestRecordAgentRunningVersionTracksOS(t *testing.T) {
 	}
 
 	// And vice versa for a Linux agent on the linux SHA.
-	recordAgentRunningVersion("test-machine-linux", agentVersionReport{RunningSHA: linuxSHA, OS: "linux", UpdateProtocol: minSignatureCapableProtocol, TransportOK: true})
+	s.recordAgentRunningVersion("test-machine-linux", agentVersionReport{RunningSHA: linuxSHA, OS: "linux", UpdateProtocol: minSignatureCapableProtocol, TransportOK: true})
 	agentRunningVersionsMu.RLock()
 	linInfo := agentRunningVersions["test-machine-linux"]
 	agentRunningVersionsMu.RUnlock()
@@ -1756,10 +1755,10 @@ func TestRecordAgentRunningVersionTracksOS(t *testing.T) {
 // post-Phase-9 unknown-OS protection silently suppresses every
 // announce and the entire fleet stops auto-updating.
 func TestLookupAgentOSNormalisesHardwareStrings(t *testing.T) {
-	_ = setupTestServer(t)
+	_, s := setupTestServer(t)
 
 	t.Cleanup(func() {
-		_, _ = db.Exec(`DELETE FROM machines WHERE id LIKE 'lookup-os-test-%'`)
+		_, _ = s.db.Exec(`DELETE FROM machines WHERE id LIKE 'lookup-os-test-%'`)
 	})
 
 	cases := []struct {
@@ -1780,14 +1779,14 @@ func TestLookupAgentOSNormalisesHardwareStrings(t *testing.T) {
 		{"lookup-os-test-empty", "", ""},
 	}
 	for _, tc := range cases {
-		_, err := db.Exec(
+		_, err := s.db.Exec(
 			`INSERT OR REPLACE INTO machines (id, hostname, os, status) VALUES (?, ?, ?, 'offline')`,
 			tc.id, tc.id, tc.stored,
 		)
 		if err != nil {
 			t.Fatalf("seed %s: %v", tc.id, err)
 		}
-		got := lookupAgentOS(tc.id)
+		got := s.lookupAgentOS(tc.id)
 		if got != tc.want {
 			t.Errorf("lookupAgentOS(stored=%q) = %q, want %q", tc.stored, got, tc.want)
 		}
@@ -1795,7 +1794,7 @@ func TestLookupAgentOSNormalisesHardwareStrings(t *testing.T) {
 }
 
 func TestAgentReconnectWithInvalidSecret(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	server := httptest.NewServer(e)
 
@@ -1811,8 +1810,8 @@ func TestAgentReconnectWithInvalidSecret(t *testing.T) {
 }
 
 func TestAgentSecretRevocation(t *testing.T) {
-	e := setupTestServer(t)
-	token := seedValidToken(t)
+	e, s := setupTestServer(t)
+	token := s.seedValidToken(t)
 
 	server := httptest.NewServer(e)
 
@@ -1836,16 +1835,16 @@ func TestAgentSecretRevocation(t *testing.T) {
 	}
 	json.Unmarshal(msg, &enrolled)
 	conn1.Close()
-	waitAgentDrain(t, "test-machine-revoke-001", 2*time.Second)
+	s.waitAgentDrain(t, "test-machine-revoke-001", 2*time.Second)
 
 	// Step 2: Revoke the credential.
-	if err := revokeAgentCredential("test-machine-revoke-001"); err != nil {
+	if err := s.revokeAgentCredential("test-machine-revoke-001"); err != nil {
 		t.Fatalf("revoke credential: %v", err)
 	}
 
 	// Verify it was deleted.
 	var count int
-	db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, "test-machine-revoke-001").Scan(&count)
+	s.db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, "test-machine-revoke-001").Scan(&count)
 	if count != 0 {
 		t.Fatal("credential should be deleted after revocation")
 	}
@@ -1861,9 +1860,9 @@ func TestAgentSecretRevocation(t *testing.T) {
 }
 
 func TestKnownMachineReconnectWithoutCredentialRejected(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 
-	if _, err := db.Exec(`INSERT INTO machines (id, hostname, status) VALUES (?, ?, ?)`,
+	if _, err := s.db.Exec(`INSERT INTO machines (id, hostname, status) VALUES (?, ?, ?)`,
 		"known-machine-without-secret", "known-host", "online"); err != nil {
 		t.Fatalf("seed known machine: %v", err)
 	}
@@ -1882,7 +1881,7 @@ func TestKnownMachineReconnectWithoutCredentialRejected(t *testing.T) {
 }
 
 func TestTerminalSessionValidPINForSetupUser(t *testing.T) {
-	e := setupEmptyTestServer(t)
+	e, _ := setupEmptyTestServer(t)
 
 	setupBody := `{"setup_token":"test-setup-token-abc123","username":"myadmin","password":"securepass123","pin":"5678"}`
 	setupReq := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(setupBody))
@@ -1927,20 +1926,20 @@ func TestTerminalSessionValidPINForSetupUser(t *testing.T) {
 
 // TestTerminalMaxConcurrentSessions verifies that the 4th terminal session is rejected.
 func TestTerminalMaxConcurrentSessions(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	token := loginAndGetToken(t, e)
-	markCredentialsRotated(t)
+	s.markCredentialsRotated(t)
 
 	// Seed a fake agent so handleStartTerminal doesn't return 404.
 	machineID := "test-machine-max-sessions"
-	db.Exec(`INSERT INTO machines (id, hostname, status) VALUES (?, ?, ?)`, machineID, "test-host", "online")
-	agentsMu.Lock()
-	agents[machineID] = &ConnectedAgent{MachineID: machineID}
-	agentsMu.Unlock()
+	s.db.Exec(`INSERT INTO machines (id, hostname, status) VALUES (?, ?, ?)`, machineID, "test-host", "online")
+	s.agentsMu.Lock()
+	s.agents[machineID] = &ConnectedAgent{MachineID: machineID}
+	s.agentsMu.Unlock()
 	defer func() {
-		agentsMu.Lock()
-		delete(agents, machineID)
-		agentsMu.Unlock()
+		s.agentsMu.Lock()
+		delete(s.agents, machineID)
+		s.agentsMu.Unlock()
 	}()
 
 	// Pre-populate 3 terminal sessions in the in-memory map.
@@ -1985,12 +1984,12 @@ func TestTerminalMaxConcurrentSessions(t *testing.T) {
 
 // TestTerminalAuditFields verifies source_ip and user_id are stored in the terminal_sessions table.
 func TestTerminalAuditFields(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	token := loginAndGetToken(t, e)
-	markCredentialsRotated(t)
+	s.markCredentialsRotated(t)
 
 	machineID := "test-machine-audit"
-	db.Exec(`INSERT INTO machines (id, hostname, status) VALUES (?, ?, ?)`, machineID, "audit-host", "online")
+	s.db.Exec(`INSERT INTO machines (id, hostname, status) VALUES (?, ?, ?)`, machineID, "audit-host", "online")
 
 	// Create a dummy WebSocket server so the agent has a real Conn.
 	dummyWS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2014,13 +2013,13 @@ func TestTerminalAuditFields(t *testing.T) {
 	}
 	defer agentConn.Close()
 
-	agentsMu.Lock()
-	agents[machineID] = &ConnectedAgent{MachineID: machineID, Conn: agentConn}
-	agentsMu.Unlock()
+	s.agentsMu.Lock()
+	s.agents[machineID] = &ConnectedAgent{MachineID: machineID, Conn: agentConn}
+	s.agentsMu.Unlock()
 	defer func() {
-		agentsMu.Lock()
-		delete(agents, machineID)
-		agentsMu.Unlock()
+		s.agentsMu.Lock()
+		delete(s.agents, machineID)
+		s.agentsMu.Unlock()
 	}()
 
 	body := `{"pin":"1234"}`
@@ -2036,7 +2035,7 @@ func TestTerminalAuditFields(t *testing.T) {
 	}
 
 	var sourceIP, userID sql.NullString
-	err = db.QueryRow(`SELECT source_ip, user_id FROM terminal_sessions WHERE machine_id = ?`, machineID).Scan(&sourceIP, &userID)
+	err = s.db.QueryRow(`SELECT source_ip, user_id FROM terminal_sessions WHERE machine_id = ?`, machineID).Scan(&sourceIP, &userID)
 	if err != nil {
 		t.Fatalf("query terminal_sessions: %v", err)
 	}
@@ -2063,17 +2062,17 @@ func TestTerminalAuditFields(t *testing.T) {
 // --- API Machine Tests ---
 
 func TestCreateAPIMachine(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	token := loginAndGetToken(t, e)
 
 	// Register API machine routes.
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
-	api.GET("/api/api-machines", handleListAPIMachines)
-	api.POST("/api/api-machines", handleCreateAPIMachine)
-	api.PATCH("/api/api-machines/:id", handleUpdateAPIMachine)
-	api.DELETE("/api/api-machines/:id", handleDeleteAPIMachine)
-	api.POST("/api/api-machines/:id/poll", handleForceAPIPoll)
+	api := e.Group("", jwtMiddleware, s.credentialRotationMiddleware)
+	api.GET("/api/api-machines", s.handleListAPIMachines)
+	api.POST("/api/api-machines", s.handleCreateAPIMachine)
+	api.PATCH("/api/api-machines/:id", s.handleUpdateAPIMachine)
+	api.DELETE("/api/api-machines/:id", s.handleDeleteAPIMachine)
+	api.POST("/api/api-machines/:id/poll", s.handleForceAPIPoll)
 
 	body := `{"name":"Test Proxmox","adapter_type":"proxmox","base_url":"https://192.168.3.2:8006","auth_config":{"token_id":"root@pam!monitor","token_secret":"xxx"},"poll_interval_secs":120}`
 	req := httptest.NewRequest(http.MethodPost, "/api/api-machines", strings.NewReader(body))
@@ -2120,12 +2119,12 @@ func TestCreateAPIMachine(t *testing.T) {
 }
 
 func TestCreateAPIMachineWithCustomCATrust(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	token := loginAndGetToken(t, e)
 
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
-	api.POST("/api/api-machines", handleCreateAPIMachine)
+	api := e.Group("", jwtMiddleware, s.credentialRotationMiddleware)
+	api.POST("/api/api-machines", s.handleCreateAPIMachine)
 
 	body := fmt.Sprintf(`{"name":"Secure Synology","adapter_type":"synology","base_url":"https://192.168.1.52:5001","auth_config":{"username":"u","password":"p"},"tls_config":{"mode":"custom_ca","ca_cert_pem":%q},"poll_interval_secs":60}`, generateTestCertPEM(t))
 	req := httptest.NewRequest(http.MethodPost, "/api/api-machines", strings.NewReader(body))
@@ -2157,12 +2156,12 @@ func TestCreateAPIMachineWithCustomCATrust(t *testing.T) {
 }
 
 func TestCreateAPIMachineInvalidAdapter(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	token := loginAndGetToken(t, e)
 
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
-	api.POST("/api/api-machines", handleCreateAPIMachine)
+	api := e.Group("", jwtMiddleware, s.credentialRotationMiddleware)
+	api.POST("/api/api-machines", s.handleCreateAPIMachine)
 
 	body := `{"name":"Bad","adapter_type":"unknown","base_url":"http://x","auth_config":{}}`
 	req := httptest.NewRequest(http.MethodPost, "/api/api-machines", strings.NewReader(body))
@@ -2178,12 +2177,12 @@ func TestCreateAPIMachineInvalidAdapter(t *testing.T) {
 }
 
 func TestCreateAPIMachineInvalidTLSConfig(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	token := loginAndGetToken(t, e)
 
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
-	api.POST("/api/api-machines", handleCreateAPIMachine)
+	api := e.Group("", jwtMiddleware, s.credentialRotationMiddleware)
+	api.POST("/api/api-machines", s.handleCreateAPIMachine)
 
 	body := `{"name":"Bad TLS","adapter_type":"synology","base_url":"https://192.168.1.1:5001","auth_config":{"username":"u","password":"p"},"tls_config":{"mode":"custom_ca","ca_cert_pem":"not a cert"}}`
 	req := httptest.NewRequest(http.MethodPost, "/api/api-machines", strings.NewReader(body))
@@ -2201,13 +2200,13 @@ func TestCreateAPIMachineInvalidTLSConfig(t *testing.T) {
 }
 
 func TestListAPIMachines(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	token := loginAndGetToken(t, e)
 
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
-	api.GET("/api/api-machines", handleListAPIMachines)
-	api.POST("/api/api-machines", handleCreateAPIMachine)
+	api := e.Group("", jwtMiddleware, s.credentialRotationMiddleware)
+	api.GET("/api/api-machines", s.handleListAPIMachines)
+	api.POST("/api/api-machines", s.handleCreateAPIMachine)
 
 	// Create two machines.
 	for _, name := range []string{"Machine A", "Machine B"} {
@@ -2254,14 +2253,14 @@ func TestListAPIMachines(t *testing.T) {
 }
 
 func TestDeleteAPIMachine(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	token := loginAndGetToken(t, e)
 
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
-	api.GET("/api/api-machines", handleListAPIMachines)
-	api.POST("/api/api-machines", handleCreateAPIMachine)
-	api.DELETE("/api/api-machines/:id", handleDeleteAPIMachine)
+	api := e.Group("", jwtMiddleware, s.credentialRotationMiddleware)
+	api.GET("/api/api-machines", s.handleListAPIMachines)
+	api.POST("/api/api-machines", s.handleCreateAPIMachine)
+	api.DELETE("/api/api-machines/:id", s.handleDeleteAPIMachine)
 
 	// Create a machine.
 	body := `{"name":"ToDelete","adapter_type":"proxmox","base_url":"https://x:8006","auth_config":{"token_id":"a","token_secret":"b"}}`
@@ -2305,13 +2304,13 @@ func TestDeleteAPIMachine(t *testing.T) {
 }
 
 func TestUpdateAPIMachine(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	token := loginAndGetToken(t, e)
 
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
-	api.POST("/api/api-machines", handleCreateAPIMachine)
-	api.PATCH("/api/api-machines/:id", handleUpdateAPIMachine)
+	api := e.Group("", jwtMiddleware, s.credentialRotationMiddleware)
+	api.POST("/api/api-machines", s.handleCreateAPIMachine)
+	api.PATCH("/api/api-machines/:id", s.handleUpdateAPIMachine)
 
 	createBody := `{"name":"Main","adapter_type":"proxmox","base_url":"https://192.168.3.2:8006","auth_config":{"token_id":"root@pam!monitor","token_secret":"xxx"},"tls_config":{"mode":"insecure"},"poll_interval_secs":120}`
 	req := httptest.NewRequest(http.MethodPost, "/api/api-machines", strings.NewReader(createBody))
@@ -2357,7 +2356,7 @@ func TestUpdateAPIMachine(t *testing.T) {
 
 	var storedName, storedTLS string
 	var storedInterval int
-	if err := db.QueryRow("SELECT name, tls_config, poll_interval_secs FROM api_machines WHERE id = ?", id).Scan(&storedName, &storedTLS, &storedInterval); err != nil {
+	if err := s.db.QueryRow("SELECT name, tls_config, poll_interval_secs FROM api_machines WHERE id = ?", id).Scan(&storedName, &storedTLS, &storedInterval); err != nil {
 		t.Fatalf("query updated machine: %v", err)
 	}
 	if storedName != "Main Updated" {
@@ -2374,13 +2373,13 @@ func TestUpdateAPIMachine(t *testing.T) {
 }
 
 func TestUpdateAPIMachineRequiresAuthConfigOnAdapterChange(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	token := loginAndGetToken(t, e)
 
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
-	api.POST("/api/api-machines", handleCreateAPIMachine)
-	api.PATCH("/api/api-machines/:id", handleUpdateAPIMachine)
+	api := e.Group("", jwtMiddleware, s.credentialRotationMiddleware)
+	api.POST("/api/api-machines", s.handleCreateAPIMachine)
+	api.PATCH("/api/api-machines/:id", s.handleUpdateAPIMachine)
 
 	createBody := `{"name":"MyNAS","adapter_type":"synology","base_url":"http://192.168.1.50:5000","auth_config":{"username":"u","password":"p"}}`
 	req := httptest.NewRequest(http.MethodPost, "/api/api-machines", strings.NewReader(createBody))
@@ -2416,12 +2415,12 @@ func TestUpdateAPIMachineRequiresAuthConfigOnAdapterChange(t *testing.T) {
 }
 
 func TestDeleteAPIMachineNotFound(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	token := loginAndGetToken(t, e)
 
-	api := e.Group("", jwtMiddleware, credentialRotationMiddleware)
-	api.DELETE("/api/api-machines/:id", handleDeleteAPIMachine)
+	api := e.Group("", jwtMiddleware, s.credentialRotationMiddleware)
+	api.DELETE("/api/api-machines/:id", s.handleDeleteAPIMachine)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/api-machines/nonexistent-id", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -2508,14 +2507,14 @@ func TestValidateBaseURL(t *testing.T) {
 // enrollment because the agent could send hardware_info before the
 // metric that creates the machines row.
 func TestHardwareInfoUpsertPreCreatesRow(t *testing.T) {
-	setupTestServer(t)
+	_, s := setupTestServer(t)
 
 	machineID := "test-hw-race-machine-id"
 	hardwareJSON := `{"type":"hardware_info","machine_id":"` + machineID + `","cpu_model":"Test CPU","cpu_cores":4,"ram_total_bytes":8589934592}`
 
 	// Step 1: simulate hardware_info arriving BEFORE any metric.
 	// This is the exact UPSERT used in hub/agentws.go.
-	if _, err := db.Exec(`
+	if _, err := s.db.Exec(`
 		INSERT INTO machines (id, hostname, status, hardware_info)
 		VALUES (?, '', 'offline', ?)
 		ON CONFLICT(id) DO UPDATE SET hardware_info = excluded.hardware_info
@@ -2526,7 +2525,7 @@ func TestHardwareInfoUpsertPreCreatesRow(t *testing.T) {
 	// Assert the row exists with hardware_info populated and hostname=''.
 	var hostname string
 	var stored sql.NullString
-	if err := db.QueryRow(`SELECT hostname, hardware_info FROM machines WHERE id = ?`, machineID).Scan(&hostname, &stored); err != nil {
+	if err := s.db.QueryRow(`SELECT hostname, hardware_info FROM machines WHERE id = ?`, machineID).Scan(&hostname, &stored); err != nil {
 		t.Fatalf("row not present after pre-metric hardware_info: %v", err)
 	}
 	if !stored.Valid || stored.String != hardwareJSON {
@@ -2537,7 +2536,7 @@ func TestHardwareInfoUpsertPreCreatesRow(t *testing.T) {
 	}
 
 	// Step 2: simulate the first metric arriving (upsertMachine semantics).
-	upsertMachine(AgentMetrics{
+	s.upsertMachine(AgentMetrics{
 		MachineID: machineID,
 		Hostname:  "test-host",
 		IP:        "10.0.0.42",
@@ -2547,7 +2546,7 @@ func TestHardwareInfoUpsertPreCreatesRow(t *testing.T) {
 	// Assert hostname/ip/os are populated AND hardware_info survived.
 	var hostname2, ip, osStr string
 	var hwAfter sql.NullString
-	if err := db.QueryRow(`SELECT hostname, COALESCE(ip,''), COALESCE(os,''), hardware_info FROM machines WHERE id = ?`, machineID).Scan(&hostname2, &ip, &osStr, &hwAfter); err != nil {
+	if err := s.db.QueryRow(`SELECT hostname, COALESCE(ip,''), COALESCE(os,''), hardware_info FROM machines WHERE id = ?`, machineID).Scan(&hostname2, &ip, &osStr, &hwAfter); err != nil {
 		t.Fatalf("query after metric failed: %v", err)
 	}
 	if hostname2 != "test-host" || ip != "10.0.0.42" || osStr != "ubuntu 24.04 (x86_64)" {
@@ -2677,8 +2676,8 @@ func TestBuildTelegramPayloadIsPlainText(t *testing.T) {
 // operator. The fix caps the request size at maxBulkCommandTargets
 // and returns 400 above that.
 func TestBulkCommandRejectsOversize(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	adminToken := loginAndGetToken(t, e)
 
 	ids := make([]string, maxBulkCommandTargets+1)
@@ -2711,8 +2710,8 @@ func TestBulkCommandRejectsOversize(t *testing.T) {
 // per-machine error is fine here, we only assert the request itself
 // wasn't bounced at the size check.)
 func TestBulkCommandAcceptsAtLimit(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	adminToken := loginAndGetToken(t, e)
 
 	ids := make([]string, maxBulkCommandTargets)
@@ -2748,7 +2747,7 @@ func TestBulkCommandAcceptsAtLimit(t *testing.T) {
 // few times per minute even on flaky networks, so wsAgentRateLimit=30
 // per minute leaves significant headroom while shutting down a flood.
 func TestAgentWSRateLimited(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	const ip = "10.99.0.1:55555"
 	var lastCode int
@@ -2769,7 +2768,7 @@ func TestAgentWSRateLimited(t *testing.T) {
 // global. Fleet-wide reconnect after a hub restart must not be blocked
 // — each agent has its own IP so each gets its own bucket.
 func TestAgentWSRateLimitPerIP(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	for i := 0; i < wsAgentRateLimit+1; i++ {
 		req := httptest.NewRequest(http.MethodGet, "/ws/agent?secret=test", nil)
@@ -2923,26 +2922,26 @@ func TestExtractAPIMachineIP(t *testing.T) {
 // unregisterAgentConnection removes the entry. Without this baseline,
 // the identity-check logic in the next test could be vacuous.
 func TestUnregisterAgentConnectionDeletesOwn(t *testing.T) {
-	_ = setupTestServer(t)
+	_, s := setupTestServer(t)
 
 	mid := "test-c2-clean-exit"
 	conn := &ConnectedAgent{}
 
 	t.Cleanup(func() {
-		agentsMu.Lock()
-		delete(agents, mid)
-		agentsMu.Unlock()
+		s.agentsMu.Lock()
+		delete(s.agents, mid)
+		s.agentsMu.Unlock()
 	})
 
-	agentsMu.Lock()
-	agents[mid] = conn
-	agentsMu.Unlock()
+	s.agentsMu.Lock()
+	s.agents[mid] = conn
+	s.agentsMu.Unlock()
 
-	unregisterAgentConnection(mid, conn)
+	s.unregisterAgentConnection(mid, conn)
 
-	agentsMu.RLock()
-	_, exists := agents[mid]
-	agentsMu.RUnlock()
+	s.agentsMu.RLock()
+	_, exists := s.agents[mid]
+	s.agentsMu.RUnlock()
 	if exists {
 		t.Errorf("agents[%q] should have been deleted by its owning connection", mid)
 	}
@@ -2959,33 +2958,33 @@ func TestUnregisterAgentConnectionDeletesOwn(t *testing.T) {
 // sequentially registering A → registering B (overwrite) → running
 // A's cleanup → asserting B is still there.
 func TestUnregisterAgentConnectionLeavesNewerEntry(t *testing.T) {
-	_ = setupTestServer(t)
+	_, s := setupTestServer(t)
 
 	mid := "test-c2-reconnect-race"
 	connA := &ConnectedAgent{}
 	connB := &ConnectedAgent{}
 
 	t.Cleanup(func() {
-		agentsMu.Lock()
-		delete(agents, mid)
-		agentsMu.Unlock()
+		s.agentsMu.Lock()
+		delete(s.agents, mid)
+		s.agentsMu.Unlock()
 	})
 
-	agentsMu.Lock()
-	agents[mid] = connA
-	agentsMu.Unlock()
+	s.agentsMu.Lock()
+	s.agents[mid] = connA
+	s.agentsMu.Unlock()
 
 	// Simulate fast reconnect — B installs itself before A's cleanup runs.
-	agentsMu.Lock()
-	agents[mid] = connB
-	agentsMu.Unlock()
+	s.agentsMu.Lock()
+	s.agents[mid] = connB
+	s.agentsMu.Unlock()
 
 	// A's defer fires. Must not touch B.
-	unregisterAgentConnection(mid, connA)
+	s.unregisterAgentConnection(mid, connA)
 
-	agentsMu.RLock()
-	got, exists := agents[mid]
-	agentsMu.RUnlock()
+	s.agentsMu.RLock()
+	got, exists := s.agents[mid]
+	s.agentsMu.RUnlock()
 	if !exists {
 		t.Fatalf("agents[%q] was deleted; expected B's entry to remain", mid)
 	}
@@ -2998,23 +2997,23 @@ func TestUnregisterAgentConnectionLeavesNewerEntry(t *testing.T) {
 // handleAgentWS may call cleanup with machineID="" if auth never
 // succeeded. Helper must no-op rather than delete the "" key.
 func TestUnregisterAgentConnectionEmptyMachineIDNoOp(t *testing.T) {
-	_ = setupTestServer(t)
+	_, s := setupTestServer(t)
 
 	sentinel := &ConnectedAgent{}
-	agentsMu.Lock()
-	agents[""] = sentinel
-	agentsMu.Unlock()
+	s.agentsMu.Lock()
+	s.agents[""] = sentinel
+	s.agentsMu.Unlock()
 	t.Cleanup(func() {
-		agentsMu.Lock()
-		delete(agents, "")
-		agentsMu.Unlock()
+		s.agentsMu.Lock()
+		delete(s.agents, "")
+		s.agentsMu.Unlock()
 	})
 
-	unregisterAgentConnection("", &ConnectedAgent{})
+	s.unregisterAgentConnection("", &ConnectedAgent{})
 
-	agentsMu.RLock()
-	got, exists := agents[""]
-	agentsMu.RUnlock()
+	s.agentsMu.RLock()
+	got, exists := s.agents[""]
+	s.agentsMu.RUnlock()
 	if !exists || got != sentinel {
 		t.Errorf("empty-machineID call must be a no-op; got=%p exists=%v want=%p", got, exists, sentinel)
 	}
@@ -3025,20 +3024,20 @@ func TestUnregisterAgentConnectionEmptyMachineIDNoOp(t *testing.T) {
 // check. Without it, a fast-reconnect briefly flips the dashboard to
 // offline before B's metrics flip it back — visible flicker on the UI.
 func TestUnregisterAgentConnectionMarksOfflineOnlyForOwn(t *testing.T) {
-	_ = setupTestServer(t)
+	_, s := setupTestServer(t)
 
 	mid := "test-c2-offline-gating"
 	connA := &ConnectedAgent{}
 	connB := &ConnectedAgent{}
 
 	t.Cleanup(func() {
-		_, _ = db.Exec(`DELETE FROM machines WHERE id = ?`, mid)
-		agentsMu.Lock()
-		delete(agents, mid)
-		agentsMu.Unlock()
+		_, _ = s.db.Exec(`DELETE FROM machines WHERE id = ?`, mid)
+		s.agentsMu.Lock()
+		delete(s.agents, mid)
+		s.agentsMu.Unlock()
 	})
 
-	if _, err := db.Exec(
+	if _, err := s.db.Exec(
 		`INSERT INTO machines (id, hostname, status) VALUES (?, ?, 'online')`,
 		mid, "c2-offline-host",
 	); err != nil {
@@ -3046,15 +3045,15 @@ func TestUnregisterAgentConnectionMarksOfflineOnlyForOwn(t *testing.T) {
 	}
 
 	// B has reconnected after A's drop.
-	agentsMu.Lock()
-	agents[mid] = connB
-	agentsMu.Unlock()
+	s.agentsMu.Lock()
+	s.agents[mid] = connB
+	s.agentsMu.Unlock()
 
 	// A's cleanup runs. Must NOT flip status to offline because B is alive.
-	unregisterAgentConnection(mid, connA)
+	s.unregisterAgentConnection(mid, connA)
 
 	var status string
-	if err := db.QueryRow(
+	if err := s.db.QueryRow(
 		`SELECT status FROM machines WHERE id = ?`, mid,
 	).Scan(&status); err != nil {
 		t.Fatalf("read status: %v", err)
@@ -3076,23 +3075,23 @@ func TestUnregisterAgentConnectionMarksOfflineOnlyForOwn(t *testing.T) {
 // This test calls the extracted markAPIMachineError helper directly so
 // failure propagates as a return value, not a swallowed log line.
 func TestAPIMachineErrorUpsert(t *testing.T) {
-	_ = setupTestServer(t)
+	_, s := setupTestServer(t)
 
 	machineID := "api-c1-test"
 	displayName := "test-synology"
 	adapter := "synology"
 
 	t.Cleanup(func() {
-		_, _ = db.Exec(`DELETE FROM machines WHERE id = ?`, machineID)
+		_, _ = s.db.Exec(`DELETE FROM machines WHERE id = ?`, machineID)
 	})
 
 	// First call: INSERT path. Must not error and must write status='error'.
-	if err := markAPIMachineError(machineID, displayName, adapter); err != nil {
+	if err := s.markAPIMachineError(machineID, displayName, adapter); err != nil {
 		t.Fatalf("markAPIMachineError (insert): %v", err)
 	}
 
 	var hostname, status, tags string
-	if err := db.QueryRow(
+	if err := s.db.QueryRow(
 		`SELECT hostname, status, COALESCE(tags, '') FROM machines WHERE id = ?`,
 		machineID,
 	).Scan(&hostname, &status, &tags); err != nil {
@@ -3110,12 +3109,12 @@ func TestAPIMachineErrorUpsert(t *testing.T) {
 
 	// Second call: ON CONFLICT UPDATE path. Must not error and must keep
 	// status='error'. (Also validates the ON CONFLICT branch itself.)
-	if err := markAPIMachineError(machineID, displayName, adapter); err != nil {
+	if err := s.markAPIMachineError(machineID, displayName, adapter); err != nil {
 		t.Fatalf("markAPIMachineError (upsert): %v", err)
 	}
 
 	var statusAfterUpsert string
-	if err := db.QueryRow(
+	if err := s.db.QueryRow(
 		`SELECT status FROM machines WHERE id = ?`, machineID,
 	).Scan(&statusAfterUpsert); err != nil {
 		t.Fatalf("read after upsert: %v", err)

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -154,6 +154,10 @@ func setupTestServer(t *testing.T) (*echo.Echo, *Server) {
 	}
 
 	s := newServer(db)
+	// Registered after the db.Close() cleanup above so it runs BEFORE it:
+	// t.Cleanup is LIFO, and background work must drain while the database
+	// it queries is still open.
+	t.Cleanup(func() { s.Shutdown(2 * time.Second) })
 	s.seedTestAdmin(t)
 	jwtSecret = []byte("test-secret-key-for-smoke-tests")
 	rateLimiter = NewRateLimiter()
@@ -202,6 +206,10 @@ func setupEmptyTestServer(t *testing.T) (*echo.Echo, *Server) {
 	setupTokenValue = "test-setup-token-abc123"
 
 	s := newServer(db)
+	// Registered after the db.Close() cleanup above so it runs BEFORE it:
+	// t.Cleanup is LIFO, and background work must drain while the database
+	// it queries is still open.
+	t.Cleanup(func() { s.Shutdown(2 * time.Second) })
 
 	e := echo.New()
 	e.HideBanner = true

--- a/hub/password_test.go
+++ b/hub/password_test.go
@@ -41,7 +41,7 @@ func TestValidatePassword(t *testing.T) {
 // endpoint enforced 8. A 7-char password should now be rejected by all four
 // password-accepting endpoints with the same error message.
 func TestChangePasswordRejectsSevenCharPassword(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 	token := loginAndGetToken(t, e)
 
 	body := `{"current_password":"bloxos","new_password":"7chars7"}`
@@ -60,8 +60,8 @@ func TestChangePasswordRejectsSevenCharPassword(t *testing.T) {
 }
 
 func TestAdminCreateUserRejectsSevenCharPassword(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	adminToken := loginAndGetToken(t, e)
 
 	body := `{"username":"shorty","password":"7chars7","pin":"1234","role":"viewer"}`

--- a/hub/preferences.go
+++ b/hub/preferences.go
@@ -84,7 +84,7 @@ type UserPreferences struct {
 }
 
 // handleGetMyPreferences returns the entire prefs bundle in one round-trip.
-func handleGetMyPreferences(c echo.Context) error {
+func (s *Server) handleGetMyPreferences(c echo.Context) error {
 	claims, ok := authClaimsFromContext(c)
 	if !ok || claims.UserID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
@@ -96,7 +96,7 @@ func handleGetMyPreferences(c echo.Context) error {
 	}
 	var avatarSHA sql.NullString
 	var hasAvatar sql.NullInt64
-	err := db.QueryRow(`
+	err := s.db.QueryRow(`
 		SELECT
 			COALESCE(display_name, ''),
 			COALESCE(density, 'comfortable'),
@@ -135,7 +135,7 @@ func handleGetMyPreferences(c echo.Context) error {
 	}
 
 	// Pinned machines (most-recent first).
-	rows, err := db.Query(`
+	rows, err := s.db.Query(`
 		SELECT machine_id FROM user_pinned_machines WHERE user_id = ? ORDER BY pinned_at DESC
 	`, claims.UserID)
 	if err != nil {
@@ -154,7 +154,7 @@ func handleGetMyPreferences(c echo.Context) error {
 	}
 
 	// Saved filters (most-recent first).
-	frows, err := db.Query(`
+	frows, err := s.db.Query(`
 		SELECT id, name, filter_json, created_at
 		FROM user_saved_filters WHERE user_id = ? ORDER BY created_at DESC
 	`, claims.UserID)
@@ -179,7 +179,7 @@ func handleGetMyPreferences(c echo.Context) error {
 }
 
 // handlePatchMyPreferences accepts {display_name?, density?, default_view?, default_sort?}.
-func handlePatchMyPreferences(c echo.Context) error {
+func (s *Server) handlePatchMyPreferences(c echo.Context) error {
 	claims, ok := authClaimsFromContext(c)
 	if !ok || claims.UserID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
@@ -239,14 +239,14 @@ func handlePatchMyPreferences(c echo.Context) error {
 
 	query := fmt.Sprintf(`UPDATE users SET %s WHERE id = ?`, strings.Join(sets, ", "))
 	args = append(args, claims.UserID)
-	if _, err := db.Exec(query, args...); err != nil {
+	if _, err := s.db.Exec(query, args...); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
-	return handleGetMyPreferences(c)
+	return s.handleGetMyPreferences(c)
 }
 
 // handleUploadAvatar accepts a PNG up to 200 KB.
-func handleUploadAvatar(c echo.Context) error {
+func (s *Server) handleUploadAvatar(c echo.Context) error {
 	claims, ok := authClaimsFromContext(c)
 	if !ok || claims.UserID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
@@ -284,33 +284,33 @@ func handleUploadAvatar(c echo.Context) error {
 	sum := sha256.Sum256(data)
 	sha := hex.EncodeToString(sum[:])[:16]
 
-	if _, err := db.Exec(
+	if _, err := s.db.Exec(
 		`UPDATE users SET avatar_data = ?, avatar_mime = ?, avatar_sha = ? WHERE id = ?`,
 		data, "image/png", sha, claims.UserID,
 	); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
-	return handleGetMyPreferences(c)
+	return s.handleGetMyPreferences(c)
 }
 
 // handleDeleteAvatar clears the avatar columns.
-func handleDeleteAvatar(c echo.Context) error {
+func (s *Server) handleDeleteAvatar(c echo.Context) error {
 	claims, ok := authClaimsFromContext(c)
 	if !ok || claims.UserID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
 	}
-	if _, err := db.Exec(
+	if _, err := s.db.Exec(
 		`UPDATE users SET avatar_data = NULL, avatar_mime = NULL, avatar_sha = NULL WHERE id = ?`,
 		claims.UserID,
 	); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
-	return handleGetMyPreferences(c)
+	return s.handleGetMyPreferences(c)
 }
 
 // handleGetAvatar returns the avatar blob for any user. Cached aggressively
 // when the request's `?v=<sha>` matches the stored SHA.
-func handleGetAvatar(c echo.Context) error {
+func (s *Server) handleGetAvatar(c echo.Context) error {
 	userID := c.Param("user_id")
 	if userID == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "missing user_id"})
@@ -320,7 +320,7 @@ func handleGetAvatar(c echo.Context) error {
 		mime     sql.NullString
 		shaStore sql.NullString
 	)
-	err := db.QueryRow(
+	err := s.db.QueryRow(
 		`SELECT avatar_data, avatar_mime, avatar_sha FROM users WHERE id = ?`, userID,
 	).Scan(&data, &mime, &shaStore)
 	if err == sql.ErrNoRows || len(data) == 0 || !mime.Valid || mime.String == "" {
@@ -339,7 +339,7 @@ func handleGetAvatar(c echo.Context) error {
 }
 
 // handlePinMachine adds machine_id to the user's pinned set (idempotent).
-func handlePinMachine(c echo.Context) error {
+func (s *Server) handlePinMachine(c echo.Context) error {
 	claims, ok := authClaimsFromContext(c)
 	if !ok || claims.UserID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
@@ -351,13 +351,13 @@ func handlePinMachine(c echo.Context) error {
 	// Verify the machine exists so we don't accumulate orphan pins for
 	// hosts that never enrolled.
 	var exists int
-	if err := db.QueryRow(`SELECT 1 FROM machines WHERE id = ?`, machineID).Scan(&exists); err != nil {
+	if err := s.db.QueryRow(`SELECT 1 FROM machines WHERE id = ?`, machineID).Scan(&exists); err != nil {
 		if err == sql.ErrNoRows {
 			return c.JSON(http.StatusNotFound, map[string]string{"error": "machine not found"})
 		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
-	if _, err := db.Exec(
+	if _, err := s.db.Exec(
 		`INSERT OR IGNORE INTO user_pinned_machines (user_id, machine_id) VALUES (?, ?)`,
 		claims.UserID, machineID,
 	); err != nil {
@@ -367,7 +367,7 @@ func handlePinMachine(c echo.Context) error {
 }
 
 // handleUnpinMachine removes a pin (idempotent).
-func handleUnpinMachine(c echo.Context) error {
+func (s *Server) handleUnpinMachine(c echo.Context) error {
 	claims, ok := authClaimsFromContext(c)
 	if !ok || claims.UserID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
@@ -376,7 +376,7 @@ func handleUnpinMachine(c echo.Context) error {
 	if machineID == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "missing machine_id"})
 	}
-	if _, err := db.Exec(
+	if _, err := s.db.Exec(
 		`DELETE FROM user_pinned_machines WHERE user_id = ? AND machine_id = ?`,
 		claims.UserID, machineID,
 	); err != nil {
@@ -386,12 +386,12 @@ func handleUnpinMachine(c echo.Context) error {
 }
 
 // handleListSavedFilters returns this user's saved filters.
-func handleListSavedFilters(c echo.Context) error {
+func (s *Server) handleListSavedFilters(c echo.Context) error {
 	claims, ok := authClaimsFromContext(c)
 	if !ok || claims.UserID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
 	}
-	rows, err := db.Query(`
+	rows, err := s.db.Query(`
 		SELECT id, name, filter_json, created_at
 		FROM user_saved_filters WHERE user_id = ? ORDER BY created_at DESC
 	`, claims.UserID)
@@ -416,7 +416,7 @@ func handleListSavedFilters(c echo.Context) error {
 }
 
 // handleCreateSavedFilter accepts {name, filter}. Caps at maxSavedFiltersPerUser.
-func handleCreateSavedFilter(c echo.Context) error {
+func (s *Server) handleCreateSavedFilter(c echo.Context) error {
 	claims, ok := authClaimsFromContext(c)
 	if !ok || claims.UserID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
@@ -447,7 +447,7 @@ func handleCreateSavedFilter(c echo.Context) error {
 
 	// Enforce the per-user cap.
 	var count int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM user_saved_filters WHERE user_id = ?`, claims.UserID).Scan(&count); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM user_saved_filters WHERE user_id = ?`, claims.UserID).Scan(&count); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
 	if count >= maxSavedFiltersPerUser {
@@ -455,7 +455,7 @@ func handleCreateSavedFilter(c echo.Context) error {
 	}
 
 	id := uuid.New().String()
-	if _, err := db.Exec(
+	if _, err := s.db.Exec(
 		`INSERT INTO user_saved_filters (id, user_id, name, filter_json) VALUES (?, ?, ?, ?)`,
 		id, claims.UserID, name, string(body.Filter),
 	); err != nil {
@@ -465,7 +465,7 @@ func handleCreateSavedFilter(c echo.Context) error {
 	// Return the created row so the dashboard can prepend without refetching.
 	var created SavedFilter
 	var filterJSON string
-	err := db.QueryRow(
+	err := s.db.QueryRow(
 		`SELECT id, name, filter_json, created_at FROM user_saved_filters WHERE id = ?`,
 		id,
 	).Scan(&created.ID, &created.Name, &filterJSON, &created.CreatedAt)
@@ -477,7 +477,7 @@ func handleCreateSavedFilter(c echo.Context) error {
 }
 
 // handleDeleteSavedFilter removes one of the user's filters.
-func handleDeleteSavedFilter(c echo.Context) error {
+func (s *Server) handleDeleteSavedFilter(c echo.Context) error {
 	claims, ok := authClaimsFromContext(c)
 	if !ok || claims.UserID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
@@ -486,7 +486,7 @@ func handleDeleteSavedFilter(c echo.Context) error {
 	if id == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "missing id"})
 	}
-	res, err := db.Exec(
+	res, err := s.db.Exec(
 		`DELETE FROM user_saved_filters WHERE id = ? AND user_id = ?`,
 		id, claims.UserID,
 	)

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -140,7 +140,7 @@ var routeScopeRequirements = map[string]string{
 	routeScopeKey(http.MethodDelete, "/api/me/filters/:id"):                    scopeAuthSelf,
 }
 
-func permissionMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+func (s *Server) permissionMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		path := c.Path()
 		if path == "" {
@@ -157,7 +157,7 @@ func permissionMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
 		}
 
-		role, err := lookupUserRole(claims.UserID)
+		role, err := s.lookupUserRole(claims.UserID)
 		if err == sql.ErrNoRows {
 			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "user not found"})
 		}
@@ -192,9 +192,9 @@ func routeScopeKey(method, path string) string {
 	return method + " " + path
 }
 
-func lookupUserRole(userID string) (UserRole, error) {
+func (s *Server) lookupUserRole(userID string) (UserRole, error) {
 	var rawRole string
-	err := db.QueryRow(`SELECT COALESCE(role, 'admin') FROM users WHERE id = ?`, userID).Scan(&rawRole)
+	err := s.db.QueryRow(`SELECT COALESCE(role, 'admin') FROM users WHERE id = ?`, userID).Scan(&rawRole)
 	if err != nil {
 		return "", err
 	}

--- a/hub/refresh.go
+++ b/hub/refresh.go
@@ -23,12 +23,12 @@ import (
  * RBAC: fleet.control scope (operators + admins).
  * ============================================================================ */
 
-func handleMachineRefresh(c echo.Context) error {
+func (s *Server) handleMachineRefresh(c echo.Context) error {
 	machineID := c.Param("id")
 
-	agentsMu.RLock()
-	agent, ok := agents[machineID]
-	agentsMu.RUnlock()
+	s.agentsMu.RLock()
+	agent, ok := s.agents[machineID]
+	s.agentsMu.RUnlock()
 	if !ok {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "agent not connected"})
 	}
@@ -54,19 +54,19 @@ func handleMachineRefresh(c echo.Context) error {
 	})
 }
 
-func handleFleetRefresh(c echo.Context) error {
-	agentsMu.RLock()
-	machineIDs := make([]string, 0, len(agents))
-	for id := range agents {
+func (s *Server) handleFleetRefresh(c echo.Context) error {
+	s.agentsMu.RLock()
+	machineIDs := make([]string, 0, len(s.agents))
+	for id := range s.agents {
 		machineIDs = append(machineIDs, id)
 	}
-	agentsMu.RUnlock()
+	s.agentsMu.RUnlock()
 
 	refreshed := 0
 	for _, id := range machineIDs {
-		agentsMu.RLock()
-		agent, ok := agents[id]
-		agentsMu.RUnlock()
+		s.agentsMu.RLock()
+		agent, ok := s.agents[id]
+		s.agentsMu.RUnlock()
 		if !ok {
 			continue
 		}

--- a/hub/server.go
+++ b/hub/server.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"database/sql"
+	"log"
 	"sync"
+	"time"
 )
 
 // Server owns the per-instance state the hub's handlers operate on. Hanging
@@ -14,6 +16,18 @@ type Server struct {
 	// Connected agents keyed by machine ID.
 	agents   map[string]*ConnectedAgent
 	agentsMu sync.RWMutex
+
+	// Tracks background work this server spawned, so a caller can wait for
+	// it to finish before tearing the server down. See goTracked/Shutdown.
+	//
+	// lifecycleMu guards the wg.Add/closing pair. sync.WaitGroup requires
+	// that an Add which takes the counter up from zero happens-before any
+	// Wait; without this lock a connection arriving during teardown races
+	// Shutdown's Wait, which the race detector reports (and which is a real
+	// contract violation, not a false positive).
+	wg          sync.WaitGroup
+	lifecycleMu sync.Mutex
+	closing     bool
 }
 
 // newServer returns a Server backed by db with an empty agent registry.
@@ -21,5 +35,59 @@ func newServer(db *sql.DB) *Server {
 	return &Server{
 		db:     db,
 		agents: make(map[string]*ConnectedAgent),
+	}
+}
+
+// goTracked runs fn in a goroutine registered against this server's WaitGroup.
+//
+// Use it for background work that touches server-owned state (s.db, s.agents).
+// Such a goroutine can outlive the request that spawned it, and in tests it can
+// outlive the test itself — which is how issue #60's race was reachable: a
+// leaked announceVersionToAgent goroutine read the database handle while the
+// next test replaced it. Ownership (each Server holding its own db) is what
+// closes that race; this exists so a caller can additionally *wait* for the
+// work to drain rather than racing teardown against it.
+// Work offered after Shutdown has begun is dropped rather than started: the
+// server is being torn down, so the only alternative is to spawn a goroutine
+// nothing will ever wait for.
+func (s *Server) goTracked(fn func()) {
+	s.lifecycleMu.Lock()
+	if s.closing {
+		s.lifecycleMu.Unlock()
+		return
+	}
+	s.wg.Add(1)
+	s.lifecycleMu.Unlock()
+
+	go func() {
+		defer s.wg.Done()
+		fn()
+	}()
+}
+
+// Shutdown blocks until background work spawned via goTracked has finished, or
+// until timeout elapses. It reports whether everything drained in time.
+//
+// A timeout rather than an unbounded Wait: a wedged background goroutine should
+// surface as a diagnosable warning, not as a test binary that hangs until the
+// harness kills it with an unreadable stack dump.
+func (s *Server) Shutdown(timeout time.Duration) bool {
+	// Close the gate before waiting. Once this returns, goTracked can no
+	// longer call wg.Add, which is what makes the Wait below well-defined.
+	s.lifecycleMu.Lock()
+	s.closing = true
+	s.lifecycleMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		log.Printf("server shutdown: background work still running after %s", timeout)
+		return false
 	}
 }

--- a/hub/server.go
+++ b/hub/server.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"database/sql"
+	"sync"
+)
+
+// Server owns the per-instance state the hub's handlers operate on. Hanging
+// this off a struct (rather than package-level globals) lets each test build a
+// fully isolated instance instead of reassigning shared globals.
+type Server struct {
+	db *sql.DB
+
+	// Connected agents keyed by machine ID.
+	agents   map[string]*ConnectedAgent
+	agentsMu sync.RWMutex
+}
+
+// newServer returns a Server backed by db with an empty agent registry.
+func newServer(db *sql.DB) *Server {
+	return &Server{
+		db:     db,
+		agents: make(map[string]*ConnectedAgent),
+	}
+}

--- a/hub/terminal.go
+++ b/hub/terminal.go
@@ -73,7 +73,7 @@ func generateTerminalBrowserToken(sessionID, userID string) (string, error) {
 }
 
 // handleStartTerminal creates a terminal session and tells the agent to spawn a PTY.
-func handleStartTerminal(c echo.Context) error {
+func (s *Server) handleStartTerminal(c echo.Context) error {
 	ip := getRealIP(c)
 	if !rateLimiter.Allow("terminal", ip, 5) {
 		log.Printf("rate limit exceeded: terminal from %s", ip)
@@ -93,7 +93,7 @@ func handleStartTerminal(c echo.Context) error {
 	if userID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
 	}
-	if err := verifyTerminalPIN(userID, body.Pin); err != nil {
+	if err := s.verifyTerminalPIN(userID, body.Pin); err != nil {
 		return c.JSON(http.StatusForbidden, map[string]string{"error": "invalid PIN"})
 	}
 
@@ -111,9 +111,9 @@ func handleStartTerminal(c echo.Context) error {
 		return c.JSON(http.StatusTooManyRequests, map[string]string{"error": "max concurrent terminal sessions reached (3)"})
 	}
 
-	agentsMu.RLock()
-	agent, ok := agents[machineID]
-	agentsMu.RUnlock()
+	s.agentsMu.RLock()
+	agent, ok := s.agents[machineID]
+	s.agentsMu.RUnlock()
 	if !ok {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "agent not connected"})
 	}
@@ -150,20 +150,20 @@ func handleStartTerminal(c echo.Context) error {
 	go func() {
 		time.Sleep(30 * time.Second)
 		termSessionsMu.RLock()
-		s, exists := termSessions[sessionID]
+		sess, exists := termSessions[sessionID]
 		termSessionsMu.RUnlock()
 		if exists {
-			s.mu.Lock()
-			agentConnected := s.AgentWS != nil
-			s.mu.Unlock()
+			sess.mu.Lock()
+			agentConnected := sess.AgentWS != nil
+			sess.mu.Unlock()
 			if !agentConnected {
 				log.Printf("terminal %s: terminal_token expired (agent never connected)", sessionID)
-				cleanupTerminalSession(sessionID)
+				s.cleanupTerminalSession(sessionID)
 			}
 		}
 	}()
 
-	_, err = db.Exec(`INSERT INTO terminal_sessions (id, machine_id, source_ip, user_id) VALUES (?, ?, ?, ?)`, sessionID, machineID, sourceIP, userID)
+	_, err = s.db.Exec(`INSERT INTO terminal_sessions (id, machine_id, source_ip, user_id) VALUES (?, ?, ?, ?)`, sessionID, machineID, sourceIP, userID)
 	if err != nil {
 		log.Printf("terminal session DB insert error: %v", err)
 	}
@@ -192,7 +192,7 @@ func handleStartTerminal(c echo.Context) error {
 	})
 }
 
-func handleCloseTerminal(c echo.Context) error {
+func (s *Server) handleCloseTerminal(c echo.Context) error {
 	sessionID := c.Param("session_id")
 
 	termSessionsMu.RLock()
@@ -207,13 +207,13 @@ func handleCloseTerminal(c echo.Context) error {
 	// are closed, and the DB row is finalized. The old inline teardown deleted
 	// the map entry and closed the sockets but never closed Done, leaking the
 	// waiter goroutine on every close.
-	cleanupTerminalSession(sessionID)
+	s.cleanupTerminalSession(sessionID)
 
 	log.Printf("terminal session %s closed via API", sessionID)
 	return c.JSON(http.StatusOK, map[string]string{"status": "closed"})
 }
 
-func handleTerminalWS(c echo.Context) error {
+func (s *Server) handleTerminalWS(c echo.Context) error {
 	sessionID := c.Param("session_id")
 	role := c.QueryParam("role")
 	browserUserID := ""
@@ -320,7 +320,7 @@ func handleTerminalWS(c echo.Context) error {
 	session.mu.Unlock()
 
 	if agentWS != nil && browserWS != nil {
-		goSafelyOnce("terminalRelay/"+sessionID, func() { terminalRelay(sessionID, session) })
+		goSafelyOnce("terminalRelay/"+sessionID, func() { s.terminalRelay(sessionID, session) })
 	} else {
 		go func() {
 			time.Sleep(30 * time.Second)
@@ -330,7 +330,7 @@ func handleTerminalWS(c echo.Context) error {
 			session.mu.Unlock()
 			if a == nil || b == nil {
 				log.Printf("terminal %s: timeout waiting for both sides, cleaning up", sessionID)
-				cleanupTerminalSession(sessionID)
+				s.cleanupTerminalSession(sessionID)
 			}
 		}()
 	}
@@ -352,7 +352,7 @@ func waitForSessionEnd(sessionID string) <-chan struct{} {
 	return session.Done
 }
 
-func terminalRelay(sessionID string, session *TerminalSession) {
+func (s *Server) terminalRelay(sessionID string, session *TerminalSession) {
 	log.Printf("terminal %s: relay started", sessionID)
 	// Terminal audit: session metadata only. No command capture by design — see hardening plan item #13.
 
@@ -438,10 +438,10 @@ func terminalRelay(sessionID string, session *TerminalSession) {
 
 	<-done
 	log.Printf("terminal %s: relay ended, cleaning up", sessionID)
-	cleanupTerminalSession(sessionID)
+	s.cleanupTerminalSession(sessionID)
 }
 
-func cleanupTerminalSession(sessionID string) {
+func (s *Server) cleanupTerminalSession(sessionID string) {
 	termSessionsMu.Lock()
 	session, ok := termSessions[sessionID]
 	if ok {
@@ -471,5 +471,5 @@ func cleanupTerminalSession(sessionID string) {
 	log.Printf("terminal session %s closed: machine=%s user=%s ip=%s duration=%s",
 		sessionID, session.MachineID, session.UserID, session.SourceIP, duration)
 
-	_, _ = db.Exec(`UPDATE terminal_sessions SET ended_at = CURRENT_TIMESTAMP, status = 'closed' WHERE id = ?`, sessionID)
+	_, _ = s.db.Exec(`UPDATE terminal_sessions SET ended_at = CURRENT_TIMESTAMP, status = 'closed' WHERE id = ?`, sessionID)
 }

--- a/hub/update_signing_test.go
+++ b/hub/update_signing_test.go
@@ -184,7 +184,7 @@ func TestDetachedSignatureFor(t *testing.T) {
 // without it the agent has nothing to verify an announcement against and
 // self-update stays disabled.
 func TestInstallScriptPinsUpdateSigningKey(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/install.sh", nil)
 	rec := httptest.NewRecorder()
@@ -210,7 +210,7 @@ func TestInstallScriptPinsUpdateSigningKey(t *testing.T) {
 }
 
 func TestWindowsInstallScriptPinsUpdateSigningKey(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/install.ps1", nil)
 	rec := httptest.NewRecorder()
@@ -239,7 +239,7 @@ func TestWindowsInstallScriptPinsUpdateSigningKey(t *testing.T) {
 // "failed" after 3 restarts and fire OnFailure=, so this is about staying on
 // the documented key, not about repairing a broken rollback.
 func TestInstallScriptStartLimitLivesInUnitSection(t *testing.T) {
-	e := setupTestServer(t)
+	e, _ := setupTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/install.sh", nil)
 	rec := httptest.NewRecorder()
@@ -313,7 +313,7 @@ func splitUnitSections(t *testing.T, unit string) (string, string) {
 // on the wire" claim is TestNoSignatureMeansNoAnnounceOnTheWire below, which
 // drives a real agent WebSocket.
 func TestNoSignatureAvailableWithoutSigningKey(t *testing.T) {
-	setupTestServer(t)
+	_, _ = setupTestServer(t)
 	withoutSigningKey(t)
 
 	dir := t.TempDir()
@@ -585,20 +585,20 @@ type announceProbe struct {
 // collectAnnounceFrames enrols an agent, sends metrics so the hub learns the
 // OS, reports agent_running_version, and returns every agent_version frame
 // the hub sent within the window.
-func collectAnnounceFrames(t *testing.T, e *echo.Echo, p announceProbe) []string {
+func (s *Server) collectAnnounceFrames(t *testing.T, e *echo.Echo, p announceProbe) []string {
 	t.Helper()
 
 	server := httptest.NewServer(e)
 	t.Cleanup(server.Close)
 
-	token := seedValidToken(t)
+	token := s.seedValidToken(t)
 	conn, err := wsDialAgent(t, server, "token="+token)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
 	t.Cleanup(func() {
 		conn.Close()
-		waitAgentDrain(t, p.machineID, 2*time.Second)
+		s.waitAgentDrain(t, p.machineID, 2*time.Second)
 	})
 
 	sendMetricsMsg(t, conn, p.machineID)
@@ -677,12 +677,12 @@ func stagePendingUpdate(t *testing.T) {
 // That agent's AgentVersionMessage has no signature field, so it would take
 // the update unverified — the exact hop an on-path attacker owns.
 func TestLegacyAgentGetsNoAnnounceOverPlaintext(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	t.Setenv("PUBLIC_URL", "http://hub.example.com")
 	stagePendingUpdate(t)
 
 	const machineID = "legacy-plaintext-machine"
-	frames := collectAnnounceFrames(t, e, announceProbe{machineID: machineID, proto: 0})
+	frames := s.collectAnnounceFrames(t, e, announceProbe{machineID: machineID, proto: 0})
 	if len(frames) != 0 {
 		t.Fatalf("hub announced an update to a pre-signature agent over plaintext: %q", frames)
 	}
@@ -693,11 +693,11 @@ func TestLegacyAgentGetsNoAnnounceOverPlaintext(t *testing.T) {
 // off-host attacker cannot reach it. This is the control for the test above —
 // same helper, same proto — so the plaintext case cannot pass vacuously.
 func TestLegacyAgentGetsAnnounceOverTLS(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	t.Setenv("PUBLIC_URL", "https://hub.example.com")
 	stagePendingUpdate(t)
 
-	frames := collectAnnounceFrames(t, e, announceProbe{machineID: "legacy-tls-machine", proto: 0})
+	frames := s.collectAnnounceFrames(t, e, announceProbe{machineID: "legacy-tls-machine", proto: 0})
 	if len(frames) == 0 {
 		t.Fatal("hub withheld the migration announce from a legacy agent on a TLS deployment")
 	}
@@ -708,7 +708,7 @@ func TestLegacyAgentGetsAnnounceOverTLS(t *testing.T) {
 // reconnect expectation that expires into a false rollout failure. This test
 // previously asserted the opposite and locked in that bug; Codex caught it.
 func TestNoAnnounceWhenAgentReportsPlaintextTransport(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	// PUBLIC_URL says TLS. The agent says otherwise about its own hub URL,
 	// and the agent is the one that has to perform the download — this is
 	// the mixed deployment PUBLIC_URL alone cannot see.
@@ -716,7 +716,7 @@ func TestNoAnnounceWhenAgentReportsPlaintextTransport(t *testing.T) {
 	stagePendingUpdate(t)
 
 	const machineID = "capable-plaintext-machine"
-	frames := collectAnnounceFrames(t, e, announceProbe{machineID: machineID, proto: 1, transportOK: false})
+	frames := s.collectAnnounceFrames(t, e, announceProbe{machineID: machineID, proto: 1, transportOK: false})
 	if len(frames) != 0 {
 		t.Fatalf("hub announced an update the agent had already said it would refuse: %q", frames)
 	}
@@ -726,11 +726,11 @@ func TestNoAnnounceWhenAgentReportsPlaintextTransport(t *testing.T) {
 // And the same agent reporting a usable transport and a pinned key is
 // announced to normally, with a signature it can actually verify.
 func TestSignatureCapableAgentWithUsableTransportGetsSignedAnnounce(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	t.Setenv("PUBLIC_URL", "https://hub.example.com")
 	stagePendingUpdate(t)
 
-	frames := collectAnnounceFrames(t, e, announceProbe{machineID: "capable-tls-machine", proto: 1, transportOK: true, keyPinned: true})
+	frames := s.collectAnnounceFrames(t, e, announceProbe{machineID: "capable-tls-machine", proto: 1, transportOK: true, keyPinned: true})
 	if len(frames) == 0 {
 		t.Fatal("hub withheld an announce from a signature-capable agent on a usable transport")
 	}
@@ -759,12 +759,12 @@ func TestSignatureCapableAgentWithUsableTransportGetsSignedAnnounce(t *testing.T
 // machines trips the fleet-wide circuit breaker — blaming agent health for
 // a refusal the hub itself provoked.
 func TestNoAnnounceWhenAgentKeyNotPinned(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	t.Setenv("PUBLIC_URL", "https://hub.example.com")
 	stagePendingUpdate(t)
 
 	const machineID = "capable-unpinned-machine"
-	frames := collectAnnounceFrames(t, e, announceProbe{machineID: machineID, proto: 1, transportOK: true, keyPinned: false})
+	frames := s.collectAnnounceFrames(t, e, announceProbe{machineID: machineID, proto: 1, transportOK: true, keyPinned: false})
 	if len(frames) != 0 {
 		t.Fatalf("hub announced an update to an agent with no pinned key: %q", frames)
 	}
@@ -791,12 +791,12 @@ func TestNoAnnounceWhenAgentKeyNotPinned(t *testing.T) {
 // bool field at its zero value, and this test is what pins that behavior in
 // place rather than trusting it not to change out from under the gate.
 func TestNoAnnounceWhenAgentOmitsKeyPinnedField(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	t.Setenv("PUBLIC_URL", "https://hub.example.com")
 	stagePendingUpdate(t)
 
 	const machineID = "capable-legacy-field-machine"
-	frames := collectAnnounceFrames(t, e, announceProbe{machineID: machineID, proto: 1, transportOK: true, omitKeyPinned: true})
+	frames := s.collectAnnounceFrames(t, e, announceProbe{machineID: machineID, proto: 1, transportOK: true, omitKeyPinned: true})
 	if len(frames) != 0 {
 		t.Fatalf("hub announced an update to an agent that never reported update_key_pinned: %q", frames)
 	}
@@ -807,7 +807,7 @@ func TestNoAnnounceWhenAgentOmitsKeyPinnedField(t *testing.T) {
 // the old TestNoSignatureMeansNoAnnounce made in its name but never tested:
 // with no signing key, nothing goes out on the socket at all.
 func TestNoSignatureMeansNoAnnounceOnTheWire(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	t.Setenv("PUBLIC_URL", "https://hub.example.com")
 	withoutSigningKey(t)
 	stagePendingUpdate(t)
@@ -815,7 +815,7 @@ func TestNoSignatureMeansNoAnnounceOnTheWire(t *testing.T) {
 	const machineID = "unsigned-hub-machine"
 	// keyPinned: true isolates the variable this test is about — the hub
 	// cannot sign — from the key-pinned gate, which has its own tests below.
-	frames := collectAnnounceFrames(t, e, announceProbe{machineID: machineID, proto: 1, transportOK: true, keyPinned: true})
+	frames := s.collectAnnounceFrames(t, e, announceProbe{machineID: machineID, proto: 1, transportOK: true, keyPinned: true})
 	if len(frames) != 0 {
 		t.Fatalf("hub announced an update it could not sign: %q", frames)
 	}
@@ -826,7 +826,7 @@ func TestNoSignatureMeansNoAnnounceOnTheWire(t *testing.T) {
 // fleet that has permanently stopped updating is indistinguishable from a
 // rollout in progress: update_pending true on every agent, forever.
 func TestVersionsAPIReportsWhyUpdatesAreWithheld(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	t.Setenv("PUBLIC_URL", "https://hub.example.com")
 	withoutSigningKey(t)
 	setUpdateSigningDisabled("the signing key at /etc/bloxos/x.key is corrupt")
@@ -850,7 +850,7 @@ func TestVersionsAPIReportsWhyUpdatesAreWithheld(t *testing.T) {
 		agentRunningVersionsMu.Unlock()
 	})
 
-	markCredentialsRotated(t)
+	s.markCredentialsRotated(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/versions", nil)
 	req.Header.Set("Authorization", "Bearer "+loginAndGetToken(t, e))
 	rec := httptest.NewRecorder()
@@ -912,8 +912,8 @@ func TestVersionsAPIReportsWhyUpdatesAreWithheld(t *testing.T) {
 // work runs in a goroutine and the test fails on a deadline instead of
 // stalling the suite silently. Run under -race for the full signal.
 func TestVersionsAPIDoesNotDeadlockWithConcurrentAgentReports(t *testing.T) {
-	e := setupTestServer(t)
-	markCredentialsRotated(t)
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
 	token := loginAndGetToken(t, e)
 	stagePendingUpdate(t)
 
@@ -961,7 +961,7 @@ func TestVersionsAPIDoesNotDeadlockWithConcurrentAgentReports(t *testing.T) {
 						return
 					default:
 					}
-					recordAgentRunningVersion(fmt.Sprintf("deadlock-probe-%d", i%machines),
+					s.recordAgentRunningVersion(fmt.Sprintf("deadlock-probe-%d", i%machines),
 						agentVersionReport{
 							RunningSHA:     strings.Repeat("44", 32),
 							OS:             "linux",

--- a/hub/user_prefs.go
+++ b/hub/user_prefs.go
@@ -31,14 +31,14 @@ type themePrefs struct {
 	ThemeMode string `json:"theme_mode"`
 }
 
-func handleGetMyThemePrefs(c echo.Context) error {
+func (s *Server) handleGetMyThemePrefs(c echo.Context) error {
 	claims, ok := authClaimsFromContext(c)
 	if !ok || claims.UserID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
 	}
 
 	var prefs themePrefs
-	err := db.QueryRow(
+	err := s.db.QueryRow(
 		`SELECT COALESCE(theme_name, 'bloxos'), COALESCE(theme_mode, 'system') FROM users WHERE id = ?`,
 		claims.UserID,
 	).Scan(&prefs.ThemeName, &prefs.ThemeMode)
@@ -60,7 +60,7 @@ func handleGetMyThemePrefs(c echo.Context) error {
 	return c.JSON(http.StatusOK, prefs)
 }
 
-func handleUpdateMyThemePrefs(c echo.Context) error {
+func (s *Server) handleUpdateMyThemePrefs(c echo.Context) error {
 	claims, ok := authClaimsFromContext(c)
 	if !ok || claims.UserID == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
@@ -108,8 +108,8 @@ func handleUpdateMyThemePrefs(c echo.Context) error {
 	query += ` WHERE id = ?`
 	args = append(args, claims.UserID)
 
-	if _, err := db.Exec(query, args...); err != nil {
+	if _, err := s.db.Exec(query, args...); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
-	return handleGetMyThemePrefs(c)
+	return s.handleGetMyThemePrefs(c)
 }

--- a/hub/users.go
+++ b/hub/users.go
@@ -23,7 +23,7 @@ type userRecord struct {
 
 var pinPattern = regexp.MustCompile(`^\d{4,}$`)
 
-func handleCreateUser(c echo.Context) error {
+func (s *Server) handleCreateUser(c echo.Context) error {
 	var body struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
@@ -53,7 +53,7 @@ func handleCreateUser(c echo.Context) error {
 	}
 
 	var existing string
-	err := db.QueryRow(`SELECT id FROM users WHERE username = ?`, body.Username).Scan(&existing)
+	err := s.db.QueryRow(`SELECT id FROM users WHERE username = ?`, body.Username).Scan(&existing)
 	if err == nil {
 		return c.JSON(http.StatusConflict, map[string]string{"error": "username already exists"})
 	}
@@ -72,7 +72,7 @@ func handleCreateUser(c echo.Context) error {
 
 	id := uuid.New().String()
 	// Admin-provisioned users must rotate the temporary credentials on first login.
-	_, err = db.Exec(
+	_, err = s.db.Exec(
 		`INSERT INTO users (id, username, password_hash, terminal_pin_hash, password_changed, pin_changed, role) VALUES (?, ?, ?, ?, FALSE, FALSE, ?)`,
 		id, body.Username, string(passwordHash), string(pinHash), role,
 	)
@@ -80,15 +80,15 @@ func handleCreateUser(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create user"})
 	}
 
-	rec, err := fetchUser(id)
+	rec, err := s.fetchUser(id)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "user created but fetch failed"})
 	}
 	return c.JSON(http.StatusCreated, rec)
 }
 
-func handleListUsers(c echo.Context) error {
-	rows, err := db.Query(
+func (s *Server) handleListUsers(c echo.Context) error {
+	rows, err := s.db.Query(
 		`SELECT id, username, COALESCE(role, 'admin'), created_at,
 		        COALESCE(password_changed, FALSE), COALESCE(pin_changed, FALSE)
 		 FROM users ORDER BY created_at ASC`,
@@ -109,7 +109,7 @@ func handleListUsers(c echo.Context) error {
 	return c.JSON(http.StatusOK, users)
 }
 
-func handleUpdateUser(c echo.Context) error {
+func (s *Server) handleUpdateUser(c echo.Context) error {
 	targetID := c.Param("id")
 	if targetID == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "user id required"})
@@ -132,7 +132,7 @@ func handleUpdateUser(c echo.Context) error {
 	}
 
 	var currentRole string
-	if err := db.QueryRow(`SELECT COALESCE(role, 'admin') FROM users WHERE id = ?`, targetID).Scan(&currentRole); err != nil {
+	if err := s.db.QueryRow(`SELECT COALESCE(role, 'admin') FROM users WHERE id = ?`, targetID).Scan(&currentRole); err != nil {
 		if err == sql.ErrNoRows {
 			return c.JSON(http.StatusNotFound, map[string]string{"error": "user not found"})
 		}
@@ -150,7 +150,7 @@ func handleUpdateUser(c echo.Context) error {
 		if currentRole == string(RoleAdmin) && newRole != RoleAdmin {
 			// Atomic check-and-demote: the subquery guard ensures we never
 			// drop below 1 admin even under concurrent requests.
-			res, err := db.Exec(
+			res, err := s.db.Exec(
 				`UPDATE users SET role = ? WHERE id = ? AND (SELECT COUNT(*) FROM users WHERE role = ?) > 1`,
 				newRole, targetID, RoleAdmin,
 			)
@@ -160,7 +160,7 @@ func handleUpdateUser(c echo.Context) error {
 			if n, _ := res.RowsAffected(); n == 0 {
 				return c.JSON(http.StatusBadRequest, map[string]string{"error": "cannot demote the last admin"})
 			}
-		} else if _, err := db.Exec(`UPDATE users SET role = ? WHERE id = ?`, newRole, targetID); err != nil {
+		} else if _, err := s.db.Exec(`UPDATE users SET role = ? WHERE id = ?`, newRole, targetID); err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update role"})
 		}
 	}
@@ -174,7 +174,7 @@ func handleUpdateUser(c echo.Context) error {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to hash password"})
 		}
 		// Force the target to rotate on next login.
-		if _, err := db.Exec(
+		if _, err := s.db.Exec(
 			`UPDATE users SET password_hash = ?, password_changed = FALSE WHERE id = ?`,
 			string(hash), targetID,
 		); err != nil {
@@ -190,7 +190,7 @@ func handleUpdateUser(c echo.Context) error {
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to hash PIN"})
 		}
-		if _, err := db.Exec(
+		if _, err := s.db.Exec(
 			`UPDATE users SET terminal_pin_hash = ?, pin_changed = FALSE WHERE id = ?`,
 			string(hash), targetID,
 		); err != nil {
@@ -198,14 +198,14 @@ func handleUpdateUser(c echo.Context) error {
 		}
 	}
 
-	rec, err := fetchUser(targetID)
+	rec, err := s.fetchUser(targetID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "user updated but fetch failed"})
 	}
 	return c.JSON(http.StatusOK, rec)
 }
 
-func handleDeleteUser(c echo.Context) error {
+func (s *Server) handleDeleteUser(c echo.Context) error {
 	targetID := c.Param("id")
 	if targetID == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "user id required"})
@@ -219,7 +219,7 @@ func handleDeleteUser(c echo.Context) error {
 	}
 
 	var role string
-	if err := db.QueryRow(`SELECT COALESCE(role, 'admin') FROM users WHERE id = ?`, targetID).Scan(&role); err != nil {
+	if err := s.db.QueryRow(`SELECT COALESCE(role, 'admin') FROM users WHERE id = ?`, targetID).Scan(&role); err != nil {
 		if err == sql.ErrNoRows {
 			return c.JSON(http.StatusNotFound, map[string]string{"error": "user not found"})
 		}
@@ -227,7 +227,7 @@ func handleDeleteUser(c echo.Context) error {
 	}
 	if role == string(RoleAdmin) {
 		// Atomic check-and-delete: only succeeds when >1 admin exists.
-		res, err := db.Exec(
+		res, err := s.db.Exec(
 			`DELETE FROM users WHERE id = ? AND (SELECT COUNT(*) FROM users WHERE role = ?) > 1`,
 			targetID, RoleAdmin,
 		)
@@ -240,15 +240,15 @@ func handleDeleteUser(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "deleted"})
 	}
 
-	if _, err := db.Exec(`DELETE FROM users WHERE id = ?`, targetID); err != nil {
+	if _, err := s.db.Exec(`DELETE FROM users WHERE id = ?`, targetID); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
 	return c.JSON(http.StatusOK, map[string]string{"status": "deleted"})
 }
 
-func fetchUser(id string) (userRecord, error) {
+func (s *Server) fetchUser(id string) (userRecord, error) {
 	var u userRecord
-	err := db.QueryRow(
+	err := s.db.QueryRow(
 		`SELECT id, username, COALESCE(role, 'admin'), created_at,
 		        COALESCE(password_changed, FALSE), COALESCE(pin_changed, FALSE)
 		 FROM users WHERE id = ?`,
@@ -257,9 +257,9 @@ func fetchUser(id string) (userRecord, error) {
 	return u, err
 }
 
-func isLastAdmin() (bool, error) {
+func (s *Server) isLastAdmin() (bool, error) {
 	var count int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM users WHERE role = ?`, RoleAdmin).Scan(&count); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM users WHERE role = ?`, RoleAdmin).Scan(&count); err != nil {
 		return false, err
 	}
 	return count <= 1, nil

--- a/hub/ws_credential_headers_test.go
+++ b/hub/ws_credential_headers_test.go
@@ -24,12 +24,12 @@ func dialWSWithHeader(t *testing.T, server *httptest.Server, path string, h http
 // TestAgentWSAuthViaSecretHeader proves /ws/agent authenticates a durable
 // secret presented in the Authorization header, with no query credentials.
 func TestAgentWSAuthViaSecretHeader(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	token := seedValidToken(t)
-	secret := enrollAndCaptureSecret(t, server, token, "machine-hdr-secret")
+	token := s.seedValidToken(t)
+	secret := s.enrollAndCaptureSecret(t, server, token, "machine-hdr-secret")
 	if secret == "" {
 		t.Fatal("enrollment did not yield a secret")
 	}
@@ -49,9 +49,9 @@ func TestAgentWSAuthViaSecretHeader(t *testing.T) {
 	// A secret-authenticated connection is registered at upgrade time.
 	deadline := time.Now().Add(2 * time.Second)
 	for {
-		agentsMu.RLock()
-		_, ok := agents["machine-hdr-secret"]
-		agentsMu.RUnlock()
+		s.agentsMu.RLock()
+		_, ok := s.agents["machine-hdr-secret"]
+		s.agentsMu.RUnlock()
 		if ok {
 			break
 		}
@@ -65,11 +65,11 @@ func TestAgentWSAuthViaSecretHeader(t *testing.T) {
 // TestAgentWSEnrollViaTokenHeader proves /ws/agent performs token enrollment
 // when the install token is presented in the X-Bloxos-Enroll-Token header.
 func TestAgentWSEnrollViaTokenHeader(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	token := seedValidToken(t)
+	token := s.seedValidToken(t)
 	h := http.Header{}
 	h.Set("X-Bloxos-Enroll-Token", token)
 	conn, resp, err := dialWSWithHeader(t, server, "/ws/agent", h)
@@ -110,12 +110,12 @@ func TestAgentWSEnrollViaTokenHeader(t *testing.T) {
 // TestAgentWSSecretQueryFallback proves the deprecated query-param credential
 // path still authenticates, so agents predating the header change keep working.
 func TestAgentWSSecretQueryFallback(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	token := seedValidToken(t)
-	secret := enrollAndCaptureSecret(t, server, token, "machine-qp-secret")
+	token := s.seedValidToken(t)
+	secret := s.enrollAndCaptureSecret(t, server, token, "machine-qp-secret")
 
 	conn, resp, err := dialWSWithHeader(t, server, "/ws/agent?secret="+secret, nil)
 	if err != nil {
@@ -129,9 +129,9 @@ func TestAgentWSSecretQueryFallback(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Second)
 	for {
-		agentsMu.RLock()
-		_, ok := agents["machine-qp-secret"]
-		agentsMu.RUnlock()
+		s.agentsMu.RLock()
+		_, ok := s.agents["machine-qp-secret"]
+		s.agentsMu.RUnlock()
 		if ok {
 			break
 		}
@@ -145,7 +145,7 @@ func TestAgentWSSecretQueryFallback(t *testing.T) {
 // TestTerminalAgentTokenViaHeader proves /ws/terminal role=agent accepts the
 // terminal token in the X-Bloxos-Terminal-Token header.
 func TestTerminalAgentTokenViaHeader(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	server := httptest.NewServer(e)
 	defer server.Close()
 
@@ -161,7 +161,7 @@ func TestTerminalAgentTokenViaHeader(t *testing.T) {
 		Done:          make(chan struct{}),
 	}
 	termSessionsMu.Unlock()
-	t.Cleanup(func() { cleanupTerminalSession(sid) })
+	t.Cleanup(func() { s.cleanupTerminalSession(sid) })
 
 	h := http.Header{}
 	h.Set("X-Bloxos-Terminal-Token", "tok-header-abc")
@@ -179,7 +179,7 @@ func TestTerminalAgentTokenViaHeader(t *testing.T) {
 // TestTerminalAgentTokenQueryFallback proves the deprecated query-param
 // terminal_token still authenticates the agent role.
 func TestTerminalAgentTokenQueryFallback(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	server := httptest.NewServer(e)
 	defer server.Close()
 
@@ -195,7 +195,7 @@ func TestTerminalAgentTokenQueryFallback(t *testing.T) {
 		Done:          make(chan struct{}),
 	}
 	termSessionsMu.Unlock()
-	t.Cleanup(func() { cleanupTerminalSession(sid) })
+	t.Cleanup(func() { s.cleanupTerminalSession(sid) })
 
 	conn, resp, err := dialWSWithHeader(t, server, "/ws/terminal/"+sid+"?role=agent&terminal_token=tok-qp-abc", nil)
 	if err != nil {
@@ -211,7 +211,7 @@ func TestTerminalAgentTokenQueryFallback(t *testing.T) {
 // TestTerminalAgentInvalidTokenHeaderRejected proves a wrong header token is
 // rejected before upgrade.
 func TestTerminalAgentInvalidTokenHeaderRejected(t *testing.T) {
-	e := setupTestServer(t)
+	e, s := setupTestServer(t)
 	server := httptest.NewServer(e)
 	defer server.Close()
 
@@ -226,7 +226,7 @@ func TestTerminalAgentInvalidTokenHeaderRejected(t *testing.T) {
 		Done:          make(chan struct{}),
 	}
 	termSessionsMu.Unlock()
-	t.Cleanup(func() { cleanupTerminalSession(sid) })
+	t.Cleanup(func() { s.cleanupTerminalSession(sid) })
 
 	h := http.Header{}
 	h.Set("X-Bloxos-Terminal-Token", "tok-wrong")


### PR DESCRIPTION
Closes #60.

Scoped deliberately: this is the subset of `BLOXOS_FUTURE.md`'s PR 0 that #60 actually requires, **not** the whole 12-PR refactor. The plan's PR 0 is rated *"~3000 LOC, Risk: Highest"* and moves ~30 globals; #60's acceptance criteria only concern the database handle and async lifecycle. Every other global (`jwtSecret`, `rateLimiter`, `telegramToken`, `sseClients`, `pendingCmds`, `termSessions`, `machineLatency`, `apiPollers`, `setupTokenValue`, the update-signing vars) stays put and migrates in follow-ups. Read-only vars — regexes, valid-value maps, `migrations`, `roleScopes` — are constants, not state, and don't move.

## The three commits, split by nature

| Commit | Kind | What |
|---|---|---|
| `6f8356a` | **Mechanical** | `db`, `agents`, `agentsMu` onto a `Server` struct; 108 production functions + 13 test helpers become methods. No behavior change. |
| `f9a5ca3` | **Behavioral** | `goTracked`/`Shutdown` so a server can wait for background work it spawned. |
| `db3f988` | **CI** | Remove `continue-on-error`, rename to `Hub Tests (race)`. Last, only after green. |

The mechanical commit is deliberately reviewable as noise: I verified it by normalizing away `s.`/receiver insertions and diffing — **574 of 596 hunks are byte-identical** after normalization. The remaining 22 are the disclosed signature changes (`setupTestServer` → `(*echo.Echo, *Server)`, `setupAlertsDB` → `*Server`), one forced local rename (`s` shadowed the receiver in `terminal.go` → `sess`), two comment trims, and `server.go` itself.

## Race proof — non-vacuous, not just "tests pass"

A green race run proves nothing on its own. So:

| Run | Result |
|---|---|
| `main` (baseline) | **2 races** — `TestAgentWSSecretQueryFallback`, `TestTerminalAgentTokenViaHeader` FAIL |
| This branch | **0 races**, 0 failures |
| This branch **+ surgical reintroduction of the shared global** | **2 races return**, the *same two tests* fail, write site `setupTestServer() main_test.go:133` |

The third run is what makes the second meaningful: put the global reassignment back and the identical race returns, so the fix is the ownership change and not scheduling luck.

Stability before flipping the gate: **four consecutive full race runs**, all clean. A flaky blocking gate would be worse than the advisory one it replaces.

## A bug this PR introduced and fixed

The first draft of `f9a5ca3` **added** 2 races. `goTracked` called `wg.Add(1)` while `Shutdown` was in `wg.Wait()` — a real `sync.WaitGroup` contract violation (an `Add` taking the counter up from zero must happen-before any `Wait`), triggered by an agent connecting during teardown. `lifecycleMu` + a `closing` flag is what makes the `Wait` well-defined. Documented in the commit because the lock looks like defensive padding otherwise.

## Verification

- `go build ./...`, `go vet ./...` clean
- `go test -count=1 ./...` green; **test count unchanged at 215**, sorted test-name sets byte-identical — nothing added, removed, renamed, or skipped
- `go test -race -count=1 ./...` clean ×4

## Out of scope, filed not fixed

- Pre-existing `gofmt` drift in `alerts_test.go`, `preferences.go`, `rbac.go`, `ssrf_test.go` — predates this branch, untouched
- `setupTestServer` still mutates `jwtSecret`/`rateLimiter`/`setupTokenValue`/`termSessions`, so its `time.Sleep(100ms)` drain hack has to stay until `termSessions` migrates
- Receiver `s` is shadowed by pre-existing locals in 5 methods — harmless today, and a future collision would be a compile error, not a silent bug

## ⚠️ Requires a repo-settings change to fully close #60

`Hub Tests (race)` still has to be added to `main`'s **required status checks**. Branch protection currently requires only `Hub Tests`, `Agent Tests`, and `Dashboard Lint + Build` — so until that list is updated, this job can fail without blocking a merge. That's #60's last unchecked box and it can't be done from a PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large hub refactor touching DB, agent WebSocket registration, and async lifecycle across most handlers; behavior should be equivalent but blast radius is the entire hub request path.
> 
> **Overview**
> **Closes #60** by moving the hub database handle and connected-agent registry off package globals onto a **`Server`** instance, so production and tests each own isolated state instead of reassigning shared globals under leaked WebSocket goroutines.
> 
> Handlers, DB paths, and agent WS logic become **`(*Server)` methods**; **`main`** builds one server via **`newServer(db)`** and wires routes through **`s.registerRoutes`**. Background work that touches server state (e.g. version announce on connect) runs via **`goTracked`**, with **`Shutdown`** waiting for drain during test teardown ( **`lifecycleMu` + `closing`** avoid WaitGroup races during shutdown).
> 
> Tests now get **`(*echo.Echo, *Server)`** from **`setupTestServer`** and call helpers like **`s.seedValidToken`** / **`s.db`** on that instance.
> 
> **CI:** **`hub-race`** drops **`continue-on-error`** and is documented as a real blocking gate now that race tests are stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db3f988236a79bd23de88864c0ad56ed22615fc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->