### PR TITLE
docs: add source-build onboarding configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,91 @@
+# BloxOS configuration reference
+#
+# Copy this file to .env for local development, then load it with:
+#   set -a; . ./.env; set +a
+# Empty optional values use the application's built-in default.
+
+# --- Hub: startup and public URL policy ---
+
+# REQUIRED unless ALLOWED_ORIGINS is set. Public browser-facing base URL used
+# for CORS fallback, generated install commands, and update transport policy.
+PUBLIC_URL=http://localhost:4000
+
+# REQUIRED unless PUBLIC_URL is set. Comma-separated browser origins allowed
+# to call the hub. Set this explicitly when dashboard and hub use different
+# origins, as they do in local development.
+ALLOWED_ORIGINS=http://localhost:3000
+
+# Hub listen address. Defaults to 127.0.0.1:4000.
+HUB_LISTEN=127.0.0.1:4000
+
+# JWT signing secret. Must be at least 32 bytes when set. If empty, the hub
+# persists a generated secret under its service user's ~/.bloxos directory.
+BLOXOS_JWT_SECRET=
+
+# Fixed first-boot setup token. If empty, the hub persists a generated token
+# under its service user's ~/.bloxos directory.
+BLOXOS_SETUP_TOKEN=
+
+# Additional CA certificate used by generated installers and agent TLS.
+BLOXOS_CA_CERT=
+
+# Absolute Linux agent binary served by the hub. Set this in deployments to
+# avoid relying on the working-directory-sensitive fallback resolver.
+BLOXOS_AGENT_BINARY=
+
+# Absolute Windows agent binary served by the hub.
+BLOXOS_AGENT_BINARY_WINDOWS=
+
+# Base64 Ed25519 public key for offline-signing mode. When set, the hub only
+# announces detached <binary>.sig signatures and holds no private key.
+BLOXOS_UPDATE_PUBKEY=
+
+# Explicit Ed25519 private-key file used for online update signing. If empty,
+# the hub uses ~/.bloxos/update-signing.key.
+BLOXOS_UPDATE_SIGNING_KEY=
+
+# Allow authenticated API-machine pollers to target RFC1918 addresses.
+# Leave disabled unless private network targets are intentional.
+BLOXOS_ALLOW_PRIVATE_TARGETS=0
+
+# Telegram bot token. Notifications are disabled unless both Telegram values
+# are set.
+BLOXOS_TELEGRAM_TOKEN=
+
+# Telegram destination chat ID. Notifications are disabled unless both
+# Telegram values are set.
+BLOXOS_TELEGRAM_CHAT_ID=
+
+# --- Agent: connection, enrollment, and local behavior ---
+
+# Hub base WebSocket URL. The agent appends /ws/agent.
+BLOXOS_HUB=ws://localhost:4000
+
+# Durable per-machine secret. Normally written by enrollment rather than set
+# by hand; it takes precedence over BLOXOS_TOKEN.
+BLOXOS_SECRET=
+
+# One-time enrollment token. Remove it after the agent stores its secret.
+BLOXOS_TOKEN=
+
+# Linux user used for terminal sessions. If empty, the agent searches common
+# non-root operator accounts before falling back to its current user.
+BLOXOS_TERMINAL_USER=
+
+# Override the pinned update-public-key file. Defaults to
+# /etc/bloxos/agent-update.pub on Linux and beside the executable on Windows.
+BLOXOS_UPDATE_PUBKEY_PATH=
+
+# Development-only TLS bypass. It is honored only by agents deliberately
+# built with "-tags insecure"; release/default builds ignore it.
+BLOXOS_TLS_INSECURE=0
+
+# ProgramFiles is supplied by Windows and is only read to locate NVIDIA tools.
+# Do not normally override the operating-system value.
+# ProgramFiles=C:\Program Files
+
+# --- Dashboard ---
+
+# Browser-visible hub origin. Set it when the dashboard and hub are served
+# from different origins. Empty means same-origin API calls.
+NEXT_PUBLIC_HUB_URL=http://localhost:4000

--- a/README.md
+++ b/README.md
@@ -107,56 +107,122 @@ SSE from hub to browser means the dashboard updates live without WebSocket compl
 
 ---
 
-## Quick start
+## Configuration
 
-> **Status:** BloxOS is pre-1.0. The core app runs in production, but the polished one-line public installer is still in progress. The commands below are the current source-built development path.
+The hub refuses to start unless an origin policy is explicit. Set
+`PUBLIC_URL`, `ALLOWED_ORIGINS`, or both before the first boot. Copy
+[.env.example](.env.example) for a commented reference covering every
+environment variable read by the Go hub and agent.
 
-### 1. Run the hub
+| Variable | Required | Purpose |
+|---|---:|---|
+| `PUBLIC_URL` | **Yes, unless `ALLOWED_ORIGINS` is set** | Browser-facing hub URL; also drives generated commands and update transport policy. |
+| `ALLOWED_ORIGINS` | **Yes, unless `PUBLIC_URL` is set** | Comma-separated browser origins permitted by CORS. |
+| `HUB_LISTEN` | No | Hub listen address; defaults to `127.0.0.1:4000`. |
+| `BLOXOS_JWT_SECRET` | No | JWT secret, at least 32 bytes; otherwise generated and persisted. |
+| `BLOXOS_SETUP_TOKEN` | No | Fixed first-boot setup token; otherwise generated and persisted. |
+| `BLOXOS_CA_CERT` | No | Additional CA certificate used by installers and agents. |
+| `BLOXOS_AGENT_BINARY` | Recommended | Absolute Linux agent binary served by the hub. |
+| `BLOXOS_AGENT_BINARY_WINDOWS` | No | Absolute Windows agent binary served by the hub. |
+| `BLOXOS_UPDATE_PUBKEY` | No | Base64 Ed25519 public key for detached-signature mode. |
+| `BLOXOS_UPDATE_SIGNING_KEY` | No | Explicit online-signing private-key path. |
+| `BLOXOS_ALLOW_PRIVATE_TARGETS` | No | Set to `1` to permit API pollers to target RFC1918 addresses. |
+| `BLOXOS_TELEGRAM_TOKEN` | No | Telegram bot token; both Telegram values are needed. |
+| `BLOXOS_TELEGRAM_CHAT_ID` | No | Telegram destination chat ID. |
+| `BLOXOS_HUB` | Agent | Hub base WebSocket URL; the agent appends `/ws/agent`. |
+| `BLOXOS_SECRET` | Agent | Durable machine credential, normally managed by enrollment. |
+| `BLOXOS_TOKEN` | Agent enrollment | One-time enrollment token. |
+| `BLOXOS_TERMINAL_USER` | No | Linux account used for terminal sessions. |
+| `BLOXOS_UPDATE_PUBKEY_PATH` | No | Override for the agent's pinned update-key file. |
+| `BLOXOS_TLS_INSECURE` | Development only | TLS bypass available only in an agent built with `-tags insecure`. |
+| `ProgramFiles` | Windows-provided | Used to discover NVIDIA tooling; normally never overridden. |
+| `NEXT_PUBLIC_HUB_URL` | Dashboard | Hub origin when dashboard and hub are not same-origin. |
 
-On any Linux machine you want as the central server:
+## Quick start from source
+
+> **Status:** BloxOS is pre-1.0. The polished public installer is still in
+> progress. This path builds the hub and Linux agent from source and keeps the
+> first enrollment on loopback.
+
+### 1. Clone and build
 
 ```bash
 git clone https://github.com/bokiko/bloxos.git
-cd bloxos/hub
-go run .
+cd bloxos
+mkdir -p bin
+(cd hub && go build -o ../bin/bloxos-hub .)
+(cd agent && go build -o ../bin/bloxos-agent .)
 ```
 
-This starts the hub API on `127.0.0.1:4000` by default. On first run it creates a setup token in `~/.bloxos/setup-token`; use that token on the dashboard setup screen to create the first admin.
+To build the Windows agent artifact:
 
-### 2. Run the dashboard
+```bash
+(cd agent && GOOS=windows GOARCH=amd64 go build -o ../bin/bloxos-agent.exe .)
+```
+
+Windows enrollment is under active rework and is intentionally not documented
+as a runnable installer flow yet.
+
+### 2. Configure and run the hub
+
+These exports set the origin policy required for startup. The explicit
+agent-binary path also ensures that the download endpoint serves the artifact
+you just built.
+
+```bash
+export PUBLIC_URL=http://localhost:4000
+export ALLOWED_ORIGINS=http://localhost:3000
+export HUB_LISTEN=127.0.0.1:4000
+export BLOXOS_AGENT_BINARY="$PWD/bin/bloxos-agent"
+./bin/bloxos-hub
+```
+
+On first run the hub creates a setup token in `~/.bloxos/setup-token`.
+Keep this shell running.
+
+### 3. Run the dashboard
 
 In another shell:
 
 ```bash
 cd bloxos/dashboard
 pnpm install
-pnpm dev
+NEXT_PUBLIC_HUB_URL=http://localhost:4000 pnpm dev
 ```
 
-Open `http://localhost:3000`. With the default empty `NEXT_PUBLIC_HUB_URL`, the browser uses the same origin for API calls. For a split dev setup, set `NEXT_PUBLIC_HUB_URL=http://localhost:4000`.
+Open `http://localhost:3000`, enter the setup token, and create the first
+admin account.
 
-For LAN production, run the hub on `127.0.0.1:4000`, run the dashboard on `127.0.0.1:3000`, and put Caddy in front using [scripts/caddy/Caddyfile](scripts/caddy/Caddyfile). Then browse to `https://<hub-host>`.
+### 4. Enroll the local Linux agent
 
-### 3. Add your first machine
+In the dashboard, choose **Add Machine → Linux** and run the generated command
+on this same machine. The loopback quick start avoids a remote first-contact
+trust decision while the public bootstrap flow is being reworked. The agent
+uses its one-time token once, stores a durable machine secret, and then appears
+in the fleet.
 
-Click **Add Machine** in the dashboard. Pick **Linux** or **Windows**. The hub creates a one-time install token and returns a command that calls the generated `/install.sh` or `/install.ps1` endpoint. Run that command on the target machine. The agent installs, registers, stores a durable per-machine secret, and shows up in the dashboard within seconds.
+For a LAN deployment, terminate TLS in front of the hub, set `PUBLIC_URL` to
+that trusted HTTPS origin, set `ALLOWED_ORIGINS` to the dashboard origin, and
+keep `BLOXOS_AGENT_BINARY` on an explicit absolute path. A safe cold-start
+bootstrap for a private or self-signed CA remains tracked in
+[#150](https://github.com/bokiko/bloxos/issues/150).
 
-For Linux:
+### 5. Production builds and sample services
+
 ```bash
-export BLOXOS_HUB=wss://<your-hub>/ws/agent BLOXOS_TOKEN=<one-time-token>
-curl -fsSL https://<your-hub>/install.sh | bash
+(cd hub && go build -o ../bin/bloxos-hub .)
+(cd agent && go build -o ../bin/bloxos-agent .)
+(cd dashboard && pnpm install --frozen-lockfile && pnpm build)
 ```
 
-For Windows (PowerShell as Administrator):
-```powershell
-$env:BLOXOS_HUB="wss://<your-hub>/ws/agent"
-$env:BLOXOS_TOKEN="<one-time-token>"
-iex (irm https://<your-hub>/install.ps1)
+The sample units in [scripts/systemd](scripts/systemd) use `<user>` and
+`/opt/bloxos` placeholders. Replace `<user>`, install the built artifacts,
+then enable each installed unit:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now bloxos-hub bloxos-dashboard bloxos-agent
 ```
-
-### 4. That's it
-
-The agent self-updates from now on. Add more machines the same way.
 
 ---
 

--- a/scripts/systemd/bloxos-agent.service
+++ b/scripts/systemd/bloxos-agent.service
@@ -5,15 +5,18 @@ Wants=bloxos-hub.service
 
 [Service]
 Type=simple
-User=bokiko
-WorkingDirectory=/home/bokiko/bloxos/agent
+User=<user>
+WorkingDirectory=/opt/bloxos/agent
 Environment="BLOXOS_HUB=ws://localhost:4000"
 Environment="BLOXOS_TOKEN="
 # If the hub uses a self-signed CA, point the agent at the trusted root cert.
 # Environment="BLOXOS_CA_CERT=/etc/bloxos/ca.crt"
-ExecStart=/home/bokiko/bloxos/agent/bloxos-agent
+ExecStart=/opt/bloxos/agent/bloxos-agent
 Restart=always
 RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
+
+# After copying this file to /etc/systemd/system/:
+# sudo systemctl daemon-reload && sudo systemctl enable --now bloxos-agent

--- a/scripts/systemd/bloxos-dashboard.service
+++ b/scripts/systemd/bloxos-dashboard.service
@@ -4,9 +4,9 @@ After=network.target bloxos-hub.service
 
 [Service]
 Type=simple
-User=bokiko
-WorkingDirectory=/home/bokiko/bloxos/dashboard
-ExecStart=/usr/bin/npx next start -H 127.0.0.1 -p 3000
+User=<user>
+WorkingDirectory=/opt/bloxos/dashboard
+ExecStart=/usr/bin/pnpm start -- -H 127.0.0.1 -p 3000
 Restart=always
 RestartSec=5
 Environment=NODE_ENV=production
@@ -14,3 +14,6 @@ Environment=NEXT_PUBLIC_HUB_URL=
 
 [Install]
 WantedBy=multi-user.target
+
+# After copying this file to /etc/systemd/system/:
+# sudo systemctl daemon-reload && sudo systemctl enable --now bloxos-dashboard

--- a/scripts/systemd/bloxos-hub.service
+++ b/scripts/systemd/bloxos-hub.service
@@ -4,13 +4,17 @@ After=network.target
 
 [Service]
 Type=simple
-User=bokiko
-WorkingDirectory=/home/bokiko/bloxos/hub
-ExecStart=/home/bokiko/bloxos/hub/bloxos-hub
+User=<user>
+WorkingDirectory=/opt/bloxos/hub
+ExecStart=/opt/bloxos/hub/bloxos-hub
 Restart=always
 RestartSec=5
 Environment=PATH=/usr/local/go/bin:/usr/bin:/bin
 Environment="BLOXOS_CA_CERT=/var/lib/caddy/.local/share/caddy/pki/authorities/local/root.crt"
+Environment="BLOXOS_AGENT_BINARY=/opt/bloxos/agent/bloxos-agent"
 
 [Install]
 WantedBy=multi-user.target
+
+# After copying this file to /etc/systemd/system/:
+# sudo systemctl daemon-reload && sudo systemctl enable --now bloxos-hub


### PR DESCRIPTION
## Summary

- add a source-derived environment variable reference and `.env.example`
- document clone-to-running-hub, Linux agent, dashboard, and Windows cross-build commands
- make the sample systemd units portable and point the hub at the built Linux agent

## Why

The existing source-build onboarding path did not document the variables required for the hub to boot, the agent build step, or portable service-unit configuration. This makes the Linux onboarding path reproducible from the README while keeping Windows enrollment explicitly out of scope until its installer is reworked.

## Validation

- `git diff --check`
- verified `.env.example` covers every direct `os.Getenv` use in `hub/` and `agent/`
- sourced `.env.example` successfully
- confirmed the diff is documentation and sample configuration only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No application code changes—only docs and example systemd templates; operators must still substitute placeholders before enabling services.
> 
> **Overview**
> **Documentation-only** change to make Linux source onboarding reproducible and to defer the polished public installer / Windows enrollment docs.
> 
> Adds **[`.env.example`](.env.example)** with commented defaults for every hub, agent, and dashboard env var the Go binaries read, plus a new **Configuration** section in the README (required `PUBLIC_URL` / `ALLOWED_ORIGINS`, hub boot policy, and a variable reference table).
> 
> Replaces the old quick start with **Quick start from source**: clone → build hub/agent (optional Windows cross-build) → export origin policy and `BLOXOS_AGENT_BINARY` → run hub and dashboard with `NEXT_PUBLIC_HUB_URL` → enroll a **local** Linux agent via the dashboard (loopback-first; LAN/TLS notes and issue **#150** for private CA bootstrap).
> 
> Sample **[`scripts/systemd`](scripts/systemd)** units drop author-specific paths in favor of `<user>` and `/opt/bloxos`, hub sets `BLOXOS_AGENT_BINARY`, dashboard uses `pnpm start`, and each unit includes enable/reload comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3bf1fe658a7713cb9e7c32ec425cc5764d9a35f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->