### PR TITLE
fix(hub): add agent credential revocation

### DIFF
--- a/dashboard/src/app/machine/[id]/page.tsx
+++ b/dashboard/src/app/machine/[id]/page.tsx
@@ -26,7 +26,7 @@ import {
   ArrowLeft, Cpu, HardDrive, MemoryStick, Thermometer,
   Activity, Zap, Terminal as TerminalIcon, RotateCcw,
   Lock, Unlock, X, Maximize2, Minimize2, Wifi, BarChart3, Trash2,
-  LayoutDashboard, Box, Container as ContainerIcon, StickyNote,
+  LayoutDashboard, Box, Container as ContainerIcon, StickyNote, KeyRound,
 } from "lucide-react";
 import { HUB_URL, getAuthHeaders } from "@/lib/session";
 import { useAuth } from "@/contexts/AuthContext";
@@ -131,7 +131,10 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
   const [showReboot, setShowReboot] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const { hasScope } = useAuth();
+  const [showRevokeConfirm, setShowRevokeConfirm] = useState(false);
+  const [revoking, setRevoking] = useState(false);
+  const [revokeError, setRevokeError] = useState<string | null>(null);
+  const { hasScope, authFetch } = useAuth();
   const canDelete = hasScope("fleet.admin");
   const canControl = hasScope("fleet.control");
   const router = useRouter();
@@ -326,6 +329,26 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
     }
   }, [id, router]);
 
+  const handleRevokeCredential = useCallback(async () => {
+    setRevoking(true);
+    setRevokeError(null);
+    try {
+      const res = await authFetch(`${HUB_URL}/api/machines/${id}/credential`, {
+        method: "DELETE",
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        setRevokeError(data?.error || `Failed to revoke credential (${res.status})`);
+        return;
+      }
+      setShowRevokeConfirm(false);
+    } catch {
+      setRevokeError("Failed to revoke credential. Is the hub reachable?");
+    } finally {
+      setRevoking(false);
+    }
+  }, [authFetch, id]);
+
   useEffect(() => {
     if (termState === "pin_entry") {
       setTimeout(() => pinInputRef.current?.focus(), 100);
@@ -397,6 +420,54 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
         </DialogContent>
       </Dialog>
 
+
+      {/* Credential revoke dialog */}
+      <Dialog
+        open={showRevokeConfirm}
+        onOpenChange={(open) => {
+          if (!open && !revoking) {
+            setShowRevokeConfirm(false);
+            setRevokeError(null);
+          }
+        }}
+      >
+        <DialogContent className="bg-blox-card border-blox-border text-blox-text ring-0 sm:max-w-md" showCloseButton={false}>
+          <DialogHeader>
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-xl bg-amber-500/10">
+                <KeyRound className="w-5 h-5 text-amber-400" />
+              </div>
+              <DialogTitle className="text-blox-text">Revoke enrollment credential</DialogTitle>
+            </div>
+            <DialogDescription className="text-blox-muted text-xs mt-2">
+              This immediately disconnects <span className="text-blox-text font-medium">{machine.hostname}</span>.
+              Its machine record and history are preserved, but it stays offline until you run a fresh Add Machine command on that host.
+            </DialogDescription>
+          </DialogHeader>
+          {revokeError && (
+            <div className="text-[11px] text-blox-red bg-blox-red/10 border border-blox-red/30 rounded-lg px-3 py-2">
+              {revokeError}
+            </div>
+          )}
+          <DialogFooter className="bg-transparent border-t-blox-border">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setShowRevokeConfirm(false);
+                setRevokeError(null);
+              }}
+              disabled={revoking}
+              className="text-xs text-blox-muted border-blox-border"
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" size="sm" onClick={handleRevokeCredential} disabled={revoking} className="text-xs">
+              {revoking ? "Revoking..." : "Revoke credential"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       {showReboot && (
         <RebootModal
           hostname={machine.hostname}
@@ -432,6 +503,20 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
               <span className="hidden sm:inline text-[10px] text-blox-muted font-mono tabular-nums mr-2">
                 {timeSince(effectiveLastUpdated)}
               </span>
+            )}
+            {canDelete && !isAPIMachine && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setRevokeError(null);
+                  setShowRevokeConfirm(true);
+                }}
+                className="text-xs border-blox-border text-blox-muted hover:text-amber-400 hover:border-amber-500/30 gap-1.5"
+              >
+                <KeyRound className="w-3.5 h-3.5" />
+                Revoke credential
+              </Button>
             )}
             {canDelete && (
               <Button

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -492,6 +492,19 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 		log.Printf("rate limit exceeded: ws_agent from %s", ip)
 		return c.JSON(http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 	}
+	// Serialize credential revocation with the short authentication window.
+	// Without this gate, a socket could validate a secret, lose a race with
+	// revocation, and register after the revoke handler had already looked for
+	// a live connection to close.
+	s.agentAuthMu.RLock()
+	authPending := true
+	completeAuth := func() {
+		if authPending {
+			authPending = false
+			s.agentAuthMu.RUnlock()
+		}
+	}
+	defer completeAuth()
 
 	// Prefer credentials from handshake headers — unlike query strings, they
 	// are not written to reverse-proxy access logs. Fall back to the deprecated
@@ -573,6 +586,7 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 	if secretMachineID != "" {
 		machineID = secretMachineID
 		s.registerAgentConnection(machineID, agent)
+		completeAuth()
 		log.Printf("agent authenticated via secret: machine_id=%s", machineID)
 	}
 
@@ -667,6 +681,7 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 				}
 
 				s.registerAgentConnection(machineID, agent)
+				completeAuth()
 				log.Printf("agent registered: %s (%s)", m.Hostname, machineID)
 			}
 
@@ -1120,6 +1135,66 @@ func (s *Server) validateAgentSecret(secret string) (string, error) {
 func (s *Server) revokeAgentCredential(machineID string) error {
 	_, err := s.db.Exec(`DELETE FROM agent_credentials WHERE machine_id = ?`, machineID)
 	return err
+}
+
+// handleRevokeAgentCredential removes only a machine's durable enrollment
+// credential. The machine and all of its history remain intact so the same
+// host can re-enroll under its stable machine ID with a fresh install token.
+// Any currently authenticated socket is closed after the database commit;
+// otherwise revocation would not take effect until that connection happened
+// to reconnect.
+func (s *Server) handleRevokeAgentCredential(c echo.Context) error {
+	s.agentAuthMu.Lock()
+	defer s.agentAuthMu.Unlock()
+	machineID := c.Param("id")
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to start transaction"})
+	}
+	defer tx.Rollback()
+
+	var exists int
+	if err := tx.QueryRow(`SELECT 1 FROM machines WHERE id = ?`, machineID).Scan(&exists); err != nil {
+		if err == sql.ErrNoRows {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "machine not found"})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to query machine"})
+	}
+
+	result, err := tx.Exec(`DELETE FROM agent_credentials WHERE machine_id = ?`, machineID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to revoke credential"})
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to confirm credential revocation"})
+	}
+	if err := tx.Commit(); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to commit credential revocation"})
+	}
+
+	// Snapshot the connection under the registry lock, then release the lock
+	// before closing the socket. The read-loop performs the normal symmetric
+	// cleanup; unregisterAgentConnection below makes the result synchronous and
+	// remains safe if that cleanup already won the race.
+	s.agentsMu.RLock()
+	agent := s.agents[machineID]
+	s.agentsMu.RUnlock()
+	connectionClosed := agent != nil && agent.Conn != nil
+	if connectionClosed {
+		_ = agent.Conn.Close()
+		s.unregisterAgentConnection(machineID, agent)
+	}
+
+	credentialExisted := rows > 0
+	log.Printf("agent credential revoked: machine_id=%s credential_existed=%t connection_closed=%t",
+		machineID, credentialExisted, connectionClosed)
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"machine_id":         machineID,
+		"credential_existed": credentialExisted,
+		"connection_closed":  connectionClosed,
+	})
 }
 
 // generateFirstRunToken creates a one-time token on first startup when no tokens and no machines exist.

--- a/hub/credential_revoke_test.go
+++ b/hub/credential_revoke_test.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testCredentialRevokePath = "/api/machines/revoke-machine/credential"
+
+func seedMachineCredential(t *testing.T, s *Server, machineID, secretHash string) {
+	t.Helper()
+	s.seedTestMachine(t, machineID)
+	if _, err := s.db.Exec(
+		`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`,
+		machineID, secretHash,
+	); err != nil {
+		t.Fatalf("seed agent credential: %v", err)
+	}
+}
+
+func revokeCredentialRequest(e http.Handler, token string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodDelete, testCredentialRevokePath, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestRevokeAgentCredentialAuthorization(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	seedMachineCredential(t, s, "revoke-machine", "original-secret-hash")
+
+	s.seedTestUser(t, "revoke-viewer", "viewerpass123", "1234", RoleViewer, true, true)
+	s.seedTestUser(t, "revoke-operator", "operatorpass123", "1234", RoleOperator, true, true)
+
+	viewerToken := loginAndGetTokenForCredentials(t, e, "revoke-viewer", "viewerpass123")
+	operatorToken := loginAndGetTokenForCredentials(t, e, "revoke-operator", "operatorpass123")
+	adminToken := loginAndGetToken(t, e)
+
+	for _, tc := range []struct {
+		name       string
+		token      string
+		wantStatus int
+	}{
+		{name: "unauthenticated", wantStatus: http.StatusUnauthorized},
+		{name: "viewer", token: viewerToken, wantStatus: http.StatusForbidden},
+		{name: "operator", token: operatorToken, wantStatus: http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := revokeCredentialRequest(e, tc.token)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	rec := revokeCredentialRequest(e, adminToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected admin revoke 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var result struct {
+		MachineID         string `json:"machine_id"`
+		CredentialExisted bool   `json:"credential_existed"`
+		ConnectionClosed  bool   `json:"connection_closed"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode revoke response: %v", err)
+	}
+	if result.MachineID != "revoke-machine" || !result.CredentialExisted || result.ConnectionClosed {
+		t.Fatalf("unexpected revoke response: %+v", result)
+	}
+}
+
+func TestRevokeAgentCredentialPreservesMachineAndHistoryAndIsIdempotent(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	seedMachineCredential(t, s, "revoke-machine", "original-secret-hash")
+	if _, err := s.db.Exec(
+		`INSERT INTO metrics (machine_id, cpu_percent, timestamp) VALUES (?, ?, CURRENT_TIMESTAMP)`,
+		"revoke-machine", 42.5,
+	); err != nil {
+		t.Fatalf("seed metric: %v", err)
+	}
+	adminToken := loginAndGetToken(t, e)
+
+	first := revokeCredentialRequest(e, adminToken)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first revoke: status %d: %s", first.Code, first.Body.String())
+	}
+	second := revokeCredentialRequest(e, adminToken)
+	if second.Code != http.StatusOK {
+		t.Fatalf("second revoke: status %d: %s", second.Code, second.Body.String())
+	}
+
+	var secondResult struct {
+		CredentialExisted bool `json:"credential_existed"`
+		ConnectionClosed  bool `json:"connection_closed"`
+	}
+	if err := json.Unmarshal(second.Body.Bytes(), &secondResult); err != nil {
+		t.Fatalf("decode second revoke: %v", err)
+	}
+	if secondResult.CredentialExisted || secondResult.ConnectionClosed {
+		t.Fatalf("repeat revoke should be an idempotent no-op: %+v", secondResult)
+	}
+
+	for name, query := range map[string]string{
+		"credential": `SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`,
+		"machine":    `SELECT COUNT(*) FROM machines WHERE id = ?`,
+		"metrics":    `SELECT COUNT(*) FROM metrics WHERE machine_id = ?`,
+	} {
+		var count int
+		if err := s.db.QueryRow(query, "revoke-machine").Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", name, err)
+		}
+		want := 1
+		if name == "credential" {
+			want = 0
+		}
+		if count != want {
+			t.Fatalf("%s count=%d, want %d", name, count, want)
+		}
+	}
+}
+
+func TestRevokeAgentCredentialClosesLiveConnection(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	token := s.seedValidToken(t)
+	secret := s.enrollAndCaptureSecret(t, server, token, "revoke-machine")
+	conn, err := wsDialAgent(t, server, "secret="+secret)
+	if err != nil {
+		t.Fatalf("reconnect with durable secret: %v", err)
+	}
+	defer conn.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		s.agentsMu.RLock()
+		_, connected := s.agents["revoke-machine"]
+		s.agentsMu.RUnlock()
+		if connected {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("agent did not register before revoke")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	rec := revokeCredentialRequest(e, loginAndGetToken(t, e))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke: status %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"connection_closed":true`) {
+		t.Fatalf("response did not report live connection closure: %s", rec.Body.String())
+	}
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	for {
+		if _, _, err := conn.ReadMessage(); err != nil {
+			break
+		}
+	}
+	s.waitAgentDrain(t, "revoke-machine", 2*time.Second)
+}
+
+func TestRevokedSecretWithFreshTokenReenrollsSameMachine(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	firstToken := s.seedValidToken(t)
+	oldSecret := s.enrollAndCaptureSecret(t, server, firstToken, "revoke-machine")
+	adminToken := loginAndGetToken(t, e)
+	if rec := revokeCredentialRequest(e, adminToken); rec.Code != http.StatusOK {
+		t.Fatalf("revoke: status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if _, resp, err := dialWSWithHeader(t, server, "/ws/agent", http.Header{
+		"Authorization": []string{"Bearer " + oldSecret},
+	}); err == nil || resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		if err == nil {
+			t.Fatal("revoked secret was accepted")
+		}
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Fatalf("revoked secret status=%d, want 401 (err=%v)", status, err)
+	}
+
+	freshToken := s.seedTokenValue(t, "fresh-reenrollment-token")
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+oldSecret)
+	h.Set(agentEnrollTokenHeader, freshToken)
+	conn, resp, err := dialWSWithHeader(t, server, "/ws/agent", h)
+	if err != nil {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Fatalf("old-secret + fresh-token dial failed: %v (status=%d)", err, status)
+	}
+	defer conn.Close()
+
+	tokenSum := sha256.Sum256([]byte(freshToken))
+	tokenHash := hex.EncodeToString(tokenSum[:])
+	var usedBefore bool
+	if err := s.db.QueryRow(`SELECT used FROM tokens WHERE token_hash = ?`, tokenHash).Scan(&usedBefore); err != nil {
+		t.Fatalf("read token before enrollment frame: %v", err)
+	}
+	if usedBefore {
+		t.Fatal("fresh token was consumed before successful enrollment")
+	}
+
+	sendMetricsMsg(t, conn, "revoke-machine")
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	var newSecret string
+	for newSecret == "" {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read re-enrollment frame: %v", err)
+		}
+		var frame struct {
+			Type        string `json:"type"`
+			AgentSecret string `json:"agent_secret"`
+		}
+		if json.Unmarshal(msg, &frame) == nil && frame.Type == "enrolled" {
+			newSecret = frame.AgentSecret
+		}
+	}
+	if newSecret == oldSecret {
+		t.Fatal("re-enrollment reused the revoked secret")
+	}
+
+	var usedAfter bool
+	if err := s.db.QueryRow(`SELECT used FROM tokens WHERE token_hash = ?`, tokenHash).Scan(&usedAfter); err != nil {
+		t.Fatalf("read token after enrollment: %v", err)
+	}
+	if !usedAfter {
+		t.Fatal("fresh token was not consumed by successful re-enrollment")
+	}
+
+	var credentialCount int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, "revoke-machine").Scan(&credentialCount); err != nil {
+		t.Fatalf("count replacement credentials: %v", err)
+	}
+	if credentialCount != 1 {
+		t.Fatalf("credential count=%d, want 1", credentialCount)
+	}
+	var machineCount int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM machines WHERE id = ?`, "revoke-machine").Scan(&machineCount); err != nil {
+		t.Fatalf("count machine rows: %v", err)
+	}
+	if machineCount != 1 {
+		t.Fatalf("machine count=%d, want 1", machineCount)
+	}
+}
+
+func TestCredentialRevokeRouteHasFleetAdminScope(t *testing.T) {
+	key := routeScopeKey(http.MethodDelete, "/api/machines/:id/credential")
+	if got := routeScopeRequirements[key]; got != scopeFleetAdmin {
+		t.Fatalf("revoke route scope=%q, want %q", got, scopeFleetAdmin)
+	}
+
+	echoServer, _ := setupTestServer(t)
+	if err := auditRBACRouteCoverage(echoServer, routeScopeRequirements); err != nil {
+		t.Fatalf("RBAC route audit: %v", err)
+	}
+}

--- a/hub/main.go
+++ b/hub/main.go
@@ -283,6 +283,7 @@ func (s *Server) registerRoutes(e *echo.Echo) {
 	api.GET("/api/machines/:id/notes", s.handleGetMachineNotes)
 	api.PUT("/api/machines/:id/notes", s.handleSetMachineNotes)
 	api.GET("/api/machines/:id/metrics/history", s.handleMetricsHistory)
+	api.DELETE("/api/machines/:id/credential", s.handleRevokeAgentCredential)
 	api.DELETE("/api/machines/:id", s.handleDeleteMachine)
 
 	api.POST("/api/machines/:id/terminal", s.handleStartTerminal)

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -95,6 +95,7 @@ var routeScopeRequirements = map[string]string{
 	routeScopeKey(http.MethodPut, "/api/machines/:id/tags"):                    scopeFleetMetadata,
 	routeScopeKey(http.MethodGet, "/api/machines/:id/notes"):                   scopeFleetRead,
 	routeScopeKey(http.MethodPut, "/api/machines/:id/notes"):                   scopeFleetMetadata,
+	routeScopeKey(http.MethodDelete, "/api/machines/:id/credential"):           scopeFleetAdmin,
 	routeScopeKey(http.MethodDelete, "/api/machines/:id"):                      scopeFleetAdmin,
 	routeScopeKey(http.MethodPost, "/api/machines/:id/terminal"):               scopeFleetControl,
 	routeScopeKey(http.MethodDelete, "/api/machines/:id/terminal/:session_id"): scopeFleetControl,

--- a/hub/server.go
+++ b/hub/server.go
@@ -17,6 +17,9 @@ type Server struct {
 	agents   map[string]*ConnectedAgent
 	agentsMu sync.RWMutex
 
+	// Serializes agent authentication/registration with credential revocation.
+	agentAuthMu sync.RWMutex
+
 	// Tracks background work this server spawned, so a caller can wait for
 	// it to finish before tearing the server down. See goTracked/Shutdown.
 	//


### PR DESCRIPTION
## Summary

- add a `fleet.admin`-gated endpoint that revokes only a machine's durable enrollment credential while preserving its record and history
- close any authenticated agent WebSocket after the credential deletion commits, with authentication/revocation synchronization to prevent a validate-register race
- add an explicit machine-page confirmation action that surfaces non-2xx API errors

## Validation

- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- dashboard `pnpm lint`
- dashboard `pnpm build`
- dashboard headless smoke: 10 screenshots, zero console or page errors
- `git diff --check`

## Scope

This is WS-3 PR 2 of 2. It adds credential revocation and re-enrollment support only. It does **not** close #150; the destructive Windows installer repair and coupled `/install.ps1` route belong to WS-3 PR 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes agent authentication, enrollment credentials, and live WebSocket lifecycle—security-sensitive fleet control—with coordinated locking to avoid revoke/register races.
> 
> **Overview**
> Adds **durable enrollment credential revocation** for fleet agents without deleting the machine record or metrics history.
> 
> The hub exposes **`DELETE /api/machines/:id/credential`** behind **`fleet.admin`**. It removes the row from `agent_credentials`, then **closes any live agent WebSocket** for that machine so revocation takes effect immediately. **`agentAuthMu`** coordinates revocation with the agent WebSocket auth/register path so a socket cannot finish registering after credentials were deleted. Repeat revokes are **idempotent** (machine/history kept; API reports whether a credential existed and whether a connection was closed). Tests cover RBAC, idempotency, live disconnect, and re-enrollment with a fresh install token after revoke.
> 
> The machine detail page adds a **Revoke credential** action (same admin gate as delete, hidden for API-polled machines) with a confirmation dialog that calls the new endpoint via **`authFetch`** and surfaces API errors in the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595e91493dc68fb97498265137830bb80f456137. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->