### PR TITLE
fix(hub): bind Windows re-enrollment to a single machine

### DIFF
--- a/agent/credential_handoff.go
+++ b/agent/credential_handoff.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// pendingCredentialSuffix names the on-disk staging file for the two-phase
+// credential handoff (see handleEnrolledFrame / handleEnrollmentConfirmed).
+// The active credential file is NEVER overwritten just because an "enrolled"
+// frame arrived — only a hash-bound "enrollment_confirmed" from the hub may
+// promote a staged secret into the active file. Without this split, a lost
+// "enrollment_confirmed" (ack never arrives, hub never promotes) would still
+// have already destroyed the old, still-hub-valid active secret locally —
+// stranding the machine with a credential the hub doesn't recognize and no
+// way back to the one it does.
+const pendingCredentialSuffix = ".pending"
+
+// pendingCredentialPath returns the staging path for activePath.
+func pendingCredentialPath(activePath string) string {
+	return activePath + pendingCredentialSuffix
+}
+
+// hashCredentialFileWith reads path via readFile and returns the hex SHA-256
+// of its trimmed contents, or "" if the file does not exist. A read error on
+// a file that DOES exist propagates rather than being folded into "absent" —
+// a transient read failure must never be silently mistaken for "no
+// credential here", which would make handleEnrollmentConfirmed's matching
+// logic wrongly treat a real, unreadable secret as a non-match.
+func hashCredentialFileWith(readFile func(string) ([]byte, error), path string) (string, error) {
+	data, err := readFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	secret := strings.TrimSpace(string(data))
+	if secret == "" {
+		return "", nil
+	}
+	h := sha256.Sum256([]byte(secret))
+	return hex.EncodeToString(h[:]), nil
+}
+
+// hashCredentialFile is hashCredentialFileWith against the real filesystem.
+func hashCredentialFile(path string) (string, error) {
+	return hashCredentialFileWith(os.ReadFile, path)
+}
+
+// credentialFileWriter groups the three durability-relevant filesystem calls
+// writeCredentialFileAtomic makes, so tests can inject a failure at any one
+// of them (in particular between Sync and Close, or between Close and
+// Rename) without needing real disk-failure conditions.
+type credentialFileWriter struct {
+	sync   func(*os.File) error
+	close  func(*os.File) error
+	rename func(oldpath, newpath string) error
+}
+
+func defaultCredentialFileWriter() credentialFileWriter {
+	return credentialFileWriter{
+		sync:  func(f *os.File) error { return f.Sync() },
+		close: func(f *os.File) error { return f.Close() },
+		// durableRename (not a plain os.Rename) so the temp -> destination
+		// commit — including for agent-secret.pending, the file
+		// enrollment_committed is gated on — gets the same durability
+		// guarantee as the pending -> active promotion in
+		// defaultCredentialConfirmDeps: both go through the identical
+		// platform-specific primitive in durable_rename_*.go.
+		rename: durableRename,
+	}
+}
+
+// writeCredentialFileAtomic durably persists secret to path: a temporary
+// file is created in the same directory, chmod'd, written, fsync'd, and
+// closed successfully — in that order — before being renamed into place.
+// The chmod request is 0600 on every platform, but what that actually buys
+// differs: on POSIX it sets real owner-only read/write permission bits; on
+// Windows, os.Chmod only toggles the read-only attribute (there is no POSIX
+// permission bit concept to set), so access control there comes from the
+// protected systemprofile credential directory's inherited ACL instead —
+// see TestWriteCredentialFileAtomicWritesModeAndContent's platform-specific
+// mode assertion. Sync is what actually makes this durable: Close alone
+// only guarantees the data left the process, not that it survived a crash
+// before the OS flushed its own buffers. The temp file is removed if
+// anything fails before the rename commits, so a crash or error never
+// leaves a partially-written credential file behind. Secret contents are
+// never logged — callers only log the destination path.
+func writeCredentialFileAtomic(path, secret string) error {
+	return writeCredentialFileAtomicWith(defaultCredentialFileWriter(), path, secret)
+}
+
+func writeCredentialFileAtomicWith(w credentialFileWriter, path, secret string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create credential dir: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".agent-secret-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp credential file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp credential file: %w", err)
+	}
+	if _, err := tmp.WriteString(secret + "\n"); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp credential file: %w", err)
+	}
+	if err := w.sync(tmp); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync temp credential file: %w", err)
+	}
+	if err := w.close(tmp); err != nil {
+		return fmt.Errorf("close temp credential file: %w", err)
+	}
+	if err := w.rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename temp credential file into place: %w", err)
+	}
+	success = true
+	return nil
+}
+
+// handleEnrolledFrame implements the ordering contract for a freshly issued
+// or staged secret: it must be durably saved to the PENDING file BEFORE
+// anything treats it as trustworthy — savePending must never write the
+// active credential file. BLOXOS_TOKEN cleanup, and the active file itself,
+// are only ever touched later by handleEnrollmentConfirmed, on receipt of
+// the hub's hash-bound "enrollment_confirmed" — never here. Sending
+// "enrollment_committed" merely asks the hub to promote/confirm; it proves
+// nothing on its own. If that send fails, the error propagates so the
+// caller tears the connection down and reconnects rather than silently
+// continuing in an unconfirmed state — a failed save sends no commit frame
+// at all, so the hub never promotes a pending credential the agent doesn't
+// actually have on disk. savePending and sendCommitted are injected so this
+// ordering is unit-testable without touching the real filesystem or network
+// socket.
+func handleEnrolledFrame(secret string, savePending func(string) error, sendCommitted func() error) (accepted bool, err error) {
+	if secret == "" {
+		return false, nil
+	}
+	if err := savePending(secret); err != nil {
+		return false, err
+	}
+	if err := sendCommitted(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// maybeCleanupTokenOnReconnect fires the once-guarded BLOXOS_TOKEN cleanup
+// for an ordinary reconnect: one that authenticated with an already-existing
+// durable secret and has no token in flight. When a token IS present
+// alongside a durable secret, a fresh or targeted re-enrollment attempt may
+// still be pending — cleanup is deferred to handleEnrollmentConfirmed
+// instead, so a legitimate retry (including across a process restart) never
+// loses BLOXOS_TOKEN to a premature wipe before enrollment actually
+// completes.
+func maybeCleanupTokenOnReconnect(haveDurableSecret, haveToken bool, cleanup func()) {
+	if haveDurableSecret && !haveToken {
+		cleanup()
+	}
+}
+
+// credentialConfirmDeps groups the filesystem operations
+// handleEnrollmentConfirmed needs, injected so the full hash-bound
+// confirmation state machine is unit-testable without touching real disk.
+type credentialConfirmDeps struct {
+	hashActive    func() (string, error)
+	hashPending   func() (string, error)
+	promote       func() error // durably replace active with pending; the commit point
+	removePending func() error
+}
+
+// enrollmentConfirmOutcome distinguishes WHY handleEnrollmentConfirmed
+// succeeded. Both non-rejected outcomes are equally safe to clear
+// BLOXOS_TOKEN on; the distinction exists so the caller can log accurately
+// and knows whether a rename actually happened.
+type enrollmentConfirmOutcome int
+
+const (
+	enrollmentConfirmRejected enrollmentConfirmOutcome = iota
+	enrollmentConfirmPromoted
+	enrollmentConfirmAlreadyActive
+)
+
+// handleEnrollmentConfirmed implements the hash-bound confirmation contract:
+// the hub's "enrollment_confirmed" always carries secret_sha256 identifying
+// EXACTLY the credential it is confirming (fresh enrollment = the active
+// hash; staged promotion = the promoted hash; pending-secret reconnect =
+// the hash that was promoted/validated; active-secret reconnect with a
+// lingering token = the active hash it actually authenticated). Local state
+// may change ONLY when that hash matches something this agent actually has
+// on disk right now:
+//
+//   - confirmedHash matches the pending file: pending is durably promoted to
+//     active (deps.promote — the one and only commit point) and then
+//     removed. This is the ONLY path that ever mutates the active
+//     credential file.
+//   - confirmedHash matches the file already active: nothing to promote —
+//     the "lingering token on an already-active reconnect" case. Any
+//     pending file left over is now provably stale (this agent process
+//     drives one connection/enrollment attempt at a time, so it cannot
+//     belong to some other still-in-flight attempt) and is removed.
+//   - Anything else — empty, or matching neither file — changes NOTHING and
+//     returns an error. The caller must close and let a fresh reconnect
+//     retry (pending first, then active) rather than guess.
+func handleEnrollmentConfirmed(confirmedHash string, deps credentialConfirmDeps) (enrollmentConfirmOutcome, error) {
+	if confirmedHash == "" {
+		return enrollmentConfirmRejected, fmt.Errorf("enrollment_confirmed missing secret_sha256")
+	}
+
+	pendingHash, err := deps.hashPending()
+	if err != nil {
+		return enrollmentConfirmRejected, fmt.Errorf("hash pending credential: %w", err)
+	}
+	if pendingHash != "" && pendingHash == confirmedHash {
+		if err := deps.promote(); err != nil {
+			return enrollmentConfirmRejected, fmt.Errorf("promote pending credential: %w", err)
+		}
+		return enrollmentConfirmPromoted, nil
+	}
+
+	activeHash, err := deps.hashActive()
+	if err != nil {
+		return enrollmentConfirmRejected, fmt.Errorf("hash active credential: %w", err)
+	}
+	if activeHash != "" && activeHash == confirmedHash {
+		if pendingHash != "" {
+			// Best-effort: a leftover stale pending file is cosmetic once
+			// the active credential is already confirmed authoritative —
+			// failing to remove it now does not affect correctness, only
+			// housekeeping, so it is not treated as a confirmation failure.
+			_ = deps.removePending()
+		}
+		return enrollmentConfirmAlreadyActive, nil
+	}
+
+	return enrollmentConfirmRejected, fmt.Errorf("enrollment_confirmed hash matches neither the pending nor the active local credential")
+}

--- a/agent/credential_handoff_mode_other_test.go
+++ b/agent/credential_handoff_mode_other_test.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// assertCredentialFileMode checks the real POSIX permission bits
+// writeCredentialFileAtomic's Chmod(0o600) call establishes: owner
+// read/write only, nothing for group or other.
+func assertCredentialFileMode(t *testing.T, info os.FileInfo) {
+	t.Helper()
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode=%v, want 0600", info.Mode().Perm())
+	}
+}

--- a/agent/credential_handoff_mode_windows_test.go
+++ b/agent/credential_handoff_mode_windows_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// assertCredentialFileMode intentionally does NOT assert POSIX permission
+// bits on Windows: os.Chmod(0o600) there only toggles the read-only
+// attribute, so os.Stat().Mode().Perm() reports something like 0666
+// regardless — that is not NTFS ACL inspection and asserting a specific
+// value would test nothing meaningful. Access control for this file comes
+// from where it lives: the protected systemprofile credential directory
+// (C:\Windows\System32\config\systemprofile\.bloxos, per install.ps1's
+// $CredDir), whose ACL is inherited by files created inside it. All this
+// test can and should verify here is that a real, regular file exists.
+func assertCredentialFileMode(t *testing.T, info os.FileInfo) {
+	t.Helper()
+	if !info.Mode().IsRegular() {
+		t.Fatalf("mode=%v, want a regular file", info.Mode())
+	}
+}

--- a/agent/credential_handoff_test.go
+++ b/agent/credential_handoff_test.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteCredentialFileAtomicWritesModeAndContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent-secret")
+
+	if err := writeCredentialFileAtomic(path, "super-secret-value"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(data) != "super-secret-value\n" {
+		t.Fatalf("content=%q, want secret+newline", data)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	assertCredentialFileMode(t, info)
+}
+
+func TestWriteCredentialFileAtomicReplacesExistingContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent-secret")
+	if err := writeCredentialFileAtomic(path, "old-value"); err != nil {
+		t.Fatalf("write old: %v", err)
+	}
+	if err := writeCredentialFileAtomic(path, "new-value"); err != nil {
+		t.Fatalf("write new: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(data) != "new-value\n" {
+		t.Fatalf("content=%q, want new-value only (no old bytes lingering)", data)
+	}
+}
+
+func TestWriteCredentialFileAtomicLeavesNoTempFileOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent-secret")
+	if err := writeCredentialFileAtomic(path, "value"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "agent-secret" {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("directory contains unexpected entries after a successful write: %v", names)
+	}
+}
+
+func TestWriteCredentialFileAtomicRemovesTempOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	// A destination inside a nonexistent nested directory that we don't
+	// pre-create makes MkdirAll succeed (it creates the dir) but we can
+	// instead force a rename failure by pointing the destination itself AT
+	// a directory, which os.Rename refuses to replace with a file.
+	destDir := filepath.Join(dir, "agent-secret")
+	if err := os.Mkdir(destDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	err := writeCredentialFileAtomic(destDir, "value")
+	if err == nil {
+		t.Fatal("expected an error writing over a directory")
+	}
+
+	entries, rderr := os.ReadDir(dir)
+	if rderr != nil {
+		t.Fatalf("readdir: %v", rderr)
+	}
+	for _, e := range entries {
+		if e.Name() != "agent-secret" && filepath.Ext(e.Name()) == ".tmp" {
+			t.Fatalf("temp file %q was not cleaned up after a failed write", e.Name())
+		}
+	}
+}
+
+func TestWriteCredentialFileAtomicCallsSyncBeforeCloseAndRename(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent-secret")
+
+	var order []string
+	w := defaultCredentialFileWriter()
+	w.sync = func(f *os.File) error { order = append(order, "sync"); return f.Sync() }
+	w.close = func(f *os.File) error { order = append(order, "close"); return f.Close() }
+	w.rename = func(oldpath, newpath string) error {
+		order = append(order, "rename")
+		return os.Rename(oldpath, newpath)
+	}
+
+	if err := writeCredentialFileAtomicWith(w, path, "value"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	want := []string{"sync", "close", "rename"}
+	if len(order) != len(want) || order[0] != want[0] || order[1] != want[1] || order[2] != want[2] {
+		t.Fatalf("order=%v, want %v", order, want)
+	}
+}
+
+func TestWriteCredentialFileAtomicFailsIfSyncFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent-secret")
+
+	renameCalled := false
+	w := defaultCredentialFileWriter()
+	w.sync = func(*os.File) error { return errors.New("sync failed") }
+	w.rename = func(oldpath, newpath string) error { renameCalled = true; return os.Rename(oldpath, newpath) }
+
+	if err := writeCredentialFileAtomicWith(w, path, "value"); err == nil {
+		t.Fatal("expected sync failure to propagate")
+	}
+	if renameCalled {
+		t.Fatal("rename must not run when sync failed — the file is not proven durable")
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("destination must not exist when sync failed")
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("temp file was not cleaned up after a sync failure: %v", entries)
+	}
+}
+
+func TestWriteCredentialFileAtomicFailsIfRenameFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent-secret")
+
+	w := defaultCredentialFileWriter()
+	w.rename = func(oldpath, newpath string) error { return errors.New("rename failed") }
+
+	if err := writeCredentialFileAtomicWith(w, path, "value"); err == nil {
+		t.Fatal("expected rename failure to propagate")
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("destination must not exist when rename failed")
+	}
+}
+
+func TestHandleEnrolledFrameSavesBeforeSendingCommit(t *testing.T) {
+	var order []string
+	save := func(secret string) error {
+		if secret != "the-secret" {
+			t.Fatalf("save got %q, want the-secret", secret)
+		}
+		order = append(order, "save")
+		return nil
+	}
+	sendCommitted := func() error { order = append(order, "commit"); return nil }
+
+	accepted, err := handleEnrolledFrame("the-secret", save, sendCommitted)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !accepted {
+		t.Fatal("expected accepted=true")
+	}
+	want := []string{"save", "commit"}
+	if len(order) != len(want) || order[0] != want[0] || order[1] != want[1] {
+		t.Fatalf("order=%v, want %v", order, want)
+	}
+}
+
+func TestHandleEnrolledFrameSendsNoCommitOnFailedSave(t *testing.T) {
+	var commitAttempted bool
+	save := func(string) error { return errors.New("disk full") }
+	sendCommitted := func() error { commitAttempted = true; return nil }
+
+	accepted, err := handleEnrolledFrame("the-secret", save, sendCommitted)
+	if err == nil {
+		t.Fatal("expected the save error to propagate")
+	}
+	if accepted {
+		t.Fatal("expected accepted=false on a failed save")
+	}
+	if commitAttempted {
+		t.Fatal("enrollment_committed must not be sent when the durable save failed")
+	}
+}
+
+// TestHandleEnrolledFrameSendFailurePropagates covers the "commit-frame send
+// failure causes reconnect/error" requirement: a failed send is NOT treated
+// as accepted, and the caller (main.go's read loop) is expected to tear the
+// connection down on this error rather than silently continuing — see
+// TestMaybeCleanupTokenOnReconnectFiresOnlyForOrdinaryReconnect for proof
+// that no cleanup path is reachable without a successful, confirmed frame.
+func TestHandleEnrolledFrameSendFailurePropagates(t *testing.T) {
+	saveCalled := false
+	save := func(string) error { saveCalled = true; return nil }
+	sendCommitted := func() error { return errors.New("connection reset") }
+
+	accepted, err := handleEnrolledFrame("the-secret", save, sendCommitted)
+	if err == nil {
+		t.Fatal("expected the send error to propagate")
+	}
+	if !saveCalled {
+		t.Fatal("save must still have been attempted (and succeeded) before the send failure")
+	}
+	if accepted {
+		t.Fatal("expected accepted=false when sending enrollment_committed fails — a failed send proves nothing was acknowledged")
+	}
+}
+
+func TestHandleEnrolledFrameIgnoresEmptySecret(t *testing.T) {
+	called := false
+	touch := func() error { called = true; return nil }
+	accepted, err := handleEnrolledFrame("", func(string) error { called = true; return nil }, touch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if accepted {
+		t.Fatal("expected accepted=false for an empty secret")
+	}
+	if called {
+		t.Fatal("no dependency should be invoked for an empty secret")
+	}
+}
+
+func TestMaybeCleanupTokenOnReconnectFiresOnlyForOrdinaryReconnect(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		haveSecret       bool
+		haveToken        bool
+		wantCleanupCalls int
+	}{
+		{name: "durable secret, no token: ordinary reconnect", haveSecret: true, haveToken: false, wantCleanupCalls: 1},
+		{name: "durable secret AND a token: deferred to handleEnrolledFrame", haveSecret: true, haveToken: true, wantCleanupCalls: 0},
+		{name: "no durable secret: fresh enrollment, deferred", haveSecret: false, haveToken: true, wantCleanupCalls: 0},
+		{name: "neither: nothing to clean up", haveSecret: false, haveToken: false, wantCleanupCalls: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			maybeCleanupTokenOnReconnect(tc.haveSecret, tc.haveToken, func() { calls++ })
+			if calls != tc.wantCleanupCalls {
+				t.Fatalf("cleanup calls=%d, want %d", calls, tc.wantCleanupCalls)
+			}
+		})
+	}
+}

--- a/agent/credential_reconnect_state_test.go
+++ b/agent/credential_reconnect_state_test.go
@@ -1,0 +1,205 @@
+package main
+
+import "testing"
+
+// ===== ROUND 5 BLOCKER 1: connectLoop must actually honor a pending
+// rejection across iterations =====
+//
+// Round 4 introduced shouldFallBackToActive and set agentSecret = active
+// before `continue`, but connectLoop's top-of-loop logic unconditionally
+// re-read agent-secret.pending FIRST on every iteration — and rejection
+// never removes that file. The very next iteration silently re-selected the
+// same already-rejected pending secret, undoing the fallback: an immediate
+// pending→401→pending loop, never actually reaching active. These tests
+// prove the fix at the level Codex asked for — not just that the single-shot
+// predicate returns true, but that a SEQUENCE of iterations, each reading
+// the (unchanged) on-disk state fresh, produces the correct candidate.
+
+func TestSelectCredentialCandidatePrefersUnrejectedPending(t *testing.T) {
+	sel := selectCredentialCandidate("pending-secret", "active-secret", "")
+	if sel.secret != "pending-secret" || !sel.usedPending {
+		t.Fatalf("got %+v, want pending selected", sel)
+	}
+}
+
+func TestSelectCredentialCandidateSkipsKnownRejectedPendingForActive(t *testing.T) {
+	sel := selectCredentialCandidate("pending-secret", "active-secret", "pending-secret")
+	if sel.secret != "active-secret" || sel.usedPending {
+		t.Fatalf("got %+v, want active selected once pending is known-rejected", sel)
+	}
+}
+
+func TestSelectCredentialCandidateRetriesRejectedPendingWhenNoActive(t *testing.T) {
+	sel := selectCredentialCandidate("pending-secret", "", "pending-secret")
+	if sel.secret != "pending-secret" || !sel.usedPending {
+		t.Fatalf("got %+v, want the only available credential (pending) retried", sel)
+	}
+}
+
+func TestSelectCredentialCandidateTriesFreshPendingDespiteOldRejection(t *testing.T) {
+	// A NEW re-enrollment attempt staged a different pending secret after
+	// the old one was abandoned — must not be confused with it.
+	sel := selectCredentialCandidate("new-pending-secret", "active-secret", "old-rejected-secret")
+	if sel.secret != "new-pending-secret" || !sel.usedPending {
+		t.Fatalf("got %+v, want the fresh pending secret tried, not skipped", sel)
+	}
+}
+
+func TestSelectCredentialCandidateNoCredentialsAtAll(t *testing.T) {
+	sel := selectCredentialCandidate("", "", "")
+	if sel.secret != "" || sel.usedPending {
+		t.Fatalf("got %+v, want empty selection", sel)
+	}
+}
+
+func TestNextRejectedPendingSecretMarksOnDefiniteRejection(t *testing.T) {
+	got := nextRejectedPendingSecret("", credentialSelection{secret: "p", usedPending: true}, authOutcomeRejected, "p")
+	if got != "p" {
+		t.Fatalf("got %q, want the rejected secret tracked", got)
+	}
+}
+
+func TestNextRejectedPendingSecretUnchangedOnTransportFailureUsingActive(t *testing.T) {
+	// Already tracking a rejection; a transport/TLS failure while retrying
+	// with ACTIVE must not clear or otherwise disturb that tracking — the
+	// pending candidate must stay avoided.
+	got := nextRejectedPendingSecret("p", credentialSelection{secret: "active-secret", usedPending: false}, authOutcomeUnknown, "p")
+	if got != "p" {
+		t.Fatalf("got %q, want rejection tracking preserved through an active-side transport failure", got)
+	}
+}
+
+func TestNextRejectedPendingSecretUnchangedOnTransportFailureUsingPending(t *testing.T) {
+	got := nextRejectedPendingSecret("", credentialSelection{secret: "p", usedPending: true}, authOutcomeUnknown, "p")
+	if got != "" {
+		t.Fatalf("got %q, want no rejection recorded for a mere transport failure", got)
+	}
+}
+
+func TestNextRejectedPendingSecretClearsWhenPendingFileGone(t *testing.T) {
+	// The tracked rejection becomes moot once the pending file itself is
+	// gone (promoted, or cleaned up as stale by a confirmed active
+	// reconnect) — nothing left to avoid, and a LATER fresh pending secret
+	// must not be mistakenly compared against a leftover value.
+	got := nextRejectedPendingSecret("p", credentialSelection{secret: "active-secret", usedPending: false}, authOutcomeUnknown, "")
+	if got != "" {
+		t.Fatalf("got %q, want tracking cleared once no pending file remains", got)
+	}
+}
+
+// simulatedConnectLoopIteration mirrors EXACTLY connectLoop's own per-
+// iteration decision + state update (selectCredentialCandidate then
+// nextRejectedPendingSecret), so a scripted sequence of on-disk states and
+// hub outcomes proves the real multi-iteration behavior — not just that the
+// underlying pure functions are individually correct in isolation.
+func simulatedConnectLoopIteration(rejectedPendingSecret, pendingOnDisk, activeOnDisk string, outcome authOutcome) (sel credentialSelection, nextRejected string, immediateRetry bool) {
+	sel = selectCredentialCandidate(pendingOnDisk, activeOnDisk, rejectedPendingSecret)
+	immediateRetry = shouldFallBackToActive(sel.usedPending, outcome, activeOnDisk != "")
+	nextRejected = nextRejectedPendingSecret(rejectedPendingSecret, sel, outcome, pendingOnDisk)
+	return sel, nextRejected, immediateRetry
+}
+
+// TestConnectLoopHonorsPendingRejectionAcrossIterations is the exact
+// reproduction Codex asked for: the pending file is NEVER deleted or
+// changed between iterations (nothing in this scenario promotes or cleans
+// it up — it just sits there, abandoned/expired hub-side), yet attempt 2
+// must use active, not immediately re-select the just-rejected pending
+// secret. Also proves the sequel: a transport failure while on the active
+// fallback keeps retrying active, never jumping back to pending.
+func TestConnectLoopHonorsPendingRejectionAcrossIterations(t *testing.T) {
+	const pending = "abandoned-pending-secret"
+	const active = "still-valid-active-secret"
+	var rejected string
+
+	// Attempt 1: pending file exists, nothing rejected yet -> try pending.
+	sel1, rejected, retry1 := simulatedConnectLoopIteration(rejected, pending, active, authOutcomeRejected)
+	if sel1.secret != pending || !sel1.usedPending {
+		t.Fatalf("attempt 1: got %+v, want pending selected", sel1)
+	}
+	if !retry1 {
+		t.Fatal("attempt 1: expected an immediate retry (active is available) after the pending rejection")
+	}
+	if rejected != pending {
+		t.Fatalf("attempt 1: rejected tracking = %q, want %q", rejected, pending)
+	}
+
+	// Attempt 2 — THE bug this test exists to catch: the pending FILE is
+	// still on disk (untouched), but the state machine must select ACTIVE,
+	// not immediately re-select the just-rejected pending value.
+	sel2, rejected, retry2 := simulatedConnectLoopIteration(rejected, pending, active, authOutcomeUnknown)
+	if sel2.usedPending {
+		t.Fatalf("attempt 2: re-selected the already-rejected pending candidate (%+v) — this IS the pending→401→pending loop bug", sel2)
+	}
+	if sel2.secret != active {
+		t.Fatalf("attempt 2: got secret %q, want the active credential %q", sel2.secret, active)
+	}
+	if retry2 {
+		t.Fatal("attempt 2: a transport failure (authOutcomeUnknown) must never trigger another immediate retry")
+	}
+	if rejected != pending {
+		t.Fatalf("attempt 2: rejected tracking changed to %q, want it to stay %q", rejected, pending)
+	}
+
+	// Attempt 3: another transport failure while still on the active
+	// fallback — must keep retrying active, not jump back to pending.
+	sel3, rejected, retry3 := simulatedConnectLoopIteration(rejected, pending, active, authOutcomeUnknown)
+	if sel3.usedPending || sel3.secret != active {
+		t.Fatalf("attempt 3: got %+v, want active retried again, not pending", sel3)
+	}
+	if retry3 {
+		t.Fatal("attempt 3: transport failure must not trigger an immediate retry")
+	}
+	if rejected != pending {
+		t.Fatalf("attempt 3: rejected tracking changed to %q, want it to stay %q", rejected, pending)
+	}
+}
+
+// TestConnectLoopRetriesPendingWithBackoffWhenNoActiveAvailable covers "no
+// active credential available -> retain pending and normal backoff": across
+// repeated rejections with nothing to fall back to, the pending file must
+// never be discarded (nowhere else has this secret), and there must be no
+// immediate-retry (busy-loop) behavior.
+func TestConnectLoopRetriesPendingWithBackoffWhenNoActiveAvailable(t *testing.T) {
+	const pending = "only-credential-we-have"
+	var rejected string
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		sel, next, retry := simulatedConnectLoopIteration(rejected, pending, "", authOutcomeRejected)
+		rejected = next
+		if sel.secret != pending || !sel.usedPending {
+			t.Fatalf("attempt %d: got %+v, want the only credential (pending) retried", attempt, sel)
+		}
+		if retry {
+			t.Fatalf("attempt %d: no active credential exists — must use normal backoff, not an immediate retry", attempt)
+		}
+		if rejected != pending {
+			t.Fatalf("attempt %d: rejected tracking = %q, want %q (retained, not discarded)", attempt, rejected, pending)
+		}
+	}
+}
+
+// TestConnectLoopTriesFreshPendingAfterOldOneWasAbandoned: once a NEW
+// re-enrollment attempt stages a genuinely different pending secret, it
+// must be tried immediately — not skipped because SOME pending value was
+// previously rejected.
+func TestConnectLoopTriesFreshPendingAfterOldOneWasAbandoned(t *testing.T) {
+	const oldPending = "abandoned-secret"
+	const active = "active-secret"
+	const newPending = "fresh-reenrollment-secret"
+
+	sel1, rejected, _ := simulatedConnectLoopIteration("", oldPending, active, authOutcomeRejected)
+	if sel1.secret != oldPending {
+		t.Fatalf("attempt 1: got %+v", sel1)
+	}
+	if rejected != oldPending {
+		t.Fatalf("rejected tracking = %q, want %q", rejected, oldPending)
+	}
+
+	// A fresh re-enrollment stages a new pending value; old pending file is
+	// gone (replaced) — the tracked rejection is now stale.
+	sel2, rejected, _ := simulatedConnectLoopIteration(rejected, newPending, active, authOutcomeUnknown)
+	if sel2.secret != newPending || !sel2.usedPending {
+		t.Fatalf("attempt 2: got %+v, want the fresh pending secret tried immediately", sel2)
+	}
+	_ = rejected
+}

--- a/agent/credential_two_phase_test.go
+++ b/agent/credential_two_phase_test.go
@@ -1,0 +1,494 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ===== BLOCKER 2 (round 4): real local two-phase credential handoff =====
+//
+// Before this fix, "enrolled" wrote straight to the active credential file:
+// if the hub's later "enrollment_confirmed" was lost, delayed, or the
+// promotion failed/expired hub-side, the local active file had already been
+// overwritten while the hub still considered the OLD secret active — a
+// split-brain the agent could not recover from on its own (the new local
+// secret was unpromoted/expired, and the old, hub-valid secret was gone).
+// These tests exercise the replacement design: "enrolled" writes only a
+// PENDING file, and only a hash-bound "enrollment_confirmed" (proven via
+// handleEnrollmentConfirmed) may ever promote it into the active file.
+
+func TestPendingCredentialPathAppendsSuffix(t *testing.T) {
+	got := pendingCredentialPath("/etc/bloxos/agent-secret")
+	want := "/etc/bloxos/agent-secret.pending"
+	if got != want {
+		t.Fatalf("pendingCredentialPath = %q, want %q", got, want)
+	}
+}
+
+func TestHashCredentialFileWithMissingFileReturnsEmpty(t *testing.T) {
+	hash, err := hashCredentialFileWith(os.ReadFile, filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash != "" {
+		t.Fatalf("hash=%q, want empty for a missing file", hash)
+	}
+}
+
+func TestHashCredentialFileWithExistingFileReturnsHashOfTrimmedContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent-secret")
+	if err := writeCredentialFileAtomic(path, "the-secret"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := hashCredentialFile(path)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	want := hashOfForTest("the-secret")
+	if got != want {
+		t.Fatalf("hash=%q, want %q", got, want)
+	}
+}
+
+// hashOfForTest mirrors hashCredentialFile's own hashing (sha256 hex of the
+// trimmed secret) so tests can compute an expected value without depending
+// on any hub-side helper.
+func hashOfForTest(secret string) string {
+	h, err := hashCredentialFileWith(func(string) ([]byte, error) {
+		return []byte(secret + "\n"), nil
+	}, "unused")
+	if err != nil {
+		panic(err)
+	}
+	return h
+}
+
+func TestHashCredentialFileWithPropagatesReadErrorForExistingFile(t *testing.T) {
+	sentinel := errors.New("permission denied")
+	_, err := hashCredentialFileWith(func(string) ([]byte, error) {
+		return nil, sentinel
+	}, "some-path")
+	if err == nil {
+		t.Fatal("expected the read error to propagate, not be folded into \"absent\"")
+	}
+}
+
+// spyConfirmDeps wraps credentialConfirmDeps with call-order tracking and
+// configurable failures, so handleEnrollmentConfirmed's state machine can be
+// tested without touching real disk except where a test explicitly wants to
+// (see the real-file variants below).
+type spyConfirmDeps struct {
+	order []string
+
+	activeHash, pendingHash string
+	activeErr, pendingErr   error
+	promoteErr, removeErr   error
+}
+
+func (s *spyConfirmDeps) deps() credentialConfirmDeps {
+	return credentialConfirmDeps{
+		hashActive:  func() (string, error) { s.order = append(s.order, "hashActive"); return s.activeHash, s.activeErr },
+		hashPending: func() (string, error) { s.order = append(s.order, "hashPending"); return s.pendingHash, s.pendingErr },
+		promote:     func() error { s.order = append(s.order, "promote"); return s.promoteErr },
+		removePending: func() error {
+			s.order = append(s.order, "removePending")
+			return s.removeErr
+		},
+	}
+}
+
+func TestHandleEnrollmentConfirmedRejectsEmptyHash(t *testing.T) {
+	s := &spyConfirmDeps{activeHash: "active-hash", pendingHash: "pending-hash"}
+	outcome, err := handleEnrollmentConfirmed("", s.deps())
+	if err == nil {
+		t.Fatal("expected an error for an empty confirmed hash")
+	}
+	if outcome != enrollmentConfirmRejected {
+		t.Fatalf("outcome=%v, want enrollmentConfirmRejected", outcome)
+	}
+	if len(s.order) != 0 {
+		t.Fatalf("no filesystem operation should run for an empty hash, got %v", s.order)
+	}
+}
+
+func TestHandleEnrollmentConfirmedPromotesMatchingPending(t *testing.T) {
+	s := &spyConfirmDeps{activeHash: "old-active-hash", pendingHash: "new-hash"}
+	outcome, err := handleEnrollmentConfirmed("new-hash", s.deps())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome != enrollmentConfirmPromoted {
+		t.Fatalf("outcome=%v, want enrollmentConfirmPromoted", outcome)
+	}
+	// promote (the commit point / rename) must run, and — since a rename IS
+	// the removal of the pending file — removePending must NOT be called
+	// separately in this branch.
+	found := false
+	for _, op := range s.order {
+		if op == "removePending" {
+			t.Fatal("removePending must not be called on the promote path — the rename already consumes the pending file")
+		}
+		if op == "promote" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("promote was never called")
+	}
+}
+
+func TestHandleEnrollmentConfirmedPromotesEvenWithNoPriorActiveFile(t *testing.T) {
+	// Covers "clean enrollment works when no active file exists": a brand
+	// new machine has no local active file at all when its first
+	// confirmation arrives — the pending-hash match alone must be enough.
+	s := &spyConfirmDeps{activeHash: "", pendingHash: "fresh-hash"}
+	outcome, err := handleEnrollmentConfirmed("fresh-hash", s.deps())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome != enrollmentConfirmPromoted {
+		t.Fatalf("outcome=%v, want enrollmentConfirmPromoted", outcome)
+	}
+}
+
+func TestHandleEnrollmentConfirmedAlreadyActiveClearsStalePending(t *testing.T) {
+	s := &spyConfirmDeps{activeHash: "active-hash", pendingHash: "some-other-stale-hash"}
+	outcome, err := handleEnrollmentConfirmed("active-hash", s.deps())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome != enrollmentConfirmAlreadyActive {
+		t.Fatalf("outcome=%v, want enrollmentConfirmAlreadyActive", outcome)
+	}
+	sawRemove, sawPromote := false, false
+	for _, op := range s.order {
+		if op == "removePending" {
+			sawRemove = true
+		}
+		if op == "promote" {
+			sawPromote = true
+		}
+	}
+	if !sawRemove {
+		t.Fatal("a stale, non-matching pending file must be cleaned up once active is confirmed authoritative")
+	}
+	if sawPromote {
+		t.Fatal("promote must never run when the confirmation already matches the active file")
+	}
+}
+
+func TestHandleEnrollmentConfirmedAlreadyActiveNoOpWhenNoPendingFile(t *testing.T) {
+	s := &spyConfirmDeps{activeHash: "active-hash", pendingHash: ""}
+	outcome, err := handleEnrollmentConfirmed("active-hash", s.deps())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome != enrollmentConfirmAlreadyActive {
+		t.Fatalf("outcome=%v, want enrollmentConfirmAlreadyActive", outcome)
+	}
+	for _, op := range s.order {
+		if op == "removePending" {
+			t.Fatal("removePending must not run when there is no pending file to remove")
+		}
+	}
+}
+
+func TestHandleEnrollmentConfirmedMismatchChangesNothing(t *testing.T) {
+	s := &spyConfirmDeps{activeHash: "active-hash", pendingHash: "pending-hash"}
+	outcome, err := handleEnrollmentConfirmed("some-unrelated-hash", s.deps())
+	if err == nil {
+		t.Fatal("expected an error when the confirmed hash matches neither file")
+	}
+	if outcome != enrollmentConfirmRejected {
+		t.Fatalf("outcome=%v, want enrollmentConfirmRejected", outcome)
+	}
+	for _, op := range s.order {
+		if op == "promote" || op == "removePending" {
+			t.Fatalf("a mismatched confirmation must not mutate anything, but ran %q", op)
+		}
+	}
+}
+
+func TestHandleEnrollmentConfirmedPromotionFailurePreservesRecoveryMaterial(t *testing.T) {
+	s := &spyConfirmDeps{activeHash: "old-active-hash", pendingHash: "new-hash", promoteErr: errors.New("rename failed: disk full")}
+	outcome, err := handleEnrollmentConfirmed("new-hash", s.deps())
+	if err == nil {
+		t.Fatal("expected the promote error to propagate")
+	}
+	if outcome != enrollmentConfirmRejected {
+		t.Fatalf("outcome=%v, want enrollmentConfirmRejected", outcome)
+	}
+	for _, op := range s.order {
+		if op == "removePending" {
+			t.Fatal("a failed promotion must not remove the pending file — it is the only remaining recovery material")
+		}
+	}
+}
+
+func TestHandleEnrollmentConfirmedPropagatesHashReadErrors(t *testing.T) {
+	s := &spyConfirmDeps{pendingErr: errors.New("read failed")}
+	if _, err := handleEnrollmentConfirmed("whatever", s.deps()); err == nil {
+		t.Fatal("expected a pending-hash read error to propagate")
+	}
+
+	s2 := &spyConfirmDeps{pendingHash: "no-match", activeErr: errors.New("read failed")}
+	if _, err := handleEnrollmentConfirmed("whatever", s2.deps()); err == nil {
+		t.Fatal("expected an active-hash read error to propagate")
+	}
+}
+
+// ===== Real-filesystem end-to-end: enrolled -> pending file only, then
+// hash-bound confirmation -> real durable promote via durableRename.
+
+func TestEnrolledFrameWritesPendingFileNeverActive(t *testing.T) {
+	dir := t.TempDir()
+	activePath := filepath.Join(dir, "agent-secret")
+	pendingPath := pendingCredentialPath(activePath)
+
+	savePending := func(secret string) error { return writeCredentialFileAtomic(pendingPath, secret) }
+	committed := false
+	accepted, err := handleEnrolledFrame("brand-new-secret", savePending, func() error { committed = true; return nil })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !accepted || !committed {
+		t.Fatalf("accepted=%v committed=%v, want both true", accepted, committed)
+	}
+
+	if _, err := os.Stat(activePath); err == nil {
+		t.Fatal("the active credential file must not exist merely from receiving \"enrolled\"")
+	}
+	data, err := os.ReadFile(pendingPath)
+	if err != nil {
+		t.Fatalf("pending file was not written: %v", err)
+	}
+	if got := string(data); got != "brand-new-secret\n" {
+		t.Fatalf("pending file content=%q, want the staged secret", got)
+	}
+}
+
+// TestFullTwoPhaseHandoffChainOnRealFiles is the end-to-end proof of "stage
+// -> local pending write -> hash-bound confirm -> local active replacement"
+// entirely from the agent's side of the protocol, using only real files (the
+// hub's own half — the CAS promotion in promotePendingCredentialCAS — is
+// proven independently by the hub's own test suite; what's proven here is
+// that the agent's local file state machine, wired together exactly as
+// main.go wires it, ends up correct).
+func TestFullTwoPhaseHandoffChainOnRealFiles(t *testing.T) {
+	dir := t.TempDir()
+	activePath := filepath.Join(dir, "agent-secret")
+	pendingPath := pendingCredentialPath(activePath)
+	if err := writeCredentialFileAtomic(activePath, "old-secret"); err != nil {
+		t.Fatalf("seed old active: %v", err)
+	}
+
+	// Step 1: "enrolled" arrives — staged to pending only.
+	savePending := func(secret string) error { return writeCredentialFileAtomic(pendingPath, secret) }
+	committedSent := false
+	accepted, err := handleEnrolledFrame("new-secret", savePending, func() error { committedSent = true; return nil })
+	if err != nil || !accepted || !committedSent {
+		t.Fatalf("handleEnrolledFrame: accepted=%v committed=%v err=%v", accepted, committedSent, err)
+	}
+	if data, _ := os.ReadFile(activePath); string(data) != "old-secret\n" {
+		t.Fatal("active file must still hold the OLD secret after staging alone")
+	}
+
+	// Step 2: hub confirms with the hash of the secret it promoted — which,
+	// on the hub side, is exactly the hash of what was staged (same value
+	// this agent just wrote to pendingPath).
+	confirmedHash, err := hashCredentialFile(pendingPath)
+	if err != nil {
+		t.Fatalf("hash pending: %v", err)
+	}
+	deps := credentialConfirmDeps{
+		hashActive:    func() (string, error) { return hashCredentialFile(activePath) },
+		hashPending:   func() (string, error) { return hashCredentialFile(pendingPath) },
+		promote:       func() error { return durableRename(pendingPath, activePath) },
+		removePending: func() error { return os.Remove(pendingPath) },
+	}
+	outcome, err := handleEnrollmentConfirmed(confirmedHash, deps)
+	if err != nil {
+		t.Fatalf("handleEnrollmentConfirmed: %v", err)
+	}
+	if outcome != enrollmentConfirmPromoted {
+		t.Fatalf("outcome=%v, want enrollmentConfirmPromoted", outcome)
+	}
+
+	// Step 3: local active replacement — the ONLY point at which it changed.
+	activeData, err := os.ReadFile(activePath)
+	if err != nil || string(activeData) != "new-secret\n" {
+		t.Fatalf("active=%q err=%v, want the newly promoted secret", activeData, err)
+	}
+	if _, err := os.Stat(pendingPath); err == nil {
+		t.Fatal("no .pending residue expected after a normal successful handoff")
+	}
+}
+
+func TestFailedPendingWriteSendsNoCommit(t *testing.T) {
+	sendAttempted := false
+	savePending := func(string) error { return errors.New("disk full") }
+	accepted, err := handleEnrolledFrame("secret", savePending, func() error { sendAttempted = true; return nil })
+	if err == nil {
+		t.Fatal("expected the save error to propagate")
+	}
+	if accepted {
+		t.Fatal("expected accepted=false")
+	}
+	if sendAttempted {
+		t.Fatal("enrollment_committed must never be sent when the pending write itself failed")
+	}
+}
+
+func TestFailedCommitSendLeavesActiveAndPendingIntact(t *testing.T) {
+	dir := t.TempDir()
+	activePath := filepath.Join(dir, "agent-secret")
+	pendingPath := pendingCredentialPath(activePath)
+	if err := writeCredentialFileAtomic(activePath, "old-active-secret"); err != nil {
+		t.Fatalf("seed active: %v", err)
+	}
+
+	savePending := func(secret string) error { return writeCredentialFileAtomic(pendingPath, secret) }
+	accepted, err := handleEnrolledFrame("new-secret", savePending, func() error { return errors.New("connection reset") })
+	if err == nil {
+		t.Fatal("expected the send error to propagate")
+	}
+	if accepted {
+		t.Fatal("expected accepted=false when the commit send fails")
+	}
+
+	activeData, aerr := os.ReadFile(activePath)
+	if aerr != nil || string(activeData) != "old-active-secret\n" {
+		t.Fatalf("active file changed despite a failed commit send: data=%q err=%v", activeData, aerr)
+	}
+	pendingData, perr := os.ReadFile(pendingPath)
+	if perr != nil || string(pendingData) != "new-secret\n" {
+		t.Fatalf("pending file was not left intact for a later retry: data=%q err=%v", pendingData, perr)
+	}
+}
+
+func TestMatchingPendingConfirmationReplacesActiveViaRealCommit(t *testing.T) {
+	dir := t.TempDir()
+	activePath := filepath.Join(dir, "agent-secret")
+	pendingPath := pendingCredentialPath(activePath)
+	if err := writeCredentialFileAtomic(activePath, "old-secret"); err != nil {
+		t.Fatalf("seed active: %v", err)
+	}
+	if err := writeCredentialFileAtomic(pendingPath, "new-secret"); err != nil {
+		t.Fatalf("seed pending: %v", err)
+	}
+
+	confirmedHash, err := hashCredentialFile(pendingPath)
+	if err != nil {
+		t.Fatalf("hash pending: %v", err)
+	}
+
+	deps := credentialConfirmDeps{
+		hashActive:    func() (string, error) { return hashCredentialFile(activePath) },
+		hashPending:   func() (string, error) { return hashCredentialFile(pendingPath) },
+		promote:       func() error { return durableRename(pendingPath, activePath) },
+		removePending: func() error { return os.Remove(pendingPath) },
+	}
+
+	outcome, err := handleEnrollmentConfirmed(confirmedHash, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome != enrollmentConfirmPromoted {
+		t.Fatalf("outcome=%v, want enrollmentConfirmPromoted", outcome)
+	}
+
+	activeData, err := os.ReadFile(activePath)
+	if err != nil {
+		t.Fatalf("read active after promotion: %v", err)
+	}
+	if string(activeData) != "new-secret\n" {
+		t.Fatalf("active content=%q, want the promoted secret", activeData)
+	}
+	if _, err := os.Stat(pendingPath); err == nil {
+		t.Fatal("pending file must be gone after a real promote (the rename IS the removal)")
+	}
+}
+
+func TestPendingToActiveReplacementFailurePreservesBothFilesOnRealDisk(t *testing.T) {
+	dir := t.TempDir()
+	activePath := filepath.Join(dir, "agent-secret")
+	pendingPath := pendingCredentialPath(activePath)
+	if err := writeCredentialFileAtomic(activePath, "old-secret"); err != nil {
+		t.Fatalf("seed active: %v", err)
+	}
+	if err := writeCredentialFileAtomic(pendingPath, "new-secret"); err != nil {
+		t.Fatalf("seed pending: %v", err)
+	}
+	confirmedHash, _ := hashCredentialFile(pendingPath)
+
+	deps := credentialConfirmDeps{
+		hashActive:  func() (string, error) { return hashCredentialFile(activePath) },
+		hashPending: func() (string, error) { return hashCredentialFile(pendingPath) },
+		// Simulate a commit-point failure without touching real disk.
+		promote:       func() error { return errors.New("simulated durability failure") },
+		removePending: func() error { return os.Remove(pendingPath) },
+	}
+
+	if _, err := handleEnrollmentConfirmed(confirmedHash, deps); err == nil {
+		t.Fatal("expected the simulated promotion failure to propagate")
+	}
+
+	activeData, err := os.ReadFile(activePath)
+	if err != nil || string(activeData) != "old-secret\n" {
+		t.Fatalf("active file must be untouched on a failed promotion: data=%q err=%v", activeData, err)
+	}
+	pendingData, err := os.ReadFile(pendingPath)
+	if err != nil || string(pendingData) != "new-secret\n" {
+		t.Fatalf("pending file must survive a failed promotion for retry: data=%q err=%v", pendingData, err)
+	}
+}
+
+// ===== Reconnect-recovery decision logic (pure, deterministic) =====
+
+func TestShouldFallBackToActive(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		usedPending bool
+		outcome     authOutcome
+		haveActive  bool
+		want        bool
+	}{
+		{"pending rejected, active available: fall back", true, authOutcomeRejected, true, true},
+		{"pending rejected, no active to fall back to", true, authOutcomeRejected, false, false},
+		{"pending attempt hit a transport/TLS failure: no fallback", true, authOutcomeUnknown, true, false},
+		{"active credential itself was rejected: no fallback loop", false, authOutcomeRejected, true, false},
+		{"active credential, transport failure: no fallback", false, authOutcomeUnknown, true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldFallBackToActive(tc.usedPending, tc.outcome, tc.haveActive)
+			if got != tc.want {
+				t.Fatalf("shouldFallBackToActive(%v, %v, %v) = %v, want %v", tc.usedPending, tc.outcome, tc.haveActive, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyDialAuthOutcome(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		resp *http.Response
+		err  error
+		want authOutcome
+	}{
+		{"401 with an error is a definitive rejection", &http.Response{StatusCode: http.StatusUnauthorized}, errors.New("bad handshake"), authOutcomeRejected},
+		{"403 is not treated as a credential rejection", &http.Response{StatusCode: http.StatusForbidden}, errors.New("bad handshake"), authOutcomeUnknown},
+		{"nil response (transport/TLS failure) is never a rejection", nil, errors.New("connection refused"), authOutcomeUnknown},
+		{"no error at all is never a rejection regardless of resp", &http.Response{StatusCode: http.StatusUnauthorized}, nil, authOutcomeUnknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyDialAuthOutcome(tc.resp, tc.err)
+			if got != tc.want {
+				t.Fatalf("classifyDialAuthOutcome() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/agent/durable_rename_other.go
+++ b/agent/durable_rename_other.go
@@ -1,0 +1,69 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// syncCloser is satisfied by *os.File — abstracted so durableRenameWith can
+// be tested deterministically against a fake, instead of depending on real
+// filesystem permission-bit behavior (which is not a reliable way to force
+// an open/sync failure: it varies by filesystem, and a process running as
+// root bypasses permission checks entirely, so a chmod-based trick silently
+// stops testing anything in that environment).
+type syncCloser interface {
+	Sync() error
+	Close() error
+}
+
+// dirOpener opens path for the sole purpose of fsync'ing it.
+type dirOpener func(path string) (syncCloser, error)
+
+func openDirForSync(path string) (syncCloser, error) {
+	return os.Open(path)
+}
+
+// durableRename is the ONE durable rename/replace primitive shared by both
+// callers that need it: writeCredentialFileAtomic's temp -> pending/active
+// commit (via defaultCredentialFileWriter's rename field), and the
+// pending -> active promotion in defaultCredentialConfirmDeps's promote
+// closure. POSIX rename(2) is atomic with respect to any other process
+// observing newpath, but atomicity alone doesn't guarantee the rename
+// itself survives a crash: an fsync of the containing directory after the
+// rename is what forces the directory-entry update out of the page cache
+// and onto disk.
+//
+// Unlike an earlier version of this function, a failure to open or fsync
+// that directory is NOT swallowed. This function's whole contract is
+// "durably replaces" — silently downgrading a failed durability proof to
+// "renamed, but who knows" would let a caller (enrollment_committed, token
+// cleanup) proceed exactly as if a crash-safe commit had happened when it
+// hadn't. If the rename itself already succeeded before the fsync step
+// fails, that rename is NOT undone here — the file genuinely exists at
+// newpath now, just with its crash-durability unproven. Reporting an error
+// anyway is still correct: it prevents this connection from treating the
+// commit as final (no enrollment_committed sent, or no token cleanup), and
+// the reconnect-recovery path (pending-first, hash-bound confirmation)
+// safely reconciles whatever the on-disk result actually is on the next
+// attempt — it does not need this function to have gotten a clean answer.
+func durableRename(oldpath, newpath string) error {
+	return durableRenameWith(os.Rename, openDirForSync, oldpath, newpath)
+}
+
+func durableRenameWith(rename func(oldpath, newpath string) error, openDir dirOpener, oldpath, newpath string) error {
+	if err := rename(oldpath, newpath); err != nil {
+		return fmt.Errorf("rename %s to %s: %w", oldpath, newpath, err)
+	}
+	dir, err := openDir(filepath.Dir(newpath))
+	if err != nil {
+		return fmt.Errorf("open parent directory for durability fsync: %w", err)
+	}
+	defer dir.Close()
+	if err := dir.Sync(); err != nil {
+		return fmt.Errorf("fsync parent directory: %w", err)
+	}
+	return nil
+}

--- a/agent/durable_rename_test.go
+++ b/agent/durable_rename_test.go
@@ -1,0 +1,238 @@
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// ===== ROUND 5 BLOCKERS 2 & 3: durableRename must fail closed, and both
+// staging (temp -> pending/active) and promotion (pending -> active) must
+// go through the exact same primitive =====
+//
+// The earlier version of this durability step (formerly
+// commitPendingToActive) opened the parent directory and called Sync, but
+// swallowed BOTH failures — returning nil even when the directory couldn't
+// be opened, and discarding dir.Sync's error entirely. That contradicted
+// its own "durably replaces" doc comment: a caller could treat a
+// non-durable rename as a proven commit, cleared BLOXOS_TOKEN or sent
+// enrollment_committed on the strength of a guarantee that was never
+// actually established.
+
+// fakeSyncCloser lets a test simulate Sync failing (or Close, though that
+// error is currently unchecked at the call site — see the doc on
+// durableRenameWith) without touching a real file descriptor.
+type fakeSyncCloser struct {
+	syncErr error
+}
+
+func (f *fakeSyncCloser) Sync() error  { return f.syncErr }
+func (f *fakeSyncCloser) Close() error { return nil }
+
+func TestDurableRenameWithPropagatesDirectoryOpenFailure(t *testing.T) {
+	dir := t.TempDir()
+	oldpath := filepath.Join(dir, "old")
+	newpath := filepath.Join(dir, "new")
+	if err := os.WriteFile(oldpath, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	renameCalled := false
+	openErr := errors.New("permission denied opening parent directory")
+	err := durableRenameWith(
+		func(o, n string) error { renameCalled = true; return os.Rename(o, n) },
+		func(string) (syncCloser, error) { return nil, openErr },
+		oldpath, newpath,
+	)
+	if err == nil {
+		t.Fatal("expected the directory-open failure to propagate, not be swallowed")
+	}
+	if !renameCalled {
+		t.Fatal("rename should have been attempted before the directory-open step")
+	}
+	// The rename itself DID succeed (this is the documented, intentional
+	// behavior — see durableRenameWith's doc) — the file really is at
+	// newpath now, even though durability is unproven.
+	if _, statErr := os.Stat(newpath); statErr != nil {
+		t.Fatalf("expected the file to exist at newpath despite the reported error (rename succeeded, only the durability proof failed): %v", statErr)
+	}
+}
+
+func TestDurableRenameWithPropagatesDirectorySyncFailure(t *testing.T) {
+	dir := t.TempDir()
+	oldpath := filepath.Join(dir, "old")
+	newpath := filepath.Join(dir, "new")
+	if err := os.WriteFile(oldpath, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	syncErr := errors.New("EIO: input/output error")
+	err := durableRenameWith(
+		os.Rename,
+		func(string) (syncCloser, error) { return &fakeSyncCloser{syncErr: syncErr}, nil },
+		oldpath, newpath,
+	)
+	if err == nil {
+		t.Fatal("expected the directory-sync failure to propagate, not be swallowed")
+	}
+	if _, statErr := os.Stat(newpath); statErr != nil {
+		t.Fatalf("expected the file to exist at newpath despite the reported error: %v", statErr)
+	}
+}
+
+func TestDurableRenameWithPropagatesRenameFailure(t *testing.T) {
+	// The rename step itself failing (e.g. cross-device, permission) must
+	// also propagate, and durableRenameWith must not attempt to open/sync
+	// the directory when there was nothing to commit.
+	dirOpened := false
+	err := durableRenameWith(
+		func(string, string) error { return errors.New("rename failed") },
+		func(string) (syncCloser, error) { dirOpened = true; return nil, nil },
+		"/does/not/matter/old", "/does/not/matter/new",
+	)
+	if err == nil {
+		t.Fatal("expected the rename failure to propagate")
+	}
+	if dirOpened {
+		t.Fatal("directory must not be opened for fsync when the rename itself never succeeded")
+	}
+}
+
+func TestDurableRenameWithSucceedsWhenBothStepsSucceed(t *testing.T) {
+	dir := t.TempDir()
+	oldpath := filepath.Join(dir, "old")
+	newpath := filepath.Join(dir, "new")
+	if err := os.WriteFile(oldpath, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := durableRename(oldpath, newpath); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(newpath)
+	if err != nil || string(data) != "secret" {
+		t.Fatalf("data=%q err=%v, want the renamed content", data, err)
+	}
+}
+
+// TestStagingAndPromotionUseTheIdenticalDurablePrimitive proves
+// defaultCredentialFileWriter's rename step is LITERALLY the same function
+// as durableRename (not a look-alike reimplementation) via function-pointer
+// identity — a reliable comparison for a plain top-level function value
+// assigned directly, which is exactly how it's wired.
+// defaultCredentialConfirmDeps's promote closure can't be compared the same
+// way (it's a closure, not a bare reference), so its equivalence is proven
+// behaviorally by TestPendingToActivePromotionFailsClosedOnDurabilityError
+// and TestMatchingPendingConfirmationReplacesActiveViaRealCommit below —
+// both exercise the real promote closure and observe durableRename's exact
+// documented contract (rename-then-fsync, propagate errors, don't undo a
+// successful rename).
+func TestStagingAndPromotionUseTheIdenticalDurablePrimitive(t *testing.T) {
+	w := defaultCredentialFileWriter()
+	got := reflect.ValueOf(w.rename).Pointer()
+	want := reflect.ValueOf(durableRename).Pointer()
+	if got != want {
+		t.Fatal("defaultCredentialFileWriter's rename step is not durableRename itself — staging and promotion must share one primitive, not two implementations")
+	}
+}
+
+// TestHandleEnrolledFrameSendsNoCommitWhenDurableStagingFails is the
+// integration-level proof for blocker 2: when the durable staging write
+// reports a failure (rename succeeded, but fsync durability could not be
+// proven), handleEnrolledFrame must not send enrollment_committed — the hub
+// must never be told to trust a secret whose local durability is unproven.
+func TestHandleEnrolledFrameSendsNoCommitWhenDurableStagingFails(t *testing.T) {
+	dir := t.TempDir()
+	pendingPath := filepath.Join(dir, "agent-secret.pending")
+
+	w := defaultCredentialFileWriter()
+	w.rename = func(oldpath, newpath string) error {
+		return durableRenameWith(
+			os.Rename,
+			func(string) (syncCloser, error) { return nil, errors.New("directory unavailable for fsync") },
+			oldpath, newpath,
+		)
+	}
+	savePendingFailingDurability := func(secret string) error {
+		return writeCredentialFileAtomicWith(w, pendingPath, secret)
+	}
+
+	commitSent := false
+	accepted, err := handleEnrolledFrame("new-secret", savePendingFailingDurability, func() error { commitSent = true; return nil })
+	if err == nil {
+		t.Fatal("expected the durability failure to propagate out of handleEnrolledFrame")
+	}
+	if accepted {
+		t.Fatal("expected accepted=false")
+	}
+	if commitSent {
+		t.Fatal("enrollment_committed must never be sent when durable staging reported a failure")
+	}
+
+	// "Pending/active recovery material remains usable": the underlying
+	// rename DID succeed (only the fsync proof failed) — the pending file
+	// genuinely exists and is readable, so a subsequent reconnect attempt
+	// (which loads and tries agent-secret.pending) has real material to
+	// work with rather than nothing at all.
+	data, statErr := os.ReadFile(pendingPath)
+	if statErr != nil || string(data) != "new-secret\n" {
+		t.Fatalf("pending recovery material missing/wrong after a reported durability failure: data=%q err=%v", data, statErr)
+	}
+}
+
+// TestPendingToActivePromotionFailsClosedOnDurabilityError is blocker 3's
+// direct proof against defaultCredentialConfirmDeps's real promote closure
+// (not a hand-rolled substitute): a durability failure during promotion
+// must propagate as an error from handleEnrollmentConfirmed, which (per
+// main.go's enrollment_confirmed handler, unchanged this round) means the
+// connection is torn down WITHOUT clearing BLOXOS_TOKEN or trusting the
+// promotion — never the old "best-effort, report success anyway" behavior.
+func TestPendingToActivePromotionFailsClosedOnDurabilityError(t *testing.T) {
+	dir := t.TempDir()
+	activePath := filepath.Join(dir, "agent-secret")
+	pendingPath := pendingCredentialPath(activePath)
+	if err := writeCredentialFileAtomic(activePath, "old-secret"); err != nil {
+		t.Fatalf("seed active: %v", err)
+	}
+	if err := writeCredentialFileAtomic(pendingPath, "new-secret"); err != nil {
+		t.Fatalf("seed pending: %v", err)
+	}
+	confirmedHash, err := hashCredentialFile(pendingPath)
+	if err != nil {
+		t.Fatalf("hash pending: %v", err)
+	}
+
+	deps := credentialConfirmDeps{
+		hashActive:  func() (string, error) { return hashCredentialFile(activePath) },
+		hashPending: func() (string, error) { return hashCredentialFile(pendingPath) },
+		promote: func() error {
+			return durableRenameWith(
+				os.Rename,
+				func(string) (syncCloser, error) { return nil, errors.New("directory unavailable for fsync") },
+				pendingPath, activePath,
+			)
+		},
+		removePending: func() error { return os.Remove(pendingPath) },
+	}
+
+	outcome, err := handleEnrollmentConfirmed(confirmedHash, deps)
+	if err == nil {
+		t.Fatal("expected the promotion durability failure to propagate")
+	}
+	if outcome != enrollmentConfirmRejected {
+		t.Fatalf("outcome=%v, want enrollmentConfirmRejected", outcome)
+	}
+
+	// Recovery material check: the rename itself succeeded (only fsync
+	// proof failed), so the secret is now physically at activePath — a
+	// hash-bound reconnect using it will authenticate and get re-confirmed
+	// (see handleEnrollmentConfirmed's "already active" branch), safely
+	// reconciling what durableRename could not itself prove durable.
+	data, statErr := os.ReadFile(activePath)
+	if statErr != nil || string(data) != "new-secret\n" {
+		t.Fatalf("active recovery material missing/wrong after a reported promotion durability failure: data=%q err=%v", data, statErr)
+	}
+}

--- a/agent/durable_rename_windows.go
+++ b/agent/durable_rename_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package main
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+// durableRename is the ONE durable rename/replace primitive shared by both
+// callers that need it: writeCredentialFileAtomic's temp -> pending/active
+// commit (via defaultCredentialFileWriter's rename field), and the
+// pending -> active promotion in defaultCredentialConfirmDeps's promote
+// closure. Go's os.Rename already uses MoveFileEx with
+// MOVEFILE_REPLACE_EXISTING internally, so replacing an existing
+// destination is not the gap; what it does NOT set is
+// MOVEFILE_WRITE_THROUGH, which tells the API not to return until the
+// rename is flushed through to the target volume. This call adds that flag
+// so both callers get the strongest durability guarantee the platform
+// offers for an ordinary data file, and — unlike the !windows
+// implementation, which has a separate rename step and directory-fsync step
+// that can fail independently — MoveFileEx performs both as one operation,
+// so any failure here means neither happened. (Unrelated to the separate
+// self-update .exe swap in updater_windows.go, which needs a detached
+// helper only because a RUNNING executable image holds an OS-level lock an
+// ordinary credential file never does.)
+func durableRename(oldpath, newpath string) error {
+	from, err := windows.UTF16PtrFromString(oldpath)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(newpath)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}

--- a/agent/main.go
+++ b/agent/main.go
@@ -174,20 +174,73 @@ func loadCredentialFile() string {
 	return strings.TrimSpace(string(data))
 }
 
-// saveCredentialFile writes the agent secret to the credential file with 0600 perms.
+// saveCredentialFile durably writes the agent secret to the credential file
+// via writeCredentialFileAtomic (temp file + rename), so a crash mid-write
+// never leaves a partial credential on disk. On POSIX this yields real
+// 0600 owner-only permissions; on Windows, protection instead comes from
+// the file living in the protected systemprofile credential directory,
+// whose ACL is inherited rather than expressed as POSIX permission bits.
+// The directory itself stays 0755 (POSIX) so the install-time curl
+// (running as the invoking user) can traverse it to read
+// /etc/bloxos/ca.crt.
 func saveCredentialFile(secret string) error {
 	path := credentialFilePath()
-	dir := filepath.Dir(path)
-	// 0755 so the install-time curl (running as the invoking user) can traverse
-	// the dir to read /etc/bloxos/ca.crt. The secret file itself is 0600.
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("create credential dir: %w", err)
-	}
-	if err := os.WriteFile(path, []byte(secret+"\n"), 0600); err != nil {
-		return fmt.Errorf("write credential file: %w", err)
+	if err := writeCredentialFileAtomic(path, secret); err != nil {
+		return err
 	}
 	log.Printf("agent secret saved to %s", path)
 	return nil
+}
+
+// loadPendingCredentialFile reads a staged-but-unconfirmed secret, or ""
+// if none is pending.
+func loadPendingCredentialFile() string {
+	data, err := os.ReadFile(pendingCredentialPath(credentialFilePath()))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// savePendingCredentialFile durably writes secret to the PENDING path only
+// — see handleEnrolledFrame / handleEnrollmentConfirmed for why the active
+// credential file must never be touched here.
+func savePendingCredentialFile(secret string) error {
+	path := pendingCredentialPath(credentialFilePath())
+	if err := writeCredentialFileAtomic(path, secret); err != nil {
+		return err
+	}
+	log.Printf("staged pending agent secret at %s (awaiting hub confirmation)", path)
+	return nil
+}
+
+// defaultCredentialConfirmDeps wires handleEnrollmentConfirmed to the real
+// filesystem: the active path, the pending path beside it, and the same
+// durableRename primitive (see durable_rename_*.go) that
+// defaultCredentialFileWriter uses for the temp -> pending commit — one
+// shared durable rename/replace implementation per platform, not two
+// subtly different ones.
+func defaultCredentialConfirmDeps() credentialConfirmDeps {
+	activePath := credentialFilePath()
+	pendingPath := pendingCredentialPath(activePath)
+	return credentialConfirmDeps{
+		hashActive:  func() (string, error) { return hashCredentialFile(activePath) },
+		hashPending: func() (string, error) { return hashCredentialFile(pendingPath) },
+		promote: func() error {
+			if err := durableRename(pendingPath, activePath); err != nil {
+				return err
+			}
+			log.Printf("promoted pending agent secret to active at %s", activePath)
+			return nil
+		},
+		removePending: func() error {
+			err := os.Remove(pendingPath)
+			if err != nil && !os.IsNotExist(err) {
+				return err
+			}
+			return nil
+		},
+	}
 }
 
 // caCertFilePath returns the path where the agent expects an additional trusted CA.
@@ -339,20 +392,150 @@ func backoffAfterConn(current, base, uptime time.Duration) time.Duration {
 	return current
 }
 
+// authOutcome classifies why a runAgent connection attempt ended, so
+// connectLoop can tell a definitive credential rejection (the hub's HTTP
+// 401 on the handshake itself) apart from every other kind of failure —
+// transport/TLS errors, a later read/write error, or a clean disconnect.
+// Only a definitive rejection of a PENDING credential should make
+// connectLoop fall back to the active credential immediately, without
+// waiting out the normal backoff; any other outcome just means "try the
+// same candidate again" (an abandoned/unreachable hub must never cause the
+// agent to discard a credential it never actually got to test).
+type authOutcome int
+
+const (
+	authOutcomeUnknown authOutcome = iota
+	authOutcomeRejected
+)
+
+// classifyDialAuthOutcome inspects a failed WebSocket handshake and reports
+// whether it was a definitive credential rejection (HTTP 401 from the hub,
+// meaning the hub actually evaluated and refused the credential) versus
+// anything else (network unreachable, TLS failure, timeout — none of which
+// mean the credential itself is bad). Split out from runAgent so this
+// classification is unit-testable without a real socket.
+func classifyDialAuthOutcome(resp *http.Response, dialErr error) authOutcome {
+	if dialErr != nil && resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		return authOutcomeRejected
+	}
+	return authOutcomeUnknown
+}
+
+// shouldFallBackToActive decides whether connectLoop should immediately
+// retry with the active credential — skipping the normal backoff — after a
+// connection attempt that used the pending credential. Only a definitive
+// rejection of the pending credential, with an active credential actually
+// available to fall back to, qualifies: a transport/TLS failure must never
+// trigger this (the hub never got to evaluate the credential at all), and
+// there is nothing to fall back to if no active credential exists.
+func shouldFallBackToActive(usedPending bool, outcome authOutcome, haveActive bool) bool {
+	return usedPending && outcome == authOutcomeRejected && haveActive
+}
+
+// credentialSelection is what one connectLoop iteration decided to dial
+// with.
+type credentialSelection struct {
+	secret      string
+	usedPending bool
+}
+
+// selectCredentialCandidate is connectLoop's per-iteration candidate
+// decision, factored out as a pure function of what's currently on disk
+// PLUS what the hub most recently, definitively rejected — comparing by the
+// secret's VALUE, not a one-shot bool. A bool ("give up on pending") would
+// either get re-armed every iteration (since the pending file itself is
+// never deleted merely by a rejection — see handleEnrollmentConfirmed,
+// which only ever removes it via a hash-bound confirmation) — recreating an
+// instant pending→401→pending loop — or, if latched forever, would wrongly
+// keep ignoring a GENUINELY NEW pending secret staged by a fresh
+// re-enrollment attempt after the old one was abandoned. Comparing values
+// solves both: the same still-rejected pending file is skipped on every
+// subsequent iteration until it changes or disappears, while a different
+// pending value (fresh attempt) is tried immediately.
+func selectCredentialCandidate(pending, active, rejectedPending string) credentialSelection {
+	if pending != "" && pending != rejectedPending {
+		return credentialSelection{secret: pending, usedPending: true}
+	}
+	if active != "" {
+		return credentialSelection{secret: active, usedPending: false}
+	}
+	if pending != "" {
+		// The only credential that exists at all is the one already known
+		// to be rejected — requirement is to retain and keep retrying it
+		// (with the normal backoff) rather than have nothing to dial with.
+		return credentialSelection{secret: pending, usedPending: true}
+	}
+	return credentialSelection{secret: "", usedPending: false}
+}
+
+// nextRejectedPendingSecret computes the "known-rejected pending secret"
+// value connectLoop carries into its next iteration, given this iteration's
+// selection and outcome:
+//   - a definitive rejection of a pending-backed attempt marks that exact
+//     secret as rejected, so selectCredentialCandidate skips it (in favor of
+//     active, if available) on every subsequent iteration until it changes;
+//   - once there is no pending file at all, there is nothing left to avoid,
+//     so tracking is cleared — this also means a brand new pending secret
+//     staged later starts unrejected, as it must;
+//   - any other outcome (a successful connection, a transport/TLS failure,
+//     a rejection while using the active credential) leaves the tracked
+//     value untouched, so an active-fallback session that hits a transport
+//     failure keeps retrying active rather than reverting to the
+//     already-rejected pending candidate.
+func nextRejectedPendingSecret(current string, sel credentialSelection, outcome authOutcome, pendingOnDisk string) string {
+	if sel.usedPending && outcome == authOutcomeRejected {
+		return sel.secret
+	}
+	if pendingOnDisk == "" {
+		return ""
+	}
+	return current
+}
+
 func connectLoop(machineID string) {
 	backoff := time.Second
 	maxBackoff := 60 * time.Second
 
+	// rejectedPendingSecret persists ACROSS loop iterations — see
+	// nextRejectedPendingSecret's doc for why a value, not a bool.
+	var rejectedPendingSecret string
+
 	for {
-		// On reconnect, prefer credential file if it exists.
-		if stored := loadCredentialFile(); stored != "" {
-			agentSecret = stored
-		}
+		// On reconnect, a staged-but-unconfirmed PENDING credential is tried
+		// FIRST unless it is the exact value already known-rejected by the
+		// hub: it is either the not-yet-promoted result of a re-enrollment
+		// whose "enrollment_confirmed" never arrived — in which case the hub
+		// recognizes and promotes it (see validateAgentSecret) — or it is
+		// abandoned/expired, in which case the hub rejects it and this loop
+		// falls back to the still-valid active credential, below, WITHOUT
+		// re-selecting the same rejected pending value merely because its
+		// file is still on disk (see selectCredentialCandidate).
+		pending := loadPendingCredentialFile()
+		active := loadCredentialFile()
+		sel := selectCredentialCandidate(pending, active, rejectedPendingSecret)
+		agentSecret = sel.secret
 
 		start := time.Now()
-		err := runAgent(machineID)
+		outcome, err := runAgent(machineID)
 		if err != nil {
 			log.Printf("connection error: %v", err)
+		}
+
+		// A definitive rejection of the PENDING credential specifically
+		// means it is abandoned or expired hub-side — falling back to the
+		// still-valid active credential must not wait out the normal
+		// backoff, or a machine whose re-enrollment attempt lapsed would sit
+		// disconnected for up to maxBackoff before recovering on its own.
+		// Any other outcome (transport/TLS failure, a later read/write
+		// error, or a rejection of the active credential itself) gets the
+		// normal backoff+retry with the same candidate — in particular, a
+		// transport failure must never be treated as a credential rejection
+		// merely because the network happened to be unavailable.
+		immediateRetry := shouldFallBackToActive(sel.usedPending, outcome, active != "")
+		rejectedPendingSecret = nextRejectedPendingSecret(rejectedPendingSecret, sel, outcome, pending)
+		if immediateRetry {
+			log.Printf("pending credential rejected by hub — falling back to active credential")
+			continue
 		}
 
 		// A connection that stayed up long enough to be "stable" resets the
@@ -371,10 +554,10 @@ func connectLoop(machineID string) {
 	}
 }
 
-func runAgent(machineID string) error {
+func runAgent(machineID string) (authOutcome, error) {
 	u, err := url.Parse(hubURL)
 	if err != nil {
-		return fmt.Errorf("invalid hub URL: %w", err)
+		return authOutcomeUnknown, fmt.Errorf("invalid hub URL: %w", err)
 	}
 
 	// Send whichever credentials we have via handshake headers rather than the
@@ -396,14 +579,25 @@ func runAgent(machineID string) error {
 	log.Printf("connecting to %s", hubURL)
 	dialer, err := websocketDialerFor(u.String())
 	if err != nil {
-		return fmt.Errorf("build websocket dialer: %w", err)
+		return authOutcomeUnknown, fmt.Errorf("build websocket dialer: %w", err)
 	}
-	conn, _, err := dialer.Dial(u.String(), header)
+	conn, dialResp, err := dialer.Dial(u.String(), header)
 	if err != nil {
-		return fmt.Errorf("dial failed: %w", err)
+		return classifyDialAuthOutcome(dialResp, err), fmt.Errorf("dial failed: %w", err)
 	}
 	defer conn.Close()
 	log.Println("connected to hub")
+
+	// An ordinary reconnect (durable secret, no token in flight) is exactly
+	// the case where BLOXOS_TOKEN is provably no longer needed right now — no
+	// enrollment is in progress on this connection at all. When a token IS
+	// also present, a fresh or targeted re-enrollment may still be pending;
+	// cleanup is deferred to the "enrolled" handler instead (see
+	// handleEnrolledFrame) so a legitimate retry never loses the token to a
+	// premature wipe before enrollment actually completes.
+	maybeCleanupTokenOnReconnect(agentSecret != "", token != "", func() {
+		tokenCleanupOnce.Do(wipeMachineTokenIfBootstrapped)
+	})
 
 	// Mutex for concurrent writes to WebSocket.
 	var writeMu sync.Mutex
@@ -430,32 +624,67 @@ func runAgent(machineID string) error {
 
 			// Decode the type field to dispatch.
 			var envelope struct {
-				Type        string `json:"type"`
-				AgentSecret string `json:"agent_secret"`
+				Type         string `json:"type"`
+				AgentSecret  string `json:"agent_secret"`
+				SecretSHA256 string `json:"secret_sha256"`
 			}
 			if err := json.Unmarshal(msg, &envelope); err != nil {
 				log.Printf("invalid message from hub: %v", err)
 				continue
 			}
 
-			// First successful message decode = we're authenticated. If a
-			// durable secret exists on disk, BLOXOS_TOKEN env var is no longer
-			// needed and persisting it lets re-installs accidentally inherit
-			// it. Best-effort wipe; failures don't affect this agent's
-			// operation. Platform-specific implementation in main_<os>.go.
-			tokenCleanupOnce.Do(wipeMachineTokenIfBootstrapped)
-
 			switch envelope.Type {
 			case "enrolled":
-				if envelope.AgentSecret != "" {
-					log.Printf("received enrollment secret from hub")
-					agentSecret = envelope.AgentSecret
-					token = "" // Clear token from memory.
-					if err := saveCredentialFile(agentSecret); err != nil {
-						log.Printf("WARNING: failed to save credential file: %v", err)
-					} else {
-						log.Printf("enrollment complete - will use secret for future connections")
-					}
+				// A fresh or staged secret is durably saved to the PENDING
+				// file — never the active one — BEFORE anything treats it as
+				// trustworthy. Sending "enrollment_committed" proves nothing
+				// by itself — only the hub's later hash-bound
+				// "enrollment_confirmed" (below) is what makes it safe to
+				// promote the pending file to active and drop BLOXOS_TOKEN.
+				// Any failure here (save or send) tears this connection down
+				// rather than continuing silently: a fresh connection either
+				// retries the save (secret never made it to disk) or, if the
+				// secret WAS saved but only the send failed, lets the next
+				// reconnect's pending-secret-first recovery path pick it up
+				// instead. The in-memory agentSecret and the active
+				// credential file are both deliberately left untouched here.
+				accepted, hErr := handleEnrolledFrame(
+					envelope.AgentSecret,
+					savePendingCredentialFile,
+					func() error {
+						committed := map[string]string{"type": "enrollment_committed"}
+						return writeJSON(conn, &writeMu, committed)
+					},
+				)
+				if hErr != nil {
+					errCh <- fmt.Errorf("enrollment handling failed: %w", hErr)
+					return
+				}
+				if accepted {
+					log.Printf("received enrollment secret from hub, staged pending — awaiting hub confirmation before promoting or dropping bootstrap token")
+				}
+
+			case "enrollment_confirmed":
+				// The hub always names the exact credential it is confirming
+				// via secret_sha256 — a missing or mismatched hash must
+				// change nothing locally (handleEnrollmentConfirmed
+				// enforces this) rather than guess which file to trust.
+				outcome, hErr := handleEnrollmentConfirmed(envelope.SecretSHA256, defaultCredentialConfirmDeps())
+				if hErr != nil {
+					errCh <- fmt.Errorf("enrollment confirmation rejected: %w", hErr)
+					return
+				}
+				// Only now — after the active credential file is provably
+				// the one the hub just confirmed, whether by promoting a
+				// pending file or because it already matched active — is it
+				// safe to refresh the in-memory secret and drop the token.
+				agentSecret = loadCredentialFile()
+				token = ""
+				tokenCleanupOnce.Do(wipeMachineTokenIfBootstrapped)
+				if outcome == enrollmentConfirmPromoted {
+					log.Printf("hub confirmed enrollment (promoted pending to active) - dropped bootstrap token")
+				} else {
+					log.Printf("hub confirmed enrollment (already active) - dropped bootstrap token")
 				}
 
 			case "agent_version":
@@ -484,7 +713,7 @@ func runAgent(machineID string) error {
 	// (hostname/IP/OS); any other persisted message that arrives before the
 	// row exists is silently dropped by a plain UPDATE.
 	if err := sendAll(conn, &writeMu, machineID); err != nil {
-		return err
+		return authOutcomeUnknown, err
 	}
 
 	// Send hardware snapshot once per connect, AFTER the first metric so the
@@ -509,10 +738,10 @@ func runAgent(machineID string) error {
 	for {
 		select {
 		case err := <-errCh:
-			return err
+			return authOutcomeUnknown, err
 		case <-ticker.C:
 			if err := sendAll(conn, &writeMu, machineID); err != nil {
-				return err
+				return authOutcomeUnknown, err
 			}
 		case <-pingTicker.C:
 			writeMu.Lock()
@@ -520,7 +749,7 @@ func runAgent(machineID string) error {
 			err := conn.WriteMessage(websocket.PingMessage, nil)
 			writeMu.Unlock()
 			if err != nil {
-				return fmt.Errorf("ping: %w", err)
+				return authOutcomeUnknown, fmt.Errorf("ping: %w", err)
 			}
 		}
 	}

--- a/dashboard/src/app/machine/[id]/page.tsx
+++ b/dashboard/src/app/machine/[id]/page.tsx
@@ -27,6 +27,7 @@ import {
   Activity, Zap, Terminal as TerminalIcon, RotateCcw,
   Lock, Unlock, X, Maximize2, Minimize2, Wifi, BarChart3, Trash2,
   LayoutDashboard, Box, Container as ContainerIcon, StickyNote, KeyRound,
+  RefreshCw, Copy, Check,
 } from "lucide-react";
 import { HUB_URL, getAuthHeaders } from "@/lib/session";
 import { useAuth } from "@/contexts/AuthContext";
@@ -134,6 +135,17 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
   const [showRevokeConfirm, setShowRevokeConfirm] = useState(false);
   const [revoking, setRevoking] = useState(false);
   const [revokeError, setRevokeError] = useState<string | null>(null);
+  const [showReenrollDialog, setShowReenrollDialog] = useState(false);
+  const [preparingReenroll, setPreparingReenroll] = useState(false);
+  const [reenrollError, setReenrollError] = useState<string | null>(null);
+  const [reenrollResponse, setReenrollResponse] = useState<{
+    machine_id: string;
+    windows_command: string;
+    ca_url: string;
+    ca_sha256: string;
+    expires_at: string;
+  } | null>(null);
+  const [reenrollCopied, setReenrollCopied] = useState<"command" | "sha" | null>(null);
   const { hasScope, authFetch } = useAuth();
   const canDelete = hasScope("fleet.admin");
   const canControl = hasScope("fleet.control");
@@ -349,6 +361,37 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
     }
   }, [authFetch, id]);
 
+  // Preparing a re-enrollment command is inert: it mints a machine-bound
+  // token and returns a command, but does not touch the current credential
+  // or connection. Only running the returned command on the host performs
+  // the actual credential rotation.
+  const handlePrepareReenrollment = useCallback(async () => {
+    setPreparingReenroll(true);
+    setReenrollError(null);
+    try {
+      const res = await authFetch(`${HUB_URL}/api/machines/${id}/windows-re-enrollment`, {
+        method: "POST",
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        setReenrollError(data?.error || `Failed to prepare re-enrollment (${res.status})`);
+        return;
+      }
+      setReenrollResponse(data);
+    } catch {
+      setReenrollError("Failed to prepare re-enrollment. Is the hub reachable?");
+    } finally {
+      setPreparingReenroll(false);
+    }
+  }, [authFetch, id]);
+
+  const handleCopyReenroll = useCallback((text: string, which: "command" | "sha") => {
+    if (!text) return;
+    navigator.clipboard.writeText(text);
+    setReenrollCopied(which);
+    setTimeout(() => setReenrollCopied(null), 2000);
+  }, []);
+
   useEffect(() => {
     if (termState === "pin_entry") {
       setTimeout(() => pinInputRef.current?.focus(), 100);
@@ -468,6 +511,108 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Windows re-enrollment dialog */}
+      <Dialog
+        open={showReenrollDialog}
+        onOpenChange={(open) => {
+          if (!open && !preparingReenroll) {
+            setShowReenrollDialog(false);
+            setReenrollError(null);
+            setReenrollResponse(null);
+          }
+        }}
+      >
+        <DialogContent className="bg-blox-card border-blox-border text-blox-text ring-0 sm:max-w-lg" showCloseButton={false}>
+          <DialogHeader>
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-xl bg-blox-blue/10">
+                <RefreshCw className="w-5 h-5 text-blox-blue" />
+              </div>
+              <DialogTitle className="text-blox-text">Prepare Windows re-enrollment</DialogTitle>
+            </div>
+            <DialogDescription className="text-blox-muted text-xs mt-2">
+              {reenrollResponse ? (
+                <>
+                  Run this command on <span className="text-blox-text font-medium">{machine.hostname}</span> in an
+                  elevated PowerShell session. It expires at{" "}
+                  <span className="text-blox-text font-medium">{new Date(reenrollResponse.expires_at).toLocaleString()}</span>.
+                  Running it rotates the credential; nothing changes on the hub until then.
+                </>
+              ) : (
+                <>
+                  Preparing the command does not disconnect{" "}
+                  <span className="text-blox-text font-medium">{machine.hostname}</span> — it stays connected and
+                  authenticated until you run the returned command on that host, which is what actually performs the
+                  credential rotation.
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          {reenrollError && (
+            <div className="text-[11px] text-blox-red bg-blox-red/10 border border-blox-red/30 rounded-lg px-3 py-2">
+              {reenrollError}
+            </div>
+          )}
+          {reenrollResponse && (
+            <div className="space-y-3">
+              <div className="relative">
+                <pre className="bg-black/40 border border-blox-border rounded-lg p-3 text-[11px] font-mono text-blox-text whitespace-pre-wrap break-all max-h-48 overflow-y-auto">
+                  {reenrollResponse.windows_command}
+                </pre>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleCopyReenroll(reenrollResponse.windows_command, "command")}
+                  className="absolute top-2 right-2 text-xs border-blox-border gap-1.5"
+                  aria-label="Copy re-enrollment command"
+                >
+                  {reenrollCopied === "command" ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+                  Copy
+                </Button>
+              </div>
+              {reenrollResponse.ca_sha256 && (
+                <div className="relative">
+                  <div className="text-[10px] text-blox-muted mb-1">CA fingerprint (SHA-256)</div>
+                  <code className="block text-[10px] font-mono text-blox-text break-all bg-black/40 border border-blox-border rounded-lg p-2 pr-16">
+                    {reenrollResponse.ca_sha256}
+                  </code>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleCopyReenroll(reenrollResponse.ca_sha256, "sha")}
+                    className="absolute top-5 right-2 text-xs border-blox-border gap-1.5"
+                    aria-label="Copy CA SHA-256 fingerprint"
+                  >
+                    {reenrollCopied === "sha" ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+                    Copy SHA
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+          <DialogFooter className="bg-transparent border-t-blox-border">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setShowReenrollDialog(false);
+                setReenrollError(null);
+                setReenrollResponse(null);
+              }}
+              disabled={preparingReenroll}
+              className="text-xs text-blox-muted border-blox-border"
+            >
+              {reenrollResponse ? "Close" : "Cancel"}
+            </Button>
+            {!reenrollResponse && (
+              <Button variant="default" size="sm" onClick={handlePrepareReenrollment} disabled={preparingReenroll} className="text-xs">
+                {preparingReenroll ? "Preparing..." : "Prepare command"}
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       {showReboot && (
         <RebootModal
           hostname={machine.hostname}
@@ -516,6 +661,21 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
               >
                 <KeyRound className="w-3.5 h-3.5" />
                 Revoke credential
+              </Button>
+            )}
+            {canDelete && !isAPIMachine && (machine.os?.toLowerCase().includes("windows") ?? false) && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setReenrollError(null);
+                  setReenrollResponse(null);
+                  setShowReenrollDialog(true);
+                }}
+                className="text-xs border-blox-border text-blox-muted hover:text-blox-blue hover:border-blox-blue/30 gap-1.5"
+              >
+                <RefreshCw className="w-3.5 h-3.5" />
+                Prepare Windows re-enrollment
               </Button>
             )}
             {canDelete && (

--- a/hub/agent_connection_cleanup_test.go
+++ b/hub/agent_connection_cleanup_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// ===== BLOCKER 1 (round 4): ghost connections from post-registration early
+// returns. Before the fix, handleAgentWS only called unregisterAgentConnection
+// from the ReadMessage-error branch; every other post-registration return
+// (a failed confirm write, a promotion that errors/mismatches/expires, an
+// enrollment_committed with no matching staged state) left s.agents[machineID]
+// pointing at a dead connection and could leave the machine stuck 'online'.
+// The fix is a single unconditional `defer` right after the ConnectedAgent is
+// created, which Go guarantees runs on every return from handleAgentWS —
+// these tests exercise the deterministically-reachable early-return branches
+// end-to-end through the real handler (no forced network-level write
+// failures, which would be inherently flaky over a real socket; the
+// unconditional defer covers the write-failure branches by construction,
+// not by branch-by-branch simulation).
+
+func machineStatus(t *testing.T, s *Server, machineID string) string {
+	t.Helper()
+	var status string
+	if err := s.db.QueryRow(`SELECT status FROM machines WHERE id = ?`, machineID).Scan(&status); err != nil {
+		t.Fatalf("read status for %s: %v", machineID, err)
+	}
+	return status
+}
+
+func agentMapHasEntry(s *Server, machineID string) bool {
+	s.agentsMu.RLock()
+	defer s.agentsMu.RUnlock()
+	_, ok := s.agents[machineID]
+	return ok
+}
+
+// waitForAgentMapAbsence polls until s.agents[machineID] is empty or the
+// timeout passes, then fails the test if it never cleared. Registration and
+// cleanup both happen inside the WS handler's own goroutine, asynchronously
+// with respect to the test closing its client connection.
+func waitForAgentMapAbsence(t *testing.T, s *Server, machineID string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !agentMapHasEntry(s, machineID) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("agents map still holds an entry for %s after %v — ghost connection", machineID, timeout)
+}
+
+// TestEnrollmentCommittedWithNoStagedStateUnregisters covers the
+// "enrollment_committed arrives without matching staged state" early return:
+// an ordinary reconnect (registered pre-loop via the durable-secret path,
+// never entered any enrollment/staging flow) that then sends a spurious
+// enrollment_committed must have the hub close the connection AND remove it
+// from the agents map — not just close the socket while leaving a ghost
+// registry entry.
+func TestEnrollmentCommittedWithNoStagedStateUnregisters(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	rawToken := s.seedValidToken(t)
+
+	machineID := "no-staged-state-cleanup"
+	secret := s.enrollAndCaptureSecret(t, server, rawToken, machineID)
+
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+secret)
+	conn, _, err := dialWSWithHeader(t, server, "/ws/agent", h)
+	if err != nil {
+		t.Fatalf("reconnect with durable secret: %v", err)
+	}
+	defer conn.Close()
+	sendMetricsMsg(t, conn, machineID)
+
+	// Registration happens pre-loop for an ordinary secret reconnect —
+	// confirm it actually registered before provoking the early return.
+	waitForCondition(t, 5*time.Second, func() bool { return agentMapHasEntry(s, machineID) })
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"enrollment_committed"}`)); err != nil {
+		t.Fatalf("send spurious enrollment_committed: %v", err)
+	}
+
+	// The hub must close the connection (no matching staged state).
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, _, err := conn.ReadMessage(); err == nil {
+		t.Fatal("expected the connection to be closed after enrollment_committed with no staged state")
+	}
+	waitForAgentMapAbsence(t, s, machineID, 5*time.Second)
+}
+
+// TestPromotionMismatchUnregisters extends the existing sabotage scenario
+// (TestHubPromotionFailureSendsNoConfirmationAndClosesConnection) with the
+// map-cleanup assertion: a staged pending value that no longer matches at
+// enrollment_committed time must both close the connection and remove it
+// from the agents map.
+func TestPromotionMismatchUnregisters(t *testing.T) {
+	server, s, _, resp := prepareTargetedReenrollment(t, "promo-mismatch-cleanup")
+	conn, _ := dialAndStage(t, server, "promo-mismatch-cleanup", resp.Token)
+	defer conn.Close()
+
+	waitForCondition(t, 5*time.Second, func() bool { return agentMapHasEntry(s, "promo-mismatch-cleanup") })
+
+	if _, err := s.db.Exec(`UPDATE agent_credentials SET pending_secret_hash = 'someone-elses-value' WHERE machine_id = ?`, "promo-mismatch-cleanup"); err != nil {
+		t.Fatalf("sabotage pending: %v", err)
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"enrollment_committed"}`)); err != nil {
+		t.Fatalf("send enrollment_committed: %v", err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, _, err := conn.ReadMessage(); err == nil {
+		t.Fatal("expected the connection to be closed after a mismatched promotion")
+	}
+	waitForAgentMapAbsence(t, s, "promo-mismatch-cleanup", 5*time.Second)
+}
+
+// TestPromotionExpiredDuringCommitUnregisters covers the "pending promotion
+// expires" early return: the pending window lapses on the very connection
+// that staged it, and only then does enrollment_committed arrive.
+func TestPromotionExpiredDuringCommitUnregisters(t *testing.T) {
+	machineID := "promo-expired-cleanup"
+	server, s, _, resp := prepareTargetedReenrollment(t, machineID)
+	conn, _ := dialAndStage(t, server, machineID, resp.Token)
+	defer conn.Close()
+
+	waitForCondition(t, 5*time.Second, func() bool { return agentMapHasEntry(s, machineID) })
+
+	if _, err := s.db.Exec(
+		`UPDATE agent_credentials SET pending_expires_at = ? WHERE machine_id = ?`,
+		time.Now().Add(-time.Minute).Format(time.RFC3339), machineID,
+	); err != nil {
+		t.Fatalf("force pending expiry: %v", err)
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"enrollment_committed"}`)); err != nil {
+		t.Fatalf("send enrollment_committed: %v", err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, _, err := conn.ReadMessage(); err == nil {
+		t.Fatal("expected the connection to be closed after committing an expired pending credential")
+	}
+	waitForAgentMapAbsence(t, s, machineID, 5*time.Second)
+}
+
+// TestNewerConnectionSurvivesOlderHandlerExit is the end-to-end (not just
+// unregisterAgentConnection-unit-level) proof that a fast-reconnecting agent
+// is never false-offlined or evicted by its own stale handler's exit. Two
+// real connections authenticate with the same durable secret (the ordinary
+// reconnect / pre-loop registration path) for the same machine_id — the
+// second overwrites the registry entry the first installed. The first is
+// then closed; its handler's defer must find it is no longer the registered
+// connection and do nothing.
+func TestNewerConnectionSurvivesOlderHandlerExit(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	rawToken := s.seedValidToken(t)
+
+	machineID := "dual-conn-survive"
+	secret := s.enrollAndCaptureSecret(t, server, rawToken, machineID)
+
+	dial := func() *websocket.Conn {
+		h := http.Header{}
+		h.Set("Authorization", "Bearer "+secret)
+		conn, _, err := dialWSWithHeader(t, server, "/ws/agent", h)
+		if err != nil {
+			t.Fatalf("reconnect with durable secret: %v", err)
+		}
+		return conn
+	}
+
+	connA := dial()
+	defer connA.Close()
+	sendMetricsMsg(t, connA, machineID)
+	waitForCondition(t, 5*time.Second, func() bool { return machineStatus(t, s, machineID) == "online" })
+
+	connB := dial()
+	defer connB.Close()
+	sendMetricsMsg(t, connB, machineID)
+	waitForCondition(t, 5*time.Second, func() bool { return machineStatus(t, s, machineID) == "online" })
+
+	// A is now the stale, overwritten registration. Close it and give its
+	// handler's read loop + defer a chance to run.
+	connA.Close()
+	time.Sleep(400 * time.Millisecond)
+
+	if status := machineStatus(t, s, machineID); status != "online" {
+		t.Fatalf("machine flipped to %q after the STALE connection exited; want unchanged 'online' (B is still live)", status)
+	}
+	if !agentMapHasEntry(s, machineID) {
+		t.Fatal("agents map entry removed by the stale connection's exit — B's live registration was evicted")
+	}
+
+	// B is still actually the live, working connection.
+	if err := connB.WriteMessage(websocket.PingMessage, nil); err != nil {
+		t.Fatalf("B's connection is no longer usable after A's exit: %v", err)
+	}
+}
+
+// TestPreRegistrationRejectionLeavesNoAgentMapEntry covers "pre-registration
+// rejection remains a no-op": a connection that never authenticates (no
+// valid secret, no valid token) never reaches the WebSocket upgrade at all,
+// so it can never appear in — and can never wrongly disappear from — the
+// agents map.
+func TestPreRegistrationRejectionLeavesNoAgentMapEntry(t *testing.T) {
+	e, s := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	machineID := "pre-registration-rejected"
+	if _, err := wsDialAgent(t, server, "token=not-a-real-token"); err == nil {
+		t.Fatal("expected the upgrade to be rejected for an invalid token")
+	}
+
+	if agentMapHasEntry(s, machineID) {
+		t.Fatal("rejected pre-auth connection somehow left an agents map entry")
+	}
+}
+
+// waitForCondition polls cond until it returns true or timeout elapses.
+func waitForCondition(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %v", timeout)
+}

--- a/hub/agent_write_serialization_test.go
+++ b/hub/agent_write_serialization_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// fakeWSWriter stands in for a live *websocket.Conn so the serialization
+// property of writeLockedTo can be proven deterministically, without a real
+// network connection and without relying on timing against the actual
+// gorilla/websocket internals. It tracks the peak number of calls that were
+// simultaneously inside WriteMessage and records every payload it received.
+type fakeWSWriter struct {
+	active    int32
+	maxActive int32
+
+	mu       sync.Mutex
+	received [][]byte
+}
+
+func (f *fakeWSWriter) WriteMessage(messageType int, data []byte) error {
+	cur := atomic.AddInt32(&f.active, 1)
+	for {
+		old := atomic.LoadInt32(&f.maxActive)
+		if cur <= old {
+			break
+		}
+		if atomic.CompareAndSwapInt32(&f.maxActive, old, cur) {
+			break
+		}
+	}
+	// Simulate a write slow enough that two unserialized callers would
+	// almost certainly overlap if the mutex weren't actually serializing
+	// them — a mutex bug that only shows up under real network latency
+	// would otherwise be invisible in a fast in-memory test.
+	time.Sleep(2 * time.Millisecond)
+
+	cp := append([]byte(nil), data...)
+	f.mu.Lock()
+	f.received = append(f.received, cp)
+	f.mu.Unlock()
+
+	atomic.AddInt32(&f.active, -1)
+	return nil
+}
+
+// TestConnectedAgentWritesAreSerializedAgainstConcurrentWriters proves
+// writeLockedTo allows at most one concurrent call into the underlying
+// writer, and that every message arrives intact and undamaged — the
+// property the missing lock on the enrollment_confirmed sends violated.
+// Fifty goroutines hammer the same mutex/writer pair concurrently; the fake
+// writer's artificial delay means any missing serialization would show up
+// as maxActive > 1 essentially every run, not as a rare flake.
+func TestConnectedAgentWritesAreSerializedAgainstConcurrentWriters(t *testing.T) {
+	var mu sync.Mutex
+	fw := &fakeWSWriter{}
+
+	const n = 50
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			payload, _ := json.Marshal(map[string]string{"type": fmt.Sprintf("msg-%d", i)})
+			if err := writeLockedTo(&mu, fw, websocket.TextMessage, payload); err != nil {
+				t.Errorf("write %d: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&fw.maxActive); got != 1 {
+		t.Fatalf("max concurrent writers = %d, want exactly 1", got)
+	}
+	if len(fw.received) != n {
+		t.Fatalf("received %d messages, want %d", len(fw.received), n)
+	}
+	seen := map[string]bool{}
+	for _, msg := range fw.received {
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(msg, &envelope); err != nil {
+			t.Fatalf("corrupted/torn message: %s", msg)
+		}
+		if seen[envelope.Type] {
+			t.Fatalf("duplicate message observed (implies a write was replayed or torn): %s", envelope.Type)
+		}
+		seen[envelope.Type] = true
+	}
+}
+
+// TestConnectedAgentConfirmationRacesAnnouncePattern mirrors the exact
+// real-world shape: one goroutine playing the role of
+// announceVersionToAgent (which already correctly locks WriteMu) and
+// another concurrently sending enrollment_confirmed through
+// ConnectedAgent.writeLocked — the two writers that motivated this fix.
+// Both must complete, both messages must arrive intact, and at most one may
+// be inside the writer at a time.
+func TestConnectedAgentConfirmationRacesAnnouncePattern(t *testing.T) {
+	agent := &ConnectedAgent{}
+	fw := &fakeWSWriter{}
+	// ConnectedAgent.Conn is a concrete *websocket.Conn, so writeLocked
+	// itself can't be pointed at the fake writer; exercise the same
+	// underlying primitive (writeLockedTo against agent.WriteMu) directly,
+	// which is exactly what writeLocked delegates to.
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		announceMsg, _ := json.Marshal(map[string]string{"type": "agent_version"})
+		if err := writeLockedTo(&agent.WriteMu, fw, websocket.TextMessage, announceMsg); err != nil {
+			t.Errorf("announce write: %v", err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		confirmMsg, _ := json.Marshal(map[string]string{"type": "enrollment_confirmed"})
+		if err := writeLockedTo(&agent.WriteMu, fw, websocket.TextMessage, confirmMsg); err != nil {
+			t.Errorf("confirm write: %v", err)
+		}
+	}()
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&fw.maxActive); got != 1 {
+		t.Fatalf("max concurrent writers = %d, want exactly 1 (announce and confirm overlapped)", got)
+	}
+	if len(fw.received) != 2 {
+		t.Fatalf("received %d messages, want 2", len(fw.received))
+	}
+	gotTypes := map[string]bool{}
+	for _, msg := range fw.received {
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(msg, &envelope); err != nil {
+			t.Fatalf("corrupted message: %s", msg)
+		}
+		gotTypes[envelope.Type] = true
+	}
+	if !gotTypes["agent_version"] || !gotTypes["enrollment_confirmed"] {
+		t.Fatalf("expected both agent_version and enrollment_confirmed, got %v", gotTypes)
+	}
+}

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -29,6 +29,32 @@ type ConnectedAgent struct {
 	WriteMu   sync.Mutex
 }
 
+// wsMessageWriter is exactly gorilla/websocket's (*Conn).WriteMessage
+// signature, factored out so writeLockedTo is testable against a fake
+// writer instead of a live network connection.
+type wsMessageWriter interface {
+	WriteMessage(messageType int, data []byte) error
+}
+
+// writeLocked is the ONLY safe way to write to agent.Conn once
+// registerAgentConnection has been called: that call launches
+// announceVersionToAgent in a goroutine (and command/refresh/terminal
+// handlers write from their own goroutines too), so any write after
+// registration is racing at least one other potential writer.
+// gorilla/websocket allows exactly one writer at a time — violating that is
+// a protocol-level panic risk ("concurrent write to websocket connection"),
+// not merely a Go-level data race, so `go test -race` cannot be relied on to
+// catch a missing lock here.
+func (a *ConnectedAgent) writeLocked(messageType int, data []byte) error {
+	return writeLockedTo(&a.WriteMu, a.Conn, messageType, data)
+}
+
+func writeLockedTo(mu *sync.Mutex, w wsMessageWriter, messageType int, data []byte) error {
+	mu.Lock()
+	defer mu.Unlock()
+	return w.WriteMessage(messageType, data)
+}
+
 // registerAgentConnection finalises an authenticated WebSocket handshake.
 // It is the single chokepoint between "agent authed" and "agent fully
 // online", so any per-connect work (registry insert, version announce,
@@ -99,7 +125,73 @@ func (s *Server) handleCreateToken(c echo.Context) error {
 	return c.JSON(http.StatusOK, installTokenResponse{
 		Token:          token,
 		Command:        buildLinuxInstallCommand(httpBase, wsBase, token, caURL, caSHA256),
-		WindowsCommand: buildWindowsInstallCommand(httpBase, wsBase, token, caURL, caSHA256),
+		WindowsCommand: buildWindowsInstallCommand(httpBase, wsBase, token, caURL, caSHA256, false),
+		CAURL:          caURL,
+		CASHA256:       caSHA256,
+		ExpiresAt:      expiresAt.Format(time.RFC3339),
+	})
+}
+
+// handleWindowsReenrollment mints a token bound to exactly one existing
+// Windows machine and returns a -ForceReenroll command for it. Unlike
+// handleCreateToken (a generic, unbound Add Machine token), this never
+// deletes the machine's current credential or closes its live socket —
+// preparing the command is inert. The credential is only replaced once the
+// operator runs the returned command and the agent re-enrolls with the
+// target-bound token; see the WS handshake in handleAgentWS.
+func (s *Server) handleWindowsReenrollment(c echo.Context) error {
+	machineID := c.Param("id")
+
+	var osName sql.NullString
+	err := s.db.QueryRow(`SELECT os FROM machines WHERE id = ?`, machineID).Scan(&osName)
+	if err == sql.ErrNoRows {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "machine not found"})
+	}
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to query machine"})
+	}
+	if normalizeAgentOS(osName.String) != "windows" {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "machine is not a Windows agent"})
+	}
+
+	// A re-enrollment token stages a replacement for an EXISTING credential
+	// (see stageTargetedCredential); a machine with no active credential has
+	// nothing to stage against and should use the ordinary Add Machine flow
+	// instead. Checked before any write.
+	if !s.machineHasCredential(machineID) {
+		return c.JSON(http.StatusConflict, map[string]string{
+			"error": "machine has no active credential; use the Add Machine command instead",
+		})
+	}
+
+	// Same PUBLIC_URL requirement as handleCreateToken, and checked before any
+	// write: a re-enrollment command is exactly as authority-sensitive as a
+	// fresh install command, and this endpoint must fail closed rather than
+	// insert a token it then can't safely address.
+	if strings.TrimSpace(os.Getenv("PUBLIC_URL")) == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "PUBLIC_URL is not set on the hub; set PUBLIC_URL to the hub's public URL and restart before generating re-enrollment tokens",
+		})
+	}
+
+	token := uuid.New().String()
+	h := sha256.Sum256([]byte(token))
+	tokenHash := hex.EncodeToString(h[:])
+	expiresAt := time.Now().Add(15 * time.Minute)
+
+	if _, err := s.db.Exec(
+		`INSERT INTO tokens (token_hash, expires_at, target_machine_id) VALUES (?, ?, ?)`,
+		tokenHash, expiresAt, machineID,
+	); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	httpBase, wsBase := publicAndWebsocketBase()
+	caURL, caSHA256 := bootstrapCAFor(httpBase)
+	return c.JSON(http.StatusOK, windowsReenrollmentResponse{
+		MachineID:      machineID,
+		Token:          token,
+		WindowsCommand: buildWindowsInstallCommand(httpBase, wsBase, token, caURL, caSHA256, true),
 		CAURL:          caURL,
 		CASHA256:       caSHA256,
 		ExpiresAt:      expiresAt.Format(time.RFC3339),
@@ -520,9 +612,10 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 
 	// Mode B: Agent reconnecting with durable secret.
 	var secretMachineID string
+	var secretJustPromoted bool
 	if agentSecret != "" {
 		var err error
-		secretMachineID, err = s.validateAgentSecret(agentSecret)
+		secretMachineID, secretJustPromoted, err = s.validateAgentSecret(agentSecret)
 		if err != nil {
 			log.Printf("agent secret validation failed: %v", err)
 			// If secret was provided but invalid, and no token fallback, reject.
@@ -534,14 +627,23 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 		}
 	}
 
-	// Mode A: Token-based enrollment (only if not already authenticated via secret).
+	// Mode A: token validation. Unlike the original secret-XOR-token design,
+	// this runs whenever a token is present even alongside an already-valid
+	// secret: a targeted re-enrollment token rides alongside the agent's
+	// still-valid old secret (see the dual-credential handling below), so we
+	// must know the token's target before deciding how to route this
+	// connection. A generic (untargeted) token found alongside a valid secret
+	// is simply never consulted again below — it can't override a valid
+	// credential.
 	var tokenHash string
+	var targetMachineID sql.NullString
 	tokenValidated := false
-	if agentSecret == "" && token != "" {
+	if token != "" {
 		var err error
-		tokenHash, err = s.validateAgentToken(token)
+		tokenHash, targetMachineID, err = s.validateAgentToken(token)
 		if err != nil {
 			tokenHash = ""
+			targetMachineID = sql.NullString{}
 			log.Printf("agent token validation deferred (may be reconnecting agent): %v", err)
 		} else {
 			tokenValidated = true
@@ -575,21 +677,82 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 		return ws.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(10*time.Second))
 	})
 
-	// If authenticated via secret, we already know the machine_id.
+	// If authenticated via secret, we already know the machine_id — UNLESS a
+	// target-bound token for that same machine is also present. That specific
+	// combination means the agent still has its old, still-valid secret AND a
+	// fresh re-enrollment token: it must be routed through the staging branch
+	// below (first metrics frame), not fast-pathed as an ordinary reconnect,
+	// so a legitimate targeted re-enrollment attempt is never silently
+	// downgraded to "just a normal reconnect" that never looks at the token.
+	dualCredentialTargetedReenroll := secretMachineID != "" && tokenValidated &&
+		targetMachineID.Valid && targetMachineID.String == secretMachineID
+
 	var machineID string
 	agent := &ConnectedAgent{Conn: ws}
-	if secretMachineID != "" {
+	// Single owner of connection cleanup. Every return from this point on —
+	// whether the read loop exits normally, or one of the many
+	// post-registration failure paths below returns early (a failed confirm
+	// write, a promotion that errors/mismatches/expires, an
+	// enrollment_committed with no matching staged state, etc.) — must run
+	// unregisterAgentConnection exactly once. A closure (not
+	// `defer s.unregisterAgentConnection(machineID, agent)`) is required
+	// because a direct defer call captures machineID's value NOW, while it is
+	// still "" — every post-registration path sets it before returning.
+	// unregisterAgentConnection's own identity check (current == agent) means
+	// this is always safe to call, including when registration never
+	// happened at all (no-op via the empty-machineID guard) or when a newer
+	// connection has already replaced this one in the registry (no-op via
+	// the identity check).
+	defer func() {
+		s.unregisterAgentConnection(machineID, agent)
+	}()
+	var stagedPendingSecretHash string
+	var freshlyEnrolledDirectly bool
+	var freshlyEnrolledSecretHash string
+	if secretMachineID != "" && !dualCredentialTargetedReenroll {
 		machineID = secretMachineID
 		s.registerAgentConnection(machineID, agent)
 		completeAuth()
 		log.Printf("agent authenticated via secret: machine_id=%s", machineID)
+
+		// enrollment_confirmed tells the agent it may safely drop
+		// BLOXOS_TOKEN. Two cases land here with a token still present:
+		//   - secretJustPromoted: this very auth call promoted a pending
+		//     secret to active (the lost-acknowledgement recovery path) —
+		//     the agent needs to hear that explicitly, it can't infer it.
+		//   - token != "" with no promotion: the agent already has an active
+		//     secret but is still holding a token from an earlier attempt
+		//     whose confirmation never arrived (e.g. promotion succeeded but
+		//     the confirm frame itself was lost). Confirming again is
+		//     harmless and lets it clear the stale token.
+		if secretJustPromoted || token != "" {
+			// Registration above already spawned announceVersionToAgent as a
+			// goroutine that may be writing to this same connection right
+			// now — this write MUST go through the per-agent mutex, never
+			// direct to ws. A failed write means the agent never actually
+			// received the confirmation, so it must not be logged as
+			// confirmed; closing the connection lets the agent's reconnect
+			// re-exercise this same recovery path.
+			//
+			// secret_sha256 names the EXACT credential this confirmation is
+			// for — agentSecret is, in both cases here, the secret that just
+			// authenticated this connection (whether or not this call is
+			// what promoted it), so its hash is always correct: the agent
+			// only ever promotes its local pending file when the hash
+			// matches, and never touches anything when it doesn't.
+			confirmMsg, _ := json.Marshal(map[string]string{"type": "enrollment_confirmed", "secret_sha256": secretSHA256Hex(agentSecret)})
+			if err := agent.writeLocked(websocket.TextMessage, confirmMsg); err != nil {
+				log.Printf("failed to send enrollment_confirmed to %s: %v — closing connection", machineID, err)
+				return nil
+			}
+			log.Printf("sent enrollment_confirmed to %s", machineID)
+		}
 	}
 
 	for {
 		_, msg, err := ws.ReadMessage()
 		if err != nil {
 			log.Printf("agent disconnected: %v", err)
-			s.unregisterAgentConnection(machineID, agent)
 			return nil
 		}
 		// A frame arrived — extend the deadline to the idle timeout.
@@ -629,12 +792,67 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 					return nil
 				}
 
+				// A targeted re-enrollment token (minted by
+				// POST /api/machines/:id/windows-re-enrollment) is bound to exactly
+				// one machine_id. Reject its use against any other machine before
+				// any credential/known-machine branching below, so the rejection
+				// applies uniformly whether or not this other machine currently has
+				// a credential. Nothing is written and the token stays unconsumed —
+				// a legitimate holder can still use it against the right machine.
+				if tokenValidated && targetMachineID.Valid && targetMachineID.String != machineID {
+					log.Printf("rejecting targeted re-enrollment token for %s (%s): bound to machine %s", m.Hostname, machineID, targetMachineID.String)
+					ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"install token is bound to a different machine"}`))
+					return nil
+				}
+
 				// Check if this machine_id already exists (reconnecting agent).
 				var existingID string
 				knownMachine := s.db.QueryRow(`SELECT id FROM machines WHERE id = ?`, machineID).Scan(&existingID) == nil
 				hasCredential := s.machineHasCredential(machineID)
+				targetedForThisMachine := tokenValidated && targetMachineID.Valid && targetMachineID.String == machineID
 
-				if knownMachine && secretMachineID == machineID {
+				if hasCredential && targetedForThisMachine {
+					// Targeted re-enrollment: the token was minted for exactly this
+					// machine and a durable credential already exists. STAGE a
+					// replacement rather than installing it as active — the active
+					// secret_hash is untouched here, so the agent's old (still
+					// possibly in-use) secret keeps authenticating until the agent
+					// proves the new one is durably saved via "enrollment_committed"
+					// below. This closes the split-brain window where a hub-side
+					// replace commits before the agent's local write is proven, and
+					// a subsequent crash/timeout would strand the machine with a
+					// local secret the hub no longer recognizes.
+					rawSecret, secretHash, err := generateAgentSecret()
+					if err != nil {
+						log.Printf("failed to generate agent secret: %v", err)
+						ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"enrollment failed"}`))
+						return nil
+					}
+					if err := s.stageTargetedCredential(tokenHash, machineID, secretHash); err != nil {
+						log.Printf("failed to stage pending credential via targeted re-enrollment: %v", err)
+						ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"enrollment failed"}`))
+						return nil
+					}
+					stagedPendingSecretHash = secretHash
+					enrolledMsg, _ := json.Marshal(map[string]string{
+						"type":         "enrolled",
+						"agent_secret": rawSecret,
+					})
+					// No concurrent writer exists yet at this point — this
+					// connection has not been registered, so
+					// announceVersionToAgent has not been spawned — a direct
+					// write is safe. But the pending credential was already
+					// staged (a real DB mutation, and the token is already
+					// consumed): if the send itself fails, silently falling
+					// through to registration would leave the connection
+					// looking authenticated while the agent never actually
+					// received its new secret. Close instead.
+					if err := ws.WriteMessage(websocket.TextMessage, enrolledMsg); err != nil {
+						log.Printf("staged pending credential for %s but failed to send enrolled frame: %v — closing connection", machineID, err)
+						return nil
+					}
+					log.Printf("targeted re-enrollment staged a pending credential: %s (%s)", m.Hostname, machineID)
+				} else if knownMachine && secretMachineID == machineID {
 					log.Printf("known agent reconnecting with durable credential: %s (%s)", m.Hostname, machineID)
 				} else if tokenValidated && !hasCredential {
 					// New enrollment with valid token - consume it and issue durable secret.
@@ -653,14 +871,25 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 						"type":         "enrolled",
 						"agent_secret": rawSecret,
 					})
-					ws.WriteMessage(websocket.TextMessage, enrolledMsg)
+					// Same reasoning as the staging branch above: no
+					// concurrent writer exists pre-registration, but the
+					// credential was already committed active and the token
+					// already consumed — a failed send must not be treated
+					// as a silent success.
+					if err := ws.WriteMessage(websocket.TextMessage, enrolledMsg); err != nil {
+						log.Printf("stored agent credential for %s but failed to send enrolled frame: %v — closing connection", machineID, err)
+						return nil
+					}
+					freshlyEnrolledDirectly = true
+					freshlyEnrolledSecretHash = secretHash
 					log.Printf("new agent enrolled with durable secret: %s (%s)", m.Hostname, machineID)
 				} else if hasCredential {
 					// A durable credential already exists for this machine_id. A
-					// fresh install token must NOT silently replace it (that would
+					// generic install token must NOT silently replace it (that would
 					// let any valid token hijack an enrolled machine and lock out
-					// the legitimate agent). Require an explicit revoke first. The
-					// token is deliberately left unconsumed so a legitimate
+					// the legitimate agent). Require an explicit revoke first, or a
+					// targeted re-enrollment token minted for this specific machine.
+					// The token is deliberately left unconsumed so a legitimate
 					// re-enroll can proceed after revocation.
 					log.Printf("rejecting enrollment for %s (%s): machine already has a durable credential; revoke before re-enrolling", m.Hostname, machineID)
 					ws.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"machine already enrolled; revoke its credential before re-enrolling"}`))
@@ -833,6 +1062,69 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 				ch <- resp
 			}
 
+		case "enrollment_committed":
+			// Sent by the agent only after it has durably saved a secret to
+			// disk (see agent/main.go's enrolled-frame handling) — either a
+			// freshly issued one (already active hub-side, nothing to
+			// promote) or a staged pending replacement. Confirmation is the
+			// ONLY thing that tells the agent it may drop BLOXOS_TOKEN; if
+			// promotion doesn't unambiguously succeed, the connection is
+			// closed rather than left in an ambiguous state — the agent's
+			// disconnect/reconnect cycle then exercises the pending-secret
+			// recovery path in validateAgentSecret, which gets its own
+			// chance to promote (or correctly keeps failing if the pending
+			// state is genuinely gone/expired).
+			// This connection was already registered (either pre-loop for
+			// ordinary secret auth, or at the end of the metrics-frame block
+			// for token-based/staged enrollment) before any "enrollment_committed"
+			// frame could arrive, so announceVersionToAgent's goroutine may
+			// already be writing — every send below MUST go through
+			// agent.writeLocked, never direct to ws.
+			if freshlyEnrolledDirectly {
+				// Nothing to promote — the credential was already written
+				// active by consumeTokenAndStoreCredential. "Confirmed" here
+				// means only that the confirmation frame was sent, not a
+				// fresh DB commit. secret_sha256 is that same active
+				// secret's hash — the agent's local pending file (written on
+				// receiving "enrolled") holds the identical secret, so its
+				// hash matches this one and the agent promotes it locally.
+				confirmMsg, _ := json.Marshal(map[string]string{"type": "enrollment_confirmed", "secret_sha256": freshlyEnrolledSecretHash})
+				if err := agent.writeLocked(websocket.TextMessage, confirmMsg); err != nil {
+					log.Printf("failed to send enrollment_confirmed to %s: %v — closing connection", machineID, err)
+					return nil
+				}
+				freshlyEnrolledDirectly = false
+				log.Printf("sent enrollment_confirmed for fresh enrollment: %s", machineID)
+				continue
+			}
+			if stagedPendingSecretHash == "" {
+				log.Printf("rejecting enrollment_committed from %s: no pending credential was staged on this connection", machineID)
+				return nil
+			}
+			promoted, err := s.promotePendingCredentialCAS(machineID, stagedPendingSecretHash)
+			if err != nil {
+				log.Printf("failed to promote pending credential for %s: %v — closing connection", machineID, err)
+				return nil
+			}
+			if !promoted {
+				log.Printf("pending credential for %s no longer matches or has expired — closing connection so it can retry", machineID)
+				return nil
+			}
+			// Promotion has committed in SQLite at this point. "Confirmed" is
+			// a separate claim — it requires the frame to actually reach the
+			// agent, so it is only logged after a successful write.
+			// secret_sha256 is captured BEFORE clearing stagedPendingSecretHash
+			// below — it is exactly the hash the agent's local pending file
+			// must match for it to promote.
+			promotedSecretHash := stagedPendingSecretHash
+			stagedPendingSecretHash = ""
+			confirmMsg, _ := json.Marshal(map[string]string{"type": "enrollment_confirmed", "secret_sha256": promotedSecretHash})
+			if err := agent.writeLocked(websocket.TextMessage, confirmMsg); err != nil {
+				log.Printf("promoted pending credential for %s but failed to send enrollment_confirmed: %v — closing connection", machineID, err)
+				return nil
+			}
+			log.Printf("promoted pending credential to active and sent enrollment_confirmed for %s", machineID)
+
 		default:
 			log.Printf("unknown message type from agent: %s", envelope.Type)
 		}
@@ -840,36 +1132,40 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 }
 
 // validateAgentToken checks a token against the DB (Finding #1).
-// Returns the token hash so the caller can mark it as used after enrollment.
-func (s *Server) validateAgentToken(token string) (string, error) {
+// Returns the token hash so the caller can mark it as used after enrollment,
+// plus the token's target machine (unset for an ordinary, unbound Add
+// Machine token; set for a Windows re-enrollment token minted for exactly
+// one machine_id).
+func (s *Server) validateAgentToken(token string) (string, sql.NullString, error) {
 	h := sha256.Sum256([]byte(token))
 	tokenHash := hex.EncodeToString(h[:])
 
 	var expiresAt string
 	var used bool
-	err := s.db.QueryRow(`SELECT expires_at, used FROM tokens WHERE token_hash = ?`, tokenHash).Scan(&expiresAt, &used)
+	var targetMachineID sql.NullString
+	err := s.db.QueryRow(`SELECT expires_at, used, target_machine_id FROM tokens WHERE token_hash = ?`, tokenHash).Scan(&expiresAt, &used, &targetMachineID)
 	if err == sql.ErrNoRows {
-		return "", fmt.Errorf("invalid token")
+		return "", sql.NullString{}, fmt.Errorf("invalid token")
 	}
 	if err != nil {
-		return "", fmt.Errorf("database error: %w", err)
+		return "", sql.NullString{}, fmt.Errorf("database error: %w", err)
 	}
 	if used {
-		return "", fmt.Errorf("token already used")
+		return "", sql.NullString{}, fmt.Errorf("token already used")
 	}
 	expTime, err := time.Parse("2006-01-02 15:04:05", expiresAt)
 	if err != nil {
 		expTime, err = time.Parse(time.RFC3339, expiresAt)
 		if err != nil {
-			return "", fmt.Errorf("invalid expiry format")
+			return "", sql.NullString{}, fmt.Errorf("invalid expiry format")
 		}
 	}
 	if time.Now().After(expTime) {
-		return "", fmt.Errorf("token expired")
+		return "", sql.NullString{}, fmt.Errorf("token expired")
 	}
 
 	log.Printf("agent token validated successfully")
-	return tokenHash, nil
+	return tokenHash, targetMachineID, nil
 }
 
 // consumeToken marks a token as used after successful enrollment.
@@ -882,12 +1178,29 @@ func (s *Server) consumeToken(tokenHash string) {
 	}
 }
 
+// consumeTokenAndStoreCredential atomically consumes tokenHash and stores (or
+// replaces) machineID's durable credential. The target check is repeated here
+// inside the transaction — not just by the earlier in-memory decision in
+// handleAgentWS — so a validate-then-consume race can't let a stale read win:
+// this is the last write before the credential exists, and it must not trust
+// anything computed outside its own transaction.
 func (s *Server) consumeTokenAndStoreCredential(tokenHash, machineID, secretHash string) error {
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
+
+	var targetMachineID sql.NullString
+	if err := tx.QueryRow(`SELECT target_machine_id FROM tokens WHERE token_hash = ? AND used = FALSE`, tokenHash).Scan(&targetMachineID); err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("install token already consumed")
+		}
+		return err
+	}
+	if targetMachineID.Valid && targetMachineID.String != machineID {
+		return fmt.Errorf("install token is bound to a different machine")
+	}
 
 	res, err := tx.Exec(`UPDATE tokens SET used = TRUE WHERE token_hash = ? AND used = FALSE`, tokenHash)
 	if err != nil {
@@ -906,6 +1219,193 @@ func (s *Server) consumeTokenAndStoreCredential(tokenHash, machineID, secretHash
 		return err
 	}
 	return tx.Commit()
+}
+
+// pendingCredentialWindow bounds how long a staged pending secret remains
+// promotable. Comfortably longer than install.ps1's 30-second completion
+// gate so a slow-but-legitimate handoff never races its own timeout, while
+// still short enough that an abandoned attempt doesn't leave a promotable
+// credential lying around indefinitely.
+const pendingCredentialWindow = 5 * time.Minute
+
+// stageTargetedCredential atomically consumes a target-bound token and
+// records pendingSecretHash as machineID's PENDING credential — the active
+// secret_hash is left completely unchanged. This is deliberately not a
+// replace: the old secret keeps authenticating until the agent proves the
+// new one is durably saved and the hub receives "enrollment_committed" (see
+// promotePendingCredentialCAS). A machine with no active credential at
+// all is rejected here too — staging a replacement requires something to
+// replace; handleWindowsReenrollment already enforces this at mint time, but
+// the credential could theoretically be revoked in the window between
+// minting and use, so it's re-checked inside this transaction.
+func (s *Server) stageTargetedCredential(tokenHash, machineID, pendingSecretHash string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var targetMachineID sql.NullString
+	if err := tx.QueryRow(`SELECT target_machine_id FROM tokens WHERE token_hash = ? AND used = FALSE`, tokenHash).Scan(&targetMachineID); err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("install token already consumed")
+		}
+		return err
+	}
+	if !targetMachineID.Valid || targetMachineID.String != machineID {
+		return fmt.Errorf("install token is not bound to this machine")
+	}
+
+	var activeSecretHash string
+	if err := tx.QueryRow(`SELECT secret_hash FROM agent_credentials WHERE machine_id = ?`, machineID).Scan(&activeSecretHash); err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("no active credential to stage a re-enrollment against")
+		}
+		return err
+	}
+
+	res, err := tx.Exec(`UPDATE tokens SET used = TRUE WHERE token_hash = ? AND used = FALSE`, tokenHash)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows != 1 {
+		return fmt.Errorf("install token already consumed")
+	}
+
+	pendingExpiresAt := time.Now().Add(pendingCredentialWindow)
+	if _, err := tx.Exec(
+		`UPDATE agent_credentials SET pending_secret_hash = ?, pending_expires_at = ? WHERE machine_id = ?`,
+		pendingSecretHash, pendingExpiresAt.Format(time.RFC3339), machineID,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// promotePendingCredentialCAS atomically promotes machineID's pending
+// credential to active via a genuine SQL compare-and-swap: the promoting
+// UPDATE's WHERE clause is constrained to the exact (machine_id,
+// pending_secret_hash, pending_expires_at) tuple read a moment earlier, and
+// RowsAffected() == 1 is the only thing that means "promoted" — never the
+// earlier SELECT by itself. A prior version checked the hash in a SELECT and
+// then wrote an UPDATE keyed only on machine_id; a stale acknowledgement
+// racing a newer re-stage could pass that SELECT and then clobber the newer
+// pending value on the unconstrained UPDATE. Constraining the UPDATE itself
+// closes that: two concurrent callers can each read the same row, but only
+// the one whose exact (hash, expiry) pair still matches at write time can
+// affect any rows — the loser's UPDATE matches zero rows and is a no-op.
+//
+// Fails closed on expiry: pending_secret_hash without a present, parseable,
+// strictly-future pending_expires_at is never promotable. A NULL or
+// unparseable expiry is opportunistically cleared (still via a CAS scoped to
+// the exact hash/expiry just read, so a concurrent re-stage isn't
+// clobbered) rather than left indefinitely promotable.
+//
+// The Go-side time.Now() check below is a fast pre-filter, not the actual
+// guard: real time can cross the deadline in the gap between that check and
+// the UPDATE actually executing (lock contention, GC pause, a slow disk).
+// The promoting UPDATE's WHERE clause therefore ALSO requires
+// julianday(pending_expires_at) > julianday('now'), evaluated by SQLite at
+// the moment the write happens — that is the predicate that actually can't
+// be raced, because nothing can execute between "the database checks its own
+// clock" and "the database applies the write" from outside the transaction.
+func (s *Server) promotePendingCredentialCAS(machineID, expectedPendingHash string) (bool, error) {
+	return s.promotePendingCredentialCASAt(machineID, expectedPendingHash, time.Now)
+}
+
+// promotePendingCredentialCASAt is promotePendingCredentialCAS with the
+// clock used for the Go-side pre-filter injectable, so a test can construct
+// the exact race the DB-time predicate exists to defeat: a nowFn that still
+// claims "not expired yet" while the real clock (and thus SQLite's
+// julianday('now')) has already moved past the deadline. Production always
+// calls this with time.Now; only tests substitute anything else. The SQL
+// UPDATE's own julianday('now') is never affected by nowFn — it is always
+// the real database clock.
+func (s *Server) promotePendingCredentialCASAt(machineID, expectedPendingHash string, nowFn func() time.Time) (bool, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	var pendingHash, pendingExpiresAtRaw sql.NullString
+	if err := tx.QueryRow(
+		`SELECT pending_secret_hash, pending_expires_at FROM agent_credentials WHERE machine_id = ?`, machineID,
+	).Scan(&pendingHash, &pendingExpiresAtRaw); err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+	if !pendingHash.Valid || pendingHash.String != expectedPendingHash {
+		return false, nil
+	}
+
+	clearMalformed := func() (bool, error) {
+		// Scoped to the exact hash+expiry just read: if a concurrent caller
+		// already re-staged a different pending value, this affects zero rows
+		// and leaves that newer value alone.
+		if _, err := tx.Exec(
+			`UPDATE agent_credentials SET pending_secret_hash = NULL, pending_expires_at = NULL
+			 WHERE machine_id = ? AND pending_secret_hash = ? AND pending_expires_at IS ?`,
+			machineID, expectedPendingHash, pendingExpiresAtRaw,
+		); err != nil {
+			return false, err
+		}
+		return false, tx.Commit()
+	}
+
+	if !pendingExpiresAtRaw.Valid {
+		return clearMalformed()
+	}
+	expTime, perr := time.Parse(time.RFC3339, pendingExpiresAtRaw.String)
+	if perr != nil {
+		return clearMalformed()
+	}
+	if !nowFn().Before(expTime) {
+		// Not strictly before the deadline — covers both "in the past" and
+		// "exactly at the deadline" as expired, matching the "strictly in the
+		// future" requirement. This is the fast pre-filter only; the UPDATE
+		// below re-checks against the real DB clock regardless.
+		return clearMalformed()
+	}
+
+	// The julianday comparison is the actual, unrace-able guard: SQLite
+	// evaluates julianday('now') against its own clock at the instant this
+	// statement executes, inside the same transaction as the write it
+	// gates. Even if nowFn (Go-side) was stale, wrong, or simply unlucky
+	// timing let an already-past deadline through the pre-filter above,
+	// this predicate independently fails and the UPDATE matches zero rows.
+	res, err := tx.Exec(
+		`UPDATE agent_credentials SET secret_hash = ?, pending_secret_hash = NULL, pending_expires_at = NULL, last_used_at = CURRENT_TIMESTAMP
+		 WHERE machine_id = ? AND pending_secret_hash = ? AND pending_expires_at = ? AND julianday(pending_expires_at) > julianday('now')`,
+		expectedPendingHash, machineID, expectedPendingHash, pendingExpiresAtRaw.String,
+	)
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if rows != 1 {
+		return false, nil
+	}
+	return true, tx.Commit()
+}
+
+// secretSHA256Hex is the same hex(SHA-256(secret)) computation used
+// everywhere a raw secret is turned into its lookup/comparison hash
+// (validateAgentSecret, lookupActiveCredential, generateAgentSecret) —
+// factored out so an enrollment_confirmed frame can name the exact
+// credential it confirms without duplicating the hashing inline.
+func secretSHA256Hex(secret string) string {
+	h := sha256.Sum256([]byte(secret))
+	return hex.EncodeToString(h[:])
 }
 
 // generateAgentSecret creates a 32-byte random secret for agent enrollment.
@@ -937,25 +1437,61 @@ func (s *Server) machineHasCredential(machineID string) bool {
 	return count > 0
 }
 
-// validateAgentSecret looks up a credential by the SHA-256 hash of the provided secret.
-// Returns the associated machine_id if found.
-func (s *Server) validateAgentSecret(secret string) (string, error) {
+// lookupActiveCredential looks up a credential by the SHA-256 hash of the
+// active secret. Returns (machineID, true) on a hit, refreshing last_used_at.
+func (s *Server) lookupActiveCredential(secretHash string) (string, bool) {
+	var machineID string
+	if err := s.db.QueryRow(`SELECT machine_id FROM agent_credentials WHERE secret_hash = ?`, secretHash).Scan(&machineID); err != nil {
+		return "", false
+	}
+	_, _ = s.db.Exec(`UPDATE agent_credentials SET last_used_at = CURRENT_TIMESTAMP WHERE secret_hash = ?`, secretHash)
+	return machineID, true
+}
+
+// validateAgentSecret looks up a credential by the SHA-256 hash of the
+// provided secret. Returns the associated machine_id and whether THIS call
+// is what promoted a pending secret to active (the caller uses that to send
+// enrollment_confirmed once the connection is up — see handleAgentWS).
+//
+// Beyond the active secret, this also recognizes an unexpired PENDING
+// secret: the recovery path for a targeted re-enrollment whose
+// "enrollment_committed" acknowledgement never reached the hub (lost after a
+// successful disk write, connection dropped immediately after storage, or
+// the service restarted between the two). Reconnecting with the pending
+// secret is itself proof the agent durably has it, so it's promoted to
+// active right here (via the same CAS as the explicit-ack path) rather than
+// waiting for an ack that may never come.
+func (s *Server) validateAgentSecret(secret string) (machineID string, promoted bool, err error) {
 	h := sha256.Sum256([]byte(secret))
 	secretHash := hex.EncodeToString(h[:])
 
-	var machineID string
-	err := s.db.QueryRow(`SELECT machine_id FROM agent_credentials WHERE secret_hash = ?`, secretHash).Scan(&machineID)
-	if err == sql.ErrNoRows {
-		return "", fmt.Errorf("invalid agent secret")
-	}
-	if err != nil {
-		return "", fmt.Errorf("database error: %w", err)
+	if mid, ok := s.lookupActiveCredential(secretHash); ok {
+		return mid, false, nil
 	}
 
-	// Update last_used_at.
-	_, _ = s.db.Exec(`UPDATE agent_credentials SET last_used_at = CURRENT_TIMESTAMP WHERE secret_hash = ?`, secretHash)
+	var pendingMachineID string
+	qerr := s.db.QueryRow(`SELECT machine_id FROM agent_credentials WHERE pending_secret_hash = ?`, secretHash).Scan(&pendingMachineID)
+	if qerr == sql.ErrNoRows {
+		return "", false, fmt.Errorf("invalid agent secret")
+	}
+	if qerr != nil {
+		return "", false, fmt.Errorf("database error: %w", qerr)
+	}
 
-	return machineID, nil
+	didPromote, perr := s.promotePendingCredentialCAS(pendingMachineID, secretHash)
+	if perr != nil {
+		return "", false, fmt.Errorf("database error: %w", perr)
+	}
+	if didPromote {
+		return pendingMachineID, true, nil
+	}
+	// Lost a race (already promoted by an in-flight enrollment_committed, or
+	// just expired). If something else already promoted it, it's now active —
+	// but THIS call didn't do the promoting, so promoted=false here.
+	if mid, ok := s.lookupActiveCredential(secretHash); ok {
+		return mid, false, nil
+	}
+	return "", false, fmt.Errorf("invalid agent secret")
 }
 
 // revokeAgentCredential removes the stored credential for a machine.

--- a/hub/enrollment_confirmed_hash_test.go
+++ b/hub/enrollment_confirmed_hash_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// ===== BLOCKER 2 (round 4): every enrollment_confirmed names the exact
+// credential it confirms via secret_sha256. Before this fix the agent had
+// no way to bind a confirmation to a specific local file — it trusted
+// whichever file it had just written, which is exactly the split-brain
+// blocker 2 closes. These tests lock in that ALL FOUR confirmation sites in
+// handleAgentWS include the correct hash, not just that a frame arrives.
+
+// readEnrollmentConfirmedHash drains conn until an "enrollment_confirmed"
+// frame arrives and returns its secret_sha256 field.
+func readEnrollmentConfirmedHash(t *testing.T, conn *websocket.Conn) string {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("waiting for enrollment_confirmed: %v", err)
+		}
+		var frame struct {
+			Type         string `json:"type"`
+			SecretSHA256 string `json:"secret_sha256"`
+		}
+		if json.Unmarshal(msg, &frame) == nil && frame.Type == "enrollment_confirmed" {
+			return frame.SecretSHA256
+		}
+	}
+}
+
+// TestFreshEnrollmentConfirmationCarriesActiveSecretHash covers "fresh
+// enrollment confirmation carries the hash stored active": a brand new
+// machine's confirmation must name the exact secret consumeTokenAndStoreCredential
+// wrote active — hashOf the plaintext the agent received AND the DB's
+// active secret_hash must both equal it.
+func TestFreshEnrollmentConfirmationCarriesActiveSecretHash(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	rawToken := s.seedValidToken(t)
+
+	conn, err := wsDialAgent(t, server, "token="+rawToken)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	sendMetricsMsg(t, conn, "fresh-hash-machine")
+	newSecret := readEnrolledSecret(t, conn)
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"enrollment_committed"}`)); err != nil {
+		t.Fatalf("send enrollment_committed: %v", err)
+	}
+	gotHash := readEnrollmentConfirmedHash(t, conn)
+
+	want := hashOf(newSecret)
+	if gotHash != want {
+		t.Fatalf("secret_sha256=%q, want hash of the issued secret %q", gotHash, want)
+	}
+	if got := activeSecretHash(t, s, "fresh-hash-machine"); got != want {
+		t.Fatalf("active secret_hash=%q, want %q — confirmation hash must match what's actually active", got, want)
+	}
+}
+
+// TestStagedPromotionConfirmationCarriesPromotedSecretHash covers "staged
+// promotion confirmation carries the promoted hash".
+func TestStagedPromotionConfirmationCarriesPromotedSecretHash(t *testing.T) {
+	server, s, _, resp := prepareTargetedReenrollment(t, "staged-hash-machine")
+	conn, newSecret := dialAndStage(t, server, "staged-hash-machine", resp.Token)
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"enrollment_committed"}`)); err != nil {
+		t.Fatalf("send enrollment_committed: %v", err)
+	}
+	gotHash := readEnrollmentConfirmedHash(t, conn)
+
+	want := hashOf(newSecret)
+	if gotHash != want {
+		t.Fatalf("secret_sha256=%q, want hash of the promoted secret %q", gotHash, want)
+	}
+	waitForPromotion(t, s, "staged-hash-machine", want)
+}
+
+// TestPendingSecretReconnectConfirmationCarriesPromotedHash covers
+// "pending-secret reconnect confirmation carries the hash that was
+// promoted/validated" — the lost-acknowledgement recovery path.
+func TestPendingSecretReconnectConfirmationCarriesPromotedHash(t *testing.T) {
+	server, _, _, resp := prepareTargetedReenrollment(t, "pending-reconnect-hash-machine")
+	conn, newSecret := dialAndStage(t, server, "pending-reconnect-hash-machine", resp.Token)
+	conn.Close() // ack lost
+
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+newSecret)
+	conn2, _, err := dialWSWithHeader(t, server, "/ws/agent", h)
+	if err != nil {
+		t.Fatalf("reconnect with pending secret: %v", err)
+	}
+	defer conn2.Close()
+
+	gotHash := readEnrollmentConfirmedHash(t, conn2)
+	want := hashOf(newSecret)
+	if gotHash != want {
+		t.Fatalf("secret_sha256=%q, want the promoted secret's hash %q", gotHash, want)
+	}
+}
+
+// TestLingeringTokenActiveReconnectConfirmationCarriesActiveHash covers
+// "active-secret reconnect with a lingering token carries the active hash it
+// actually authenticated".
+func TestLingeringTokenActiveReconnectConfirmationCarriesActiveHash(t *testing.T) {
+	server, s, _, resp := prepareTargetedReenrollment(t, "lingering-token-hash-machine")
+	conn, newSecret := dialAndStage(t, server, "lingering-token-hash-machine", resp.Token)
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"enrollment_committed"}`)); err != nil {
+		t.Fatalf("send enrollment_committed: %v", err)
+	}
+	waitForPromotion(t, s, "lingering-token-hash-machine", hashOf(newSecret))
+	conn.Close()
+
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+newSecret)
+	h.Set(agentEnrollTokenHeader, resp.Token)
+	conn2, _, err := dialWSWithHeader(t, server, "/ws/agent", h)
+	if err != nil {
+		t.Fatalf("reconnect: %v", err)
+	}
+	defer conn2.Close()
+
+	gotHash := readEnrollmentConfirmedHash(t, conn2)
+	want := hashOf(newSecret)
+	if gotHash != want {
+		t.Fatalf("secret_sha256=%q, want the active secret's hash %q (the one this reconnect actually authenticated with)", gotHash, want)
+	}
+}
+
+// TestStaleAcknowledgementCannotEmitConfirmationForNewerPendingHash: once a
+// connection's staged pending value no longer matches what it originally
+// staged (sabotaged here to stand in for a genuine concurrent re-stage —
+// see TestStaleAcknowledgementCannotClobberNewerReStagedPending for the
+// direct CAS-level proof of that race), committing on that connection must
+// close it with NO confirmation frame at all — never a confirmation naming
+// some other hash, which would wrongly tell the agent it may trust a secret
+// it never actually received.
+func TestStaleAcknowledgementCannotEmitConfirmationForNewerPendingHash(t *testing.T) {
+	server, s, _, resp := prepareTargetedReenrollment(t, "stale-ack-hash-machine")
+	connA, _ := dialAndStage(t, server, "stale-ack-hash-machine", resp.Token)
+	defer connA.Close()
+
+	if _, err := s.db.Exec(`UPDATE agent_credentials SET pending_secret_hash = 'someone-elses-newer-hash' WHERE machine_id = ?`, "stale-ack-hash-machine"); err != nil {
+		t.Fatalf("sabotage pending: %v", err)
+	}
+
+	if err := connA.WriteMessage(websocket.TextMessage, []byte(`{"type":"enrollment_committed"}`)); err != nil {
+		t.Fatalf("send stale enrollment_committed: %v", err)
+	}
+	connA.SetReadDeadline(time.Now().Add(2 * time.Second))
+	assertNoFrameType(t, connA, "enrollment_confirmed")
+}

--- a/hub/install_commands.go
+++ b/hub/install_commands.go
@@ -17,6 +17,19 @@ type installTokenResponse struct {
 	ExpiresAt      string `json:"expires_at"`
 }
 
+// windowsReenrollmentResponse is the contract for a machine-bound Windows
+// re-enrollment token. Unlike installTokenResponse it carries no Linux
+// command (this flow is Windows-only) and echoes machine_id so the caller
+// can confirm the token was minted for the machine it asked about.
+type windowsReenrollmentResponse struct {
+	MachineID      string `json:"machine_id"`
+	Token          string `json:"token"`
+	WindowsCommand string `json:"windows_command"`
+	CAURL          string `json:"ca_url"`
+	CASHA256       string `json:"ca_sha256"`
+	ExpiresAt      string `json:"expires_at"`
+}
+
 func shellSingleQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }
@@ -71,10 +84,14 @@ env BLOXOS_HUB="$HUB_WS" BLOXOS_TOKEN="$TOKEN" "${CA_ENV[@]}" bash "$INSTALLER"`
 		shellSingleQuote(caURL), shellSingleQuote(caSHA256))
 }
 
-func buildWindowsInstallCommand(httpBase, wsBase, token, caURL, caSHA256 string) string {
+func buildWindowsInstallCommand(httpBase, wsBase, token, caURL, caSHA256 string, forceReenroll bool) string {
 	httpWarning := ""
 	if strings.HasPrefix(httpBase, "http://") {
 		httpWarning = `Write-Warning "Direct HTTP bootstrap is unencrypted and is intended only for loopback or isolated test networks."`
+	}
+	installerArgs := ""
+	if forceReenroll {
+		installerArgs = " -ForceReenroll"
 	}
 	return fmt.Sprintf(`$ErrorActionPreference = 'Stop'
 $HubHttp = %s
@@ -113,11 +130,11 @@ try {
     $env:BLOXOS_HUB = $HubWs
     $env:BLOXOS_TOKEN = $Token
     $env:BLOXOS_CA_SHA256 = $ExpectedCaSha
-    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $Installer
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $Installer%s
     if ($LASTEXITCODE -ne 0) { throw "Installer failed (exit $LASTEXITCODE)" }
 } finally {
     Remove-Item -LiteralPath $TempDir -Recurse -Force -ErrorAction SilentlyContinue
 }`,
 		powershellSingleQuote(httpBase), powershellSingleQuote(wsBase), powershellSingleQuote(token),
-		powershellSingleQuote(caURL), powershellSingleQuote(caSHA256), httpWarning)
+		powershellSingleQuote(caURL), powershellSingleQuote(caSHA256), httpWarning, installerArgs)
 }

--- a/hub/main.go
+++ b/hub/main.go
@@ -284,6 +284,7 @@ func (s *Server) registerRoutes(e *echo.Echo) {
 	api.PUT("/api/machines/:id/notes", s.handleSetMachineNotes)
 	api.GET("/api/machines/:id/metrics/history", s.handleMetricsHistory)
 	api.DELETE("/api/machines/:id/credential", s.handleRevokeAgentCredential)
+	api.POST("/api/machines/:id/windows-re-enrollment", s.handleWindowsReenrollment)
 	api.DELETE("/api/machines/:id", s.handleDeleteMachine)
 
 	api.POST("/api/machines/:id/terminal", s.handleStartTerminal)

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -907,7 +907,7 @@ func TestValidateAgentTokenValid(t *testing.T) {
 		t.Fatalf("insert token: %v", err)
 	}
 
-	gotHash, valErr := s.validateAgentToken(rawToken)
+	gotHash, _, valErr := s.validateAgentToken(rawToken)
 	if valErr != nil {
 		t.Fatalf("expected valid token, got error: %v", valErr)
 	}
@@ -931,7 +931,7 @@ func TestValidateAgentTokenUsed(t *testing.T) {
 		t.Fatalf("insert token: %v", err)
 	}
 
-	_, valErr := s.validateAgentToken(rawToken)
+	_, _, valErr := s.validateAgentToken(rawToken)
 	if valErr == nil {
 		t.Fatal("expected error for used token, got nil")
 	}
@@ -955,7 +955,7 @@ func TestValidateAgentTokenExpired(t *testing.T) {
 		t.Fatalf("insert token: %v", err)
 	}
 
-	_, valErr := s.validateAgentToken(rawToken)
+	_, _, valErr := s.validateAgentToken(rawToken)
 	if valErr == nil {
 		t.Fatal("expected error for expired token, got nil")
 	}

--- a/hub/migrations.go
+++ b/hub/migrations.go
@@ -370,6 +370,28 @@ var migrations = []migration{
 			return err
 		},
 	},
+	{
+		description: "add nullable target_machine_id to tokens for machine-bound Windows re-enrollment",
+		apply: func(tx *sql.Tx) error {
+			_, err := tx.Exec(`ALTER TABLE tokens ADD COLUMN target_machine_id TEXT`)
+			if err != nil && isDuplicateColumnErr(err) {
+				return nil
+			}
+			return err
+		},
+	},
+	{
+		description: "add nullable pending_secret_hash and pending_expires_at to agent_credentials for staged Windows re-enrollment handoff",
+		apply: func(tx *sql.Tx) error {
+			if _, err := tx.Exec(`ALTER TABLE agent_credentials ADD COLUMN pending_secret_hash TEXT`); err != nil && !isDuplicateColumnErr(err) {
+				return err
+			}
+			if _, err := tx.Exec(`ALTER TABLE agent_credentials ADD COLUMN pending_expires_at DATETIME`); err != nil && !isDuplicateColumnErr(err) {
+				return err
+			}
+			return nil
+		},
+	},
 }
 
 // isDuplicateColumnErr returns true when SQLite rejects an ALTER TABLE ADD

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -96,6 +96,7 @@ var routeScopeRequirements = map[string]string{
 	routeScopeKey(http.MethodGet, "/api/machines/:id/notes"):                   scopeFleetRead,
 	routeScopeKey(http.MethodPut, "/api/machines/:id/notes"):                   scopeFleetMetadata,
 	routeScopeKey(http.MethodDelete, "/api/machines/:id/credential"):           scopeFleetAdmin,
+	routeScopeKey(http.MethodPost, "/api/machines/:id/windows-re-enrollment"):  scopeFleetAdmin,
 	routeScopeKey(http.MethodDelete, "/api/machines/:id"):                      scopeFleetAdmin,
 	routeScopeKey(http.MethodPost, "/api/machines/:id/terminal"):               scopeFleetControl,
 	routeScopeKey(http.MethodDelete, "/api/machines/:id/terminal/:session_id"): scopeFleetControl,

--- a/hub/windows_force_reenroll_test.go
+++ b/hub/windows_force_reenroll_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fetchInstallPS1 serves /install.ps1 against a fresh test server with a
+// generated Windows binary fixture and returns its body.
+func fetchInstallPS1(t *testing.T) string {
+	t.Helper()
+	e, _ := setupTestServer(t)
+	useGeneratedTestBinary(t, "windows")
+	req := httptest.NewRequest(http.MethodGet, "/install.ps1", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("install.ps1 status=%d: %s", rec.Code, rec.Body.String())
+	}
+	return rec.Body.String()
+}
+
+// TestWindowsInstallerParamBlockPrecedesExecutableStatements locks in that
+// param([switch]$ForceReenroll) is a valid PowerShell param block: nothing
+// but the leading comment line may precede it.
+func TestWindowsInstallerParamBlockPrecedesExecutableStatements(t *testing.T) {
+	body := fetchInstallPS1(t)
+	lines := strings.Split(body, "\n")
+	paramLineIdx := -1
+	for i, line := range lines {
+		if strings.Contains(line, "param(") && strings.Contains(line, "$ForceReenroll") {
+			paramLineIdx = i
+			break
+		}
+	}
+	if paramLineIdx < 0 {
+		t.Fatal("install.ps1 does not declare param([switch]$ForceReenroll)")
+	}
+	for i := 0; i < paramLineIdx; i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		t.Fatalf("non-comment statement %q precedes the param() block at line %d", trimmed, i)
+	}
+}
+
+// TestWindowsInstallerFastPathGatedByForceReenroll locks in that FastPath's
+// no-op short-circuit cannot trigger when the caller explicitly asked for a
+// forced re-enrollment.
+func TestWindowsInstallerFastPathGatedByForceReenroll(t *testing.T) {
+	body := fetchInstallPS1(t)
+	fastPathIdx := strings.Index(body, "$FastPath =")
+	if fastPathIdx < 0 {
+		t.Fatal("install.ps1 does not assign $FastPath")
+	}
+	// The assignment (through its trailing -and chain) must reference
+	// $ForceReenroll before the "if ($FastPath)" no-op check.
+	ifFastPathIdx := strings.Index(body, "if ($FastPath)")
+	if ifFastPathIdx < 0 {
+		t.Fatal("install.ps1 does not check if ($FastPath)")
+	}
+	assignmentBlock := body[fastPathIdx:ifFastPathIdx]
+	if !strings.Contains(assignmentBlock, "-not $ForceReenroll") {
+		t.Fatalf("FastPath assignment does not gate on (-not $ForceReenroll): %q", assignmentBlock)
+	}
+}
+
+// TestWindowsInstallerForcedReenrollPreservesAndCanRestoreSecret locks in the
+// secret-handling contract for -ForceReenroll: the existing secret is backed
+// up by exact path — recording only its hash, never moving, deleting, or
+// otherwise disturbing the file — and that the completion gate waits for its
+// hash to change rather than for its absence/reappearance. This is BLOCKER 1
+// from the Codex review: the old credential must stay valid, on disk, in
+// place, for as long as the hub might still need to accept it, because the
+// hub's own promotion (not this script) is what invalidates it.
+func TestWindowsInstallerForceReenrollNeverMovesOrDeletesSecret(t *testing.T) {
+	body := fetchInstallPS1(t)
+
+	for _, forbidden := range []string{
+		"Remove-Item -Path $CredDir -Recurse",
+		"Remove-Item -LiteralPath $CredDir -Recurse",
+		"Remove-Item -Recurse -Path $CredDir",
+		"Remove-Item -Recurse -LiteralPath $CredDir",
+		"Move-Item -LiteralPath $SecretPath",
+		"Move-Item -LiteralPath \"$SecretPath\"",
+		"Remove-Item -LiteralPath $SecretPath",
+		"Remove-Item -LiteralPath \"$SecretPath\"",
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("install.ps1 moves, deletes, or recursively clears the credential: %q", forbidden)
+		}
+	}
+	if strings.Contains(body, "SecretBackupPath") {
+		t.Fatal("install.ps1 still references a secret backup path — the old design's move-aside/restore machinery was not fully removed")
+	}
+
+	// Only the hash is recorded, and only for comparison, before the service
+	// transaction — read-only, so a later download/fingerprint failure has
+	// nothing to roll back with respect to the secret.
+	if !strings.Contains(body, "$OldSecretHash = (Get-FileHash") {
+		t.Fatal("install.ps1 does not record the old secret's hash for ForceReenroll comparison")
+	}
+	forceBlockStart := strings.Index(body, "if ($ForceReenroll")
+	tryBlockIdx := strings.Index(body, "\ntry {\n    if ($ServiceExisted) {")
+	if forceBlockStart < 0 || tryBlockIdx < 0 || forceBlockStart >= tryBlockIdx {
+		t.Fatalf("expected a $ForceReenroll hash-recording block before the try{} service transaction (forceBlockStart=%d tryBlockIdx=%d)", forceBlockStart, tryBlockIdx)
+	}
+
+	// Restore-PreviousInstall must not touch agent-secret at all — nothing
+	// was ever moved, so there is nothing for it to put back.
+	restoreFuncIdx := strings.Index(body, "function Restore-PreviousInstall")
+	if restoreFuncIdx < 0 {
+		t.Fatal("install.ps1 has no Restore-PreviousInstall function")
+	}
+	restoreBody := body[restoreFuncIdx:]
+	if closeBrace := strings.Index(restoreBody, "\n}\n"); closeBrace > 0 {
+		restoreBody = restoreBody[:closeBrace]
+	}
+	if strings.Contains(restoreBody, "$SecretPath") {
+		t.Fatalf("Restore-PreviousInstall touches agent-secret, but the secret was never moved to begin with: %q", restoreBody)
+	}
+}
+
+// TestWindowsInstallerForceReenrollWaitsForSecretHashChange locks in the
+// completion gate's ForceReenroll branch: it must wait for the file at
+// $SecretPath to acquire a DIFFERENT hash than the one recorded before the
+// service transaction, proving the agent actually wrote a new credential —
+// not merely that the service reached Running.
+func TestWindowsInstallerForceReenrollWaitsForSecretHashChange(t *testing.T) {
+	body := fetchInstallPS1(t)
+	assertOrdered(t, body,
+		"$OldSecretHash = (Get-FileHash",
+		"Start-Service -Name BloxOSAgent",
+		"if ($ForceReenroll) {",
+		"$NewSecretHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $SecretPath).Hash",
+		"if ($NewSecretHash -ne $OldSecretHash) { $EnrollmentComplete = $true }",
+		"BloxOS agent installed and running.",
+	)
+}
+
+// TestWindowsInstallerCleanInstallRequiresNewSecretBeforeSuccess locks in
+// that install.ps1 does not print its success message merely because the
+// service reached Running — a clean install must first observe a newly
+// issued, non-empty secret.
+func TestWindowsInstallerCleanInstallRequiresNewSecretBeforeSuccess(t *testing.T) {
+	body := fetchInstallPS1(t)
+	if !strings.Contains(body, "SecretExistedBefore") {
+		t.Fatal("install.ps1 does not track whether a secret existed before this run")
+	}
+	assertOrdered(t, body,
+		"Start-Service -Name BloxOSAgent",
+		"-not $SecretExistedBefore",
+		"BloxOS agent installed and running.",
+	)
+	if !strings.Contains(body, "did not complete enrollment") && !strings.Contains(body, "did not complete") {
+		t.Fatal("install.ps1 has no bounded enrollment-completion timeout error")
+	}
+}
+
+// TestWindowsInstallerNeverEmitsSecretContents locks in that no branch of
+// install.ps1 writes secret file contents to the console; only hash
+// comparisons are permitted.
+func TestWindowsInstallerNeverEmitsSecretContents(t *testing.T) {
+	body := fetchInstallPS1(t)
+	for _, forbidden := range []string{
+		"Write-Host $NewSecret",
+		"Write-Host $OldSecret",
+		"Write-Warning $NewSecret",
+		"Write-Warning $OldSecret",
+		"Write-Output $NewSecret",
+		"Write-Output $OldSecret",
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("install.ps1 may emit secret contents: %q", forbidden)
+		}
+	}
+	if !strings.Contains(body, "Get-FileHash") {
+		t.Fatal("install.ps1 does not use Get-FileHash for internal secret comparison")
+	}
+}

--- a/hub/windows_installer.go
+++ b/hub/windows_installer.go
@@ -8,6 +8,8 @@ import (
 )
 
 const windowsInstallerScript = `# BloxOS Windows Agent installer
+param([switch]$ForceReenroll)
+
 $ErrorActionPreference = 'Stop'
 
 $Current = [Security.Principal.WindowsIdentity]::GetCurrent()
@@ -83,9 +85,12 @@ if ($KeyWasAlreadyPinned) {
     }
 }
 
+$SecretExistedBefore = Test-Path -LiteralPath $SecretPath
+
 $Service = Get-Service -Name BloxOSAgent -ErrorAction SilentlyContinue
 $ExistingHub = [Environment]::GetEnvironmentVariable("BLOXOS_HUB", "Machine")
-$FastPath = $KeyWasAlreadyPinned -and
+$FastPath = (-not $ForceReenroll) -and
+    $KeyWasAlreadyPinned -and
     (Test-Path -LiteralPath $AgentExe) -and
     ((Get-FileHash -Algorithm SHA256 -LiteralPath $AgentExe).Hash.ToLower() -eq $ExpectedSha.ToLower()) -and
     (Test-Path -LiteralPath $SecretPath) -and
@@ -125,6 +130,27 @@ $OldHub = [Environment]::GetEnvironmentVariable("BLOXOS_HUB", "Machine")
 $OldToken = [Environment]::GetEnvironmentVariable("BLOXOS_TOKEN", "Machine")
 $OldCa = [Environment]::GetEnvironmentVariable("BLOXOS_CA_CERT", "Machine")
 
+$OldSecretHash = $null
+if ($ForceReenroll -and $SecretExistedBefore) {
+    # Record the existing secret's hash WITHOUT touching the file itself.
+    # The hub now stages a re-enrollment as a PENDING credential rather than
+    # replacing the active one, so the old secret must keep authenticating
+    # for as long as it sits on disk — moving, deleting, or otherwise
+    # disturbing it here would just recreate the split-brain window this
+    # design exists to close (the hub could still accept it while the local
+    # copy is unavailable). The restarted agent sends this secret alongside
+    # the fresh target-bound token; the hub explicitly detects that
+    # combination and stages a pending credential without touching the
+    # active one. The old secret stops being accepted only after the agent
+    # durably saves the new one AND the hub's compare-and-swap promotion of
+    # that exact pending value actually commits in its own database and the
+    # resulting "enrollment_confirmed" frame is delivered back to the agent
+    # — a fully hub-side transition, never triggered by this script deleting
+    # a local file, and never assumed to have happened just because a frame
+    # was sent.
+    $OldSecretHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $SecretPath).Hash
+}
+
 function Restore-PreviousInstall {
     $CurrentService = Get-Service -Name BloxOSAgent -ErrorAction SilentlyContinue
     if ($CurrentService -and (Test-Path -LiteralPath $AgentExe)) {
@@ -138,6 +164,11 @@ function Restore-PreviousInstall {
     [Environment]::SetEnvironmentVariable("BLOXOS_HUB", $OldHub, "Machine")
     [Environment]::SetEnvironmentVariable("BLOXOS_TOKEN", $OldToken, "Machine")
     [Environment]::SetEnvironmentVariable("BLOXOS_CA_CERT", $OldCa, "Machine")
+    # agent-secret is deliberately untouched by this script (see the
+    # ForceReenroll block above) — there is nothing to restore here. The hub
+    # still holds the old credential as active because it was only ever
+    # staged as pending, never replaced, so no local rollback is needed for
+    # the machine to keep authenticating.
     if ($ServiceExisted -and (Test-Path -LiteralPath $AgentExe)) {
         & $AgentExe -install-service | Out-Null
         if ($LASTEXITCODE -ne 0) { throw "Rollback could not restore BloxOSAgent service" }
@@ -157,9 +188,72 @@ try {
     & $AgentExe -install-service
     if ($LASTEXITCODE -ne 0) { throw "Service installation failed (exit $LASTEXITCODE)" }
     Start-Service -Name BloxOSAgent
-    Start-Sleep -Seconds 2
-    $InstalledService = Get-Service -Name BloxOSAgent -ErrorAction SilentlyContinue
-    if (-not $InstalledService -or $InstalledService.Status -ne 'Running') { throw "BloxOSAgent service did not reach Running" }
+
+    # Bounded enrollment-completion gate. Reaching Running in the Windows
+    # Service Control Manager proves the process started — it says nothing
+    # about whether the agent actually authenticated with the hub, so success
+    # is never reported on SCM status alone:
+    #   - clean install (no prior secret): a new non-empty secret must appear;
+    #   - ForceReenroll: agent-secret was left in place untouched above, still
+    #     holding the OLD content — the restarted agent authenticates with
+    #     that still-valid old secret alongside the fresh target-bound token,
+    #     and the hub stages a pending replacement. The agent's own local
+    #     state machine now enforces a real two-phase handoff: a staged
+    #     secret is written ONLY to a separate agent-secret.pending file, and
+    #     $SecretPath (agent-secret, the ACTIVE file) is rewritten only after
+    #     the agent receives a hash-bound "enrollment_confirmed" from the hub
+    #     naming that exact pending file's contents and durably promotes it.
+    #     That means waiting for the hash at $SecretPath to differ from the
+    #     recorded old one is no longer merely "the agent wrote something
+    #     locally" — it IS proof that the hub's compare-and-swap promotion
+    #     already committed AND the agent already verified the confirmation
+    #     was hash-bound to what it actually staged before touching the
+    #     active file at all. This script still does not independently query
+    #     the hub's own view of the credential or BLOXOS_TOKEN removal — that
+    #     remains a separate acceptance check — but the local signal it does
+    #     wait for is now a strong one, not a weak one;
+    #   - ordinary non-FastPath repair with an existing credential: the
+    #     credential is retained as-is, so service health is the only signal
+    #     available and is sufficient.
+    # Secret contents are never read for comparison, only their SHA-256 hash.
+    # If this gate times out, agent-secret is exactly what it was before this
+    # script ran — the hub never invalidates the old credential until the
+    # agent proves the new one is durable, so a timeout here does not strand
+    # the machine's authentication either way. A ForceReenroll timeout may
+    # still leave agent-secret.pending on disk (the staged secret, awaiting a
+    # confirmation that never arrived or is still in flight) — that file is
+    # deliberately not created, inspected, or removed by this script; it is
+    # the agent's own recovery material for its next reconnect attempt, and
+    # Restore-PreviousInstall below never touches it either.
+    $EnrollDeadline = (Get-Date).AddSeconds(30)
+    $EnrollmentComplete = $false
+    while (-not $EnrollmentComplete -and (Get-Date) -lt $EnrollDeadline) {
+        $InstalledService = Get-Service -Name BloxOSAgent -ErrorAction SilentlyContinue
+        if (-not $InstalledService -or $InstalledService.Status -ne 'Running') {
+            Start-Sleep -Milliseconds 500
+            continue
+        }
+        if ($ForceReenroll) {
+            if (Test-Path -LiteralPath $SecretPath) {
+                $NewSecretHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $SecretPath).Hash
+                if ($NewSecretHash -ne $OldSecretHash) { $EnrollmentComplete = $true }
+            }
+        } elseif (-not $SecretExistedBefore) {
+            if ((Test-Path -LiteralPath $SecretPath) -and (Get-Item -LiteralPath $SecretPath).Length -gt 0) {
+                $EnrollmentComplete = $true
+            }
+        } else {
+            $EnrollmentComplete = $true
+        }
+        if (-not $EnrollmentComplete) { Start-Sleep -Milliseconds 500 }
+    }
+    if (-not $EnrollmentComplete) {
+        if ($ForceReenroll -and (Test-Path -LiteralPath "$SecretPath.pending")) {
+            throw "Agent service is running but did not complete enrollment within the timeout. A staged agent-secret.pending is present at $SecretPath.pending — this is expected recovery material, not corruption; the agent will retry with it on its own next reconnect attempt. Do not delete it manually."
+        }
+        throw "Agent service is running but did not complete enrollment within the timeout"
+    }
+
     if ($BackupExe) { Remove-Item -LiteralPath $BackupExe -Force -ErrorAction SilentlyContinue }
     Write-Host "BloxOS agent installed and running."
 } catch {

--- a/hub/windows_reenrollment_confirm_test.go
+++ b/hub/windows_reenrollment_confirm_test.go
@@ -1,0 +1,461 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// readFrameType drains conn until it sees a frame whose "type" field equals
+// want, or the deadline set by the caller expires.
+func readFrameType(t *testing.T, conn *websocket.Conn, want string) {
+	t.Helper()
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("waiting for %q frame: %v", want, err)
+		}
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(msg, &envelope) == nil && envelope.Type == want {
+			return
+		}
+	}
+}
+
+// assertNoFrameType fails if a frame of type unwanted arrives before the
+// connection's already-set read deadline expires; a clean read timeout or
+// disconnect is the expected/passing outcome.
+func assertNoFrameType(t *testing.T, conn *websocket.Conn, unwanted string) {
+	t.Helper()
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			return // timeout or close — exactly what we want
+		}
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(msg, &envelope) == nil && envelope.Type == unwanted {
+			t.Fatalf("unexpected %q frame: %s", unwanted, msg)
+		}
+	}
+}
+
+// ===== BLOCKER 1: deterministic (non-goroutine) proof of the real CAS =====
+
+// TestStaleAcknowledgementCannotClobberNewerReStagedPending is the
+// deterministic reproduction Codex asked for, not a goroutine race: stage A,
+// capture what a connection holding A's ack would present, re-stage B
+// (simulating a second re-enrollment attempt prepared before A's ack
+// arrives), deliver the stale A acknowledgement, and prove active is
+// unchanged and pending is still B. Then acknowledge B and prove only B
+// promotes.
+func TestStaleAcknowledgementCannotClobberNewerReStagedPending(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedWindowsMachine(t, "win-stale-ack")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`, "win-stale-ack", "orig-active-hash"); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+
+	// Stage A.
+	tokenAHash := hashOf("stale-ack-token-a")
+	if _, err := s.db.Exec(
+		`INSERT INTO tokens (token_hash, expires_at, used, target_machine_id) VALUES (?, ?, FALSE, ?)`,
+		tokenAHash, time.Now().Add(15*time.Minute).Format(time.RFC3339), "win-stale-ack",
+	); err != nil {
+		t.Fatalf("seed token A: %v", err)
+	}
+	if err := s.stageTargetedCredential(tokenAHash, "win-stale-ack", "pending-hash-A"); err != nil {
+		t.Fatalf("stage A: %v", err)
+	}
+
+	// Re-stage B before A's acknowledgement is delivered — the exact
+	// scenario a stale ack must not be allowed to clobber.
+	tokenBHash := hashOf("stale-ack-token-b")
+	if _, err := s.db.Exec(
+		`INSERT INTO tokens (token_hash, expires_at, used, target_machine_id) VALUES (?, ?, FALSE, ?)`,
+		tokenBHash, time.Now().Add(15*time.Minute).Format(time.RFC3339), "win-stale-ack",
+	); err != nil {
+		t.Fatalf("seed token B: %v", err)
+	}
+	if err := s.stageTargetedCredential(tokenBHash, "win-stale-ack", "pending-hash-B"); err != nil {
+		t.Fatalf("stage B: %v", err)
+	}
+
+	// Deliver the stale A acknowledgement.
+	promotedA, err := s.promotePendingCredentialCAS("win-stale-ack", "pending-hash-A")
+	if err != nil {
+		t.Fatalf("promote A: %v", err)
+	}
+	if promotedA {
+		t.Fatal("stale acknowledgement A must not promote once B has been re-staged")
+	}
+
+	// Active untouched, pending is still B (not cleared, not A).
+	if got := activeSecretHash(t, s, "win-stale-ack"); got != "orig-active-hash" {
+		t.Fatalf("active secret_hash=%q after a stale ack, want unchanged %q", got, "orig-active-hash")
+	}
+	pendingHash, _ := pendingState(t, s, "win-stale-ack")
+	if pendingHash != "pending-hash-B" {
+		t.Fatalf("pending_secret_hash=%q after stale ack A, want B's hash still staged: %q", pendingHash, "pending-hash-B")
+	}
+
+	// Now acknowledge B — only B may promote.
+	promotedB, err := s.promotePendingCredentialCAS("win-stale-ack", "pending-hash-B")
+	if err != nil {
+		t.Fatalf("promote B: %v", err)
+	}
+	if !promotedB {
+		t.Fatal("B's acknowledgement should promote — it is the current pending value")
+	}
+	if got := activeSecretHash(t, s, "win-stale-ack"); got != "pending-hash-B" {
+		t.Fatalf("active secret_hash=%q after promoting B, want %q", got, "pending-hash-B")
+	}
+}
+
+// ===== BLOCKER 2: fail-closed on malformed/missing/exactly-expired expiry =====
+
+func seedRawPending(t *testing.T, s *Server, machineID, hash string, expiresAt interface{}) {
+	t.Helper()
+	if _, err := s.db.Exec(
+		`UPDATE agent_credentials SET pending_secret_hash = ?, pending_expires_at = ? WHERE machine_id = ?`,
+		hash, expiresAt, machineID,
+	); err != nil {
+		t.Fatalf("seed raw pending state: %v", err)
+	}
+}
+
+func TestPendingWithNullExpiryNeverPromotesOrAuthenticates(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedWindowsMachine(t, "win-null-exp")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`, "win-null-exp", "active-hash"); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	seedRawPending(t, s, "win-null-exp", "pending-hash-null", nil)
+
+	promoted, err := s.promotePendingCredentialCAS("win-null-exp", "pending-hash-null")
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if promoted {
+		t.Fatal("a NULL pending_expires_at must never promote")
+	}
+	if got := activeSecretHash(t, s, "win-null-exp"); got != "active-hash" {
+		t.Fatalf("active secret_hash=%q, want unchanged", got)
+	}
+	pendingHash, _ := pendingState(t, s, "win-null-exp")
+	if pendingHash != "" {
+		t.Fatalf("malformed pending state was not cleared: hash=%q", pendingHash)
+	}
+}
+
+func TestPendingWithMalformedExpiryNeverPromotesOrAuthenticates(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedWindowsMachine(t, "win-bad-exp")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`, "win-bad-exp", "active-hash"); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	seedRawPending(t, s, "win-bad-exp", "pending-hash-bad", "not-a-valid-timestamp")
+
+	promoted, err := s.promotePendingCredentialCAS("win-bad-exp", "pending-hash-bad")
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if promoted {
+		t.Fatal("an unparseable pending_expires_at must never promote")
+	}
+	if got := activeSecretHash(t, s, "win-bad-exp"); got != "active-hash" {
+		t.Fatalf("active secret_hash=%q, want unchanged", got)
+	}
+	pendingHash, _ := pendingState(t, s, "win-bad-exp")
+	if pendingHash != "" {
+		t.Fatalf("malformed pending state was not cleared: hash=%q", pendingHash)
+	}
+}
+
+func TestPendingExactlyAtExpiryNeverPromotesOldActiveRemainsValid(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedWindowsMachine(t, "win-exact-exp")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`, "win-exact-exp", "active-hash"); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	// "Exactly" expired: the boundary itself and anything not strictly in the
+	// future must reject. time.Now() formatted now will already be <= the
+	// check's later time.Now() by the time promotePendingCredentialCAS runs.
+	seedRawPending(t, s, "win-exact-exp", "pending-hash-exact", time.Now().Format(time.RFC3339))
+
+	promoted, err := s.promotePendingCredentialCAS("win-exact-exp", "pending-hash-exact")
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if promoted {
+		t.Fatal("an expiry that is not strictly in the future must never promote")
+	}
+	if got := activeSecretHash(t, s, "win-exact-exp"); got != "active-hash" {
+		t.Fatalf("active secret_hash=%q, want unchanged", got)
+	}
+}
+
+func TestMalformedPendingDoesNotClobberConcurrentlyReStagedValue(t *testing.T) {
+	// The malformed-expiry clear must itself be CAS-scoped: if a valid
+	// re-stage happened between the read and the clear attempt, the clear
+	// must not touch it.
+	_, s := setupTestServer(t)
+	s.seedWindowsMachine(t, "win-malformed-race")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`, "win-malformed-race", "active-hash"); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	// Attempt to promote a hash that was never actually staged (simulating
+	// "read a malformed snapshot, but reality has since moved on").
+	seedRawPending(t, s, "win-malformed-race", "real-pending-hash", time.Now().Add(time.Minute).Format(time.RFC3339))
+
+	promoted, err := s.promotePendingCredentialCAS("win-malformed-race", "some-other-stale-hash")
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if promoted {
+		t.Fatal("a non-matching hash must never promote")
+	}
+	// The real, valid pending value must be untouched.
+	pendingHash, pendingExp := pendingState(t, s, "win-malformed-race")
+	if pendingHash != "real-pending-hash" || pendingExp == "" {
+		t.Fatalf("valid pending state was clobbered by an unrelated promotion attempt: hash=%q expires=%q", pendingHash, pendingExp)
+	}
+}
+
+// TestDBClockExpiryGuardDefeatsStaleGoSideCheck is the deterministic
+// TOCTOU reproduction: it constructs exactly the race blocker 2 describes —
+// the Go-side pre-filter says "not expired yet" (via an injected clock that
+// lies about the current time), while the REAL database clock, which the
+// promoting UPDATE's julianday predicate checks independently, has already
+// moved past the deadline. If the UPDATE only re-checked the Go-computed
+// verdict (or nothing at all), this would incorrectly promote; the DB-time
+// predicate must reject it regardless of what the injected clock claimed.
+func TestDBClockExpiryGuardDefeatsStaleGoSideCheck(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedWindowsMachine(t, "win-toctou")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`, "win-toctou", "active-hash"); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+
+	// A real, already-past expiry — the actual database clock (and an
+	// honest Go clock) both agree this is expired right now.
+	realExpiry := time.Now().Add(-2 * time.Second)
+	seedRawPending(t, s, "win-toctou", "pending-hash-toctou", realExpiry.Format(time.RFC3339))
+
+	// The injected clock claims "now" is well BEFORE that expiry — exactly
+	// what a stale/delayed Go-side check would see if real time raced past
+	// the deadline between the parse/compare and the UPDATE executing.
+	lyingNow := func() time.Time { return realExpiry.Add(-time.Hour) }
+
+	promoted, err := s.promotePendingCredentialCASAt("win-toctou", "pending-hash-toctou", lyingNow)
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if promoted {
+		t.Fatal("promotion succeeded despite the real DB clock being past the recorded expiry — the Go-side pre-filter alone is not a sufficient guard")
+	}
+	if got := activeSecretHash(t, s, "win-toctou"); got != "active-hash" {
+		t.Fatalf("active secret_hash=%q, want unchanged", got)
+	}
+}
+
+// TestDBClockExpiryGuardAllowsGenuinelyFuturePending is the companion
+// positive case: when both the Go-side pre-filter and the real DB clock
+// agree the deadline is still ahead, promotion must succeed — the new
+// predicate must not be so strict it rejects legitimate, unexpired pending
+// credentials.
+func TestDBClockExpiryGuardAllowsGenuinelyFuturePending(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedWindowsMachine(t, "win-genuinely-future")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`, "win-genuinely-future", "active-hash"); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+
+	futureExpiry := time.Now().Add(pendingCredentialWindow)
+	seedRawPending(t, s, "win-genuinely-future", "pending-hash-future", futureExpiry.Format(time.RFC3339))
+
+	promoted, err := s.promotePendingCredentialCAS("win-genuinely-future", "pending-hash-future")
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if !promoted {
+		t.Fatal("a genuinely future, correctly matching pending credential must promote")
+	}
+	if got := activeSecretHash(t, s, "win-genuinely-future"); got != "pending-hash-future" {
+		t.Fatalf("active secret_hash=%q, want promoted %q", got, "pending-hash-future")
+	}
+}
+
+// TestJuliandayParsesStageTargetedCredentialsExactFormat locks in that the
+// exact RFC3339 string stageTargetedCredential actually writes (not a
+// hand-picked example) round-trips correctly through SQLite's julianday(),
+// for both a future and a past instance of that same format.
+func TestJuliandayParsesStageTargetedCredentialsExactFormat(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedWindowsMachine(t, "win-julianday-format")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`, "win-julianday-format", "active-hash"); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	tokenHash := hashOf("julianday-format-token")
+	if _, err := s.db.Exec(
+		`INSERT INTO tokens (token_hash, expires_at, used, target_machine_id) VALUES (?, ?, FALSE, ?)`,
+		tokenHash, time.Now().Add(15*time.Minute).Format(time.RFC3339), "win-julianday-format",
+	); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+	if err := s.stageTargetedCredential(tokenHash, "win-julianday-format", "pending-hash-format"); err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+	_, storedExpiry := pendingState(t, s, "win-julianday-format")
+	if storedExpiry == "" {
+		t.Fatal("stageTargetedCredential did not store an expiry")
+	}
+
+	var isFuture bool
+	if err := s.db.QueryRow(`SELECT julianday(?) > julianday('now')`, storedExpiry).Scan(&isFuture); err != nil {
+		t.Fatalf("julianday query on stageTargetedCredential's own format: %v", err)
+	}
+	if !isFuture {
+		t.Fatalf("SQLite did not parse stageTargetedCredential's stored format %q as a future timestamp", storedExpiry)
+	}
+
+	// And the exact same value, once genuinely in the past, is correctly
+	// recognized as such too.
+	promoted, err := s.promotePendingCredentialCAS("win-julianday-format", "some-unrelated-hash")
+	if err != nil {
+		t.Fatalf("promote unrelated hash: %v", err)
+	}
+	if promoted {
+		t.Fatal("an unrelated hash must never promote regardless of expiry")
+	}
+}
+
+// ===== BLOCKER 3: enrollment_confirmed round-trip and lost-frame recovery =====
+
+// TestSuccessfulStagedPromotionSendsConfirmationFrame proves the CAS
+// promotion path sends an explicit "enrollment_confirmed" frame — not just
+// that the DB ends up promoted (already covered by
+// TestEnrollmentCommittedPromotesPendingAndInvalidatesOld).
+func TestSuccessfulStagedPromotionSendsConfirmationFrame(t *testing.T) {
+	server, _, _, resp := prepareTargetedReenrollment(t, "win-confirm-frame")
+	conn, _ := dialAndStage(t, server, "win-confirm-frame", resp.Token)
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"enrollment_committed"}`)); err != nil {
+		t.Fatalf("send enrollment_committed: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	readFrameType(t, conn, "enrollment_confirmed")
+}
+
+// TestFreshEnrollmentAlsoReceivesConfirmationBeforeCleanupIsExpected proves
+// the fix isn't scoped to targeted re-enrollment only: an ordinary first
+// enrollment (no pre-existing credential) that sends enrollment_committed
+// also gets enrollment_confirmed back.
+func TestFreshEnrollmentAlsoReceivesConfirmationFrame(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	rawToken := s.seedValidToken(t)
+
+	conn, err := wsDialAgent(t, server, "token="+rawToken)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	sendMetricsMsg(t, conn, "fresh-confirm-machine")
+	readEnrolledSecret(t, conn)
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"enrollment_committed"}`)); err != nil {
+		t.Fatalf("send enrollment_committed: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	readFrameType(t, conn, "enrollment_confirmed")
+}
+
+// TestHubPromotionFailureSendsNoConfirmationAndClosesConnection: when the
+// staged pending value no longer matches (already promoted/cleared by
+// something else) at the time enrollment_committed arrives, the hub must
+// send no confirmation and close the connection rather than leave the agent
+// in an ambiguous "did it work?" state.
+func TestHubPromotionFailureSendsNoConfirmationAndClosesConnection(t *testing.T) {
+	server, s, _, resp := prepareTargetedReenrollment(t, "win-promo-fail")
+	conn, _ := dialAndStage(t, server, "win-promo-fail", resp.Token)
+	defer conn.Close()
+
+	// Sabotage the staged pending value out from under this connection,
+	// simulating "something else already consumed/cleared it".
+	if _, err := s.db.Exec(`UPDATE agent_credentials SET pending_secret_hash = 'someone-elses-value' WHERE machine_id = ?`, "win-promo-fail"); err != nil {
+		t.Fatalf("sabotage pending: %v", err)
+	}
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"enrollment_committed"}`)); err != nil {
+		t.Fatalf("send enrollment_committed: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	assertNoFrameType(t, conn, "enrollment_confirmed")
+
+	// The connection itself must be closed (next read fails), not just silent.
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, _, err := conn.ReadMessage(); err == nil {
+		t.Fatal("expected the connection to be closed after a failed promotion")
+	}
+}
+
+// TestLostConfirmationReconnectWithPendingSecretYieldsConfirmation extends
+// TestAcknowledgementLostReconnectWithPendingSecretPromotesIt with an
+// explicit check that the recovery reconnect actually receives
+// enrollment_confirmed once upgraded — proof the agent has a real signal to
+// act on, not just that the DB quietly ended up correct.
+func TestLostConfirmationReconnectWithPendingSecretYieldsConfirmation(t *testing.T) {
+	server, _, _, resp := prepareTargetedReenrollment(t, "win-recover-confirm")
+	conn, newSecret := dialAndStage(t, server, "win-recover-confirm", resp.Token)
+	conn.Close() // ack lost
+
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+newSecret)
+	conn2, _, err := dialWSWithHeader(t, server, "/ws/agent", h)
+	if err != nil {
+		t.Fatalf("reconnect with pending secret: %v", err)
+	}
+	defer conn2.Close()
+	conn2.SetReadDeadline(time.Now().Add(5 * time.Second))
+	readFrameType(t, conn2, "enrollment_confirmed")
+}
+
+// TestLingeringTokenOnActiveReconnectStillReceivesConfirmation covers "promotion
+// succeeded but confirmation/upgrade was lost": a later reconnect using the
+// now-fully-active secret, but still carrying a (now stale/consumed) token
+// header from the original attempt, must still receive enrollment_confirmed
+// so the agent can safely drop that token.
+func TestLingeringTokenOnActiveReconnectStillReceivesConfirmation(t *testing.T) {
+	server, s, _, resp := prepareTargetedReenrollment(t, "win-lingering-token")
+	conn, newSecret := dialAndStage(t, server, "win-lingering-token", resp.Token)
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"enrollment_committed"}`)); err != nil {
+		t.Fatalf("send enrollment_committed: %v", err)
+	}
+	waitForPromotion(t, s, "win-lingering-token", hashOf(newSecret))
+	conn.Close()
+
+	// Reconnect with the now-active secret AND the original (already
+	// consumed) token still present — exactly what a process restart between
+	// promotion and the confirm frame arriving would look like.
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+newSecret)
+	h.Set(agentEnrollTokenHeader, resp.Token)
+	conn2, _, err := dialWSWithHeader(t, server, "/ws/agent", h)
+	if err != nil {
+		t.Fatalf("reconnect: %v", err)
+	}
+	defer conn2.Close()
+	conn2.SetReadDeadline(time.Now().Add(5 * time.Second))
+	readFrameType(t, conn2, "enrollment_confirmed")
+}

--- a/hub/windows_reenrollment_dashboard_test.go
+++ b/hub/windows_reenrollment_dashboard_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func readMachineDetailPageSource(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("..", "dashboard", "src", "app", "machine", "[id]", "page.tsx"))
+	if err != nil {
+		t.Fatalf("read machine detail page: %v", err)
+	}
+	return string(body)
+}
+
+// TestMachineDetailPageOffersSeparateReenrollmentAction locks in that the
+// dashboard adds a distinct "Prepare Windows re-enrollment" action alongside
+// (not replacing) the existing revoke-only action, gated the same way
+// (fleet.admin) plus a Windows-only condition, and requires confirmation.
+func TestMachineDetailPageOffersSeparateReenrollmentAction(t *testing.T) {
+	source := readMachineDetailPageSource(t)
+
+	if !strings.Contains(source, "Revoke credential") {
+		t.Fatal("existing revoke-only action was removed or renamed")
+	}
+	if !strings.Contains(source, "/credential") {
+		t.Fatal("revoke action no longer calls DELETE .../credential")
+	}
+
+	if !strings.Contains(source, "windows-re-enrollment") {
+		t.Fatal("dashboard does not call the windows-re-enrollment endpoint")
+	}
+	if !strings.Contains(source, "Windows re-enrollment") && !strings.Contains(source, "Re-enroll Windows") {
+		t.Fatal("dashboard has no distinct Windows re-enrollment action label")
+	}
+	// Windows-only: gated on machine.os, not shown unconditionally.
+	if !strings.Contains(source, `machine.os`) {
+		t.Fatal("re-enrollment action is not gated on machine.os")
+	}
+}
+
+// TestMachineDetailPageReenrollmentRendersOnlyServerResponse mirrors
+// TestDashboardRendersOnlyServerGeneratedCommands: the new dialog must render
+// only fields the hub actually returned (windows_command, ca_sha256,
+// expires_at) and must never derive a command, authority, or token
+// client-side.
+func TestMachineDetailPageReenrollmentRendersOnlyServerResponse(t *testing.T) {
+	source := readMachineDetailPageSource(t)
+
+	for _, required := range []string{"windows_command", "ca_sha256", "expires_at"} {
+		if !strings.Contains(source, required) {
+			t.Fatalf("re-enrollment UI missing server-response field %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"deriveHttpHubBase", "deriveWsHubBase", "buildWindowsCommand",
+		"ServerCertificateValidationCallback", "iwr -UseBasicParsing",
+	} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("re-enrollment UI builds/trusts a command client-side: %s", forbidden)
+		}
+	}
+}
+
+// TestMachineDetailPageReenrollmentSurfacesFailures locks in that a non-2xx
+// response body is surfaced to the operator rather than silently swallowed —
+// mirroring how the existing revoke flow already handles res.ok/data?.error.
+func TestMachineDetailPageReenrollmentSurfacesFailures(t *testing.T) {
+	source := readMachineDetailPageSource(t)
+
+	reenrollIdx := strings.Index(source, "windows-re-enrollment")
+	if reenrollIdx < 0 {
+		t.Fatal("dashboard does not call the windows-re-enrollment endpoint")
+	}
+	// Look at a window around the call site for the same res.ok / data?.error
+	// failure-surfacing pattern the revoke handler uses.
+	start := reenrollIdx - 200
+	if start < 0 {
+		start = 0
+	}
+	end := reenrollIdx + 800
+	if end > len(source) {
+		end = len(source)
+	}
+	window := source[start:end]
+	if !strings.Contains(window, "res.ok") {
+		t.Fatalf("re-enrollment handler does not check res.ok: %q", window)
+	}
+	if !strings.Contains(window, "error") {
+		t.Fatalf("re-enrollment handler does not surface an error field: %q", window)
+	}
+}

--- a/hub/windows_reenrollment_pending_test.go
+++ b/hub/windows_reenrollment_pending_test.go
@@ -1,0 +1,387 @@
+package main
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// prepareTargetedReenrollment seeds a Windows machine with an active
+// credential, mints a re-enrollment token for it via the real endpoint, and
+// returns the server, the old secret, and the parsed token response.
+func prepareTargetedReenrollment(t *testing.T, machineID string) (*httptest.Server, *Server, string, windowsReenrollmentResponse) {
+	t.Helper()
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	t.Cleanup(server.Close)
+	t.Setenv("PUBLIC_URL", "https://hub.example")
+
+	s.seedWindowsMachine(t, machineID)
+	firstToken := s.seedTokenValue(t, machineID+"-initial")
+	oldSecret := s.enrollAndCaptureSecret(t, server, firstToken, machineID)
+	s.setMachineOS(t, machineID, "windows") // restore os=windows clobbered by the metrics fixture
+
+	adminToken := loginAndGetToken(t, e)
+	rec := windowsReenrollmentRequest(e, machineID, adminToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("prepare re-enrollment: status %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp windowsReenrollmentResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return server, s, oldSecret, resp
+}
+
+func dialAndStage(t *testing.T, server *httptest.Server, machineID, token string) (*websocket.Conn, string) {
+	t.Helper()
+	conn, err := wsDialAgent(t, server, "token="+token)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	sendMetricsMsg(t, conn, machineID)
+	newSecret := readEnrolledSecret(t, conn)
+	return conn, newSecret
+}
+
+func activeSecretHash(t *testing.T, s *Server, machineID string) string {
+	t.Helper()
+	var hash string
+	if err := s.db.QueryRow(`SELECT secret_hash FROM agent_credentials WHERE machine_id = ?`, machineID).Scan(&hash); err != nil {
+		t.Fatalf("read active secret_hash: %v", err)
+	}
+	return hash
+}
+
+func pendingState(t *testing.T, s *Server, machineID string) (hash string, expiresAt string) {
+	t.Helper()
+	var h, exp sql.NullString
+	if err := s.db.QueryRow(`SELECT pending_secret_hash, pending_expires_at FROM agent_credentials WHERE machine_id = ?`, machineID).Scan(&h, &exp); err != nil {
+		t.Fatalf("read pending state: %v", err)
+	}
+	return h.String, exp.String
+}
+
+func hashOf(secret string) string {
+	h := sha256.Sum256([]byte(secret))
+	return hex.EncodeToString(h[:])
+}
+
+func secretAuthenticates(t *testing.T, server *httptest.Server, secret string) bool {
+	t.Helper()
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+secret)
+	conn, resp, err := dialWSWithHeader(t, server, "/ws/agent", h)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+			return false
+		}
+		t.Fatalf("dial: %v (status=%v)", err, respStatus(resp))
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+func respStatus(resp *http.Response) int {
+	if resp == nil {
+		return 0
+	}
+	return resp.StatusCode
+}
+
+// TestTargetedReenrollmentStagesPendingKeepingOldActive is the core positive
+// path for BLOCKER 1: staging a targeted re-enrollment must NOT touch the
+// active credential. The old secret is proven still valid by actually
+// authenticating with it against the running hub, not merely by reading a
+// row count.
+func TestTargetedReenrollmentStagesPendingKeepingOldActive(t *testing.T) {
+	server, s, oldSecret, resp := prepareTargetedReenrollment(t, "win-stage")
+	oldActiveHash := activeSecretHash(t, s, "win-stage")
+
+	conn, newSecret := dialAndStage(t, server, "win-stage", resp.Token)
+	defer conn.Close()
+	if newSecret == oldSecret {
+		t.Fatal("staged secret reused the old secret")
+	}
+
+	// Active credential is untouched.
+	if got := activeSecretHash(t, s, "win-stage"); got != oldActiveHash {
+		t.Fatalf("active secret_hash changed merely by staging: got %q, want unchanged %q", got, oldActiveHash)
+	}
+	// Pending reflects the new secret.
+	pendingHash, pendingExp := pendingState(t, s, "win-stage")
+	if pendingHash != hashOf(newSecret) {
+		t.Fatalf("pending_secret_hash=%q, want hash of the staged secret", pendingHash)
+	}
+	if pendingExp == "" {
+		t.Fatal("pending_expires_at not set")
+	}
+
+	// The old secret still actually authenticates against the running hub.
+	if !secretAuthenticates(t, server, oldSecret) {
+		t.Fatal("old secret no longer authenticates immediately after staging — this is exactly the split-brain risk being fixed")
+	}
+}
+
+// TestDualCredentialConnectionRoutesToStagingNotOrdinaryReconnect covers the
+// actual real-world shape of a -ForceReenroll restart: the agent's old
+// secret file is still on disk (no longer moved aside per blocker 1's fix)
+// AND BLOXOS_TOKEN is freshly set, so the very first connection attempt
+// presents BOTH credentials together in one handshake — exactly what
+// agent/main.go's runAgent does whenever both agentSecret and token are
+// non-empty. This must be detected and routed to staging, not silently
+// fast-pathed as an ordinary secret reconnect that never looks at the token.
+func TestDualCredentialConnectionRoutesToStagingNotOrdinaryReconnect(t *testing.T) {
+	server, s, oldSecret, resp := prepareTargetedReenrollment(t, "win-dual")
+	oldActiveHash := activeSecretHash(t, s, "win-dual")
+
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+oldSecret)
+	h.Set(agentEnrollTokenHeader, resp.Token)
+	conn, _, err := dialWSWithHeader(t, server, "/ws/agent", h)
+	if err != nil {
+		t.Fatalf("dual-credential dial: %v", err)
+	}
+	defer conn.Close()
+	sendMetricsMsg(t, conn, "win-dual")
+	newSecret := readEnrolledSecret(t, conn)
+
+	if newSecret == oldSecret {
+		t.Fatal("dual-credential connection did not stage a new secret")
+	}
+	// Proves staging (not ordinary-reconnect fast path, which would never
+	// have consumed the token or produced an "enrolled" frame at all): active
+	// unchanged, pending set to the new secret.
+	if got := activeSecretHash(t, s, "win-dual"); got != oldActiveHash {
+		t.Fatalf("active secret_hash changed on a dual-credential connection before any commit: got %q, want unchanged %q", got, oldActiveHash)
+	}
+	pendingHash, _ := pendingState(t, s, "win-dual")
+	if pendingHash != hashOf(newSecret) {
+		t.Fatalf("pending_secret_hash=%q, want hash of the newly staged secret", pendingHash)
+	}
+	// The token was actually consumed — proof the token was looked at at all,
+	// not ignored the way a generic/irrelevant token riding along would be.
+	h2 := sha256.Sum256([]byte(resp.Token))
+	var used bool
+	if err := s.db.QueryRow(`SELECT used FROM tokens WHERE token_hash = ?`, hex.EncodeToString(h2[:])).Scan(&used); err != nil {
+		t.Fatalf("read token: %v", err)
+	}
+	if !used {
+		t.Fatal("targeted token was not consumed on the dual-credential connection")
+	}
+}
+
+// TestDualCredentialWithGenericTokenIsOrdinaryReconnectTokenIgnored: when the
+// secret is valid but the accompanying token is generic (unbound) rather
+// than targeted at this machine, it must never override the valid
+// credential — this is just an ordinary reconnect, and the token is left
+// completely unconsumed.
+func TestDualCredentialWithGenericTokenIsOrdinaryReconnectTokenIgnored(t *testing.T) {
+	server, s, oldSecret, _ := prepareTargetedReenrollment(t, "win-dual-generic")
+	genericToken := s.seedTokenValue(t, "win-dual-generic-irrelevant-token")
+
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+oldSecret)
+	h.Set(agentEnrollTokenHeader, genericToken)
+	conn, _, err := dialWSWithHeader(t, server, "/ws/agent", h)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	sendMetricsMsg(t, conn, "win-dual-generic")
+
+	// No "enrolled" frame should ever arrive for an ordinary reconnect. Give
+	// it a short bounded window, then confirm nothing changed.
+	conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	if _, msg, err := conn.ReadMessage(); err == nil && strings.Contains(string(msg), "enrolled") {
+		t.Fatalf("ordinary reconnect with a generic token unexpectedly staged/enrolled: %s", msg)
+	}
+
+	h2 := sha256.Sum256([]byte(genericToken))
+	var used bool
+	if err := s.db.QueryRow(`SELECT used FROM tokens WHERE token_hash = ?`, hex.EncodeToString(h2[:])).Scan(&used); err != nil {
+		t.Fatalf("read token: %v", err)
+	}
+	if used {
+		t.Fatal("generic token riding alongside a valid secret was consumed")
+	}
+	pendingHash, _ := pendingState(t, s, "win-dual-generic")
+	if pendingHash != "" {
+		t.Fatal("pending state was set despite the token being generic, not targeted")
+	}
+}
+
+// TestNoAcknowledgementOldSecretStillAuthenticates: if the agent never sends
+// enrollment_committed at all (frame lost, agent crashed after receiving the
+// pending secret but before/instead of acking), the old secret must remain
+// the one that authenticates — proving the fix actually closes blocker 1's
+// failure window rather than just moving it.
+func TestNoAcknowledgementOldSecretStillAuthenticates(t *testing.T) {
+	server, s, oldSecret, resp := prepareTargetedReenrollment(t, "win-noack")
+	conn, _ := dialAndStage(t, server, "win-noack", resp.Token)
+	conn.Close() // simulate the agent vanishing before ever acking
+
+	if !secretAuthenticates(t, server, oldSecret) {
+		t.Fatal("old secret was invalidated despite no enrollment_committed ever being sent")
+	}
+	// And nothing was promoted.
+	pendingHash, _ := pendingState(t, s, "win-noack")
+	if pendingHash == "" {
+		t.Fatal("pending state was cleared without ever being acknowledged")
+	}
+}
+
+// TestEnrollmentCommittedPromotesPendingAndInvalidatesOld: once the agent
+// sends enrollment_committed on the connection that staged it, the pending
+// secret becomes active and the old one is invalidated — this is the ONLY
+// point at which the old credential should stop working.
+func TestEnrollmentCommittedPromotesPendingAndInvalidatesOld(t *testing.T) {
+	server, s, oldSecret, resp := prepareTargetedReenrollment(t, "win-commit")
+	conn, newSecret := dialAndStage(t, server, "win-commit", resp.Token)
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"enrollment_committed"}`)); err != nil {
+		t.Fatalf("send enrollment_committed: %v", err)
+	}
+	waitForPromotion(t, s, "win-commit", hashOf(newSecret))
+
+	if got := activeSecretHash(t, s, "win-commit"); got != hashOf(newSecret) {
+		t.Fatalf("active secret_hash=%q, want the promoted new secret's hash", got)
+	}
+	pendingHash, pendingExp := pendingState(t, s, "win-commit")
+	if pendingHash != "" || pendingExp != "" {
+		t.Fatalf("pending state not cleared after promotion: hash=%q expires=%q", pendingHash, pendingExp)
+	}
+
+	if secretAuthenticates(t, server, oldSecret) {
+		t.Fatal("old secret still authenticates after successful promotion")
+	}
+	if !secretAuthenticates(t, server, newSecret) {
+		t.Fatal("new secret does not authenticate after promotion")
+	}
+}
+
+// waitForPromotion polls until machine_id's active secret_hash equals want or
+// a short deadline passes — promotion happens in the WS read-loop goroutine,
+// asynchronously with respect to the test's WriteMessage call.
+func waitForPromotion(t *testing.T, s *Server, machineID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if activeSecretHash(t, s, machineID) == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("promotion did not complete within timeout")
+}
+
+// TestAcknowledgementLostReconnectWithPendingSecretPromotesIt covers the
+// recovery path: the agent durably saved its new secret and reconnects with
+// it (proving durability), but the hub never received an
+// enrollment_committed (connection dropped right after storage, or a service
+// restart happened between save and ack). validateAgentSecret must recognize
+// and promote the pending secret on this reconnect.
+func TestAcknowledgementLostReconnectWithPendingSecretPromotesIt(t *testing.T) {
+	server, s, oldSecret, resp := prepareTargetedReenrollment(t, "win-recover")
+	conn, newSecret := dialAndStage(t, server, "win-recover", resp.Token)
+	conn.Close() // ack lost
+
+	// Fresh connection, reconnecting with the durably-saved pending secret —
+	// no token this time, exactly like a real agent restart.
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+newSecret)
+	conn2, _, err := dialWSWithHeader(t, server, "/ws/agent", h)
+	if err != nil {
+		t.Fatalf("reconnect with pending secret: %v", err)
+	}
+	defer conn2.Close()
+
+	waitForPromotion(t, s, "win-recover", hashOf(newSecret))
+	pendingHash, _ := pendingState(t, s, "win-recover")
+	if pendingHash != "" {
+		t.Fatal("pending state not cleared after recovery promotion")
+	}
+	if secretAuthenticates(t, server, oldSecret) {
+		t.Fatal("old secret still authenticates after recovery promotion")
+	}
+}
+
+// TestExpiredPendingSecretRejectedOldActiveRemainsValid: a pending secret
+// that's aged past its bounded window must not authenticate, and the old
+// active secret must remain valid throughout the abandoned attempt.
+func TestExpiredPendingSecretRejectedOldActiveRemainsValid(t *testing.T) {
+	server, s, oldSecret, resp := prepareTargetedReenrollment(t, "win-expired")
+	conn, newSecret := dialAndStage(t, server, "win-expired", resp.Token)
+	conn.Close()
+
+	if _, err := s.db.Exec(
+		`UPDATE agent_credentials SET pending_expires_at = ? WHERE machine_id = ?`,
+		time.Now().Add(-time.Minute).Format(time.RFC3339), "win-expired",
+	); err != nil {
+		t.Fatalf("force pending expiry: %v", err)
+	}
+
+	if secretAuthenticates(t, server, newSecret) {
+		t.Fatal("expired pending secret was accepted")
+	}
+	if !secretAuthenticates(t, server, oldSecret) {
+		t.Fatal("old active secret stopped working while the pending attempt merely expired")
+	}
+}
+
+// TestConcurrentTargetedConsumptionsProduceAtMostOnePendingCredential races
+// two goroutines staging the SAME targeted token for the same machine —
+// exactly one may succeed, and the resulting pending state must reflect a
+// single, internally consistent outcome (not a partially-applied mix).
+func TestConcurrentTargetedConsumptionsProduceAtMostOnePendingCredential(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedWindowsMachine(t, "win-stage-race")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`, "win-stage-race", "race-active-hash"); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+
+	rawToken := "win-stage-race-token"
+	tokenHash := hashOf(rawToken)
+	if _, err := s.db.Exec(
+		`INSERT INTO tokens (token_hash, expires_at, used, target_machine_id) VALUES (?, ?, FALSE, ?)`,
+		tokenHash, time.Now().Add(15*time.Minute).Format(time.RFC3339), "win-stage-race",
+	); err != nil {
+		t.Fatalf("seed targeted token: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	results := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = s.stageTargetedCredential(tokenHash, "win-stage-race", "pending-hash-"+string(rune('A'+idx)))
+		}(i)
+	}
+	wg.Wait()
+
+	successes := 0
+	for _, err := range results {
+		if err == nil {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("expected exactly 1 successful staging of a raced token, got %d", successes)
+	}
+	if got := activeSecretHash(t, s, "win-stage-race"); got != "race-active-hash" {
+		t.Fatalf("active credential was touched by racing staging attempts: %q", got)
+	}
+}

--- a/hub/windows_reenrollment_test.go
+++ b/hub/windows_reenrollment_test.go
@@ -1,0 +1,589 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// setMachineOS updates an existing machine row's os column.
+func (s *Server) setMachineOS(t *testing.T, id, osName string) {
+	t.Helper()
+	if _, err := s.db.Exec(`UPDATE machines SET os = ? WHERE id = ?`, osName, id); err != nil {
+		t.Fatalf("set machine os=%q: %v", osName, err)
+	}
+}
+
+// seedWindowsMachine seeds a fresh machine row with os='windows'.
+func (s *Server) seedWindowsMachine(t *testing.T, id string) {
+	t.Helper()
+	s.seedTestMachine(t, id)
+	s.setMachineOS(t, id, "windows")
+}
+
+func windowsReenrollmentPath(machineID string) string {
+	return "/api/machines/" + machineID + "/windows-re-enrollment"
+}
+
+func windowsReenrollmentRequest(e http.Handler, machineID, authToken string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, windowsReenrollmentPath(machineID), nil)
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestTokensMigrationAddsNullableTargetMachineIDWithoutAlteringExisting locks
+// in that the schema change is additive: a token inserted the old way (no
+// target_machine_id) reads back with an unbound (NULL) target, and its
+// existing validate/consume behavior is untouched.
+func TestTokensMigrationAddsNullableTargetMachineIDWithoutAlteringExisting(t *testing.T) {
+	_, s := setupTestServer(t)
+
+	rawToken := "pre-migration-shape-token"
+	h := sha256.Sum256([]byte(rawToken))
+	tokenHash := hex.EncodeToString(h[:])
+	expiresAt := time.Now().Add(15 * time.Minute).Format(time.RFC3339)
+
+	// Insert exactly the way pre-existing code paths do: no target_machine_id.
+	if _, err := s.db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, FALSE)`, tokenHash, expiresAt); err != nil {
+		t.Fatalf("insert legacy-shaped token: %v", err)
+	}
+
+	gotHash, target, err := s.validateAgentToken(rawToken)
+	if err != nil {
+		t.Fatalf("expected valid unbound token, got error: %v", err)
+	}
+	if gotHash != tokenHash {
+		t.Fatalf("hash mismatch: got %s want %s", gotHash, tokenHash)
+	}
+	if target.Valid {
+		t.Fatalf("expected NULL target_machine_id for a legacy-shaped token, got %q", target.String)
+	}
+}
+
+// TestOrdinaryTokensRemainUnboundAndPreserveExistingBehavior locks in that a
+// token minted by the ordinary POST /api/tokens flow has no target, so all
+// pre-existing generic-enrollment behavior (including the takeover refusal
+// covered by TestInstallTokenCannotTakeOverEnrolledMachine) is unaffected.
+func TestOrdinaryTokensRemainUnboundAndPreserveExistingBehavior(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	adminToken := loginAndGetToken(t, e)
+	t.Setenv("PUBLIC_URL", "https://hub.example")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create token: status %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp installTokenResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	_, target, err := s.validateAgentToken(resp.Token)
+	if err != nil {
+		t.Fatalf("validate ordinary token: %v", err)
+	}
+	if target.Valid {
+		t.Fatalf("ordinary Add Machine token must be unbound, got target %q", target.String)
+	}
+}
+
+// TestWindowsReenrollmentAuthorization locks in the RBAC/existence gate:
+// 401 unauthenticated, 403 viewer/operator, 404 missing machine, 404
+// non-Windows machine, 200 fleet.admin against a real Windows machine.
+func TestWindowsReenrollmentAuthorization(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "https://hub.example")
+	s.seedWindowsMachine(t, "win-authz")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`, "win-authz", "authz-secret-hash"); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	s.seedTestMachine(t, "linux-authz") // os left unset -> normalizes to "linux"
+
+	s.seedTestUser(t, "wre-viewer", "viewerpass123", "1234", RoleViewer, true, true)
+	s.seedTestUser(t, "wre-operator", "operatorpass123", "1234", RoleOperator, true, true)
+	viewerToken := loginAndGetTokenForCredentials(t, e, "wre-viewer", "viewerpass123")
+	operatorToken := loginAndGetTokenForCredentials(t, e, "wre-operator", "operatorpass123")
+	adminToken := loginAndGetToken(t, e)
+
+	for _, tc := range []struct {
+		name       string
+		machineID  string
+		token      string
+		wantStatus int
+	}{
+		{name: "unauthenticated", machineID: "win-authz", wantStatus: http.StatusUnauthorized},
+		{name: "viewer", machineID: "win-authz", token: viewerToken, wantStatus: http.StatusForbidden},
+		{name: "operator", machineID: "win-authz", token: operatorToken, wantStatus: http.StatusForbidden},
+		{name: "missing machine", machineID: "no-such-machine", token: adminToken, wantStatus: http.StatusNotFound},
+		{name: "non-Windows machine", machineID: "linux-authz", token: adminToken, wantStatus: http.StatusNotFound},
+		{name: "fleet.admin on Windows machine", machineID: "win-authz", token: adminToken, wantStatus: http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := windowsReenrollmentRequest(e, tc.machineID, tc.token)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestWindowsReenrollmentRequiresActiveCredential locks in that the endpoint
+// refuses to mint a re-enrollment token for a Windows machine with no active
+// credential — there is nothing for it to stage a replacement against — and
+// that the refusal inserts no token row.
+func TestWindowsReenrollmentRequiresActiveCredential(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	s.seedWindowsMachine(t, "win-no-credential")
+	adminToken := loginAndGetToken(t, e)
+	t.Setenv("PUBLIC_URL", "https://hub.example")
+
+	rec := windowsReenrollmentRequest(e, "win-no-credential", adminToken)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for a machine with no active credential, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var tokenCount int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM tokens`).Scan(&tokenCount); err != nil {
+		t.Fatalf("count tokens: %v", err)
+	}
+	if tokenCount != 0 {
+		t.Fatalf("expected no token minted on refusal, got %d", tokenCount)
+	}
+}
+
+// TestWindowsReenrollmentRequiresPublicURLAndMutatesNothingOnFailure locks in
+// that a missing PUBLIC_URL refuses before any write: no token row, and (when
+// a credential already exists) that credential is untouched.
+func TestWindowsReenrollmentRequiresPublicURLAndMutatesNothingOnFailure(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	s.seedWindowsMachine(t, "win-nopublicurl")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`, "win-nopublicurl", "existing-hash"); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	adminToken := loginAndGetToken(t, e)
+	t.Setenv("PUBLIC_URL", "")
+
+	rec := windowsReenrollmentRequest(e, "win-nopublicurl", adminToken)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when PUBLIC_URL unset, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "PUBLIC_URL") {
+		t.Fatalf("expected error to mention PUBLIC_URL, got %s", rec.Body.String())
+	}
+
+	var tokenCount int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM tokens`).Scan(&tokenCount); err != nil {
+		t.Fatalf("count tokens: %v", err)
+	}
+	if tokenCount != 0 {
+		t.Fatalf("expected no token minted on refusal, got %d", tokenCount)
+	}
+	var secretHash string
+	if err := s.db.QueryRow(`SELECT secret_hash FROM agent_credentials WHERE machine_id = ?`, "win-nopublicurl").Scan(&secretHash); err != nil {
+		t.Fatalf("read credential: %v", err)
+	}
+	if secretHash != "existing-hash" {
+		t.Fatalf("credential was mutated by a refused request: %q", secretHash)
+	}
+}
+
+// TestWindowsReenrollmentInsertsTargetedTokenWithoutTouchingLiveState locks in
+// that preparing the command is inert: the token is minted target-bound and
+// unused, but no credential is deleted and no live socket is closed.
+func TestWindowsReenrollmentInsertsTargetedTokenWithoutTouchingLiveState(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	t.Setenv("PUBLIC_URL", "https://hub.example")
+
+	s.seedWindowsMachine(t, "win-inert")
+	firstToken := s.seedTokenValue(t, "win-inert-initial-token")
+	oldSecret := s.enrollAndCaptureSecret(t, server, firstToken, "win-inert")
+	if oldSecret == "" {
+		t.Fatal("initial enrollment did not yield a secret")
+	}
+	// enrollAndCaptureSecret's metrics fixture reports os="linux/amd64" and
+	// upsertMachine writes that back — restore os=windows so the machine
+	// still qualifies for the endpoint, matching what a real Windows agent's
+	// own metrics frames would report.
+	s.setMachineOS(t, "win-inert", "windows")
+
+	adminToken := loginAndGetToken(t, e)
+	rec := windowsReenrollmentRequest(e, "win-inert", adminToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("prepare re-enrollment: status %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp windowsReenrollmentResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.MachineID != "win-inert" || resp.Token == "" || resp.WindowsCommand == "" || resp.ExpiresAt == "" {
+		t.Fatalf("incomplete response: %+v", resp)
+	}
+
+	// Token is target-bound and unused.
+	h := sha256.Sum256([]byte(resp.Token))
+	tokenHash := hex.EncodeToString(h[:])
+	var used bool
+	var targetMachineID string
+	if err := s.db.QueryRow(`SELECT used, target_machine_id FROM tokens WHERE token_hash = ?`, tokenHash).Scan(&used, &targetMachineID); err != nil {
+		t.Fatalf("read minted token: %v", err)
+	}
+	if used {
+		t.Fatal("token was consumed merely by preparing the command")
+	}
+	if targetMachineID != "win-inert" {
+		t.Fatalf("token target=%q, want win-inert", targetMachineID)
+	}
+
+	// Existing credential untouched.
+	var secretHash string
+	if err := s.db.QueryRow(`SELECT secret_hash FROM agent_credentials WHERE machine_id = ?`, "win-inert").Scan(&secretHash); err != nil {
+		t.Fatalf("credential deleted merely by preparing the command: %v", err)
+	}
+
+	// No socket close: the still-enrolled agent's secret keeps authenticating.
+	authHeader := http.Header{}
+	authHeader.Set("Authorization", "Bearer "+oldSecret)
+	liveConn, liveResp, err := dialWSWithHeader(t, server, "/ws/agent", authHeader)
+	if err != nil {
+		status := 0
+		if liveResp != nil {
+			status = liveResp.StatusCode
+		}
+		t.Fatalf("preparing the command disconnected/invalidated the live agent: status=%d err=%v", status, err)
+	}
+	liveConn.Close()
+}
+
+// TestWindowsReenrollmentCommandUsesPublicURLAndForceReenroll locks in that
+// the returned command is generated exclusively from PUBLIC_URL (never a
+// request Host header) and invokes install.ps1 with -ForceReenroll, while the
+// ordinary POST /api/tokens Windows command omits the switch entirely.
+func TestWindowsReenrollmentCommandUsesPublicURLAndForceReenroll(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	s.seedWindowsMachine(t, "win-cmd")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials (machine_id, secret_hash) VALUES (?, ?)`, "win-cmd", "cmd-secret-hash"); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	adminToken := loginAndGetToken(t, e)
+	t.Setenv("PUBLIC_URL", "https://hub.public.example")
+
+	req := httptest.NewRequest(http.MethodPost, windowsReenrollmentPath("win-cmd"), nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Host = "evil.example"
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("prepare re-enrollment: status %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp windowsReenrollmentResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if strings.Contains(resp.WindowsCommand, "evil.example") {
+		t.Fatalf("command used the request Host instead of PUBLIC_URL: %q", resp.WindowsCommand)
+	}
+	if !strings.Contains(resp.WindowsCommand, "hub.public.example") {
+		t.Fatalf("command did not use PUBLIC_URL: %q", resp.WindowsCommand)
+	}
+	if !strings.Contains(resp.WindowsCommand, "-ForceReenroll") {
+		t.Fatalf("re-enrollment command missing -ForceReenroll: %q", resp.WindowsCommand)
+	}
+
+	// Ordinary Add Machine command must NOT carry the switch.
+	ordReq := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
+	ordReq.Header.Set("Authorization", "Bearer "+adminToken)
+	ordRec := httptest.NewRecorder()
+	e.ServeHTTP(ordRec, ordReq)
+	if ordRec.Code != http.StatusOK {
+		t.Fatalf("create ordinary token: status %d: %s", ordRec.Code, ordRec.Body.String())
+	}
+	var ordResp installTokenResponse
+	if err := json.Unmarshal(ordRec.Body.Bytes(), &ordResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if strings.Contains(ordResp.WindowsCommand, "-ForceReenroll") {
+		t.Fatalf("ordinary Add Machine Windows command must not contain -ForceReenroll: %q", ordResp.WindowsCommand)
+	}
+}
+
+// TestTargetedTokenRejectedByWrongMachineAndLeftUnused locks in the early
+// enrollment guard: a token minted for machine A must be rejected when
+// presented by machine B, whether or not B already has a credential, and the
+// token must remain usable afterward (not silently burned by the attempt).
+func TestTargetedTokenRejectedByWrongMachineAndLeftUnused(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	t.Setenv("PUBLIC_URL", "https://hub.example")
+
+	s.seedWindowsMachine(t, "win-target-a")
+	firstToken := s.seedTokenValue(t, "win-target-a-initial")
+	s.enrollAndCaptureSecret(t, server, firstToken, "win-target-a")
+	s.setMachineOS(t, "win-target-a", "windows") // restore os=windows clobbered by the metrics fixture
+
+	adminToken := loginAndGetToken(t, e)
+	rec := windowsReenrollmentRequest(e, "win-target-a", adminToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("prepare re-enrollment: status %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp windowsReenrollmentResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// A different, uninvolved machine tries to use A's targeted token.
+	conn, err := wsDialAgent(t, server, "token="+resp.Token)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	sendMetricsMsg(t, conn, "win-target-b")
+
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("expected a rejection frame, got read error: %v", err)
+	}
+	if strings.Contains(string(msg), "agent_secret") {
+		t.Fatalf("wrong-machine use of a targeted token was accepted: %s", string(msg))
+	}
+	if !strings.Contains(string(msg), "different machine") {
+		t.Fatalf("expected a bound-to-a-different-machine rejection, got %s", string(msg))
+	}
+
+	// Token must remain unused.
+	h := sha256.Sum256([]byte(resp.Token))
+	tokenHash := hex.EncodeToString(h[:])
+	var used bool
+	if err := s.db.QueryRow(`SELECT used FROM tokens WHERE token_hash = ?`, tokenHash).Scan(&used); err != nil {
+		t.Fatalf("read token: %v", err)
+	}
+	if used {
+		t.Fatal("targeted token was consumed by a wrong-machine rejection")
+	}
+
+	// And win-target-b must not have gained a credential.
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, "win-target-b").Scan(&count); err != nil {
+		t.Fatalf("count credentials: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("wrong-machine targeted-token use created a credential: count=%d", count)
+	}
+}
+
+// TestGenericTokenStillCannotReplaceEnrolledMachineCredential re-confirms,
+// after the target-binding change, that an ordinary unbound token still
+// cannot silently replace an already-enrolled machine's credential — this is
+// the same invariant as TestInstallTokenCannotTakeOverEnrolledMachine,
+// exercised again here alongside the new targeted-token paths so a future
+// change to the branch logic that weakens one can't slip past only testing
+// the other.
+func TestGenericTokenStillCannotReplaceEnrolledMachineCredential(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	s.seedWindowsMachine(t, "win-generic-guard")
+	firstToken := s.seedTokenValue(t, "win-generic-guard-initial")
+	before := s.enrollAndCaptureSecret(t, server, firstToken, "win-generic-guard")
+
+	genericToken := s.seedTokenValue(t, "win-generic-guard-attacker")
+	conn, err := wsDialAgent(t, server, "token="+genericToken)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	sendMetricsMsg(t, conn, "win-generic-guard")
+
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("expected rejection, got read error: %v", err)
+	}
+	if strings.Contains(string(msg), "agent_secret") {
+		t.Fatal("generic token replaced an enrolled machine's credential")
+	}
+
+	var after string
+	if err := s.db.QueryRow(`SELECT secret_hash FROM agent_credentials WHERE machine_id = ?`, "win-generic-guard").Scan(&after); err != nil {
+		t.Fatalf("read credential: %v", err)
+	}
+	h := sha256.Sum256([]byte(before))
+	beforeHash := hex.EncodeToString(h[:])
+	if after != beforeHash {
+		t.Fatal("credential was replaced despite generic-token guard")
+	}
+}
+
+// TestTargetedTokenConsumedOnceAndCannotBeReplayed covers the token-lifecycle
+// half of the positive path — the full credential-handoff protocol (staging,
+// the old secret remaining valid, and enrollment_committed promotion) is
+// covered by windows_reenrollment_pending_test.go.
+func TestTargetedTokenConsumedOnceAndCannotBeReplayed(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	t.Setenv("PUBLIC_URL", "https://hub.example")
+
+	s.seedWindowsMachine(t, "win-target-once")
+	firstToken := s.seedTokenValue(t, "win-target-once-initial")
+	s.enrollAndCaptureSecret(t, server, firstToken, "win-target-once")
+	s.setMachineOS(t, "win-target-once", "windows") // restore os=windows clobbered by the metrics fixture
+
+	adminToken := loginAndGetToken(t, e)
+	rec := windowsReenrollmentRequest(e, "win-target-once", adminToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("prepare re-enrollment: status %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp windowsReenrollmentResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	conn, err := wsDialAgent(t, server, "token="+resp.Token)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	sendMetricsMsg(t, conn, "win-target-once")
+	readEnrolledSecret(t, conn)
+
+	h := sha256.Sum256([]byte(resp.Token))
+	tokenHash := hex.EncodeToString(h[:])
+	var used bool
+	if err := s.db.QueryRow(`SELECT used FROM tokens WHERE token_hash = ?`, tokenHash).Scan(&used); err != nil {
+		t.Fatalf("read token: %v", err)
+	}
+	if !used {
+		t.Fatal("targeted token was not marked used after staging")
+	}
+
+	// Cannot be replayed. A consumed token has neither a valid secret nor a
+	// valid token behind it, so handleAgentWS's pre-upgrade guard rejects the
+	// handshake outright (401) rather than upgrading and rejecting on the
+	// first frame.
+	if conn2, resp2, err := dialWSWithHeader(t, server, "/ws/agent?token="+resp.Token, http.Header{}); err == nil {
+		conn2.Close()
+		t.Fatal("consumed targeted token was replayed successfully (handshake upgraded)")
+	} else if resp2 == nil || resp2.StatusCode != http.StatusUnauthorized {
+		status := 0
+		if resp2 != nil {
+			status = resp2.StatusCode
+		}
+		t.Fatalf("expected 401 rejecting the replayed token, got status=%d err=%v", status, err)
+	}
+}
+
+// readEnrolledSecret drains frames on conn until it sees an "enrolled" frame
+// and returns its agent_secret.
+func readEnrolledSecret(t *testing.T, conn *websocket.Conn) string {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read enrolled frame: %v", err)
+		}
+		var frame struct {
+			Type        string `json:"type"`
+			AgentSecret string `json:"agent_secret"`
+		}
+		if json.Unmarshal(msg, &frame) == nil && frame.Type == "enrolled" && frame.AgentSecret != "" {
+			return frame.AgentSecret
+		}
+	}
+}
+
+// TestConsumeTokenAndStoreCredentialEnforcesTargetInsideTransaction defeats a
+// validate/consume race: two goroutines race to consume the same targeted
+// token for its correct machine_id. Exactly one must win; the DB-level
+// UPDATE ... WHERE used = FALSE guard (re-checked inside the same
+// transaction as the target lookup) must make the second a clean failure,
+// not a lost update.
+func TestConsumeTokenAndStoreCredentialEnforcesTargetInsideTransaction(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedWindowsMachine(t, "win-race")
+
+	rawToken := "win-race-targeted-token"
+	h := sha256.Sum256([]byte(rawToken))
+	tokenHash := hex.EncodeToString(h[:])
+	expiresAt := time.Now().Add(15 * time.Minute).Format(time.RFC3339)
+	if _, err := s.db.Exec(
+		`INSERT INTO tokens (token_hash, expires_at, used, target_machine_id) VALUES (?, ?, FALSE, ?)`,
+		tokenHash, expiresAt, "win-race",
+	); err != nil {
+		t.Fatalf("seed targeted token: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	results := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = s.consumeTokenAndStoreCredential(tokenHash, "win-race", "secret-hash-race")
+		}(i)
+	}
+	wg.Wait()
+
+	successes := 0
+	for _, err := range results {
+		if err == nil {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("expected exactly 1 successful consumption of a raced token, got %d", successes)
+	}
+
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = ?`, "win-race").Scan(&count); err != nil {
+		t.Fatalf("count credentials: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 credential row after a raced consume, got %d", count)
+	}
+}
+
+// TestWindowsReenrollmentRouteHasFleetAdminScope mirrors
+// TestCredentialRevokeRouteHasFleetAdminScope: the new route must be present
+// in routeScopeRequirements with fleet.admin, and the generic startup audit
+// (auditRBACRouteCoverage) must pass with it registered.
+func TestWindowsReenrollmentRouteHasFleetAdminScope(t *testing.T) {
+	key := routeScopeKey(http.MethodPost, "/api/machines/:id/windows-re-enrollment")
+	if got := routeScopeRequirements[key]; got != scopeFleetAdmin {
+		t.Fatalf("windows-re-enrollment route scope=%q, want %q", got, scopeFleetAdmin)
+	}
+
+	echoServer, _ := setupTestServer(t)
+	if err := auditRBACRouteCoverage(echoServer, routeScopeRequirements); err != nil {
+		t.Fatalf("RBAC route audit: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/machines/:id/windows-re-enrollment` (fleet.admin): mints a machine-bound token and a `-ForceReenroll` command so a revoked/reset Windows agent can be re-enrolled without the installer FastPath's split-brain risk.
- Two-phase credential handoff (hub: `agent_credentials.pending_secret_hash`/`pending_expires_at`, migration 19; agent: `agent-secret.pending` staged locally, `agent-secret` promoted only on a hash-bound `enrollment_confirmed` carrying `secret_sha256`) — the active credential is never overwritten until the hub's compare-and-swap promotion is proven and durably committed on both sides.
- Six rounds of adversarial review (Codex) found and fixed six real, verified issues along the way: split-brain rollback + token-cleanup ordering, a non-constrained CAS + fail-open expiry, an unconfirmed acknowledgement, a concurrent-WebSocket-writer bug + expiry TOCTOU, ghost connections on post-registration early returns + a half-finished local two-phase handoff, and a reconnect fallback state machine that didn't actually fall back + two rename points that silently swallowed durability failures. All fixed and independently re-verified; see the commit body for full detail per round.

Refs #150 — intentionally does not close it. #150 stays open until the physical 7-scenario Windows acceptance session (clean install, idempotent rerun, expired-token no-op, fingerprint-mismatch abort, revoke/re-enroll via this new endpoint, non-Caddy, unsupported-curl) passes on real Windows hardware.

## Test plan
- `cd hub && go vet ./... && go test ./... && go test ./... -race` — green (race also re-run at `-count=20` on every connection-cleanup and concurrency-sensitive test).
- `cd agent && go vet ./... && go test ./... && go test ./... -race` — green (race also re-run at `-count=20` on the reconnect state machine and durable-rename tests, and `-count=3` full suite); also built/vetted with `-tags insecure` and cross-compiled/vetted/`test -c`'d for `windows/amd64`.
- `cd proto && go vet ./... && go test ./...` — green.
- `cd dashboard && pnpm lint && pnpm build` — green; isolated Playwright smoke skill run in an earlier round (10 screenshots, 0 console errors) — dashboard untouched since.
- `git diff --check` — clean.

## Notes for reviewers
- Code-only. No live deployment yet — coupled to a separate, already-scoped hub rebuild (new resolver requires migrating the Linux serve path to a root-owned directory first).
- A pre-existing, extremely rare test-fixture race was discovered (not introduced) in `prepareTargetedReenrollment`'s OS-restore step vs. the server's own `upsertMachine` write — seen once under `-race -count=3` on the full suite, 100/100 clean in isolation at `-race -count=100`. Worth its own follow-up issue if it recurs; not blocking here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication, credential storage, enrollment WebSocket protocol, and hub DB promotion semantics; mistakes could strand agents or allow incorrect credential promotion.
> 
> **Overview**
> Introduces **machine-bound Windows re-enrollment**: `POST /api/machines/:id/windows-re-enrollment` mints a targeted token and a `-ForceReenroll` install command; the dashboard adds a **Prepare Windows re-enrollment** flow that only displays hub-returned command/CA metadata.
> 
> **Credential rotation** no longer overwrites the active secret on `enrolled`. The hub stages `pending_secret_hash` with expiry; the agent writes **`agent-secret.pending`** only, sends `enrollment_committed`, and promotes to **`agent-secret`** when `enrollment_confirmed` includes matching **`secret_sha256`**. Hub promotion uses a **compare-and-swap** UPDATE; pending secrets can also promote on reconnect if the ack was lost. **`BLOXOS_TOKEN`** cleanup is deferred until confirmation (or safe ordinary reconnect).
> 
> **Agent `connectLoop`** prefers pending credentials unless the hub already rejected that value, then falls back to active without backoff on a definitive 401; **`writeCredentialFileAtomic`** / **`durableRename`** (POSIX dir fsync; Windows `MOVEFILE_WRITE_THROUGH`) fail closed instead of swallowing durability errors.
> 
> **Hub WebSocket** handling adds `enrollment_committed` processing, mutex-serialized writes for `enrollment_confirmed`, dual-credential targeted re-enroll routing, and **unconditional `defer` unregister** so early post-registration exits do not leave ghost connections. **`install.ps1`** gains `-ForceReenroll`: it records the old secret hash without moving/deleting the file and waits for active-file hash change (or bounded timeout) before success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77f10bdcbdbad41a1fca6cee4e52a66b0ae7dd3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->