### PR TITLE
Fix Windows agent update verification and swap logic

### DIFF
--- a/agent/marker.go
+++ b/agent/marker.go
@@ -1,4 +1,3 @@
-
 package main
 
 import (

--- a/agent/marker.go
+++ b/agent/marker.go
@@ -1,0 +1,32 @@
+
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+type pendingMarker struct {
+	ExpectedSHA string
+	Signature   string
+}
+
+// parsePendingMarker reads the marker file and extracts sha256 and signature.
+// It handles arbitrary ordering, unknown fields, and duplicate fields (takes the last one).
+func parsePendingMarker(path string) (pendingMarker, error) {
+	var pm pendingMarker
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return pm, err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "sha256=") {
+			pm.ExpectedSHA = strings.TrimPrefix(line, "sha256=")
+		} else if strings.HasPrefix(line, "signature=") {
+			pm.Signature = strings.TrimPrefix(line, "signature=")
+		}
+	}
+	return pm, nil
+}

--- a/agent/marker_test.go
+++ b/agent/marker_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParsePendingMarker(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marker.pending")
+
+	tests := []struct {
+		name        string
+		content     string
+		expectedSHA string
+		expectedSig string
+	}{
+		{
+			name:        "normal",
+			content:     "source=a\ntarget=b\nat=time\nsha256=123456\nsignature=base64pad==\n",
+			expectedSHA: "123456",
+			expectedSig: "base64pad==",
+		},
+		{
+			name:        "different order with unknown fields",
+			content:     "unknown=value\nsignature=sig=\ntarget=b\nsha256=abcdef\nfoo=bar\n",
+			expectedSHA: "abcdef",
+			expectedSig: "sig=",
+		},
+		{
+			name:        "duplicate fields take last",
+			content:     "sha256=first\nsha256=last\nsignature=sig1\nsignature=sig2\n",
+			expectedSHA: "last",
+			expectedSig: "sig2",
+		},
+		{
+			name:        "missing signature",
+			content:     "sha256=123456\n",
+			expectedSHA: "123456",
+			expectedSig: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("write failed: %v", err)
+			}
+			pm, err := parsePendingMarker(path)
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+			if pm.ExpectedSHA != tt.expectedSHA {
+				t.Errorf("expected sha256 %q, got %q", tt.expectedSHA, pm.ExpectedSHA)
+			}
+			if pm.Signature != tt.expectedSig {
+				t.Errorf("expected signature %q, got %q", tt.expectedSig, pm.Signature)
+			}
+		})
+	}
+}

--- a/agent/updater_windows.go
+++ b/agent/updater_windows.go
@@ -206,20 +206,9 @@ func applyPendingUpdate() {
 	markerPath := exe + ".pending"
 	newPath := exe + ".new"
 
-	if _, err := os.Stat(markerPath); err != nil {
-		return // no pending update
-	}
-	if _, err := os.Stat(newPath); err != nil {
-		// Marker present but new binary missing — clean up the stale marker.
-		log.Printf("update: stale .pending marker (no .new binary), cleaning up")
-		os.Remove(markerPath)
-		return
-	}
-
-	if err := validatePendingUpdate(exe, markerPath, newPath); err != nil {
-		log.Printf("update: %v, cleaning up", err)
-		os.Remove(markerPath)
-		os.Remove(newPath)
+	if err := checkAndCleanPendingUpdate(exe, markerPath, newPath); err != nil {
+		// checkAndCleanPendingUpdate handles its own logging and cleanup,
+		// but also cleanly returns err for missing markers where we just abort.
 		return
 	}
 
@@ -244,6 +233,28 @@ func applyPendingUpdate() {
 
 	log.Printf("update: helper spawned, exiting so SCM can restart on new binary")
 	os.Exit(0)
+}
+
+// checkAndCleanPendingUpdate wraps the validation of a pending update and centralizes
+// the failure cleanup. If validation fails, it deletes both files.
+func checkAndCleanPendingUpdate(exe, markerPath, newPath string) error {
+	if _, err := os.Stat(markerPath); err != nil {
+		return err // No pending update marker, expected standard abort path.
+	}
+	if _, err := os.Stat(newPath); err != nil {
+		log.Printf("update: stale .pending marker (no .new binary), cleaning up")
+		os.Remove(markerPath)
+		return fmt.Errorf("missing .new binary")
+	}
+
+	if err := validatePendingUpdate(exe, markerPath, newPath); err != nil {
+		log.Printf("update: %v, cleaning up", err)
+		os.Remove(markerPath)
+		os.Remove(newPath)
+		return err
+	}
+
+	return nil
 }
 
 // validatePendingUpdate reads and validates the marker, hashes the staged .new file,

--- a/agent/updater_windows.go
+++ b/agent/updater_windows.go
@@ -117,7 +117,7 @@ func handleAgentVersion(msg []byte) {
 			updateInFlightWindows = false
 			updateMuWindows.Unlock()
 		}()
-		if err := performUpdateWindows(version.SHA256); err != nil {
+		if err := performUpdateWindows(version.SHA256, version.Signature); err != nil {
 			log.Printf("update: FAILED — %v (continuing on current version)", err)
 		}
 	}()
@@ -126,7 +126,7 @@ func handleAgentVersion(msg []byte) {
 // performUpdateWindows downloads the new binary, verifies its SHA, writes a
 // marker file, and exits. SCM will restart us; applyPendingUpdate runs on
 // boot and arranges the actual swap via a helper batch script.
-func performUpdateWindows(expectedSHA string) error {
+func performUpdateWindows(expectedSHA, signature string) error {
 	exe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("get executable path: %w", err)
@@ -169,14 +169,14 @@ func performUpdateWindows(expectedSHA string) error {
 	// Write the pending marker so applyPendingUpdate, on next boot,
 	// picks up the swap.
 	now := time.Now().UTC().Format(time.RFC3339)
-	marker := fmt.Sprintf("source=%s\ntarget=%s\nat=%s\n", newPath, exe, now)
+	marker := fmt.Sprintf("source=%s\ntarget=%s\nat=%s\nsha256=%s\nsignature=%s\n", newPath, exe, now, expectedSHA, signature)
 	if err := os.WriteFile(markerPath, []byte(marker), 0644); err != nil {
 		os.Remove(newPath)
 		return fmt.Errorf("write pending marker: %w", err)
 	}
 
 	log.Printf("update: marker written, exiting for SCM restart + helper to apply swap")
-	os.Exit(0)
+	os.Exit(1)
 	return nil // unreachable
 }
 
@@ -215,6 +215,53 @@ func applyPendingUpdate() {
 		return
 	}
 
+	markerData, err := os.ReadFile(markerPath)
+	if err != nil {
+		log.Printf("update: could not read .pending marker, cleaning up")
+		os.Remove(markerPath)
+		os.Remove(newPath)
+		return
+	}
+
+	var expectedSHA, signature string
+	for _, line := range strings.Split(string(markerData), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "sha256=") {
+			expectedSHA = strings.TrimPrefix(line, "sha256=")
+		} else if strings.HasPrefix(line, "signature=") {
+			signature = strings.TrimPrefix(line, "signature=")
+		}
+	}
+
+	if expectedSHA == "" || signature == "" {
+		log.Printf("update: invalid .pending marker (missing sha256 or signature), cleaning up")
+		os.Remove(markerPath)
+		os.Remove(newPath)
+		return
+	}
+
+	downloadedSHA, err := computeFileSHA256(newPath)
+	if err != nil {
+		log.Printf("update: failed to compute SHA of .new binary: %v, cleaning up", err)
+		os.Remove(markerPath)
+		os.Remove(newPath)
+		return
+	}
+
+	if !strings.EqualFold(downloadedSHA, expectedSHA) {
+		log.Printf("update: SHA mismatch for staged binary (expected %s, got %s), cleaning up", shortSHA(expectedSHA), shortSHA(downloadedSHA))
+		os.Remove(markerPath)
+		os.Remove(newPath)
+		return
+	}
+
+	if err := verifyAnnouncedRelease(exe, "windows", downloadedSHA, signature); err != nil {
+		log.Printf("update: staged binary failed signature verification: %v, cleaning up", err)
+		os.Remove(markerPath)
+		os.Remove(newPath)
+		return
+	}
+
 	log.Printf("update: applying pending update via batch helper")
 
 	dir := filepath.Dir(exe)
@@ -247,7 +294,6 @@ func buildHelperBatch(target, newBin, marker string) string {
 	marker = filepath.FromSlash(marker)
 	return "@echo off\r\n" +
 		"timeout /t 3 /nobreak > nul\r\n" +
-		"del \"" + target + "\" 2> nul\r\n" +
 		"move /Y \"" + newBin + "\" \"" + target + "\" > nul\r\n" +
 		"del \"" + marker + "\" 2> nul\r\n" +
 		"sc.exe start " + windowsServiceName + " > nul\r\n" +

--- a/agent/updater_windows.go
+++ b/agent/updater_windows.go
@@ -216,38 +216,8 @@ func applyPendingUpdate() {
 		return
 	}
 
-	pm, err := parsePendingMarker(markerPath)
-	if err != nil {
-		log.Printf("update: could not read .pending marker, cleaning up")
-		os.Remove(markerPath)
-		os.Remove(newPath)
-		return
-	}
-
-	if pm.ExpectedSHA == "" || pm.Signature == "" {
-		log.Printf("update: invalid .pending marker (missing sha256 or signature), cleaning up")
-		os.Remove(markerPath)
-		os.Remove(newPath)
-		return
-	}
-
-	downloadedSHA, err := computeFileSHA256(newPath)
-	if err != nil {
-		log.Printf("update: failed to compute SHA of .new binary: %v, cleaning up", err)
-		os.Remove(markerPath)
-		os.Remove(newPath)
-		return
-	}
-
-	if !strings.EqualFold(downloadedSHA, pm.ExpectedSHA) {
-		log.Printf("update: SHA mismatch for staged binary (expected %s, got %s), cleaning up", shortSHA(pm.ExpectedSHA), shortSHA(downloadedSHA))
-		os.Remove(markerPath)
-		os.Remove(newPath)
-		return
-	}
-
-	if err := verifyAnnouncedRelease(exe, "windows", downloadedSHA, pm.Signature); err != nil {
-		log.Printf("update: staged binary failed signature verification: %v, cleaning up", err)
+	if err := validatePendingUpdate(exe, markerPath, newPath); err != nil {
+		log.Printf("update: %v, cleaning up", err)
 		os.Remove(markerPath)
 		os.Remove(newPath)
 		return
@@ -274,6 +244,34 @@ func applyPendingUpdate() {
 
 	log.Printf("update: helper spawned, exiting so SCM can restart on new binary")
 	os.Exit(0)
+}
+
+// validatePendingUpdate reads and validates the marker, hashes the staged .new file,
+// and calls the real signature-verification mechanism. Returns an error if any step fails.
+func validatePendingUpdate(exe, markerPath, newPath string) error {
+	pm, err := parsePendingMarker(markerPath)
+	if err != nil {
+		return fmt.Errorf("could not read .pending marker: %w", err)
+	}
+
+	if pm.ExpectedSHA == "" || pm.Signature == "" {
+		return fmt.Errorf("invalid .pending marker (missing sha256 or signature)")
+	}
+
+	downloadedSHA, err := computeFileSHA256(newPath)
+	if err != nil {
+		return fmt.Errorf("failed to compute SHA of .new binary: %w", err)
+	}
+
+	if !strings.EqualFold(downloadedSHA, pm.ExpectedSHA) {
+		return fmt.Errorf("SHA mismatch for staged binary (expected %s, got %s)", shortSHA(pm.ExpectedSHA), shortSHA(downloadedSHA))
+	}
+
+	if err := verifyAnnouncedRelease(exe, "windows", downloadedSHA, pm.Signature); err != nil {
+		return fmt.Errorf("staged binary failed signature verification: %w", err)
+	}
+
+	return nil
 }
 
 // buildHelperBatch returns the contents of the .bat we leave on disk.

--- a/agent/updater_windows.go
+++ b/agent/updater_windows.go
@@ -33,11 +33,12 @@ import (
  *   1. Hub announces a new SHA via agent_version frame.
  *   2. Agent downloads to <exe>.new, verifies SHA.
  *   3. Agent writes a marker file <exe>.pending describing the swap.
- *   4. Agent exits cleanly. SCM restarts us per recovery actions.
+ *   4. Agent exits with failure (code 1) so SCM restarts us per recovery actions.
  *   5. NEW process boot: applyPendingUpdate() runs BEFORE the SCM main
- *      loop. If <exe>.pending + <exe>.new exist, spawn a detached batch
- *      helper that: sleeps, deletes the running exe, renames .new ->
- *      target, removes marker, restarts the service, and self-deletes.
+ *      loop. If <exe>.pending + <exe>.new exist, it reads the marker, verifies
+ *      the signature and SHA, and spawns a detached batch helper that:
+ *      sleeps, moves .new -> target over the running exe, removes marker,
+ *      restarts the service, and self-deletes.
  *   6. The newly-restarted service boots from the new binary cleanly.
  *
  * Why a batch helper instead of doing the work in-process: by the time
@@ -215,7 +216,7 @@ func applyPendingUpdate() {
 		return
 	}
 
-	markerData, err := os.ReadFile(markerPath)
+	pm, err := parsePendingMarker(markerPath)
 	if err != nil {
 		log.Printf("update: could not read .pending marker, cleaning up")
 		os.Remove(markerPath)
@@ -223,17 +224,7 @@ func applyPendingUpdate() {
 		return
 	}
 
-	var expectedSHA, signature string
-	for _, line := range strings.Split(string(markerData), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "sha256=") {
-			expectedSHA = strings.TrimPrefix(line, "sha256=")
-		} else if strings.HasPrefix(line, "signature=") {
-			signature = strings.TrimPrefix(line, "signature=")
-		}
-	}
-
-	if expectedSHA == "" || signature == "" {
+	if pm.ExpectedSHA == "" || pm.Signature == "" {
 		log.Printf("update: invalid .pending marker (missing sha256 or signature), cleaning up")
 		os.Remove(markerPath)
 		os.Remove(newPath)
@@ -248,14 +239,14 @@ func applyPendingUpdate() {
 		return
 	}
 
-	if !strings.EqualFold(downloadedSHA, expectedSHA) {
-		log.Printf("update: SHA mismatch for staged binary (expected %s, got %s), cleaning up", shortSHA(expectedSHA), shortSHA(downloadedSHA))
+	if !strings.EqualFold(downloadedSHA, pm.ExpectedSHA) {
+		log.Printf("update: SHA mismatch for staged binary (expected %s, got %s), cleaning up", shortSHA(pm.ExpectedSHA), shortSHA(downloadedSHA))
 		os.Remove(markerPath)
 		os.Remove(newPath)
 		return
 	}
 
-	if err := verifyAnnouncedRelease(exe, "windows", downloadedSHA, signature); err != nil {
+	if err := verifyAnnouncedRelease(exe, "windows", downloadedSHA, pm.Signature); err != nil {
 		log.Printf("update: staged binary failed signature verification: %v, cleaning up", err)
 		os.Remove(markerPath)
 		os.Remove(newPath)

--- a/agent/updater_windows_test.go
+++ b/agent/updater_windows_test.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildHelperBatchMovesNotDeletes(t *testing.T) {
+	helper := buildHelperBatch("target.exe", "new.exe", "marker.pending")
+	if strings.Contains(helper, "del \"target.exe\"") {
+		t.Errorf("buildHelperBatch contains del target: %s", helper)
+	}
+	if !strings.Contains(helper, "move /Y \"new.exe\" \"target.exe\"") {
+		t.Errorf("buildHelperBatch does not contain move /Y: %s", helper)
+	}
+}

--- a/agent/updater_windows_test.go
+++ b/agent/updater_windows_test.go
@@ -3,9 +3,136 @@
 package main
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// The newTestKey and signFor helpers are copied from update_verify_test.go because tests cannot
+// easily export cross-package or cross-file without a separate test package.
+func genTestKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return pub, priv
+}
+
+func signData(t *testing.T, priv ed25519.PrivateKey, osName, sha string) string {
+	t.Helper()
+	return base64.StdEncoding.EncodeToString(ed25519.Sign(priv, updateSigningMessage(osName, sha)))
+}
+
+func pinTestKey(t *testing.T, pub ed25519.PublicKey) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "agent-update.pub")
+	body := "# bloxos agent update signing key\n" +
+		base64.StdEncoding.EncodeToString(pub) + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write pinned key: %v", err)
+	}
+	t.Setenv("BLOXOS_UPDATE_PUBKEY_PATH", path)
+	return path
+}
+
+func writeTestBinary(t *testing.T, path string, content string) string {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	h := sha256.New()
+	h.Write([]byte(content))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func writeTestMarker(t *testing.T, path, sha, sig string) {
+	t.Helper()
+	content := "sha256=" + sha + "\nsignature=" + sig + "\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+}
+
+func TestValidatePendingUpdate(t *testing.T) {
+	pub, priv := genTestKey(t)
+	pinTestKey(t, pub)
+
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "agent.exe")
+	newPath := exe + ".new"
+	markerPath := exe + ".pending"
+
+	// Create dummy binary
+	validSHA := writeTestBinary(t, newPath, "dummy exe content")
+	validSig := signData(t, priv, "windows", validSHA)
+
+	tests := []struct {
+		name        string
+		setup       func()
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "success",
+			setup: func() {
+				writeTestMarker(t, markerPath, validSHA, validSig)
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing SHA in marker",
+			setup: func() {
+				writeTestMarker(t, markerPath, "", validSig)
+			},
+			wantErr:     true,
+			errContains: "missing sha256 or signature",
+		},
+		{
+			name: "missing signature in marker",
+			setup: func() {
+				writeTestMarker(t, markerPath, validSHA, "")
+			},
+			wantErr:     true,
+			errContains: "missing sha256 or signature",
+		},
+		{
+			name: "mismatched SHA",
+			setup: func() {
+				writeTestMarker(t, markerPath, strings.Repeat("0", 64), validSig)
+			},
+			wantErr:     true,
+			errContains: "SHA mismatch",
+		},
+		{
+			name: "invalid signature",
+			setup: func() {
+				writeTestMarker(t, markerPath, validSHA, "invalid_base64_sig")
+			},
+			wantErr:     true,
+			errContains: "signature verification",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			err := validatePendingUpdate(exe, markerPath, newPath)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validatePendingUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("error = %v, should contain %q", err, tt.errContains)
+			}
+		})
+	}
+}
 
 func TestBuildHelperBatchMovesNotDeletes(t *testing.T) {
 	helper := buildHelperBatch("target.exe", "new.exe", "marker.pending")
@@ -14,5 +141,41 @@ func TestBuildHelperBatchMovesNotDeletes(t *testing.T) {
 	}
 	if !strings.Contains(helper, "move /Y \"new.exe\" \"target.exe\"") {
 		t.Errorf("buildHelperBatch does not contain move /Y: %s", helper)
+	}
+}
+
+// TestApplyPendingUpdateCleanup verifies that if validatePendingUpdate fails,
+// both .new and .pending files are removed.
+func TestApplyPendingUpdateCleanup(t *testing.T) {
+	pub, _ := genTestKey(t)
+	pinTestKey(t, pub) // Use a valid pinned key, but we'll provide bad marker data to force failure.
+
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "agent.exe")
+	newPath := exe + ".new"
+	markerPath := exe + ".pending"
+
+	// Setup: create both files. The marker data is invalid (empty), so validatePendingUpdate will fail.
+	writeTestBinary(t, newPath, "dummy content")
+	writeTestMarker(t, markerPath, "", "")
+
+	// Emulate the first half of applyPendingUpdate.
+	// Since applyPendingUpdate directly accesses os.Executable and calls os.Exit, we test the snippet
+	// that performs validation and cleanup.
+
+	err := validatePendingUpdate(exe, markerPath, newPath)
+	if err != nil {
+		os.Remove(markerPath)
+		os.Remove(newPath)
+	} else {
+		t.Fatal("validatePendingUpdate should have failed")
+	}
+
+	// Verify both files are removed.
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Errorf("marker path %s should have been removed", markerPath)
+	}
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Errorf("new binary path %s should have been removed", newPath)
 	}
 }

--- a/agent/updater_windows_test.go
+++ b/agent/updater_windows_test.go
@@ -3,44 +3,13 @@
 package main
 
 import (
-	"crypto/ed25519"
-	"crypto/rand"
 	"crypto/sha256"
-	"encoding/base64"
 	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
-
-// The newTestKey and signFor helpers are copied from update_verify_test.go because tests cannot
-// easily export cross-package or cross-file without a separate test package.
-func genTestKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
-	t.Helper()
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatalf("generate key: %v", err)
-	}
-	return pub, priv
-}
-
-func signData(t *testing.T, priv ed25519.PrivateKey, osName, sha string) string {
-	t.Helper()
-	return base64.StdEncoding.EncodeToString(ed25519.Sign(priv, updateSigningMessage(osName, sha)))
-}
-
-func pinTestKey(t *testing.T, pub ed25519.PublicKey) string {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), "agent-update.pub")
-	body := "# bloxos agent update signing key\n" +
-		base64.StdEncoding.EncodeToString(pub) + "\n"
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
-		t.Fatalf("write pinned key: %v", err)
-	}
-	t.Setenv("BLOXOS_UPDATE_PUBKEY_PATH", path)
-	return path
-}
 
 func writeTestBinary(t *testing.T, path string, content string) string {
 	t.Helper()
@@ -60,75 +29,101 @@ func writeTestMarker(t *testing.T, path, sha, sig string) {
 	}
 }
 
-func TestValidatePendingUpdate(t *testing.T) {
-	pub, priv := genTestKey(t)
-	pinTestKey(t, pub)
+func TestCheckAndCleanPendingUpdate(t *testing.T) {
+	// Reuse helpers from update_verify_test.go (they are in package main so available here)
+	pub, priv := newTestKey(t)
+	pinKey(t, pub)
 
 	dir := t.TempDir()
 	exe := filepath.Join(dir, "agent.exe")
 	newPath := exe + ".new"
 	markerPath := exe + ".pending"
 
-	// Create dummy binary
+	// Create dummy binary to generate valid references
 	validSHA := writeTestBinary(t, newPath, "dummy exe content")
-	validSig := signData(t, priv, "windows", validSHA)
+	validSig := signFor(t, priv, "windows", validSHA)
 
 	tests := []struct {
-		name        string
-		setup       func()
-		wantErr     bool
-		errContains string
+		name    string
+		setup   func()
+		wantErr bool
 	}{
 		{
-			name: "success",
+			name: "success - keeps files",
 			setup: func() {
+				writeTestBinary(t, newPath, "dummy exe content")
 				writeTestMarker(t, markerPath, validSHA, validSig)
 			},
 			wantErr: false,
 		},
 		{
-			name: "missing SHA in marker",
+			name: "missing SHA - deletes files",
 			setup: func() {
+				writeTestBinary(t, newPath, "dummy exe content")
 				writeTestMarker(t, markerPath, "", validSig)
 			},
-			wantErr:     true,
-			errContains: "missing sha256 or signature",
+			wantErr: true,
 		},
 		{
-			name: "missing signature in marker",
+			name: "missing signature - deletes files",
 			setup: func() {
+				writeTestBinary(t, newPath, "dummy exe content")
 				writeTestMarker(t, markerPath, validSHA, "")
 			},
-			wantErr:     true,
-			errContains: "missing sha256 or signature",
+			wantErr: true,
 		},
 		{
-			name: "mismatched SHA",
+			name: "mismatched SHA - deletes files",
 			setup: func() {
+				writeTestBinary(t, newPath, "dummy exe content")
 				writeTestMarker(t, markerPath, strings.Repeat("0", 64), validSig)
 			},
-			wantErr:     true,
-			errContains: "SHA mismatch",
+			wantErr: true,
 		},
 		{
-			name: "invalid signature",
+			name: "invalid signature - deletes files",
 			setup: func() {
+				writeTestBinary(t, newPath, "dummy exe content")
 				writeTestMarker(t, markerPath, validSHA, "invalid_base64_sig")
 			},
-			wantErr:     true,
-			errContains: "signature verification",
+			wantErr: true,
+		},
+		{
+			name: "missing new binary - deletes marker",
+			setup: func() {
+				os.Remove(newPath)
+				writeTestMarker(t, markerPath, validSHA, validSig)
+			},
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			os.Remove(newPath)
+			os.Remove(markerPath)
 			tt.setup()
-			err := validatePendingUpdate(exe, markerPath, newPath)
+
+			err := checkAndCleanPendingUpdate(exe, markerPath, newPath)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("validatePendingUpdate() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("checkAndCleanPendingUpdate() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if tt.wantErr && !strings.Contains(err.Error(), tt.errContains) {
-				t.Errorf("error = %v, should contain %q", err, tt.errContains)
+
+			// Verify presence of files based on wantErr
+			if tt.wantErr {
+				if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+					t.Errorf("marker file should be deleted on error")
+				}
+				if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+					t.Errorf("new binary should be deleted on error")
+				}
+			} else {
+				if _, err := os.Stat(markerPath); os.IsNotExist(err) {
+					t.Errorf("marker file should NOT be deleted on success")
+				}
+				if _, err := os.Stat(newPath); os.IsNotExist(err) {
+					t.Errorf("new binary should NOT be deleted on success")
+				}
 			}
 		})
 	}
@@ -141,41 +136,5 @@ func TestBuildHelperBatchMovesNotDeletes(t *testing.T) {
 	}
 	if !strings.Contains(helper, "move /Y \"new.exe\" \"target.exe\"") {
 		t.Errorf("buildHelperBatch does not contain move /Y: %s", helper)
-	}
-}
-
-// TestApplyPendingUpdateCleanup verifies that if validatePendingUpdate fails,
-// both .new and .pending files are removed.
-func TestApplyPendingUpdateCleanup(t *testing.T) {
-	pub, _ := genTestKey(t)
-	pinTestKey(t, pub) // Use a valid pinned key, but we'll provide bad marker data to force failure.
-
-	dir := t.TempDir()
-	exe := filepath.Join(dir, "agent.exe")
-	newPath := exe + ".new"
-	markerPath := exe + ".pending"
-
-	// Setup: create both files. The marker data is invalid (empty), so validatePendingUpdate will fail.
-	writeTestBinary(t, newPath, "dummy content")
-	writeTestMarker(t, markerPath, "", "")
-
-	// Emulate the first half of applyPendingUpdate.
-	// Since applyPendingUpdate directly accesses os.Executable and calls os.Exit, we test the snippet
-	// that performs validation and cleanup.
-
-	err := validatePendingUpdate(exe, markerPath, newPath)
-	if err != nil {
-		os.Remove(markerPath)
-		os.Remove(newPath)
-	} else {
-		t.Fatal("validatePendingUpdate should have failed")
-	}
-
-	// Verify both files are removed.
-	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
-		t.Errorf("marker path %s should have been removed", markerPath)
-	}
-	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
-		t.Errorf("new binary path %s should have been removed", newPath)
 	}
 }


### PR DESCRIPTION
This commit addresses issue #144 where the Windows agent's `applyPendingUpdate` did not verify the staging binary's SHA and signature before swapping it over the running binary. It implements the suggested fixes:
- Records the verified SHA and signature in the `.pending` marker file.
- Changes `applyPendingUpdate` to read the marker file and strictly re-verify the staged `.new` binary before invoking the swap helper.
- Modifies `performUpdateWindows` to exit with code 1 instead of 0 to ensure proper SCM restart handling.
- Updates the helper batch script to perform a "move-not-delete" by dropping the `del target` command.

---
*PR created automatically by Jules for task [2589803896229289901](https://jules.google.com/task/2589803896229289901) started by @bokiko*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes agent self-update and cryptographic verification immediately before replacing the running Windows binary; bugs could block updates or weaken swap-time checks.
> 
> **Overview**
> **Hardens the Windows self-update path** so a staged binary is not swapped in unless SHA and hub signature are re-checked at boot, using values persisted in the `.pending` marker.
> 
> `performUpdateWindows` now records `sha256` and `signature` in the marker, passes the announcement signature through the update flow, and exits with code **1** (instead of 0) so SCM recovery restarts the agent as intended. On boot, `applyPendingUpdate` delegates to `checkAndCleanPendingUpdate` / `validatePendingUpdate`, which parse the marker via new `parsePendingMarker`, hash the `.new` file, and call `verifyAnnouncedRelease`; failures remove the marker and staged binary.
> 
> The update helper batch script **drops** `del` on the running target and relies on **`move /Y`** to replace the exe. Unit tests cover marker parsing, validation/cleanup behavior, and batch script contents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d5c6eeee2425fc7b9dbd45982e54c2d23858e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Closes #144
