### PR TITLE
docs: reconcile update behavior with current implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Fleet management dashboard for AI machines. Go hub + agent, Next.js dashboard.
 ## Architecture
 - `hub/` — Go API server (Echo + gorilla/websocket), port 4000
 - `agent/` — Go agent binary (gopsutil, go-nvml, creack/pty)
-- `dashboard/` — Next.js 15 frontend (React, Tailwind, Recharts, xterm.js)
+- `dashboard/` — Next.js 16 frontend (React 19, Tailwind, Recharts, xterm.js)
 - `proto/` — Shared protocol definitions
 - `scripts/` — Install/deploy scripts
 
@@ -15,9 +15,30 @@ Fleet management dashboard for AI machines. Go hub + agent, Next.js dashboard.
 - Dashboard: `cd dashboard && pnpm dev`
 
 ## Rules
-- Agent runs as non-root user with sudo whitelist
-- Terminal sessions require re-auth (PIN/password gate)
-- All terminal I/O logged for audit
+- The agent service runs with full privilege on both platforms: **Linux** uses
+  `User=root` in the generated systemd unit; **Windows** runs as `LocalSystem`.
+  It needs that to collect hardware inventory and manage services.
+- Terminal support is **Linux-only**, and the shell it spawns **drops to the
+  configured non-root user** — do not confuse the service account with the
+  terminal's.
+- Terminal sessions require re-auth (server-side PIN gate, bcrypt-verified)
+- **Only terminal session metadata is audited** — the `terminal_sessions` row
+  records machine, user, source IP, start/end and status. Terminal **content
+  and I/O are not recorded**; the hub relays frames without capturing them.
+  A full audit log is on the roadmap, not shipped.
+- Agent updates carry an Ed25519 release signature. **Protocol-v1** agents
+  verify it against their pinned key (Linux: `/etc/bloxos/agent-update.pub`;
+  Windows: beside the agent executable) and accept an update only when the
+  signature verifies and the transport is permitted. For those agents the hub
+  fails closed on missing signature, plaintext transport, or unpinned key.
+- **Exception — the legacy migration hop.** Protocol-0 agents cannot verify
+  signatures, because verification cannot be retrofitted into an already-running
+  binary. They take an unverifiable migration hop to reach protocol v1, and the
+  hub permits it only when `PUBLIC_URL` is TLS or loopback. After it, the agent
+  is withheld (`agent_key_not_pinned`) until its update key is pinned through a
+  trusted provisioning path.
+- The signature may come from a detached `<binary>.sig` produced offline, in
+  which case the hub holds no private key — do not assume the hub signs.
 - Credentials NEVER committed — use env vars or local config
 - Dark mode is the default UI theme
 - Caddy TLS uses RSA-2048 keys, not ECDSA. Do not change without testing on stock Windows PowerShell 5.1.

--- a/BLOXOS_FUTURE.md
+++ b/BLOXOS_FUTURE.md
@@ -103,6 +103,28 @@ Each PR has: **Goal** (one line), **Mechanics** (concrete moves), **Verification
 **LOC touched:** ~3000 (every handler + every test)
 **Risk:** Highest. Pure mechanical transformation, no extraction.
 
+> ⚠️ **PARTIALLY SUPERSEDED by #148 — do not start this from scratch, and do
+> not treat it as finished either.**
+>
+> #148 landed a deliberately **scoped subset** of this PR, sized to what
+> issue #60 actually required rather than the full transformation below:
+>
+> - `Server` struct exists in `package main` (`hub/server.go`)
+> - **only** `db`, `agents`, and `agentsMu` moved onto it
+> - most handlers became methods on `*Server`
+> - `goTracked` / `Shutdown` added, so a server waits for work it spawned
+>
+> **Still outstanding:** most package-level mutable state is untouched —
+> `sseClients`, `pendingCmds`, `termSessions`, `jwtSecret`, `rateLimiter`,
+> `setupTokenValue`, `machineLatency`, `apiPollers`, the telegram config, and
+> the rollout/version caches all remain package-level. `newServer` and
+> `registerRoutes` exist in narrower forms than described below, and no `Run`
+> method exists.
+>
+> The remaining scope should be reassessed against the current code before any
+> of it is implemented — the description below predates #148 and no longer
+> describes the starting point.
+
 **Goal:** Move every package-level mutable global into `*Server` fields. Convert every handler to a method on `*Server`. `main()` shrinks to: build config, build server, register routes, listen.
 
 **Mechanics:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,18 +32,31 @@ See `AGENTS.md` for repo conventions.
 Before pushing, run the same checks CI runs:
 
 ```sh
-( cd hub      && go test -count=1 ./... )
-( cd agent    && go test -count=1 ./... )
-( cd dashboard && pnpm lint && pnpm build )
+# Hub Tests
+( cd hub   && go vet ./... && go test -count=1 ./... )
+
+# Hub Tests (race)
+( cd hub   && go test -race -count=1 -timeout=10m ./... )
+
+# Agent Tests
+( cd agent && go vet ./... && go test -count=1 ./... )
+( cd agent && go vet -tags insecure ./... && go test -tags insecure -count=1 ./... )
+
+# Dashboard Lint + Build
+( cd dashboard && pnpm install --frozen-lockfile && pnpm lint && pnpm build )
 ```
 
-`go vet ./...` is recommended for Go changes, but it is not currently a CI gate.
-
-For agent changes that affect the Windows build, also run:
+The fifth required check, `Agent Tests (windows)`, runs `go vet ./...` and
+`go test -count=1 ./...` natively on a Windows runner. A Linux host cannot run
+that native job locally. For agent changes that affect Windows, cross-vet as a
+precheck before pushing:
 
 ```sh
 ( cd agent && GOOS=windows go vet ./... )
 ```
+
+All five checks are blocking on `main`. The race and native-Windows jobs cover
+behavior that ordinary Linux `go test` does not.
 
 ## Merge policy
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,19 @@ xterm.js, theme-aware, stable 360px pane. Hit a machine, get a real shell. No SS
 ### Two operating systems, one dashboard
 The Linux agent and the Windows agent speak the same WebSocket protocol to the same hub. The Windows agent registers itself as a Windows Service via SCM, collects hardware via WMI, and supports the same auto-update flow. From the dashboard, a Windows machine and a Linux machine look and behave identically.
 
-### Auto-update with rollback
-The hub announces the agent's current SHA. Agents compare against their own binary. If different, they download the new version, verify the SHA, save the previous binary as `.prev`, atomically rename, and exit — systemd or SCM restarts them on the new version. If anything goes wrong, a recovery service swaps the previous binary back. A circuit breaker pauses rollout after two failures in five minutes.
+### Signed auto-update and recovery
+Protocol-v1 agents accept an update only when its Ed25519 release signature verifies against their pinned key and the transport is permitted. Protocol-0 agents require a deliberately limited migration hop to reach protocol v1, because signature verification cannot be retrofitted into an already-running binary; the hub permits that hop only over TLS or loopback. After migration, the agent is withheld until its update key is pinned through a trusted provisioning path.
 
-You push an update to the hub. The fleet self-heals to the new version. Or rolls back. Either way, you don't get paged.
+The signature covers `bloxos-agent-update:v1:<os>:<sha>`. It may come from a detached `<binary>.sig` produced offline, in which case the hub holds no private key, or from a hub-held signing key. Protocol-v1 updates fail closed when the signature is missing or invalid, the transport is plaintext, or the agent has no pinned key.
+
+Both platforms use a `.prev` file for recovery, but their behavior differs:
+
+- **Linux** verifies the update, replaces the executable atomically, and exits for systemd to restart it. An `OnFailure` recovery unit can automatically restore `.prev` after repeated startup failure.
+- **Windows** attempts to snapshot `.prev`, downloads to `<exe>.new`, and writes `<exe>.pending` with the expected `sha256` and `signature`. On the SCM restart, `applyPendingUpdate` hashes `.new`, compares the SHA, and verifies the signature against the pinned key before spawning the swap helper. `performUpdateWindows` exits with code `1` to trigger that SCM restart. The helper attempts `move /Y` before deleting the marker, but marker deletion is unconditional; Windows has no automatic rollback, so restoring `.prev` remains manual.
+
+A circuit breaker pauses fleet rollout after two failures in five minutes. Signatures still have no downgrade or monotonicity protection: a previously valid `(os, sha)` pair remains valid indefinitely ([#145](https://github.com/bokiko/bloxos/issues/145)).
+
+You push an update to the hub and the fleet moves to the new version on its own. On Linux, a bad build can also recover automatically.
 
 ### Multi-user with real permissions
 Viewers, operators, admins. Every endpoint has a scope (`fleet.read`, `fleet.control`, `fleet.metadata`, `fleet.admin`, `branding.admin`, `users.admin`). Operators can run actions but not change roles. Admins can change branding. Viewers can look but not touch. JWT-based, bcrypt for passwords.

--- a/dashboard/src/app/versions/page.tsx
+++ b/dashboard/src/app/versions/page.tsx
@@ -105,7 +105,8 @@ export default function VersionsPage() {
           </div>
           <p className="text-[12px] text-blox-muted mt-1.5">
             Auto-update status and version visibility across the fleet.
-            Agents check the hub&apos;s announced SHA on connect; mismatches trigger silent updates with automatic rollback on failure.
+            Protocol-v1 agents verify signed updates against their pinned key.
+            Windows revalidates the staged binary&apos;s SHA and signature on service restart, but still requires manual rollback.
           </p>
         </div>
       </section>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,19 @@ SQLite migrations live in `hub/migrations.go`. The hub explicitly enables
 foreign keys, but not every machine-keyed table has `ON DELETE CASCADE`, so some
 cleanup still happens in handlers.
 
+### Server struct
+
+A `Server` struct in `hub/server.go` owns the database handle and the connected
+agent registry (`db`, `agents`, `agentsMu`), and most handlers are methods on
+`*Server`. It also tracks the goroutines it spawns, so a server can be shut down
+without racing work still in flight — which is what makes the hub test suite
+race-clean.
+
+Ownership is deliberately partial. Most other mutable state — SSE clients,
+pending commands, terminal sessions, the JWT secret, the rate limiter, API
+pollers, and the rollout/version caches — is still package-level. Moving the
+rest is planned work, not a description of today's code; see `BLOXOS_FUTURE.md`.
+
 ## Agent
 
 Agents are native Go binaries.
@@ -77,12 +90,54 @@ which is the intended Caddy-backed production mode.
 ## Update Flow
 
 The hub hashes the configured agent binaries and announces the expected SHA to
-connected agents. Agents compare that SHA with their running binary, download
-`/download/agent` when needed, verify the SHA, replace the executable, and let
-systemd or SCM restart them.
+connected agents, together with an Ed25519 signature over
+`bloxos-agent-update:v1:<os>:<sha>`. The signature comes from either a detached
+`<binary>.sig` produced offline or a hub-held signing key.
+
+Protocol-v1 agents accept an update only when the signature verifies against
+their pinned key and the transport is permitted. The pinned key lives at
+`/etc/bloxos/agent-update.pub` on Linux and beside the executable on Windows.
+Protocol-0 agents cannot verify signatures and are permitted one migration hop
+only when `PUBLIC_URL` is TLS or loopback. Afterward, the hub withholds further
+updates until the agent's key is pinned through a trusted provisioning path.
+
+`announceDecision` is shared by the announcement path and versions API. It
+fails closed for protocol-v1 agents when no valid signature is available, the
+transport is plaintext, or the update key is unpinned. Withheld agents do not
+create reconnect expectations. A circuit breaker pauses rollout after repeated
+genuine failures.
+
+Linux verifies the update, replaces its executable atomically, and relies on
+systemd plus an `OnFailure` recovery unit to restore `.prev` after repeated
+startup failure.
+
+Windows stages the download as `<exe>.new` and writes `<exe>.pending` with the
+expected `sha256` and `signature`. `performUpdateWindows` exits with code `1`
+for SCM to restart the service. Before the swap, `applyPendingUpdate` parses the
+marker, hashes `.new`, compares the SHA, and verifies the signature against the
+pinned key. Validation failure removes both staged files. On success it spawns
+a helper that attempts `move /Y` before deleting the marker; marker deletion is
+unconditional, not evidence that the move succeeded. Windows attempts to
+snapshot `.prev` but has no automatic rollback, so recovery remains manual.
 
 The hub tracks reported running versions so the dashboard can show rollout
 state and pending updates.
+
+Signatures still carry no downgrade or monotonicity protection, so a previously
+valid `(os, sha)` pair remains valid indefinitely ([#145]).
+
+### Resolving the served binary (Linux)
+
+For Linux agents, `agentBinaryPathFor` resolves the served binary from an
+ordered candidate list: `$BLOXOS_AGENT_BINARY`, then `./agent/bloxos-agent`
+relative to the hub's working directory, then `/usr/local/bin/bloxos-agent`.
+The relative candidate does not resolve when the hub's `WorkingDirectory` is
+the `hub/` subdirectory, and the fallback is silent. Set
+`BLOXOS_AGENT_BINARY` explicitly in deployments to avoid serving a stale binary
+([#149]). Windows resolution uses its own environment variable and fallbacks.
+
+[#145]: https://github.com/bokiko/bloxos/issues/145
+[#149]: https://github.com/bokiko/bloxos/issues/149
 
 ## Deployment Assets
 


### PR DESCRIPTION
## Summary

- reconcile documentation with the signed protocol-v1 update behavior delivered by #152
- document the current Linux recovery and Windows manual-rollback behavior without overstating marker deletion or swap success
- update contributor CI instructions, current server ownership, terminal-audit scope, and the dashboard rollout copy

## Why

The parked documentation work predated #152 and the onboarding/dashboard changes in #161 and #162. Re-authoring the still-relevant pieces on current `main` avoids restoring superseded onboarding or installer guidance while removing claims that are now false.

## Validation

- `pnpm lint`
- `pnpm build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes with no runtime or security logic touched; risk is limited to documentation drift if implementation changes again.
> 
> **Overview**
> Documentation is brought in line with **signed protocol-v1 agent updates** (#152) and recent hub/dashboard reality, replacing SHA-only auto-update and overstated rollback claims.
> 
> **`README.md`**, **`docs/architecture.md`**, and **`AGENTS.md`** now describe Ed25519 signatures, pinned keys, fail-closed hub **`announceDecision`**, the protocol-0 TLS/loopback migration hop, Linux systemd/`.prev` recovery vs Windows staged `.new`/`.pending` swaps with **manual** rollback, detached `.sig` vs hub signing, and known gaps ([#145] no downgrade protection, [#149] Linux binary path resolution).
> 
> **`AGENTS.md`** also clarifies agent service privilege (root/LocalSystem) vs Linux terminal shells dropping to a non-root user, and limits terminal audit to **`terminal_sessions` metadata** (no I/O capture).
> 
> **`CONTRIBUTING.md`** documents the full five blocking CI jobs (hub vet/test/race, agent + `insecure` tag tests, dashboard lint/build, native Windows agent tests).
> 
> **`BLOXOS_FUTURE.md`** marks PR 0’s global **`Server`** refactor as **partially done in #148**, with remaining package-level state still outstanding.
> 
> The dashboard **versions** page blurb now matches signed updates and Windows revalidation on restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24dca2a9b30744711b951de55263543d241c5794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->