### PR TITLE
fix(hub): install Linux agent with root ownership

### DIFF
--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -225,7 +225,8 @@ if ! id -u bloxos &>/dev/null; then
 fi
 
 # Install binary.
-sudo mv /tmp/bloxos-agent /usr/local/bin/bloxos-agent
+sudo install -o root -g root -m 0755 /tmp/bloxos-agent /usr/local/bin/bloxos-agent
+rm -f /tmp/bloxos-agent
 
 # Create credential directory for agent secret (post-enrollment).
 sudo mkdir -p /etc/bloxos

--- a/hub/install_enrollment_test.go
+++ b/hub/install_enrollment_test.go
@@ -199,6 +199,31 @@ func TestInstallScriptPinsAgentBinaryHash(t *testing.T) {
 	}
 }
 
+// The generated Linux installer must not preserve the unprivileged
+// downloader's ownership on a binary that systemd later executes as root.
+func TestInstallScriptInstallsAgentBinaryAsRoot(t *testing.T) {
+	e, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/install.sh", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+	const install = "sudo install -o root -g root -m 0755 /tmp/bloxos-agent /usr/local/bin/bloxos-agent"
+	if !strings.Contains(body, install) {
+		t.Fatal("install.sh does not install the agent root-owned with mode 0755")
+	}
+	if strings.Contains(body, "sudo mv /tmp/bloxos-agent /usr/local/bin/bloxos-agent") {
+		t.Fatal("install.sh still preserves the downloaded agent's unprivileged ownership")
+	}
+	if !strings.Contains(body, "rm -f /tmp/bloxos-agent") {
+		t.Fatal("install.sh leaves the downloaded temporary agent behind")
+	}
+}
+
 // TestWindowsInstallScriptPinsHashAndVerifiesBinaryDownload locks in item 3
 // (Windows): install.ps1 must pin the agent .exe SHA-256 and must download the
 // binary with TLS verification (via the bootstrapped CA), not curl -k. The


### PR DESCRIPTION
## Summary

- install the downloaded Linux agent with explicit `root:root` ownership and mode `0755`
- remove the exact temporary download after a successful install
- add a regression test for the generated enrollment script

## Why

The installer previously moved a binary downloaded by the enrolling user into `/usr/local/bin`. `mv` preserved that user's ownership even though systemd later executes the agent as root. A user who could replace the installed binary could therefore gain root execution on the next service restart.

Using `sudo install` makes the ownership and executable mode explicit at the privilege boundary.

## Validation

- `go test ./... -run TestInstallScriptInstallsAgentBinaryAsRoot -count=1`
- `go test ./...`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Linux enrollment install script at the root privilege boundary; behavior is narrow and covered by a new regression test.
> 
> **Overview**
> Fixes a **local privilege escalation** in the generated Linux `install.sh`: the agent was moved into `/usr/local/bin` with `sudo mv`, which kept the enrolling user’s ownership even though **systemd runs `bloxos-agent` as root**.
> 
> The installer now uses **`sudo install -o root -g root -m 0755`** so the on-disk binary is explicitly root-owned and executable, and **`rm -f /tmp/bloxos-agent`** removes the temp download after a successful install.
> 
> Adds **`TestInstallScriptInstallsAgentBinaryAsRoot`** to lock in the new install line and reject the old `mv` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03929debf2fef024ad5f8383617441259d35392a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->