### PR TITLE
feat(hub): add offline agent signing tool

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -4,8 +4,11 @@ go 1.25.0
 
 toolchain go1.25.9
 
+replace github.com/bokiko/bloxos/proto => ../proto
+
 require (
 	github.com/StackExchange/wmi v1.2.1
+	github.com/bokiko/bloxos/proto v0.0.0
 	github.com/creack/pty v1.1.24
 	github.com/gorilla/websocket v1.5.3
 	github.com/shirou/gopsutil/v4 v4.26.6

--- a/agent/update_verify.go
+++ b/agent/update_verify.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"crypto/ed25519"
-	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
 )
 
 /* ============================================================================
@@ -29,14 +29,9 @@ import (
  * The signed message binds the OS so a signature issued for the Linux binary
  * cannot be replayed as the Windows announcement.
  *
- * updateSigContext and updateSigningMessage are duplicated in
- * hub/update_signing.go. Both sides assert the exact literal format in their
- * tests so the two cannot drift apart silently.
+ * The canonical message and key codecs live in the updatesigning package,
+ * shared by the agent, hub, and offline signing tool.
  * ============================================================================ */
-
-// updateSigContext namespaces the signature so this key can never be
-// repurposed to sign anything else meaningful.
-const updateSigContext = "bloxos-agent-update:v1"
 
 // agentUpdateProtocol is reported to the hub in every agent_running_version
 // frame. Version 1 means "this binary verifies signed announcements."
@@ -54,11 +49,9 @@ const agentUpdateProtocol = 1
 // the key. Windows pins it next to the agent executable instead.
 const defaultUpdatePublicKeyPathLinux = "/etc/bloxos/agent-update.pub"
 
-// updateSigningMessage builds the exact byte string that gets signed.
+// updateSigningMessage delegates to the canonical shared message format.
 func updateSigningMessage(osName, sha256hex string) []byte {
-	return []byte(updateSigContext + ":" +
-		strings.ToLower(strings.TrimSpace(osName)) + ":" +
-		strings.ToLower(strings.TrimSpace(sha256hex)))
+	return updatesigning.Message(osName, sha256hex)
 }
 
 // selfUpdateTransportOK reports whether this agent's actual hub URL permits a
@@ -128,46 +121,16 @@ func updatePublicKeyPath(exePath string) string {
 // parseUpdatePublicKey reads a pinned key file: the first non-empty,
 // non-comment line, base64-standard-encoded.
 func parseUpdatePublicKey(data []byte) (ed25519.PublicKey, error) {
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		raw, err := base64.StdEncoding.DecodeString(line)
-		if err != nil {
-			return nil, fmt.Errorf("key is not valid base64: %w", err)
-		}
-		if len(raw) != ed25519.PublicKeySize {
-			return nil, fmt.Errorf("key is %d bytes, want %d", len(raw), ed25519.PublicKeySize)
-		}
-		return ed25519.PublicKey(raw), nil
-	}
-	return nil, fmt.Errorf("no key found in file")
+	return updatesigning.DecodePublicKey(data)
 }
 
 // verifyUpdateSignature checks sigB64 over (osName, sha256hex) against pub.
 func verifyUpdateSignature(pub ed25519.PublicKey, osName, sha256hex, sigB64 string) error {
-	if len(pub) != ed25519.PublicKeySize {
-		return fmt.Errorf("pinned key is malformed")
-	}
-	sigB64 = strings.TrimSpace(sigB64)
-	if sigB64 == "" {
+	if strings.TrimSpace(sigB64) == "" {
 		return fmt.Errorf("hub announced no signature for the %s binary", osName)
 	}
-	sig, err := base64.StdEncoding.DecodeString(sigB64)
-	if err != nil {
-		return fmt.Errorf("signature is not valid base64: %w", err)
-	}
-	if len(sig) != ed25519.SignatureSize {
-		return fmt.Errorf("signature is %d bytes, want %d", len(sig), ed25519.SignatureSize)
-	}
-	// Reject a non-hex "SHA" before it reaches the signed message — it would
-	// otherwise be possible to sign an arbitrary string in the SHA slot.
-	if _, err := hex.DecodeString(strings.TrimSpace(sha256hex)); err != nil {
-		return fmt.Errorf("announced SHA is not hex: %w", err)
-	}
-	if !ed25519.Verify(pub, updateSigningMessage(osName, sha256hex), sig) {
-		return fmt.Errorf("signature does not verify against the pinned update key")
+	if err := updatesigning.Verify(pub, osName, sha256hex, sigB64); err != nil {
+		return fmt.Errorf("signature does not verify against the pinned update key: %w", err)
 	}
 	return nil
 }

--- a/agent/update_verify_test.go
+++ b/agent/update_verify_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
 )
 
 // TestUpdateSigningMessageFormat locks the exact bytes that get signed. The
@@ -107,6 +109,35 @@ func TestVerifyUpdateSignature(t *testing.T) {
 			t.Fatal("accepted a non-hex SHA even though it was correctly signed")
 		}
 	})
+}
+
+func TestOfflineSigningToolRoundTripAgentVerification(t *testing.T) {
+	pub, priv := newTestKey(t)
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bloxos-agent")
+	if err := os.WriteFile(bin, []byte("offline-signed agent"), 0o755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	keyPath := filepath.Join(dir, "update-signing.key")
+	if err := os.WriteFile(keyPath, []byte(base64.StdEncoding.EncodeToString(priv)+"\n"), 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+
+	result, err := updatesigning.SignFile(bin, "linux", keyPath)
+	if err != nil {
+		t.Fatalf("sign file: %v", err)
+	}
+	pinKey(t, pub)
+
+	if err := verifyAnnouncedRelease(bin, "linux", result.SHA256, result.Signature); err != nil {
+		t.Fatalf("tool signature rejected by agent: %v", err)
+	}
+	if err := verifyAnnouncedRelease(bin, "windows", result.SHA256, result.Signature); err == nil {
+		t.Fatal("linux tool signature accepted for windows")
+	}
+	if err := verifyAnnouncedRelease(bin, "linux", strings.Repeat("ab", 32), result.Signature); err == nil {
+		t.Fatal("tool signature accepted for wrong SHA")
+	}
 }
 
 func TestParseUpdatePublicKey(t *testing.T) {

--- a/docs/offline-update-signing.md
+++ b/docs/offline-update-signing.md
@@ -1,0 +1,158 @@
+# Offline agent release signing
+
+This runbook builds and signs Linux and Windows agent releases on **FAT-LOLO**,
+then installs the binary/signature pairs into root-owned serve directories on
+the hub. The private Ed25519 key stays on the offline build host.
+
+> **Scope boundary:** this document describes the later one-time keyless
+> cutover, but this PR does not perform it. Do not set
+> `BLOXOS_UPDATE_PUBKEY`, move or remove the hub's private key, restart the hub,
+> or deploy an agent release without a separate, environment-specific approval.
+
+## Invariants
+
+- Build from a pinned, clean commit and record it with the artifact hashes.
+- The signing input and private key remain on FAT-LOLO. Never copy the private
+  key to the hub or print it in a terminal transcript.
+- `bloxos-sign` and both agents use `updatesigning.Message`; the signed bytes
+  are `bloxos-agent-update:v1:<os>:<sha256>` after trimming and lowercasing the
+  OS and SHA.
+- A detached signature is standard-base64 Ed25519 in `<binary>.sig`, with one
+  trailing newline. The hub verifies it against the configured public key
+  before announcing it.
+- The hub's configured Linux and Windows binary paths must be explicit and
+  rooted in a `root:root` chain that is not group- or other-writable. Do not
+  rely on relative paths or fallbacks.
+- Pause rollout before changing a served artifact. A served SHA change clears
+  the current in-memory pause, so verify and re-pause immediately after each
+  change before allowing agents to reconnect.
+
+## 1. Build on FAT-LOLO
+
+Use a fresh clone rather than a worktree so Go VCS stamping is unambiguous.
+Replace `<commit>` with the approved full commit SHA.
+
+```sh
+set -euo pipefail
+SRC=/home/bokiko/bloxos-release-src
+ART=/home/bokiko/bloxos-release-artifacts
+COMMIT=<commit>
+
+[ ! -e "$SRC" ] && [ ! -e "$ART" ]
+git clone https://github.com/bokiko/bloxos.git "$SRC"
+git -C "$SRC" checkout --detach "$COMMIT"
+[ -z "$(git -C "$SRC" status --porcelain)" ]
+mkdir -m 700 "$ART"
+
+( cd "$SRC/hub" && go build -o "$ART/bloxos-sign" ./cmd/bloxos-sign )
+( cd "$SRC/agent" && go build -o "$ART/bloxos-agent-linux" . )
+( cd "$SRC/agent" && GOOS=windows GOARCH=amd64 go build -o "$ART/bloxos-agent-windows.exe" . )
+
+file "$ART/bloxos-sign" "$ART/bloxos-agent-linux" "$ART/bloxos-agent-windows.exe"
+go version -m "$ART/bloxos-agent-linux"
+go version -m "$ART/bloxos-agent-windows.exe"
+```
+
+Gate: both agents report `vcs.revision=<commit>` and `vcs.modified=false`; the
+Windows artifact is PE32+ x86-64 and the Linux artifact is the expected ELF.
+
+## 2. Sign on FAT-LOLO
+
+`-key` takes precedence over `BLOXOS_UPDATE_SIGNING_KEY`; when neither is set,
+the tool uses `~/.bloxos/update-signing.key`. The tool prints only the target
+OS, SHA-256, and signature path — never private key material.
+
+```sh
+set -euo pipefail
+KEY=/secure/offline/bloxos-update-signing.key
+ART=/home/bokiko/bloxos-release-artifacts
+
+"$ART/bloxos-sign" -key "$KEY" -os linux "$ART/bloxos-agent-linux"
+"$ART/bloxos-sign" -key "$KEY" -os windows "$ART/bloxos-agent-windows.exe"
+"$ART/bloxos-sign" -key "$KEY" -print-public-key > "$ART/update-signing.pub"
+
+sha256sum \
+  "$ART/bloxos-agent-linux" "$ART/bloxos-agent-linux.sig" \
+  "$ART/bloxos-agent-windows.exe" "$ART/bloxos-agent-windows.exe.sig" \
+  "$ART/bloxos-sign" > "$ART/SHA256SUMS"
+chmod 0444 "$ART"/*.sig "$ART/update-signing.pub" "$ART/SHA256SUMS"
+```
+
+Record the full artifact hashes and public key through a separately trusted
+handoff. The private-key file must remain mode `0600` in a non-shared path.
+
+## 3. Stage on the hub
+
+The example paths assume the service is explicitly configured with:
+
+```text
+BLOXOS_AGENT_BINARY=/usr/local/lib/bloxos/linux/bloxos-agent
+BLOXOS_AGENT_BINARY_WINDOWS=/usr/local/lib/bloxos/windows/bloxos-agent.exe
+```
+
+Transfer into a mode-`0700` user-owned transit directory, authenticate the
+manifest/hashes received through the trusted handoff, then use `sudo install`
+to copy into a root-owned staging directory. Delete only the named transit
+files after the root-owned hashes match. The transit directory is never a
+signing input.
+
+Before deployment, assert every ancestor of `/usr/local/lib/bloxos` is
+`root:root`, is traversable by the hub service user, and is not group- or
+other-writable. Audit unexpected ownership or mode; do not normalize it into a
+pass.
+
+## 4. Deploy a signed release
+
+This is a live rollout step and requires its own approval. Keep target agents
+offline or rollout-paused according to the release plan.
+
+For each platform, install the **signature first**, then the binary, using
+temporary files in the same root-owned serve directory and atomic renames:
+
+```sh
+# Example: Linux. Repeat with the Windows names and directory.
+set -euo pipefail
+STAGE=/usr/local/lib/bloxos/staging
+SERVE=/usr/local/lib/bloxos/linux/bloxos-agent
+
+sudo install -o root -g root -m 0644 "$STAGE/bloxos-agent-linux.sig" "$SERVE.sig.tmp"
+sudo install -o root -g root -m 0755 "$STAGE/bloxos-agent-linux" "$SERVE.tmp"
+# Verify both temp-file hashes against the approved manifest here.
+sudo mv -f "$SERVE.sig.tmp" "$SERVE.sig"
+sudo mv -f "$SERVE.tmp" "$SERVE"
+```
+
+Installing the signature first is fail-closed. While it belongs to the next
+binary, it cannot verify for the currently served SHA. In hub-held-key mode the
+hub can continue signing the current release; in offline mode it withholds an
+announcement during that brief mismatch instead of emitting an invalid one.
+After the binary rename, wait for `hub_sha`/`hub_windows_sha` to equal the
+approved SHA, then re-pause immediately because the SHA transition clears the
+in-memory pause. Resume only through the approved fleet rollout procedure.
+
+## 5. One-time keyless cutover — not part of this PR
+
+Perform this only under a separate reviewed runbook and approval:
+
+1. While the hub still holds the existing private key, sign the **currently
+   served** Linux and Windows binaries offline with that same key.
+2. Pre-place each matching `.sig` beside its unchanged binary. This is
+   operationally a no-op: the hub prefers a detached signature only after it
+   verifies for the exact current `(os, sha)`, and Ed25519 signing is
+   deterministic. Assert the announced SHAs and signatures are unchanged.
+3. Derive the public half with `bloxos-sign -key <offline-key>
+   -print-public-key`. Verify it byte-for-byte against the public key already
+   pinned across the fleet.
+4. Set `BLOXOS_UPDATE_PUBKEY` to that public value and remove/unset
+   `BLOXOS_UPDATE_SIGNING_KEY` in the hub service configuration. Restart the
+   hub while rollout is controlled, and verify the log reports offline mode,
+   the hub holds no private key, both detached signatures verify, and no agent
+   sees a changed SHA.
+5. Only after those assertions pass, remove the private key from the hub host.
+   Preserve independently verified offline backups; losing the sole signing
+   key prevents future updates to every pinned agent.
+
+Rollback before step 5 is restoring the previous service configuration and
+restarting with the existing key file. After step 5, restore only from the
+approved offline backup — never generate a replacement key for an existing
+fleet.

--- a/hub/cmd/bloxos-sign/main.go
+++ b/hub/cmd/bloxos-sign/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
+)
+
+const keyEnv = "BLOXOS_UPDATE_SIGNING_KEY"
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "bloxos-sign: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("bloxos-sign", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	osName := fs.String("os", "", "target operating system: linux or windows")
+	keyPath := fs.String("key", "", "Ed25519 private key path")
+	printPublicKey := fs.Bool("print-public-key", false, "print the matching base64 public key and exit")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	resolvedKey, err := resolveKeyPath(*keyPath)
+	if err != nil {
+		return err
+	}
+	if *printPublicKey {
+		if fs.NArg() != 0 || strings.TrimSpace(*osName) != "" {
+			return fmt.Errorf("-print-public-key does not accept -os or a binary path")
+		}
+		pub, err := publicKeyFor(resolvedKey)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(stdout, base64.StdEncoding.EncodeToString(pub))
+		return nil
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: bloxos-sign -os <linux|windows> [-key path] <agent-binary>")
+	}
+
+	result, err := updatesigning.SignFile(fs.Arg(0), *osName, resolvedKey)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "signed os=%s sha256=%s signature=%s\n",
+		strings.ToLower(strings.TrimSpace(*osName)), result.SHA256, result.SignaturePath)
+	return nil
+}
+
+func resolveKeyPath(flagValue string) (string, error) {
+	if path := strings.TrimSpace(flagValue); path != "" {
+		return path, nil
+	}
+	if path := strings.TrimSpace(os.Getenv(keyEnv)); path != "" {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve default signing key path: %w", err)
+	}
+	return filepath.Join(home, ".bloxos", "update-signing.key"), nil
+}
+
+func publicKeyFor(keyPath string) (ed25519.PublicKey, error) {
+	data, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read private key %s: %w", keyPath, err)
+	}
+	priv, err := updatesigning.DecodePrivateKey(data)
+	if err != nil {
+		return nil, fmt.Errorf("decode private key %s: %w", keyPath, err)
+	}
+	return priv.Public().(ed25519.PublicKey), nil
+}

--- a/hub/cmd/bloxos-sign/main_test.go
+++ b/hub/cmd/bloxos-sign/main_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
+)
+
+func testSigningKey(t *testing.T) (string, ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "update-signing.key")
+	if err := os.WriteFile(path, []byte(base64.StdEncoding.EncodeToString(priv)+"\n"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return path, pub, priv
+}
+
+func TestRunSignsWithEnvironmentKey(t *testing.T) {
+	keyPath, pub, priv := testSigningKey(t)
+	t.Setenv(keyEnv, keyPath)
+	bin := filepath.Join(t.TempDir(), "bloxos-agent")
+	if err := os.WriteFile(bin, []byte("agent release"), 0o755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := run([]string{"-os", "linux", bin}, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	sigData, err := os.ReadFile(bin + ".sig")
+	if err != nil {
+		t.Fatalf("read signature: %v", err)
+	}
+	shaResult, err := updatesigning.SignFile(bin, "linux", keyPath)
+	if err != nil {
+		t.Fatalf("re-sign for verification: %v", err)
+	}
+	if err := updatesigning.Verify(pub, "linux", shaResult.SHA256, string(sigData)); err != nil {
+		t.Fatalf("written signature does not verify: %v", err)
+	}
+	if strings.Contains(out.String(), base64.StdEncoding.EncodeToString(priv)) {
+		t.Fatal("command output exposed private key material")
+	}
+}
+
+func TestRunPrintsOnlyPublicKey(t *testing.T) {
+	keyPath, pub, priv := testSigningKey(t)
+	var out bytes.Buffer
+	if err := run([]string{"-key", keyPath, "-print-public-key"}, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got, want := strings.TrimSpace(out.String()), base64.StdEncoding.EncodeToString(pub); got != want {
+		t.Fatalf("public key = %q, want %q", got, want)
+	}
+	if strings.Contains(out.String(), base64.StdEncoding.EncodeToString(priv)) {
+		t.Fatal("command output exposed private key material")
+	}
+}
+
+func TestResolveKeyPathDefaultsUnderHome(t *testing.T) {
+	t.Setenv(keyEnv, "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	got, err := resolveKeyPath("")
+	if err != nil {
+		t.Fatalf("resolveKeyPath: %v", err)
+	}
+	want := filepath.Join(home, ".bloxos", "update-signing.key")
+	if got != want {
+		t.Fatalf("default key path = %q, want %q", got, want)
+	}
+}

--- a/hub/go.mod
+++ b/hub/go.mod
@@ -2,7 +2,10 @@ module github.com/bokiko/bloxos/hub
 
 go 1.25.0
 
+replace github.com/bokiko/bloxos/proto => ../proto
+
 require (
+	github.com/bokiko/bloxos/proto v0.0.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3

--- a/hub/update_signing.go
+++ b/hub/update_signing.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
 )
 
 /* ============================================================================
@@ -44,13 +46,9 @@ import (
  * has downgrade/monotonicity protection yet. That is a separate gap, not
  * closed by either signing mode.
  *
- * updateSigContext and updateSigningMessage are duplicated in
- * agent/update_verify.go. Both sides assert the exact literal format in
- * their tests so the two cannot drift apart silently.
+ * The canonical message and key codecs live in the updatesigning package,
+ * shared by the hub, agent, and offline signing tool.
  * ============================================================================ */
-
-// updateSigContext namespaces the signature. Must match the agent's constant.
-const updateSigContext = "bloxos-agent-update:v1"
 
 var (
 	updateSigningKey    ed25519.PrivateKey
@@ -65,12 +63,9 @@ var (
 	updateSigningMu             sync.RWMutex
 )
 
-// updateSigningMessage builds the exact byte string that gets signed.
-// Must match agent/update_verify.go byte for byte.
+// updateSigningMessage delegates to the canonical shared message format.
 func updateSigningMessage(osName, sha256hex string) []byte {
-	return []byte(updateSigContext + ":" +
-		strings.ToLower(strings.TrimSpace(osName)) + ":" +
-		strings.ToLower(strings.TrimSpace(sha256hex)))
+	return updatesigning.Message(osName, sha256hex)
 }
 
 // initUpdateSigning resolves the hub's update signing material at startup.
@@ -217,37 +212,11 @@ func updateSigningStatus() (enabled bool, reason string) {
 }
 
 func decodeUpdatePublicKey(b64 string) (ed25519.PublicKey, error) {
-	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64))
-	if err != nil {
-		return nil, fmt.Errorf("not valid base64: %w", err)
-	}
-	if len(raw) != ed25519.PublicKeySize {
-		return nil, fmt.Errorf("key is %d bytes, want %d", len(raw), ed25519.PublicKeySize)
-	}
-	return ed25519.PublicKey(raw), nil
+	return updatesigning.DecodePublicKey([]byte(b64))
 }
 
 func decodeUpdatePrivateKey(data []byte) (ed25519.PrivateKey, error) {
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		raw, err := base64.StdEncoding.DecodeString(line)
-		if err != nil {
-			return nil, fmt.Errorf("not valid base64: %w", err)
-		}
-		switch len(raw) {
-		case ed25519.PrivateKeySize:
-			return ed25519.PrivateKey(raw), nil
-		case ed25519.SeedSize:
-			return ed25519.NewKeyFromSeed(raw), nil
-		default:
-			return nil, fmt.Errorf("key is %d bytes, want %d (private) or %d (seed)",
-				len(raw), ed25519.PrivateKeySize, ed25519.SeedSize)
-		}
-	}
-	return nil, fmt.Errorf("no key found in file")
+	return updatesigning.DecodePrivateKey(data)
 }
 
 // updateSigningPublicKeyBase64 returns the key that installers pin on the
@@ -272,8 +241,8 @@ func signAgentRelease(osName, sha string) string {
 }
 
 // detachedSignatureFor reads <binaryPath>.sig, an offline-produced base64
-// ed25519 signature. Returns "" if absent, malformed, or — when a public key
-// is known — if it does not actually verify for this (os, sha). Announcing a
+// ed25519 signature. Returns "" if absent, malformed, no public key is
+// configured, or it does not verify for this (os, sha). Announcing a
 // stale signature would only make every agent in the fleet reject the update
 // with a confusing error, so it is better caught here.
 func detachedSignatureFor(binaryPath, osName, sha string) string {
@@ -297,7 +266,10 @@ func detachedSignatureFor(binaryPath, osName, sha string) string {
 	updateSigningMu.RLock()
 	pub := updateSigningPub
 	updateSigningMu.RUnlock()
-	if pub != nil && !ed25519.Verify(pub, updateSigningMessage(osName, sha), sig) {
+	if pub == nil {
+		return ""
+	}
+	if err := updatesigning.Verify(pub, osName, sha, sigB64); err != nil {
 		log.Printf("update signing: %s.sig does not verify for the %s binary currently served "+
 			"(sha %s) — re-sign it, agents will reject this announcement",
 			binaryPath, osName, versionShortSHA(sha))

--- a/hub/update_signing_test.go
+++ b/hub/update_signing_test.go
@@ -17,9 +17,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bokiko/bloxos/proto/updatesigning"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 )
+
+func writeOfflineSigningKey(t *testing.T, priv ed25519.PrivateKey) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "update-signing.key")
+	body := base64.StdEncoding.EncodeToString(priv) + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+	return path
+}
 
 // ensureTestUpdateSigningKey gives the test binary a process-lifetime signing
 // key. Production does this in main() via initUpdateSigning(); without it
@@ -177,6 +188,74 @@ func TestDetachedSignatureFor(t *testing.T) {
 
 	if got := detachedSignatureFor("", "linux", sha); got != "" {
 		t.Fatalf("empty binary path returned %q", got)
+	}
+}
+
+func TestOfflineSigningToolRoundTripDetachedSignature(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bloxos-agent")
+	if err := os.WriteFile(bin, []byte("offline-signed agent"), 0o755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+
+	result, err := updatesigning.SignFile(bin, "linux", writeOfflineSigningKey(t, priv))
+	if err != nil {
+		t.Fatalf("sign file: %v", err)
+	}
+
+	updateSigningMu.Lock()
+	oldPub := updateSigningPub
+	updateSigningPub = pub
+	updateSigningMu.Unlock()
+	t.Cleanup(func() {
+		updateSigningMu.Lock()
+		updateSigningPub = oldPub
+		updateSigningMu.Unlock()
+	})
+
+	if got := detachedSignatureFor(bin, "linux", result.SHA256); got != result.Signature {
+		t.Fatalf("detachedSignatureFor = %q, want tool signature %q", got, result.Signature)
+	}
+	if got := detachedSignatureFor(bin, "windows", result.SHA256); got != "" {
+		t.Fatalf("linux signature accepted for windows: %q", got)
+	}
+	if got := detachedSignatureFor(bin, "linux", strings.Repeat("ab", 32)); got != "" {
+		t.Fatalf("signature accepted for wrong SHA: %q", got)
+	}
+}
+
+func TestDetachedSignatureForFailsClosedWithoutPublicKey(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bloxos-agent")
+	if err := os.WriteFile(bin, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	sha := strings.Repeat("cd", 32)
+	sig := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, updateSigningMessage("linux", sha)))
+	if err := os.WriteFile(bin+".sig", []byte(sig+"\n"), 0o644); err != nil {
+		t.Fatalf("write signature: %v", err)
+	}
+
+	updateSigningMu.Lock()
+	oldPub := updateSigningPub
+	updateSigningPub = nil
+	updateSigningMu.Unlock()
+	t.Cleanup(func() {
+		updateSigningMu.Lock()
+		updateSigningPub = oldPub
+		updateSigningMu.Unlock()
+	})
+
+	if got := detachedSignatureFor(bin, "linux", sha); got != "" {
+		t.Fatalf("detached signature returned without a public key: %q", got)
 	}
 }
 

--- a/proto/go.mod
+++ b/proto/go.mod
@@ -1,0 +1,3 @@
+module github.com/bokiko/bloxos/proto
+
+go 1.25.0

--- a/proto/updatesigning/signing.go
+++ b/proto/updatesigning/signing.go
@@ -1,0 +1,180 @@
+// Package updatesigning defines the canonical BloxOS agent-update signature
+// format and the helpers used to create and verify detached release signatures.
+package updatesigning
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Context namespaces agent-update signatures from every other use of the key.
+const Context = "bloxos-agent-update:v1"
+
+// Result describes a detached signature written by SignFile.
+type Result struct {
+	SHA256        string
+	Signature     string
+	SignaturePath string
+}
+
+// Message returns the exact bytes signed for an agent release.
+func Message(osName, sha256hex string) []byte {
+	return []byte(Context + ":" +
+		strings.ToLower(strings.TrimSpace(osName)) + ":" +
+		strings.ToLower(strings.TrimSpace(sha256hex)))
+}
+
+// DecodePublicKey parses the first non-empty, non-comment base64 Ed25519 public key.
+func DecodePublicKey(data []byte) (ed25519.PublicKey, error) {
+	raw, err := decodeFirstLine(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("key is %d bytes, want %d", len(raw), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(raw), nil
+}
+
+// DecodePrivateKey parses the first non-empty, non-comment base64 Ed25519
+// private key. Both a full private key and a seed are accepted.
+func DecodePrivateKey(data []byte) (ed25519.PrivateKey, error) {
+	raw, err := decodeFirstLine(data)
+	if err != nil {
+		return nil, err
+	}
+	switch len(raw) {
+	case ed25519.PrivateKeySize:
+		return ed25519.PrivateKey(raw), nil
+	case ed25519.SeedSize:
+		return ed25519.NewKeyFromSeed(raw), nil
+	default:
+		return nil, fmt.Errorf("key is %d bytes, want %d (private) or %d (seed)",
+			len(raw), ed25519.PrivateKeySize, ed25519.SeedSize)
+	}
+}
+
+func decodeFirstLine(data []byte) ([]byte, error) {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		raw, err := base64.StdEncoding.DecodeString(line)
+		if err != nil {
+			return nil, fmt.Errorf("not valid base64: %w", err)
+		}
+		return raw, nil
+	}
+	return nil, fmt.Errorf("no key found in file")
+}
+
+// Verify checks a base64 Ed25519 signature for the supplied OS and SHA.
+func Verify(pub ed25519.PublicKey, osName, sha256hex, sigB64 string) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return fmt.Errorf("public key is malformed")
+	}
+	sha256hex = strings.TrimSpace(sha256hex)
+	rawSHA, err := hex.DecodeString(sha256hex)
+	if err != nil || len(rawSHA) != sha256.Size {
+		return fmt.Errorf("SHA-256 must be exactly %d hex bytes", sha256.Size)
+	}
+	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(sigB64))
+	if err != nil {
+		return fmt.Errorf("signature is not valid base64: %w", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("signature is %d bytes, want %d", len(sig), ed25519.SignatureSize)
+	}
+	if !ed25519.Verify(pub, Message(osName, sha256hex), sig) {
+		return fmt.Errorf("signature does not verify against the update key")
+	}
+	return nil
+}
+
+// SignFile hashes binaryPath, signs its canonical release message with the key
+// at privateKeyPath, and atomically writes a base64 signature to <binary>.sig.
+func SignFile(binaryPath, osName, privateKeyPath string) (Result, error) {
+	osName = strings.ToLower(strings.TrimSpace(osName))
+	if osName != "linux" && osName != "windows" {
+		return Result{}, fmt.Errorf("unsupported OS %q: want linux or windows", osName)
+	}
+	if strings.TrimSpace(binaryPath) == "" {
+		return Result{}, fmt.Errorf("binary path is required")
+	}
+	if strings.TrimSpace(privateKeyPath) == "" {
+		return Result{}, fmt.Errorf("private key path is required")
+	}
+
+	keyData, err := os.ReadFile(privateKeyPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("read private key %s: %w", privateKeyPath, err)
+	}
+	priv, err := DecodePrivateKey(keyData)
+	if err != nil {
+		return Result{}, fmt.Errorf("decode private key %s: %w", privateKeyPath, err)
+	}
+
+	f, err := os.Open(binaryPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("open binary %s: %w", binaryPath, err)
+	}
+	h := sha256.New()
+	_, copyErr := io.Copy(h, f)
+	closeErr := f.Close()
+	if copyErr != nil {
+		return Result{}, fmt.Errorf("hash binary %s: %w", binaryPath, copyErr)
+	}
+	if closeErr != nil {
+		return Result{}, fmt.Errorf("close binary %s: %w", binaryPath, closeErr)
+	}
+	sha := hex.EncodeToString(h.Sum(nil))
+	sig := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, Message(osName, sha)))
+	sigPath := binaryPath + ".sig"
+	if err := writeSignatureAtomic(sigPath, sig+"\n"); err != nil {
+		return Result{}, err
+	}
+	return Result{SHA256: sha, Signature: sig, SignaturePath: sigPath}, nil
+}
+
+func writeSignatureAtomic(path, body string) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*")
+	if err != nil {
+		return fmt.Errorf("create temporary signature beside %s: %w", path, err)
+	}
+	tmpPath := tmp.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("set signature permissions: %w", err)
+	}
+	if _, err := io.WriteString(tmp, body); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write signature: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync signature: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close signature: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("install signature %s: %w", path, err)
+	}
+	removeTemp = false
+	return nil
+}


### PR DESCRIPTION
## Summary

- add `bloxos-sign`, an offline Ed25519 release-signing tool that hashes an agent binary and atomically writes the detached `<binary>.sig`
- move the canonical update-signing message and key codecs into `proto/updatesigning`, shared by the hub, agent, and tool so the signed bytes cannot drift
- make `detachedSignatureFor` fail closed when no hub public key is configured, even if a detached signature exists
- document the build, signing, staging, deployment, and separately approved keyless-cutover procedure

## Why

Offline signing keeps the fleet update private key off the hub while preserving the exact message format already verified by deployed protocol-v1 agents. The shared package removes the former duplicated hub/agent implementation, and the fail-closed fix prevents the hub from returning an unverified detached signature when its public key is unavailable.

## Verification

- round-trip tool output through the hub's real `detachedSignatureFor` path
- round-trip tool output through the agent's real `verifyAnnouncedRelease` path
- reject wrong OS, wrong SHA, wrong key, malformed signature, and missing public key
- assert CLI output never contains private key material
- `go vet ./...` and `go test -count=1 ./...` in `proto`, `hub`, and `agent`
- agent insecure-tag vet/tests
- Windows agent cross-vet
- `git diff --check`

## Out of scope

This PR makes no live hub or fleet changes. It does **not** set `BLOXOS_UPDATE_PUBKEY`, move or remove the current private key, restart the hub, or deploy a signed agent binary. The keyless cutover described in the runbook requires a separate, environment-specific approval and verification run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent self-update verification and hub announcement signing paths; behavior change in `detachedSignatureFor` could withhold updates when pubkey is missing, but reduces risk of announcing unverified signatures.
> 
> **Overview**
> Introduces **`bloxos-sign`**, an offline CLI that SHA-256-hashes an agent binary, signs the canonical `bloxos-agent-update:v1:<os>:<sha256>` message, and atomically writes `<binary>.sig`.
> 
> **Signing logic is centralized** in new `proto/updatesigning` (message format, key decode, `Verify`, `SignFile`). The hub and agent drop duplicated helpers and depend on this package via `go.mod` `replace` so signed bytes cannot drift between offline tool, hub, and fleet agents.
> 
> The hub’s **`detachedSignatureFor`** now **fails closed** when no public key is configured—it returns empty instead of surfacing a detached `.sig` that was not verified against a pinned key.
> 
> Adds **`docs/offline-update-signing.md`** (build/sign/stage/deploy on an offline host; keyless cutover documented but explicitly out of scope for this PR). Round-trip tests wire tool output through real hub `detachedSignatureFor` and agent `verifyAnnouncedRelease` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c33f811c87aaa2ff878a630358fe4045c53cb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->