### PR TITLE
fix(dashboard): expose rollout readiness

### DIFF
--- a/dashboard/.claude/skills/run-dashboard/SKILL.md
+++ b/dashboard/.claude/skills/run-dashboard/SKILL.md
@@ -31,7 +31,8 @@ this container).
 ## Build
 
 ```bash
-mkdir -p /tmp/bloxos-dashboard-smoke/hub-run
+mkdir -p /tmp/bloxos-dashboard-smoke/{home,hub-run}
+chmod 0700 /tmp/bloxos-dashboard-smoke/home
 ( cd ../hub && go build -o /tmp/bloxos-dashboard-smoke/hub-run/bloxos-hub . )
 ```
 
@@ -47,6 +48,7 @@ already up.
 ```bash
 # 1. Hub — from a scratch working directory, NOT hub/ (see Gotchas)
 cd /tmp/bloxos-dashboard-smoke/hub-run
+HOME=/tmp/bloxos-dashboard-smoke/home \
 BLOXOS_SETUP_TOKEN=smoketest-setup-token-12345 \
 ALLOWED_ORIGINS=http://localhost:3000 \
 nohup ./bloxos-hub > hub.log 2>&1 &
@@ -94,7 +96,7 @@ lsof -ti:4000 -sTCP:LISTEN | xargs -r kill -9
 ## Run (human path)
 
 ```bash
-( cd ../hub && go run . )                        # separate terminal, from a scratch cwd
+( cd ../hub && HOME=/tmp/bloxos-dashboard-smoke/home go run . ) # separate terminal
 NEXT_PUBLIC_HUB_URL=http://localhost:4000 pnpm dev         # from dashboard/
 ```
 
@@ -122,6 +124,11 @@ at runtime.
 - **Hub writes `bloxos.db` as a relative path.** Running it from
   `hub/` creates a stray SQLite file in the repo checkout. Always run
   the built binary from a scratch directory.
+- **Hub secrets follow `HOME`.** The hub reads or creates its JWT secret,
+  update-signing key, setup token, and first-run token under `~/.bloxos`.
+  Always point `HOME` at the smoke directory, or a sandbox run can read or
+  overwrite the operator's real local credentials even though its database is
+  in scratch.
 - **Hub fails closed on CORS by design.** With neither `ALLOWED_ORIGINS`
   nor `PUBLIC_URL` set, it refuses to start at all rather than fall
   back to a wildcard origin (`refusing to start with wildcard origin`).

--- a/dashboard/.claude/skills/run-dashboard/driver.mjs
+++ b/dashboard/.claude/skills/run-dashboard/driver.mjs
@@ -110,6 +110,22 @@ async function main() {
   log("command palette opened, NAVIGATE section visible:", navigateVisible);
   await page.keyboard.press("Escape");
 
+  // --- Agent versions: rollout status must be reachable and legible ---
+  await page.goto(BASE + "/versions", { waitUntil: "networkidle" });
+  await page.waitForTimeout(500);
+  await shot(page, "versions-page");
+  const keyPinnedColumnVisible = await page.getByRole("columnheader", { name: "Key pinned" }).isVisible();
+  const blockedReasonColumnVisible = await page
+    .getByRole("columnheader", { name: "Blocked reason" })
+    .isVisible();
+  const signingBannerVisible = await page.locator('[data-testid="signing-status-banner"]').isVisible();
+  log(
+    "versions rendered:",
+    `keyPinned=${keyPinnedColumnVisible}`,
+    `blockedReason=${blockedReasonColumnVisible}`,
+    `signingBanner=${signingBannerVisible}`,
+  );
+
   await browser.close();
 
   log("");
@@ -120,7 +136,13 @@ async function main() {
     log("FAIL: console errors were captured during the run");
     process.exit(1);
   }
-  if (!modalTitleVisible || !navigateVisible) {
+  if (
+    !modalTitleVisible ||
+    !navigateVisible ||
+    !keyPinnedColumnVisible ||
+    !blockedReasonColumnVisible ||
+    !signingBannerVisible
+  ) {
     log("FAIL: an expected element did not render");
     process.exit(1);
   }

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -34,6 +34,7 @@ import {
   Plus, WifiOff, Search, LayoutGrid, List,
   ChevronDown, Square, CheckSquare, RotateCcw, Trash2, Pencil,
   ArrowUpDown, Filter, Monitor, Server, RefreshCw, Boxes,
+  GitCompareArrows,
 } from "lucide-react";
 import Link from "next/link";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -409,6 +410,15 @@ export default function Home() {
               aria-label="Hardware inventory"
             >
               <Boxes className="w-4 h-4" />
+            </Link>
+
+            <Link
+              href="/versions"
+              className="inline-flex items-center justify-center rounded-md w-8 h-8 text-blox-muted hover:text-blox-text hover:bg-blox-border/50 transition-colors"
+              title="Agent versions"
+              aria-label="Agent versions"
+            >
+              <GitCompareArrows className="w-4 h-4" />
             </Link>
 
             {/* Vertical divider — separates utility icons from create actions */}

--- a/dashboard/src/app/versions/page.tsx
+++ b/dashboard/src/app/versions/page.tsx
@@ -12,6 +12,8 @@ import {
   AlertTriangle,
   CheckCircle2,
   Clock,
+  KeyRound,
+  ShieldCheck,
 } from "lucide-react";
 import { useVersions } from "@/contexts/VersionsContext";
 import { useAuth } from "@/contexts/AuthContext";
@@ -113,7 +115,7 @@ export default function VersionsPage() {
           <div className="flex items-start gap-3 rounded-xl border border-red-500/20 bg-red-500/5 px-4 py-3">
             <AlertTriangle className="w-4 h-4 text-red-400 mt-0.5 shrink-0" />
             <div className="flex-1">
-              <p className="text-sm text-blox-text font-medium">Failed to load versions</p>
+              <p className="text-sm text-blox-text font-medium">Versions request failed</p>
               <p className="text-xs text-blox-muted mt-1">{error}</p>
             </div>
           </div>
@@ -121,6 +123,31 @@ export default function VersionsPage() {
 
         {data && (
           <>
+            <div
+              className={`flex items-start gap-3 rounded-xl border px-4 py-3 ${
+                data.signing_enabled
+                  ? "border-emerald-500/20 bg-emerald-500/5"
+                  : "border-red-500/20 bg-red-500/5"
+              }`}
+              data-testid="signing-status-banner"
+            >
+              {data.signing_enabled ? (
+                <ShieldCheck className="w-4 h-4 text-emerald-400 mt-0.5 shrink-0" />
+              ) : (
+                <AlertTriangle className="w-4 h-4 text-red-400 mt-0.5 shrink-0" />
+              )}
+              <div>
+                <p className="text-sm text-blox-text font-medium">
+                  Update signing {data.signing_enabled ? "enabled" : "disabled"}
+                </p>
+                <p className="text-xs text-blox-muted mt-1">
+                  {data.signing_enabled
+                    ? "The hub can authenticate agent update announcements."
+                    : data.signing_disabled_reason || "The hub cannot produce update signatures."}
+                </p>
+              </div>
+            </div>
+
             {/* Hub binary status card */}
             <div className="bg-blox-card border border-blox-border rounded-xl p-5">
               <div className="flex items-center justify-between gap-4 flex-wrap">
@@ -194,7 +221,7 @@ export default function VersionsPage() {
             </div>
 
             {/* Agents table */}
-            <div className="bg-blox-card border border-blox-border rounded-xl overflow-hidden">
+            <div className="bg-blox-card border border-blox-border rounded-xl overflow-x-auto">
               <Table>
                 <TableHeader>
                   <TableRow className="border-b-blox-border hover:bg-transparent">
@@ -208,6 +235,12 @@ export default function VersionsPage() {
                       Status
                     </TableHead>
                     <TableHead className="text-blox-muted text-[11px] uppercase tracking-[0.06em] font-medium">
+                      Key pinned
+                    </TableHead>
+                    <TableHead className="text-blox-muted text-[11px] uppercase tracking-[0.06em] font-medium">
+                      Blocked reason
+                    </TableHead>
+                    <TableHead className="text-blox-muted text-[11px] uppercase tracking-[0.06em] font-medium">
                       Last connect
                     </TableHead>
                   </TableRow>
@@ -216,7 +249,7 @@ export default function VersionsPage() {
                   {data.agents.length === 0 ? (
                     <TableRow>
                       <TableCell
-                        colSpan={4}
+                        colSpan={6}
                         className="text-center py-8 text-blox-muted text-xs"
                       >
                         No agents have reported their version yet
@@ -239,7 +272,15 @@ export default function VersionsPage() {
                             {shortSHA(agent.running_sha)}
                           </TableCell>
                           <TableCell>
-                            {agent.update_pending ? (
+                            {agent.update_pending && agent.update_blocked_reason ? (
+                              <Badge
+                                variant="outline"
+                                className="border-red-500/30 bg-red-500/10 text-red-400 text-[10px]"
+                              >
+                                <AlertTriangle className="w-2.5 h-2.5 mr-1" />
+                                Withheld
+                              </Badge>
+                            ) : agent.update_pending ? (
                               <Badge
                                 variant="outline"
                                 className="border-amber-500/30 bg-amber-500/10 text-amber-400 text-[10px]"
@@ -256,6 +297,38 @@ export default function VersionsPage() {
                                 Up to date
                               </Badge>
                             )}
+                          </TableCell>
+                          <TableCell>
+                            {agent.update_protocol < 1 ? (
+                              <Badge
+                                variant="outline"
+                                className="border-blox-border text-blox-muted text-[10px]"
+                              >
+                                Not reported
+                              </Badge>
+                            ) : agent.update_key_pinned ? (
+                              <Badge
+                                variant="outline"
+                                className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-[10px]"
+                              >
+                                <KeyRound className="w-2.5 h-2.5 mr-1" />
+                                Pinned
+                              </Badge>
+                            ) : (
+                              <Badge
+                                variant="outline"
+                                className="border-red-500/30 bg-red-500/10 text-red-400 text-[10px]"
+                              >
+                                <AlertTriangle className="w-2.5 h-2.5 mr-1" />
+                                Missing
+                              </Badge>
+                            )}
+                          </TableCell>
+                          <TableCell
+                            className="max-w-[360px] whitespace-normal text-xs text-blox-muted"
+                            title={agent.update_blocked_reason || undefined}
+                          >
+                            {agent.update_blocked_reason || "—"}
                           </TableCell>
                           <TableCell className="text-xs text-blox-muted font-mono tabular-nums">
                             {timeSince(agent.reported_at)}

--- a/dashboard/src/components/AddMachineModal.tsx
+++ b/dashboard/src/components/AddMachineModal.tsx
@@ -87,7 +87,8 @@ export function AddMachineModal({ open, onClose }: AddMachineModalProps) {
         headers,
       });
       if (!res.ok) {
-        setError("Failed to generate token. Is the hub reachable?");
+        const data = await res.json().catch(() => null);
+        setError(data?.error || `Failed to generate token (${res.status})`);
         setState({ kind: "choose-os" });
         return;
       }

--- a/dashboard/src/contexts/VersionsContext.tsx
+++ b/dashboard/src/contexts/VersionsContext.tsx
@@ -17,9 +17,15 @@ export interface AgentVersionInfo {
   running_sha?: string;
   reported_at: string;
   update_pending: boolean;
+  update_blocked_reason?: string;
+  update_key_pinned: boolean;
+  update_transport_ok: boolean;
+  update_protocol: number;
 }
 
 export interface VersionsResponse {
+  signing_enabled: boolean;
+  signing_disabled_reason: string;
   hub_sha: string;
   hub_short_sha: string;
   hub_mtime: string;
@@ -67,21 +73,31 @@ export function VersionsProvider({ children }: { children: ReactNode }) {
 
   const pauseRollout = useCallback(async () => {
     if (!isAuthenticated) return;
+    setError(null);
     try {
-      await authFetch(`${HUB_URL}/api/versions/pause`, { method: "POST" });
+      const res = await authFetch(`${HUB_URL}/api/versions/pause`, { method: "POST" });
+      if (!res.ok) {
+        const json = await res.json().catch(() => null);
+        throw new Error(json?.error || `Failed to pause rollout (${res.status})`);
+      }
       await refresh();
     } catch (err) {
-      console.warn("pauseRollout failed:", err);
+      setError(err instanceof Error ? err.message : "Failed to pause rollout");
     }
   }, [authFetch, isAuthenticated, refresh]);
 
   const resumeRollout = useCallback(async () => {
     if (!isAuthenticated) return;
+    setError(null);
     try {
-      await authFetch(`${HUB_URL}/api/versions/resume`, { method: "POST" });
+      const res = await authFetch(`${HUB_URL}/api/versions/resume`, { method: "POST" });
+      if (!res.ok) {
+        const json = await res.json().catch(() => null);
+        throw new Error(json?.error || `Failed to resume rollout (${res.status})`);
+      }
       await refresh();
     } catch (err) {
-      console.warn("resumeRollout failed:", err);
+      setError(err instanceof Error ? err.message : "Failed to resume rollout");
     }
   }, [authFetch, isAuthenticated, refresh]);
 


### PR DESCRIPTION
## Summary

- surface hub response errors in the Add Machine flow
- expose rollout readiness, signing state, key pinning, and blocked reasons on `/versions`
- add `/versions` to the main navigation and report pause or resume failures
- extend the dashboard smoke driver and isolate all smoke-hub credentials under a scratch HOME

## Why

The dashboard hid actionable enrollment errors and represented permanently withheld updates as ordinary pending work. Rollout controls could also fail silently, while the versions page was effectively hidden outside the command palette.

This makes rollout state honest and discoverable and prevents dashboard smoke runs from reading or modifying the operator's real hub credentials.

## Validation

- `pnpm lint`
- `pnpm build`
- headless dashboard smoke: zero console or page errors
- verified `/versions` renders the Key pinned and Blocked reason columns plus the signing banner
- validated the `run-dashboard` skill and its isolated-HOME launch paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only UX, error handling, and smoke-test isolation; no changes to hub rollout or signing logic in this diff.
> 
> **Overview**
> Makes **agent rollout readiness** visible and honest on `/versions`, and surfaces hub errors instead of silent failures elsewhere.
> 
> The versions page now shows an **update signing** banner, per-agent **Key pinned** and **Blocked reason** columns, and a **Withheld** status when an update is pending but blocked—so withheld work is not shown as ordinary “Update pending.” `VersionsContext` consumes the expanded hub payload and **pause/resume** failures appear in the page error state instead of only logging to the console.
> 
> **Add Machine** displays the hub’s JSON `error` (or status) when token creation fails. The fleet header adds a direct **Agent versions** link beside inventory.
> 
> Smoke docs and `driver.mjs` require an isolated scratch **`HOME`** so local hub secrets under `~/.bloxos` are not touched during dashboard smoke runs; the driver also asserts the new versions UI columns and signing banner render.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4db3fa27c0adf17c7b0e560e54c27151963e9f28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->