### PR TITLE
fix(hub): trust one agent binary resolver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,12 +29,15 @@ BLOXOS_SETUP_TOKEN=
 # Additional CA certificate used by generated installers and agent TLS.
 BLOXOS_CA_CERT=
 
-# Absolute Linux agent binary served by the hub. Set this in deployments to
-# avoid relying on the working-directory-sensitive fallback resolver.
-BLOXOS_AGENT_BINARY=
+# Absolute Linux agent binary served by the hub. The binary and every ancestor
+# must be root-owned and not group/other-writable. If unset, the resolver checks
+# /usr/local/lib/bloxos/linux/bloxos-agent, then the hub executable's directory.
+BLOXOS_AGENT_BINARY=/usr/local/lib/bloxos/linux/bloxos-agent
 
-# Absolute Windows agent binary served by the hub.
-BLOXOS_AGENT_BINARY_WINDOWS=
+# Absolute Windows agent binary served by the hub, under the same trust rules.
+# If unset, the resolver checks /usr/local/lib/bloxos/windows/bloxos-agent.exe,
+# then the hub executable's directory.
+BLOXOS_AGENT_BINARY_WINDOWS=/usr/local/lib/bloxos/windows/bloxos-agent.exe
 
 # Base64 Ed25519 public key for offline-signing mode. When set, the hub only
 # announces detached <binary>.sig signatures and holds no private key.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ cd bloxos
 mkdir -p bin
 (cd hub && go build -o ../bin/bloxos-hub .)
 (cd agent && go build -o ../bin/bloxos-agent .)
+sudo install -d -o root -g root -m 0755 /usr/local/lib/bloxos/linux
+sudo install -o root -g root -m 0755 bin/bloxos-agent \
+  /usr/local/lib/bloxos/linux/bloxos-agent
 ```
 
 To build the Windows agent artifact:
@@ -182,7 +185,7 @@ you just built.
 export PUBLIC_URL=http://localhost:4000
 export ALLOWED_ORIGINS=http://localhost:3000
 export HUB_LISTEN=127.0.0.1:4000
-export BLOXOS_AGENT_BINARY="$PWD/bin/bloxos-agent"
+export BLOXOS_AGENT_BINARY=/usr/local/lib/bloxos/linux/bloxos-agent
 ./bin/bloxos-hub
 ```
 
@@ -225,8 +228,10 @@ bootstrap for a private or self-signed CA remains tracked in
 ```
 
 The sample units in [scripts/systemd](scripts/systemd) use `<user>` and
-`/opt/bloxos` placeholders. Replace `<user>`, install the built artifacts,
-then enable each installed unit:
+`/opt/bloxos` placeholders. Replace `<user>` and install the hub and dashboard
+artifacts there. Keep the served agent binary on the root-owned path shown
+above (or another absolute path whose complete ancestor chain is root-owned and
+not group/other-writable), then enable each installed unit:
 
 ```bash
 sudo systemctl daemon-reload

--- a/dashboard/.claude/skills/run-dashboard/driver.mjs
+++ b/dashboard/.claude/skills/run-dashboard/driver.mjs
@@ -119,11 +119,15 @@ async function main() {
     .getByRole("columnheader", { name: "Blocked reason" })
     .isVisible();
   const signingBannerVisible = await page.locator('[data-testid="signing-status-banner"]').isVisible();
+  const linuxBinaryVisible = await page.locator('[data-testid="agent-binary-linux"]').isVisible();
+  const windowsBinaryVisible = await page.locator('[data-testid="agent-binary-windows"]').isVisible();
   log(
     "versions rendered:",
     `keyPinned=${keyPinnedColumnVisible}`,
     `blockedReason=${blockedReasonColumnVisible}`,
     `signingBanner=${signingBannerVisible}`,
+    `linuxBinary=${linuxBinaryVisible}`,
+    `windowsBinary=${windowsBinaryVisible}`,
   );
 
   await browser.close();
@@ -141,7 +145,9 @@ async function main() {
     !navigateVisible ||
     !keyPinnedColumnVisible ||
     !blockedReasonColumnVisible ||
-    !signingBannerVisible
+    !signingBannerVisible ||
+    !linuxBinaryVisible ||
+    !windowsBinaryVisible
   ) {
     log("FAIL: an expected element did not render");
     process.exit(1);

--- a/dashboard/src/app/versions/page.tsx
+++ b/dashboard/src/app/versions/page.tsx
@@ -15,7 +15,7 @@ import {
   KeyRound,
   ShieldCheck,
 } from "lucide-react";
-import { useVersions } from "@/contexts/VersionsContext";
+import { AgentBinaryInfo, useVersions } from "@/contexts/VersionsContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import {
@@ -47,10 +47,92 @@ function timeSince(iso: string | undefined): string {
   return `${d}d ago`;
 }
 
+function AgentBinaryCard({
+  platform,
+  binary,
+}: {
+  platform: "Linux" | "Windows";
+  binary: AgentBinaryInfo;
+}) {
+  const available = Boolean(binary.sha) && !binary.error;
+
+  return (
+    <div
+      className={`rounded-xl border p-4 ${
+        available
+          ? "border-blox-border bg-blox-card"
+          : "border-red-500/20 bg-red-500/5"
+      }`}
+      data-testid={`agent-binary-${platform.toLowerCase()}`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-[0.1em] text-blox-muted/70 font-medium">
+          <Server className="w-3 h-3" />
+          {platform} agent binary
+        </div>
+        <Badge
+          variant="outline"
+          className={
+            available
+              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-[10px]"
+              : "border-red-500/30 bg-red-500/10 text-red-400 text-[10px]"
+          }
+        >
+          {available ? "Trusted" : "Unavailable"}
+        </Badge>
+      </div>
+      {available ? (
+        <>
+          <div className="flex items-baseline gap-3 mt-3">
+            <code className="text-sm font-mono font-semibold text-blox-text">
+              {shortSHA(binary.sha)}
+            </code>
+            <span className="text-[11px] text-blox-muted">
+              checked {timeSince(binary.mtime)}
+            </span>
+          </div>
+          <dl className="mt-3 grid gap-2 text-[11px]">
+            <div>
+              <dt className="text-blox-muted">Source</dt>
+              <dd className="text-blox-text font-mono break-all">{binary.source}</dd>
+            </div>
+            <div>
+              <dt className="text-blox-muted">Resolved path</dt>
+              <dd className="text-blox-text font-mono break-all">{binary.path}</dd>
+            </div>
+          </dl>
+        </>
+      ) : (
+        <p className="text-xs text-red-300 mt-3 break-words">
+          {binary.error || "No trusted binary resolved for this platform."}
+        </p>
+      )}
+    </div>
+  );
+}
+
 export default function VersionsPage() {
   const { data, loading, error, refresh, pauseRollout, resumeRollout } = useVersions();
   const { hasScope } = useAuth();
   const canManageRollout = hasScope("fleet.admin");
+  const binaries = data
+    ? data.agent_binaries ?? {
+        linux: {
+          path: "",
+          source: "legacy API",
+          sha: data.hub_sha,
+          mtime: data.hub_mtime,
+          error: "Resolver details require an updated hub.",
+        },
+        windows: {
+          path: "",
+          source: "legacy API",
+          sha: data.hub_windows_sha,
+          mtime: data.hub_windows_mtime,
+          error: "Resolver details require an updated hub.",
+        },
+      }
+    : null;
 
   useEffect(() => {
     refresh();
@@ -149,22 +231,30 @@ export default function VersionsPage() {
               </div>
             </div>
 
+            <section aria-labelledby="served-agent-binaries">
+              <h2
+                id="served-agent-binaries"
+                className="text-sm font-medium text-blox-text mb-3"
+              >
+                Served agent binaries
+              </h2>
+              <div className="grid gap-3 md:grid-cols-2">
+                <AgentBinaryCard platform="Linux" binary={binaries!.linux} />
+                <AgentBinaryCard platform="Windows" binary={binaries!.windows} />
+              </div>
+            </section>
+
             {/* Hub binary status card */}
             <div className="bg-blox-card border border-blox-border rounded-xl p-5">
               <div className="flex items-center justify-between gap-4 flex-wrap">
                 <div>
                   <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-[0.1em] text-blox-muted/70 font-medium mb-2">
                     <Server className="w-3 h-3" />
-                    Hub binary
+                    Fleet rollout
                   </div>
-                  <div className="flex items-baseline gap-3">
-                    <code className="text-base font-mono font-semibold text-blox-text">
-                      {shortSHA(data.hub_sha)}
-                    </code>
-                    <span className="text-[11px] text-blox-muted">
-                      built {timeSince(data.hub_mtime)}
-                    </span>
-                  </div>
+                  <p className="text-xs text-blox-muted">
+                    Control update announcements for every platform.
+                  </p>
                 </div>
 
                 {/* Rollout pause/resume control */}

--- a/dashboard/src/contexts/VersionsContext.tsx
+++ b/dashboard/src/contexts/VersionsContext.tsx
@@ -23,12 +23,27 @@ export interface AgentVersionInfo {
   update_protocol: number;
 }
 
+export interface AgentBinaryInfo {
+  path: string;
+  source: string;
+  sha: string;
+  mtime: string;
+  error: string;
+}
+
 export interface VersionsResponse {
   signing_enabled: boolean;
   signing_disabled_reason: string;
   hub_sha: string;
   hub_short_sha: string;
   hub_mtime: string;
+  hub_windows_sha: string;
+  hub_windows_short_sha: string;
+  hub_windows_mtime: string;
+  agent_binaries?: {
+    linux: AgentBinaryInfo;
+    windows: AgentBinaryInfo;
+  };
   agents: AgentVersionInfo[];
   rollout_paused: boolean;
   pause_reason: string;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,18 +126,31 @@ state and pending updates.
 Signatures still carry no downgrade or monotonicity protection, so a previously
 valid `(os, sha)` pair remains valid indefinitely ([#145]).
 
-### Resolving the served binary (Linux)
+### Resolving served agent binaries
 
-For Linux agents, `agentBinaryPathFor` resolves the served binary from an
-ordered candidate list: `$BLOXOS_AGENT_BINARY`, then `./agent/bloxos-agent`
-relative to the hub's working directory, then `/usr/local/bin/bloxos-agent`.
-The relative candidate does not resolve when the hub's `WorkingDirectory` is
-the `hub/` subdirectory, and the fallback is silent. Set
-`BLOXOS_AGENT_BINARY` explicitly in deployments to avoid serving a stale binary
-([#149]). Windows resolution uses its own environment variable and fallbacks.
+A single resolver supplies the path used to hash, find the detached `.sig`, and
+serve `/download/agent`. Linux and Windows resolve independently. An explicit
+`BLOXOS_AGENT_BINARY` or `BLOXOS_AGENT_BINARY_WINDOWS` is authoritative: it
+must be absolute and trusted, and a missing or rejected configured path fails
+closed without falling through. Without an override, each platform checks its
+root-owned system default under `/usr/local/lib/bloxos/`, then a sibling of the
+running hub executable. Resolution never depends on the process working
+directory.
+
+The resolver canonicalizes the path and requires the binary plus every ancestor
+to be root-owned and not group/other-writable. The API and Versions dashboard
+show the selected path, source, SHA, mtime, or platform-specific resolution
+error. A failure clears only that platform's advertised SHA, so one missing
+artifact cannot leave a stale digest or disable the other platform.
+
+Deploying this resolver requires a coupled live migration, not a hub-only
+upgrade. Before restarting the updated hub, place the currently served Linux
+binary and its valid detached signature in a root-owned directory, and update
+`BLOXOS_AGENT_BINARY` to that path. Preserve the prior binary, signature, and
+service configuration for rollback. The migration and restart are operational
+changes and are intentionally separate from the code change.
 
 [#145]: https://github.com/bokiko/bloxos/issues/145
-[#149]: https://github.com/bokiko/bloxos/issues/149
 
 ## Deployment Assets
 

--- a/hub/agent_binary.go
+++ b/hub/agent_binary.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	linuxAgentBinaryDefault   = "/usr/local/lib/bloxos/linux/bloxos-agent"
+	windowsAgentBinaryDefault = "/usr/local/lib/bloxos/windows/bloxos-agent.exe"
+)
+
+type agentBinaryResolution struct {
+	Path    string
+	Source  string
+	Skipped []string
+}
+
+type agentBinaryState struct {
+	Path   string    `json:"path"`
+	Source string    `json:"source"`
+	SHA    string    `json:"sha"`
+	Mtime  time.Time `json:"mtime"`
+	Error  string    `json:"error"`
+}
+
+type agentBinaryResolver struct {
+	executablePath func() (string, error)
+	validate       func(string) (string, error)
+}
+
+var (
+	hubAgentBinaryMu  sync.RWMutex
+	agentBinaryStates = map[string]agentBinaryState{
+		"linux":   {},
+		"windows": {},
+	}
+	resolveAgentBinaryFor = productionAgentBinaryResolver().resolve
+)
+
+func productionAgentBinaryResolver() agentBinaryResolver {
+	return agentBinaryResolver{
+		executablePath: os.Executable,
+		validate:       validateTrustedAgentBinary,
+	}
+}
+
+func normalizeAgentOS(osName string) string {
+	if strings.EqualFold(strings.TrimSpace(osName), "windows") {
+		return "windows"
+	}
+	return "linux"
+}
+
+func agentBinaryConfig(osName string) (envName, filename, systemDefault string) {
+	if normalizeAgentOS(osName) == "windows" {
+		return "BLOXOS_AGENT_BINARY_WINDOWS", "bloxos-agent.exe", windowsAgentBinaryDefault
+	}
+	return "BLOXOS_AGENT_BINARY", "bloxos-agent", linuxAgentBinaryDefault
+}
+
+func (r agentBinaryResolver) resolve(osName string) (agentBinaryResolution, error) {
+	osName = normalizeAgentOS(osName)
+	envName, filename, systemDefault := agentBinaryConfig(osName)
+	if configured := strings.TrimSpace(os.Getenv(envName)); configured != "" {
+		resolution := agentBinaryResolution{Path: filepath.Clean(configured), Source: "environment:" + envName}
+		if !filepath.IsAbs(configured) {
+			return resolution, fmt.Errorf("%s=%q must be an absolute path", envName, configured)
+		}
+		path, err := r.validate(configured)
+		if err != nil {
+			return resolution, fmt.Errorf("%s=%q is unusable: %w", envName, configured, err)
+		}
+		resolution.Path = path
+		return resolution, nil
+	}
+
+	executable, err := r.executablePath()
+	if err != nil {
+		return agentBinaryResolution{}, fmt.Errorf("resolve hub executable: %w", err)
+	}
+	executable, err = filepath.Abs(executable)
+	if err != nil {
+		return agentBinaryResolution{}, fmt.Errorf("make hub executable path absolute: %w", err)
+	}
+	executable, err = filepath.EvalSymlinks(executable)
+	if err != nil {
+		return agentBinaryResolution{}, fmt.Errorf("canonicalize hub executable path %s: %w", executable, err)
+	}
+	candidates := []agentBinaryResolution{
+		{Path: systemDefault, Source: "system-default"},
+		{Path: filepath.Join(filepath.Dir(executable), filename), Source: "hub-executable-directory"},
+	}
+
+	var failures []string
+	for _, candidate := range candidates {
+		path, err := r.validate(candidate.Path)
+		if err == nil {
+			candidate.Path = path
+			candidate.Skipped = append([]string(nil), failures...)
+			return candidate, nil
+		}
+		failures = append(failures, fmt.Sprintf("%s %s: %v", candidate.Source, candidate.Path, err))
+	}
+	return agentBinaryResolution{}, fmt.Errorf("no trusted %s agent binary: %s",
+		osName, strings.Join(failures, "; "))
+}
+
+func validateTrustedAgentBinary(path string) (string, error) {
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("path %q is not absolute", path)
+	}
+	lexical := filepath.Clean(path)
+	info, err := os.Lstat(lexical)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("final binary path %s is a symlink", lexical)
+	}
+
+	resolved, err := filepath.EvalSymlinks(lexical)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize %s: %w", lexical, err)
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("make canonical path absolute: %w", err)
+	}
+
+	for current := resolved; ; current = filepath.Dir(current) {
+		component, err := os.Stat(current)
+		if err != nil {
+			return "", fmt.Errorf("stat trusted path component %s: %w", current, err)
+		}
+		stat, ok := component.Sys().(*syscall.Stat_t)
+		if !ok {
+			return "", fmt.Errorf("inspect owner of %s: unsupported file metadata", current)
+		}
+		if stat.Uid != 0 {
+			return "", fmt.Errorf("%s is owned by uid %d, want root", current, stat.Uid)
+		}
+		if component.Mode().Perm()&0o022 != 0 {
+			return "", fmt.Errorf("%s mode %04o is group- or other-writable", current, component.Mode().Perm())
+		}
+		if current == resolved {
+			if !component.Mode().IsRegular() {
+				return "", fmt.Errorf("%s is not a regular file", current)
+			}
+		} else if !component.IsDir() {
+			return "", fmt.Errorf("ancestor %s is not a directory", current)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+	}
+
+	f, err := os.Open(resolved)
+	if err != nil {
+		return "", fmt.Errorf("open trusted binary %s: %w", resolved, err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("close trusted binary %s: %w", resolved, err)
+	}
+	return resolved, nil
+}
+
+func currentAgentBinaryState(osName string) agentBinaryState {
+	hubAgentBinaryMu.RLock()
+	defer hubAgentBinaryMu.RUnlock()
+	return agentBinaryStates[normalizeAgentOS(osName)]
+}
+
+func replaceAgentBinaryState(osName string, state agentBinaryState) agentBinaryState {
+	osName = normalizeAgentOS(osName)
+	hubAgentBinaryMu.Lock()
+	defer hubAgentBinaryMu.Unlock()
+	previous := agentBinaryStates[osName]
+	agentBinaryStates[osName] = state
+	return previous
+}
+
+func failAgentBinaryState(osName string, resolution agentBinaryResolution, err error) {
+	osName = normalizeAgentOS(osName)
+	state := agentBinaryState{Path: resolution.Path, Source: resolution.Source, Error: err.Error()}
+	previous := replaceAgentBinaryState(osName, state)
+	if previous.Error != state.Error || previous.SHA != "" {
+		log.Printf("version: %s agent binary unavailable: %v", osName, err)
+	}
+}

--- a/hub/agent_binary_test.go
+++ b/hub/agent_binary_test.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
+)
+
+func TestResolveAgentBinaryConfiguredMissingFailsClosed(t *testing.T) {
+	t.Setenv("BLOXOS_AGENT_BINARY", filepath.Join(t.TempDir(), "missing-agent"))
+
+	r := agentBinaryResolver{
+		executablePath: func() (string, error) {
+			t.Fatal("configured-path failure must not fall through to defaults")
+			return "", nil
+		},
+		validate: func(path string) (string, error) {
+			return "", os.ErrNotExist
+		},
+	}
+	got, err := r.resolve("linux")
+	if err == nil || !strings.Contains(err.Error(), "BLOXOS_AGENT_BINARY") {
+		t.Fatalf("resolve error = %v, want configured-path failure", err)
+	}
+	if got.Path == "" || got.Source != "environment:BLOXOS_AGENT_BINARY" {
+		t.Fatalf("failed resolution = %+v, want configured path and source preserved", got)
+	}
+}
+
+func TestResolveAgentBinaryIsWorkingDirectoryIndependent(t *testing.T) {
+	t.Setenv("BLOXOS_AGENT_BINARY", "")
+	exeDir := t.TempDir()
+	exe := filepath.Join(exeDir, "bloxos-hub")
+	agent := filepath.Join(exeDir, "bloxos-agent")
+	if err := os.WriteFile(exe, []byte("hub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(agent, []byte("agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r := agentBinaryResolver{
+		executablePath: func() (string, error) { return exe, nil },
+		validate: func(path string) (string, error) {
+			if path == linuxAgentBinaryDefault {
+				return "", os.ErrNotExist
+			}
+			return path, nil
+		},
+	}
+
+	original, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(original) })
+
+	var paths []string
+	for range 2 {
+		if err := os.Chdir(t.TempDir()); err != nil {
+			t.Fatal(err)
+		}
+		got, err := r.resolve("linux")
+		if err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, got.Path)
+	}
+	if paths[0] != agent || paths[1] != agent {
+		t.Fatalf("resolved paths = %q, want executable-relative %q", paths, agent)
+	}
+	got, err := r.resolve("linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Source != "hub-executable-directory" || len(got.Skipped) != 1 || !strings.Contains(got.Skipped[0], linuxAgentBinaryDefault) {
+		t.Fatalf("resolution metadata = %+v, want source and skipped system default", got)
+	}
+}
+
+func TestValidateTrustedAgentBinaryRejectsFinalSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "agent")
+	if err := os.WriteFile(target, []byte("agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := validateTrustedAgentBinary(link); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("validate error = %v, want symlink rejection", err)
+	}
+}
+
+func TestValidateTrustedAgentBinaryRejectsWritableAncestor(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent")
+	if err := os.WriteFile(path, []byte("agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := validateTrustedAgentBinary(path); err == nil ||
+		(!strings.Contains(err.Error(), "writable") && !strings.Contains(err.Error(), "owned by uid")) {
+		t.Fatalf("validate error = %v, want untrusted-ancestor rejection", err)
+	}
+}
+
+func TestRecomputeFailureClearsOnlyFailedPlatformState(t *testing.T) {
+	withAgentBinaryState(t)
+	setAgentBinaryState("linux", agentBinaryState{Path: "/old/linux", SHA: strings.Repeat("a", 64)})
+	setAgentBinaryState("windows", agentBinaryState{Path: "/old/windows", SHA: strings.Repeat("b", 64)})
+
+	windowsPath := filepath.Join(t.TempDir(), "bloxos-agent.exe")
+	windowsBody := []byte("new trusted windows binary")
+	if err := os.WriteFile(windowsPath, windowsBody, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	windowsSum := sha256.Sum256(windowsBody)
+	windowsSHA := hex.EncodeToString(windowsSum[:])
+
+	oldResolver := resolveAgentBinaryFor
+	resolveAgentBinaryFor = func(osName string) (agentBinaryResolution, error) {
+		if osName == "linux" {
+			return agentBinaryResolution{Path: "/missing/linux", Source: "environment:BLOXOS_AGENT_BINARY"}, os.ErrNotExist
+		}
+		return agentBinaryResolution{Path: windowsPath, Source: "test:windows"}, nil
+	}
+	t.Cleanup(func() { resolveAgentBinaryFor = oldResolver })
+
+	recomputeAgentBinarySHA()
+	linux := currentAgentBinaryState("linux")
+	windows := currentAgentBinaryState("windows")
+	if linux.SHA != "" || linux.Error == "" || linux.Path != "/missing/linux" || linux.Source == "" {
+		t.Fatalf("linux state = %+v, want stale SHA cleared and error surfaced", linux)
+	}
+	if windows.SHA != windowsSHA || windows.Path != windowsPath || windows.Error != "" {
+		t.Fatalf("windows state = %+v, want independently refreshed state", windows)
+	}
+}
+
+func TestHashDownloadAndSignatureUseSameResolvedPath(t *testing.T) {
+	e, _ := setupTestServer(t)
+	withAgentBinaryState(t)
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "served-agent")
+	body := []byte("one canonical binary for hash download and signature")
+	if err := os.WriteFile(bin, body, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldResolver := resolveAgentBinaryFor
+	resolveAgentBinaryFor = func(osName string) (agentBinaryResolution, error) {
+		return agentBinaryResolution{Path: bin, Source: "test:canonical"}, nil
+	}
+	t.Cleanup(func() { resolveAgentBinaryFor = oldResolver })
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updateSigningMu.Lock()
+	oldKey, oldPub, oldB64 := updateSigningKey, updateSigningPub, updateSigningPubB64
+	updateSigningKey, updateSigningPub = nil, pub
+	updateSigningPubB64 = base64.StdEncoding.EncodeToString(pub)
+	updateSigningMu.Unlock()
+	t.Cleanup(func() {
+		updateSigningMu.Lock()
+		updateSigningKey, updateSigningPub, updateSigningPubB64 = oldKey, oldPub, oldB64
+		updateSigningMu.Unlock()
+	})
+
+	sum := sha256.Sum256(body)
+	sha := hex.EncodeToString(sum[:])
+	sig := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, updatesigning.Message("linux", sha)))
+	if err := os.WriteFile(bin+".sig", []byte(sig+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	recomputeBinaryFor("linux")
+	state := currentAgentBinaryState("linux")
+	if state.Path != bin || state.Source != "test:canonical" || state.SHA != sha {
+		t.Fatalf("cached state = %+v", state)
+	}
+	if got := announcedSignatureFor("linux", sha); got != sig {
+		t.Fatalf("announced signature = %q, want detached signature from cached path", got)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/download/agent?os=linux", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("download status %d: %s", rec.Code, rec.Body.String())
+	}
+	downloaded := rec.Body.Bytes()
+	downloadSum := sha256.Sum256(downloaded)
+	if got := hex.EncodeToString(downloadSum[:]); got != state.SHA {
+		t.Fatalf("download SHA = %s, API/cache SHA = %s", got, state.SHA)
+	}
+	if string(downloaded) != string(body) {
+		t.Fatal("download did not serve the cached resolved path")
+	}
+}
+
+func TestVersionsAPIExposesResolvedBinaryState(t *testing.T) {
+	e, server := setupTestServer(t)
+	withAgentBinaryState(t)
+	linux := agentBinaryState{
+		Path:   "/usr/local/lib/bloxos/linux/bloxos-agent",
+		Source: "system-default",
+		SHA:    strings.Repeat("a", 64),
+		Mtime:  time.Unix(123, 0).UTC(),
+	}
+	windows := agentBinaryState{
+		Path:   "/srv/bloxos/windows/bloxos-agent.exe",
+		Source: "environment:BLOXOS_AGENT_BINARY_WINDOWS",
+		Error:  "configured path is untrusted",
+	}
+	setAgentBinaryState("linux", linux)
+	setAgentBinaryState("windows", windows)
+	server.markCredentialsRotated(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/versions", nil)
+	req.Header.Set("Authorization", "Bearer "+loginAndGetToken(t, e))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		AgentBinaries map[string]agentBinaryState `json:"agent_binaries"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if got := response.AgentBinaries["linux"]; got.Path != linux.Path || got.Source != linux.Source || got.SHA != linux.SHA {
+		t.Fatalf("linux API state = %+v, want %+v", got, linux)
+	}
+	if got := response.AgentBinaries["windows"]; got.SHA != "" || got.Error != windows.Error || got.Path != windows.Path || got.Source != windows.Source {
+		t.Fatalf("windows API state = %+v, want failed state %+v", got, windows)
+	}
+}
+
+func withAgentBinaryState(t *testing.T) {
+	t.Helper()
+	hubAgentBinaryMu.Lock()
+	oldLinux := agentBinaryStates["linux"]
+	oldWindows := agentBinaryStates["windows"]
+	agentBinaryStates["linux"] = agentBinaryState{}
+	agentBinaryStates["windows"] = agentBinaryState{}
+	hubAgentBinaryMu.Unlock()
+	t.Cleanup(func() {
+		hubAgentBinaryMu.Lock()
+		agentBinaryStates["linux"] = oldLinux
+		agentBinaryStates["windows"] = oldWindows
+		hubAgentBinaryMu.Unlock()
+	})
+}
+
+func setAgentBinaryState(osName string, state agentBinaryState) {
+	hubAgentBinaryMu.Lock()
+	defer hubAgentBinaryMu.Unlock()
+	if state.Mtime.IsZero() {
+		state.Mtime = time.Now()
+	}
+	agentBinaryStates[osName] = state
+}
+
+func useGeneratedTestBinary(t *testing.T, osName string) string {
+	t.Helper()
+	name := "bloxos-agent"
+	if normalizeAgentOS(osName) == "windows" {
+		name += ".exe"
+	}
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("test "+osName+" agent binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withAgentBinaryState(t)
+	useTestResolvedBinary(t, osName, path)
+	return path
+}
+
+func useTestResolvedBinary(t *testing.T, osName, path string) {
+	t.Helper()
+	oldResolver := resolveAgentBinaryFor
+	resolveAgentBinaryFor = func(requestedOS string) (agentBinaryResolution, error) {
+		if normalizeAgentOS(requestedOS) == normalizeAgentOS(osName) {
+			return agentBinaryResolution{Path: path, Source: "test:fixture"}, nil
+		}
+		return oldResolver(requestedOS)
+	}
+	t.Cleanup(func() { resolveAgentBinaryFor = oldResolver })
+}

--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -105,14 +105,6 @@ type rolloutFailure struct {
 }
 
 var (
-	hubAgentBinarySHA   string
-	hubAgentBinaryMtime time.Time
-	// Phase 9 — separate Windows binary SHA so a Windows agent doesn't
-	// mistake the Linux SHA for "out of date" and update-loop forever.
-	hubWindowsAgentBinarySHA   string
-	hubWindowsAgentBinaryMtime time.Time
-	hubAgentBinaryMu           sync.RWMutex
-
 	agentRunningVersions   = make(map[string]agentVersionInfo)
 	agentRunningVersionsMu sync.RWMutex
 
@@ -128,6 +120,9 @@ var (
 
 // initAgentVersionTracking is called from main() at hub startup.
 func initAgentVersionTracking() {
+	// Populate both platform states synchronously so the first installer,
+	// download, API read, or agent connection sees the same resolved paths.
+	recomputeAgentBinarySHA()
 	goSafelyForever("versionRefreshLoop", versionRefreshLoop)
 	goSafelyForever("reconnectMonitorLoop", reconnectMonitorLoop)
 }
@@ -174,63 +169,52 @@ func recomputeAgentBinarySHA() {
 }
 
 func recomputeBinaryFor(osName string) {
-	binaryPath := agentBinaryPathFor(osName)
-	if binaryPath == "" {
-		return
-	}
-
-	info, err := os.Stat(binaryPath)
+	osName = normalizeAgentOS(osName)
+	resolved, err := resolveAgentBinaryFor(osName)
 	if err != nil {
+		failAgentBinaryState(osName, resolved, err)
 		return
 	}
-
-	hubAgentBinaryMu.RLock()
-	var cached time.Time
-	var cachedSHA string
-	switch osName {
-	case "windows":
-		cached = hubWindowsAgentBinaryMtime
-		cachedSHA = hubWindowsAgentBinarySHA
-	default:
-		cached = hubAgentBinaryMtime
-		cachedSHA = hubAgentBinarySHA
-	}
-	hubAgentBinaryMu.RUnlock()
-
-	if info.ModTime().Equal(cached) && cachedSHA != "" {
-		return
-	}
-
-	f, err := os.Open(binaryPath)
+	info, err := os.Stat(resolved.Path)
 	if err != nil {
+		failAgentBinaryState(osName, resolved, fmt.Errorf("stat resolved path %s: %w", resolved.Path, err))
 		return
 	}
-	defer f.Close()
+	cached := currentAgentBinaryState(osName)
+	if cached.Path == resolved.Path && cached.Source == resolved.Source &&
+		info.ModTime().Equal(cached.Mtime) && cached.SHA != "" && cached.Error == "" {
+		return
+	}
 
+	f, err := os.Open(resolved.Path)
+	if err != nil {
+		failAgentBinaryState(osName, resolved, fmt.Errorf("open resolved path %s: %w", resolved.Path, err))
+		return
+	}
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
-		log.Printf("version: hash error (%s): %v", osName, err)
+		_ = f.Close()
+		failAgentBinaryState(osName, resolved, fmt.Errorf("hash resolved path %s: %w", resolved.Path, err))
+		return
+	}
+	if err := f.Close(); err != nil {
+		failAgentBinaryState(osName, resolved, fmt.Errorf("close resolved path %s: %w", resolved.Path, err))
 		return
 	}
 	sha := hex.EncodeToString(h.Sum(nil))
 
-	hubAgentBinaryMu.Lock()
-	var previousSHA string
-	switch osName {
-	case "windows":
-		previousSHA = hubWindowsAgentBinarySHA
-		hubWindowsAgentBinarySHA = sha
-		hubWindowsAgentBinaryMtime = info.ModTime()
-	default:
-		previousSHA = hubAgentBinarySHA
-		hubAgentBinarySHA = sha
-		hubAgentBinaryMtime = info.ModTime()
+	state := agentBinaryState{Path: resolved.Path, Source: resolved.Source, SHA: sha, Mtime: info.ModTime()}
+	previous := replaceAgentBinaryState(osName, state)
+	if previous.Path != state.Path || previous.Source != state.Source || previous.Error != "" {
+		log.Printf("version: %s agent binary resolved source=%s path=%s", osName, state.Source, state.Path)
 	}
-	hubAgentBinaryMu.Unlock()
+	for _, skipped := range resolved.Skipped {
+		log.Printf("version: %s agent binary candidate skipped: %s", osName, skipped)
+	}
 
-	if previousSHA != "" && previousSHA != sha {
+	if previous.SHA != "" && previous.SHA != sha {
 		log.Printf("version: %s agent binary changed (%s -> %s), update will propagate",
-			osName, versionShortSHA(previousSHA), versionShortSHA(sha))
+			osName, versionShortSHA(previous.SHA), versionShortSHA(sha))
 		// Reset circuit breaker — a fresh build deserves a fresh rollout.
 		rolloutFailuresMu.Lock()
 		rolloutFailures = nil
@@ -249,33 +233,11 @@ func agentBinaryPath() string {
 	return agentBinaryPathFor("linux")
 }
 
-// agentBinaryPathFor returns the on-disk path of the agent binary for
-// the given OS, mirroring the resolution in handleDownloadAgent.
+// agentBinaryPathFor returns the exact cached path whose bytes produced the
+// advertised SHA. Hashing, detached-signature lookup, and downloads all use
+// this state rather than resolving independently.
 func agentBinaryPathFor(osName string) string {
-	var candidates []string
-	switch osName {
-	case "windows":
-		candidates = []string{
-			os.Getenv("BLOXOS_AGENT_BINARY_WINDOWS"),
-			"./agent/bloxos-agent.exe",
-			"/usr/local/bin/bloxos-agent.exe",
-		}
-	default:
-		candidates = []string{
-			os.Getenv("BLOXOS_AGENT_BINARY"),
-			"./agent/bloxos-agent",
-			"/usr/local/bin/bloxos-agent",
-		}
-	}
-	for _, p := range candidates {
-		if p == "" {
-			continue
-		}
-		if _, err := os.Stat(p); err == nil {
-			return p
-		}
-	}
-	return ""
+	return currentAgentBinaryState(osName).Path
 }
 
 // announceVersionToAgent sends an "agent_version" frame to a connected agent,
@@ -449,34 +411,16 @@ func announceDecision(report *agentVersionInfo, osName, sha string) (sig string,
 	return sig, ""
 }
 
-// announcedSHAFor returns the SHA the hub will announce to an agent of
-// the given OS. Falls back to the linux SHA for unknown / empty OS so
-// pre-Phase-9 agents still see something coherent.
+// announcedSHAFor returns the platform-specific SHA the hub will announce.
+// Unknown or empty OS values stay unannounced until the agent reports its OS;
+// sending the wrong platform's SHA would cause a perpetual update loop.
 func announcedSHAFor(osName string) string {
-	hubAgentBinaryMu.RLock()
-	defer hubAgentBinaryMu.RUnlock()
-	switch osName {
+	switch strings.ToLower(strings.TrimSpace(osName)) {
 	case "windows":
-		if hubWindowsAgentBinarySHA != "" {
-			return hubWindowsAgentBinarySHA
-		}
-		// Don't announce a Linux SHA to a Windows agent — that would
-		// trigger a perpetual update loop. Better to stay quiet.
-		return ""
+		return currentAgentBinaryState("windows").SHA
 	case "linux":
-		return hubAgentBinarySHA
+		return currentAgentBinaryState("linux").SHA
 	default:
-		// Unknown/empty OS — don't announce a SHA at all. Same logic as
-		// the Windows protective comment above: announcing the wrong-OS
-		// SHA loops the agent through perpetual self-update. The legacy
-		// "fall back to Linux SHA for pre-Phase-9 agents" behavior is
-		// dropped because (a) every agent in the fleet now sends an `os`
-		// field with agent_running_version, and (b) lookupMetricsOS
-		// recovers the OS from DB-stored metrics for any agent that has
-		// previously sent metrics. recordAgentRunningVersion triggers a
-		// fresh announce as soon as the OS is learned, so brand-new
-		// agents still get auto-update propagation — just deferred from
-		// WS-upgrade time to first-message-arrival time.
 		return ""
 	}
 }
@@ -688,12 +632,8 @@ func (s *Server) lookupVersionHostname(machineID string) string {
  * ============================================================================ */
 
 func (s *Server) handleListVersions(c echo.Context) error {
-	hubAgentBinaryMu.RLock()
-	hubSHA := hubAgentBinarySHA
-	hubMtime := hubAgentBinaryMtime
-	hubWindowsSHA := hubWindowsAgentBinarySHA
-	hubWindowsMtime := hubWindowsAgentBinaryMtime
-	hubAgentBinaryMu.RUnlock()
+	linuxState := currentAgentBinaryState("linux")
+	windowsState := currentAgentBinaryState("windows")
 
 	// Snapshot under the lock and do all the work outside it. Two reasons:
 	// announceDecision must never be reached with agentRunningVersionsMu
@@ -729,15 +669,19 @@ func (s *Server) handleListVersions(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]interface{}{
 		"signing_enabled":         signingEnabled,
 		"signing_disabled_reason": signingDisabledReason,
-		"hub_sha":                 hubSHA,
-		"hub_short_sha":           versionShortSHA(hubSHA),
-		"hub_mtime":               hubMtime.Format(time.RFC3339),
-		"hub_windows_sha":         hubWindowsSHA,
-		"hub_windows_short_sha":   versionShortSHA(hubWindowsSHA),
-		"hub_windows_mtime":       hubWindowsMtime.Format(time.RFC3339),
-		"agents":                  versions,
-		"rollout_paused":          paused,
-		"pause_reason":            pauseReason,
+		"hub_sha":                 linuxState.SHA,
+		"hub_short_sha":           versionShortSHA(linuxState.SHA),
+		"hub_mtime":               linuxState.Mtime.Format(time.RFC3339),
+		"hub_windows_sha":         windowsState.SHA,
+		"hub_windows_short_sha":   versionShortSHA(windowsState.SHA),
+		"hub_windows_mtime":       windowsState.Mtime.Format(time.RFC3339),
+		"agent_binaries": map[string]agentBinaryState{
+			"linux":   linuxState,
+			"windows": windowsState,
+		},
+		"agents":         versions,
+		"rollout_paused": paused,
+		"pause_reason":   pauseReason,
 	})
 }
 

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -325,8 +325,14 @@ echo "Check status: systemctl status bloxos-agent"
 `
 	// Pin the hash of the binary the hub actually serves. recompute is
 	// mtime-cached, so this is cheap on the hot path.
-	recomputeAgentBinarySHA()
-	script = strings.ReplaceAll(script, "__EXPECTED_AGENT_SHA256__", announcedSHAFor("linux"))
+	recomputeBinaryFor("linux")
+	linuxState := currentAgentBinaryState("linux")
+	if linuxState.Error != "" || linuxState.SHA == "" {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{
+			"error": "Linux agent binary unavailable: " + linuxState.Error,
+		})
+	}
+	script = strings.ReplaceAll(script, "__EXPECTED_AGENT_SHA256__", linuxState.SHA)
 	script = strings.ReplaceAll(script, "__UPDATE_PUBKEY__", updateSigningPublicKeyBase64())
 	return c.String(http.StatusOK, script)
 }
@@ -402,55 +408,35 @@ func buildInstallCommand(httpBase, wsBase, token string) (command string, caURL 
 }
 
 func handleDownloadAgent(c echo.Context) error {
-	// Phase 9: per-OS binary resolution. The target OS is detected from
-	// either the explicit ?os= query parameter (PowerShell installer
-	// passes this) or the User-Agent string.
+	// The target OS is detected from either the explicit ?os= query parameter
+	// or the User-Agent string. Resolution itself is centralized: recompute
+	// hashes a trusted path and the handler serves that exact cached path.
 	osName := strings.ToLower(strings.TrimSpace(c.QueryParam("os")))
 	if osName == "" {
 		ua := strings.ToLower(c.Request().UserAgent())
 		if strings.Contains(ua, "windows") {
 			osName = "windows"
-		} else {
-			osName = "linux"
 		}
 	}
-
-	var candidates []string
-	switch osName {
-	case "windows":
-		candidates = []string{
-			os.Getenv("BLOXOS_AGENT_BINARY_WINDOWS"),
-			"./agent/bloxos-agent.exe",
-			"/usr/local/bin/bloxos-agent.exe",
+	osName = normalizeAgentOS(osName)
+	recomputeBinaryFor(osName)
+	state := currentAgentBinaryState(osName)
+	if state.Error != "" || state.Path == "" || state.SHA == "" {
+		reason := state.Error
+		if reason == "" {
+			reason = "no trusted binary is available"
 		}
-	default:
-		osName = "linux"
-		candidates = []string{
-			os.Getenv("BLOXOS_AGENT_BINARY"),
-			"./agent/bloxos-agent",
-			"/usr/local/bin/bloxos-agent",
-		}
-	}
-
-	binaryPath := ""
-	for _, p := range candidates {
-		if p == "" {
-			continue
-		}
-		if _, err := os.Stat(p); err == nil {
-			binaryPath = p
-			break
-		}
-	}
-	if binaryPath == "" {
-		return c.JSON(http.StatusNotFound, map[string]string{
-			"error": fmt.Sprintf("agent binary for os=%s not found; set BLOXOS_AGENT_BINARY%s env var", osName, map[string]string{"windows": "_WINDOWS"}[osName]),
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{
+			"error":  fmt.Sprintf("agent binary for os=%s unavailable: %s", osName, reason),
+			"os":     osName,
+			"source": state.Source,
 		})
 	}
 
 	arch := c.QueryParam("arch")
-	log.Printf("agent download: os=%s arch=%s path=%s", osName, arch, binaryPath)
-	return c.File(binaryPath)
+	log.Printf("agent download: os=%s arch=%s source=%s path=%s sha=%s",
+		osName, arch, state.Source, state.Path, versionShortSHA(state.SHA))
+	return c.File(state.Path)
 }
 
 func handleDownloadCACert(c echo.Context) error {
@@ -999,8 +985,14 @@ if ($svc -and $svc.Status -eq 'Running') {
     Write-Warning "BloxOSAgent service is not running. Check Event Viewer or services.msc."
 }
 `
-	recomputeAgentBinarySHA()
-	script = strings.ReplaceAll(script, "__EXPECTED_AGENT_SHA256__", announcedSHAFor("windows"))
+	recomputeBinaryFor("windows")
+	windowsState := currentAgentBinaryState("windows")
+	if windowsState.Error != "" || windowsState.SHA == "" {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{
+			"error": "Windows agent binary unavailable: " + windowsState.Error,
+		})
+	}
+	script = strings.ReplaceAll(script, "__EXPECTED_AGENT_SHA256__", windowsState.SHA)
 	script = strings.ReplaceAll(script, "__UPDATE_PUBKEY__", updateSigningPublicKeyBase64())
 	return c.String(http.StatusOK, script)
 }

--- a/hub/install_enrollment_test.go
+++ b/hub/install_enrollment_test.go
@@ -170,16 +170,8 @@ func TestInstallScriptPinsAgentBinaryHash(t *testing.T) {
 	}
 	t.Setenv("BLOXOS_AGENT_BINARY", bin)
 
-	hubAgentBinaryMu.Lock()
-	prevSHA, prevMtime := hubAgentBinarySHA, hubAgentBinaryMtime
-	hubAgentBinarySHA = ""
-	hubAgentBinaryMtime = time.Time{}
-	hubAgentBinaryMu.Unlock()
-	t.Cleanup(func() {
-		hubAgentBinaryMu.Lock()
-		hubAgentBinarySHA, hubAgentBinaryMtime = prevSHA, prevMtime
-		hubAgentBinaryMu.Unlock()
-	})
+	withAgentBinaryState(t)
+	useTestResolvedBinary(t, "linux", bin)
 
 	sum := sha256.Sum256(content)
 	want := hex.EncodeToString(sum[:])
@@ -203,6 +195,7 @@ func TestInstallScriptPinsAgentBinaryHash(t *testing.T) {
 // downloader's ownership on a binary that systemd later executes as root.
 func TestInstallScriptInstallsAgentBinaryAsRoot(t *testing.T) {
 	e, _ := setupTestServer(t)
+	useGeneratedTestBinary(t, "linux")
 
 	req := httptest.NewRequest(http.MethodGet, "/install.sh", nil)
 	rec := httptest.NewRecorder()
@@ -239,16 +232,8 @@ func TestWindowsInstallScriptPinsHashAndVerifiesBinaryDownload(t *testing.T) {
 	}
 	t.Setenv("BLOXOS_AGENT_BINARY_WINDOWS", bin)
 
-	hubAgentBinaryMu.Lock()
-	prevSHA, prevMtime := hubWindowsAgentBinarySHA, hubWindowsAgentBinaryMtime
-	hubWindowsAgentBinarySHA = ""
-	hubWindowsAgentBinaryMtime = time.Time{}
-	hubAgentBinaryMu.Unlock()
-	t.Cleanup(func() {
-		hubAgentBinaryMu.Lock()
-		hubWindowsAgentBinarySHA, hubWindowsAgentBinaryMtime = prevSHA, prevMtime
-		hubAgentBinaryMu.Unlock()
-	})
+	withAgentBinaryState(t)
+	useTestResolvedBinary(t, "windows", bin)
 
 	sum := sha256.Sum256(content)
 	want := hex.EncodeToString(sum[:])

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -1562,15 +1562,8 @@ func TestAgentVersionAnnouncedOnReconnect(t *testing.T) {
 	t.Setenv("PUBLIC_URL", "https://hub.example.com")
 
 	const stagedSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-	hubAgentBinaryMu.Lock()
-	prevSHA := hubAgentBinarySHA
-	hubAgentBinarySHA = stagedSHA
-	hubAgentBinaryMu.Unlock()
-	t.Cleanup(func() {
-		hubAgentBinaryMu.Lock()
-		hubAgentBinarySHA = prevSHA
-		hubAgentBinaryMu.Unlock()
-	})
+	withAgentBinaryState(t)
+	setAgentBinaryState("linux", agentBinaryState{SHA: stagedSHA})
 
 	server := httptest.NewServer(e)
 	defer server.Close()
@@ -1657,18 +1650,9 @@ func TestAnnouncedSHAIsPerPlatform(t *testing.T) {
 	const linuxSHA = "1111111111111111111111111111111111111111111111111111111111111111"
 	const windowsSHA = "2222222222222222222222222222222222222222222222222222222222222222"
 
-	hubAgentBinaryMu.Lock()
-	prevLinux := hubAgentBinarySHA
-	prevWindows := hubWindowsAgentBinarySHA
-	hubAgentBinarySHA = linuxSHA
-	hubWindowsAgentBinarySHA = windowsSHA
-	hubAgentBinaryMu.Unlock()
-	t.Cleanup(func() {
-		hubAgentBinaryMu.Lock()
-		hubAgentBinarySHA = prevLinux
-		hubWindowsAgentBinarySHA = prevWindows
-		hubAgentBinaryMu.Unlock()
-	})
+	withAgentBinaryState(t)
+	setAgentBinaryState("linux", agentBinaryState{SHA: linuxSHA})
+	setAgentBinaryState("windows", agentBinaryState{SHA: windowsSHA})
 
 	if got := announcedSHAFor("linux"); got != linuxSHA {
 		t.Fatalf("announcedSHAFor(linux) = %s, want %s", got, linuxSHA)
@@ -1702,18 +1686,9 @@ func TestRecordAgentRunningVersionTracksOS(t *testing.T) {
 	const linuxSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	const windowsSHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
-	hubAgentBinaryMu.Lock()
-	prevLinux := hubAgentBinarySHA
-	prevWindows := hubWindowsAgentBinarySHA
-	hubAgentBinarySHA = linuxSHA
-	hubWindowsAgentBinarySHA = windowsSHA
-	hubAgentBinaryMu.Unlock()
-	t.Cleanup(func() {
-		hubAgentBinaryMu.Lock()
-		hubAgentBinarySHA = prevLinux
-		hubWindowsAgentBinarySHA = prevWindows
-		hubAgentBinaryMu.Unlock()
-	})
+	withAgentBinaryState(t)
+	setAgentBinaryState("linux", agentBinaryState{SHA: linuxSHA})
+	setAgentBinaryState("windows", agentBinaryState{SHA: windowsSHA})
 
 	// Cleanup test entries from the in-memory map.
 	t.Cleanup(func() {

--- a/hub/update_signing_test.go
+++ b/hub/update_signing_test.go
@@ -264,6 +264,7 @@ func TestDetachedSignatureForFailsClosedWithoutPublicKey(t *testing.T) {
 // self-update stays disabled.
 func TestInstallScriptPinsUpdateSigningKey(t *testing.T) {
 	e, _ := setupTestServer(t)
+	useGeneratedTestBinary(t, "linux")
 
 	req := httptest.NewRequest(http.MethodGet, "/install.sh", nil)
 	rec := httptest.NewRecorder()
@@ -290,6 +291,7 @@ func TestInstallScriptPinsUpdateSigningKey(t *testing.T) {
 
 func TestWindowsInstallScriptPinsUpdateSigningKey(t *testing.T) {
 	e, _ := setupTestServer(t)
+	useGeneratedTestBinary(t, "windows")
 
 	req := httptest.NewRequest(http.MethodGet, "/install.ps1", nil)
 	rec := httptest.NewRecorder()
@@ -319,6 +321,7 @@ func TestWindowsInstallScriptPinsUpdateSigningKey(t *testing.T) {
 // the documented key, not about repairing a broken rollback.
 func TestInstallScriptStartLimitLivesInUnitSection(t *testing.T) {
 	e, _ := setupTestServer(t)
+	useGeneratedTestBinary(t, "linux")
 
 	req := httptest.NewRequest(http.MethodGet, "/install.sh", nil)
 	rec := httptest.NewRecorder()
@@ -429,20 +432,14 @@ func withoutSigningKey(t *testing.T) {
 	})
 }
 
-// stageLinuxBinarySHA clears the cached linux SHA so the next recompute picks
-// up whatever BLOXOS_AGENT_BINARY currently points at, and restores it after.
+// stageLinuxBinarySHA clears the cached Linux state so recompute hashes the
+// test fixture selected by BLOXOS_AGENT_BINARY.
 func stageLinuxBinarySHA(t *testing.T) {
 	t.Helper()
-	hubAgentBinaryMu.Lock()
-	prevSHA, prevMtime := hubAgentBinarySHA, hubAgentBinaryMtime
-	hubAgentBinarySHA, hubAgentBinaryMtime = "", time.Time{}
-	hubAgentBinaryMu.Unlock()
-	t.Cleanup(func() {
-		hubAgentBinaryMu.Lock()
-		hubAgentBinarySHA, hubAgentBinaryMtime = prevSHA, prevMtime
-		hubAgentBinaryMu.Unlock()
-	})
-	recomputeAgentBinarySHA()
+	path := os.Getenv("BLOXOS_AGENT_BINARY")
+	withAgentBinaryState(t)
+	useTestResolvedBinary(t, "linux", path)
+	recomputeBinaryFor("linux")
 }
 
 /* ----------------------------------------------------------------------------

--- a/scripts/systemd/bloxos-hub.service
+++ b/scripts/systemd/bloxos-hub.service
@@ -11,7 +11,7 @@ Restart=always
 RestartSec=5
 Environment=PATH=/usr/local/go/bin:/usr/bin:/bin
 Environment="BLOXOS_CA_CERT=/var/lib/caddy/.local/share/caddy/pki/authorities/local/root.crt"
-Environment="BLOXOS_AGENT_BINARY=/opt/bloxos/agent/bloxos-agent"
+Environment="BLOXOS_AGENT_BINARY=/usr/local/lib/bloxos/linux/bloxos-agent"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- replace the duplicated Linux/Windows agent-binary candidate lists with one trusted resolver used for hashing, detached-signature lookup, and `/download/agent`
- fail closed when an explicit configured path is missing or untrusted, remove the CWD-relative candidate, and validate canonical paths plus their complete root-owned, non-writable ancestor chain
- cache each platform's resolved path, source, SHA, mtime, and error together so downloads serve the exact path that produced the advertised SHA
- isolate platform failures, clear stale advertised SHAs, and expose resolver path/source/error through `/api/versions` and the Versions dashboard
- update the source quick start and sample hub unit to stage the Linux agent under `/usr/local/lib/bloxos/linux/`

## Deployment boundary

This PR changes code and documentation only. It does not rebuild or restart the live hub, move a served binary, or modify its service configuration.

Deploying it requires a separately approved, coupled live migration: pre-place the currently served Linux binary and its valid detached `.sig` in a trusted root-owned directory, update `BLOXOS_AGENT_BINARY`, and only then restart the updated hub. A hub-only deployment is intentionally out of scope.

## Validation

- `go vet ./...` and `go test ./...` in `hub/`, `agent/`, and `proto/`
- `go test -race ./...` in `hub/`
- `pnpm lint` and `pnpm build` in `dashboard/`
- headless dashboard smoke: `/versions` renders both resolver cards with zero browser console errors

Closes #149

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how served agent binaries are resolved and validated; a misconfigured or untrusted path can block downloads, installers, and fleet updates until operators migrate binaries to root-owned paths.
> 
> **Overview**
> Replaces duplicated per-platform candidate lists with a **single trusted resolver** used for hashing, detached `.sig` lookup, `/download/agent`, and installer SHA pinning. Explicit `BLOXOS_AGENT_BINARY` / `BLOXOS_AGENT_BINARY_WINDOWS` must be absolute and pass validation; bad configured paths **fail closed** (no fallback). Defaults move to `/usr/local/lib/bloxos/{linux,windows}/` and hub-executable siblings; **CWD-relative paths are removed**. Paths must be canonical, root-owned, and not group/other-writable along the full ancestor chain.
> 
> Each platform caches **path, source, SHA, mtime, and error** together so downloads and announcements always match the hashed file. Resolution failures clear only that platform’s advertised SHA. `/api/versions` adds `agent_binaries`; the **Versions** page shows Linux/Windows “Served agent binaries” cards. Install scripts return **503** when the platform binary is unavailable.
> 
> Docs, `.env.example`, README quick start, sample systemd unit, and architecture notes describe the new layout and that rollout needs a **coupled ops migration** (trusted binary + `.sig` + env) before hub restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e3228e9afedd08fce68ca1768d8752d1ceda9c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->