### PR TITLE
feat: one-setting Docker Compose install for the hub with published images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,9 +26,9 @@ agent/bloxos-agent
 **/*.db-journal
 
 # Environment and secrets; the commented reference stays
-.env
-.env.*
-!.env.example
+**/.env
+**/.env.*
+!**/.env.example
 **/*.local
 **/.bloxos
 **/*.key

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Version control and tooling
+.git
+.github
+**/.claude
+.backups
+.turbo
+.idea
+.vscode
+**/.DS_Store
+
+# Dependencies and build outputs
+**/node_modules
+dashboard/.next
+dashboard/out
+bin
+hub/hub
+hub/bloxos-hub
+agent/agent
+agent/bloxos-agent
+**/*.exe
+
+# Databases
+**/*.db
+**/*.db-wal
+**/*.db-shm
+**/*.db-journal
+
+# Environment and secrets; the commented reference stays
+.env
+.env.*
+!.env.example
+**/*.local
+**/.bloxos
+**/*.key
+**/*.pem
+**/*.sig

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,113 @@
+name: Docker
+
+on:
+  pull_request:
+    paths:
+      - "Dockerfile.hub"
+      - "Dockerfile.dashboard"
+      - ".dockerignore"
+      - "docker/**"
+      - "scripts/smoke/**"
+      - ".github/workflows/docker.yml"
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  HUB_IMAGE: ghcr.io/${{ github.repository_owner }}/bloxos-hub
+  DASHBOARD_IMAGE: ghcr.io/${{ github.repository_owner }}/bloxos-dashboard
+
+jobs:
+  # Builds both images for the runner's platform and enrolls the runner as an
+  # agent through the Compose stack (scripts/smoke/compose-enroll.sh). Gates
+  # publishing and checks container-related pull requests.
+  smoke:
+    name: Compose smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v3
+      - name: Build hub image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.hub
+          load: true
+          tags: ${{ env.HUB_IMAGE }}:latest
+          cache-from: type=gha,scope=hub
+          cache-to: type=gha,scope=hub,mode=max
+      - name: Build dashboard image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.dashboard
+          load: true
+          tags: ${{ env.DASHBOARD_IMAGE }}:latest
+          cache-from: type=gha,scope=dashboard
+          cache-to: type=gha,scope=dashboard,mode=max
+      - name: Enroll the runner through the stack
+        env:
+          SMOKE_CONFIRM_DISPOSABLE: "1"
+          HUB_HOST: 127.0.0.1
+        run: scripts/smoke/compose-enroll.sh
+
+  # Multi-platform build and push, version tags only. This is the only job
+  # with package write permission.
+  publish:
+    name: Publish images
+    needs: smoke
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: hub-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.HUB_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+      - name: Push hub image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.hub
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.hub-meta.outputs.tags }}
+          labels: ${{ steps.hub-meta.outputs.labels }}
+          cache-from: type=gha,scope=hub
+      - id: dashboard-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DASHBOARD_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+      - name: Push dashboard image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.dashboard
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.dashboard-meta.outputs.tags }}
+          labels: ${{ steps.dashboard-meta.outputs.labels }}
+          cache-from: type=gha,scope=dashboard

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,10 @@ jobs:
         run: scripts/smoke/compose-enroll.sh
 
   # Multi-platform build and push, version tags only. This is the only job
-  # with package write permission.
+  # with package write permission. Both images are pushed by digest first,
+  # with no tags, and promoted to the version and latest tags only after
+  # both pushes succeeded, so a failed build never leaves a mixed pair
+  # behind the default tags.
   publish:
     name: Publish images
     needs: smoke
@@ -77,37 +80,37 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - id: hub-meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.HUB_IMAGE }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
-      - name: Push hub image
+      - name: Push hub image by digest
+        id: hub
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.hub
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.hub-meta.outputs.tags }}
-          labels: ${{ steps.hub-meta.outputs.labels }}
+          outputs: type=image,name=${{ env.HUB_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha,scope=hub
-      - id: dashboard-meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.DASHBOARD_IMAGE }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
-      - name: Push dashboard image
+      - name: Push dashboard image by digest
+        id: dashboard
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.dashboard
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.dashboard-meta.outputs.tags }}
-          labels: ${{ steps.dashboard-meta.outputs.labels }}
+          outputs: type=image,name=${{ env.DASHBOARD_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha,scope=dashboard
+      - name: Promote both images to the version and latest tags
+        env:
+          VERSION: ${{ github.ref_name }}
+          HUB_DIGEST: ${{ steps.hub.outputs.digest }}
+          DASHBOARD_DIGEST: ${{ steps.dashboard.outputs.digest }}
+        run: |
+          set -euo pipefail
+          version="${VERSION#v}"
+          docker buildx imagetools create -t "$HUB_IMAGE:$version" -t "$HUB_IMAGE:latest" "$HUB_IMAGE@$HUB_DIGEST"
+          docker buildx imagetools create -t "$DASHBOARD_IMAGE:$version" -t "$DASHBOARD_IMAGE:latest" "$DASHBOARD_IMAGE@$DASHBOARD_DIGEST"

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.7
+# BloxOS dashboard image: Next.js standalone server, served same-origin
+# with the hub behind one reverse proxy, so NEXT_PUBLIC_HUB_URL is empty.
+
+FROM node:22-alpine AS build
+ENV PNPM_HOME=/pnpm \
+    PATH=/pnpm:$PATH \
+    NEXT_TELEMETRY_DISABLED=1 \
+    NEXT_PUBLIC_HUB_URL=
+RUN corepack enable && corepack prepare pnpm@10.33.2 --activate
+WORKDIR /app
+COPY dashboard/package.json dashboard/pnpm-lock.yaml ./
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+COPY dashboard/ ./
+RUN pnpm build
+
+FROM node:22-alpine
+ENV NODE_ENV=production \
+    HOSTNAME=0.0.0.0 \
+    PORT=3000 \
+    NEXT_TELEMETRY_DISABLED=1
+WORKDIR /app
+COPY --from=build --chown=node:node /app/.next/standalone ./
+COPY --from=build --chown=node:node /app/.next/static ./.next/static
+COPY --from=build --chown=node:node /app/public ./public
+USER node
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3000/login >/dev/null || exit 1
+CMD ["node", "server.js"]

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -1,8 +1,13 @@
 # syntax=docker/dockerfile:1.7
 # BloxOS dashboard image: Next.js standalone server, served same-origin
 # with the hub behind one reverse proxy, so NEXT_PUBLIC_HUB_URL is empty.
+#
+# The build stage runs on the build platform: the output is JavaScript and
+# static assets, and the dashboard never uses next/image (see next.config.ts),
+# so no target-specific native module is needed. The runtime stage has no
+# RUN steps, so a multi-platform build needs no emulation.
 
-FROM node:22-alpine AS build
+FROM --platform=$BUILDPLATFORM node:22-alpine AS build
 ENV PNPM_HOME=/pnpm \
     PATH=/pnpm:$PATH \
     NEXT_TELEMETRY_DISABLED=1 \

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1.7
+# BloxOS hub image.
+#
+# One build of this checkout produces the hub binary and the agent binaries
+# the hub serves to enrolling machines, so a running hub always offers
+# agents from the same commit. The served Linux agent matches the image's
+# own architecture (an arm64 image serves arm64 agents, an amd64 image
+# serves amd64 agents); the served Windows agent is always amd64. A single
+# image therefore serves one Linux architecture; see docker/README.md.
+#
+# Builds are deterministic for a given commit and toolchain (-trimpath,
+# no VCS stamping, stripped), so rebuilding does not change the served
+# agent hash and does not trigger a fleet rollout.
+
+FROM --platform=$BUILDPLATFORM golang:1.25.9-alpine AS build
+ARG TARGETARCH
+ENV CGO_ENABLED=0 \
+    GOTOOLCHAIN=local \
+    GOFLAGS="-trimpath -buildvcs=false"
+WORKDIR /src
+COPY proto/ proto/
+COPY hub/go.mod hub/go.sum hub/
+COPY agent/go.mod agent/go.sum agent/
+RUN --mount=type=cache,target=/go/pkg/mod \
+    (cd hub && go mod download) && (cd agent && go mod download)
+COPY hub/ hub/
+COPY agent/ agent/
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    mkdir -p /out/linux /out/windows \
+ && (cd hub   && GOOS=linux   GOARCH="$TARGETARCH" go build -ldflags='-s -w' -o /out/bloxos-hub .) \
+ && (cd agent && GOOS=linux   GOARCH="$TARGETARCH" go build -ldflags='-s -w' -o /out/linux/bloxos-agent .) \
+ && (cd agent && GOOS=windows GOARCH=amd64        go build -ldflags='-s -w' -o /out/windows/bloxos-agent.exe .)
+
+FROM alpine:3.22
+RUN apk add --no-cache ca-certificates \
+ && addgroup -g 65532 -S nonroot \
+ && adduser -u 65532 -S -G nonroot -h /data -s /sbin/nologin nonroot \
+ && mkdir -p /data && chown nonroot:nonroot /data && chmod 0700 /data
+# The hub's served-binary resolver requires root-owned, non-writable
+# artifacts and ancestors; the hub itself runs unprivileged.
+COPY --from=build --chown=root:root --chmod=0755 /out/bloxos-hub /usr/local/bin/bloxos-hub
+COPY --from=build --chown=root:root --chmod=0755 /out/linux/bloxos-agent /usr/local/lib/bloxos/linux/bloxos-agent
+COPY --from=build --chown=root:root --chmod=0755 /out/windows/bloxos-agent.exe /usr/local/lib/bloxos/windows/bloxos-agent.exe
+# State lives in one volume: bloxos.db in the working directory, secrets,
+# setup token and signing key under $HOME/.bloxos.
+ENV HOME=/data \
+    HUB_LISTEN=0.0.0.0:4000
+WORKDIR /data
+VOLUME ["/data"]
+USER nonroot
+EXPOSE 4000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:4000/health >/dev/null || exit 1
+ENTRYPOINT ["/usr/local/bin/bloxos-hub"]

--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -6,6 +6,10 @@ const nextConfig: NextConfig = {
   // Pin the project root so file tracing does not climb to a lockfile in a
   // parent directory and nest the standalone output under that path.
   turbopack: { root: process.cwd() },
+  // The dashboard uses plain <img> for the one user-provided image, so no
+  // server-side optimizer (sharp) is ever required; this keeps the container
+  // image free of platform-specific native modules.
+  images: { unoptimized: true },
 };
 
 export default nextConfig;

--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Self-contained server for the container image (Dockerfile.dashboard).
+  output: "standalone",
+  // Pin the project root so file tracing does not climb to a lockfile in a
+  // parent directory and nest the standalone output under that path.
+  turbopack: { root: process.cwd() },
 };
 
 export default nextConfig;

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,5 @@
+# The hostname or IP address that browsers and agents will use to reach this
+# hub. Caddy serves https://HUB_HOST with an internal CA and the hub's
+# PUBLIC_URL is derived from it. No scheme and no port: the stack publishes
+# ports 80 and 443.
+HUB_HOST=hub.lan

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,0 +1,38 @@
+{
+	# Caddy runs unprivileged here and cannot install its root certificate
+	# into the container's trust store; clients receive the CA through the
+	# hub's install flow instead.
+	skip_install_trust
+	# Clients that connect by IP address send no SNI; serve HUB_HOST's
+	# certificate to them.
+	default_sni {$HUB_HOST}
+}
+
+https://{$HUB_HOST} {
+	tls internal
+
+	# Hub API, agent and terminal WebSockets, installers and downloads.
+	handle /api/* {
+		reverse_proxy hub:4000
+	}
+	handle /ws/* {
+		reverse_proxy hub:4000
+	}
+	handle /health {
+		reverse_proxy hub:4000
+	}
+	handle /install.sh {
+		reverse_proxy hub:4000
+	}
+	handle /install.ps1 {
+		reverse_proxy hub:4000
+	}
+	handle /download/* {
+		reverse_proxy hub:4000
+	}
+
+	# Dashboard (everything else)
+	handle {
+		reverse_proxy dashboard:3000
+	}
+}

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -9,7 +9,11 @@
 }
 
 https://{$HUB_HOST} {
-	tls internal
+	# RSA-2048 leaf certificates: stock Windows PowerShell 5.1 clients do not
+	# accept Caddy's default ECDSA keys (see AGENTS.md).
+	tls internal {
+		key_type rsa2048
+	}
 
 	# Hub API, agent and terminal WebSockets, installers and downloads.
 	handle /api/* {

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,6 +14,12 @@ cp .env.example .env      # set HUB_HOST to this machine's hostname or IP
 docker compose up -d --build
 ```
 
+Published images are an alternative to building: every `v*` tag publishes
+`ghcr.io/bokiko/bloxos-hub` and `ghcr.io/bokiko/bloxos-dashboard` for
+amd64 and arm64, tagged with the version and `latest`. To use them, replace
+the last command with `docker compose pull && docker compose up -d`; set
+`BLOXOS_VERSION` in `.env` to pin a version instead of `latest`.
+
 Then read the first-boot setup token and open the dashboard:
 
 ```bash
@@ -51,9 +57,10 @@ clients share one address there; rootful Docker passes the real address.
 
 Operations:
 
-- Upgrade: `git pull` then `docker compose up -d --build`. The hub and the
-  agents it serves are rebuilt from the same commit; connected agents that
-  have pinned the update key self-update.
+- Upgrade: `git pull` then `docker compose up -d --build`, or with published
+  images `docker compose pull && docker compose up -d`. The hub and the
+  agents it serves come from the same commit; connected agents that have
+  pinned the update key self-update.
 - Back up the `bloxos-data` volume (database, secrets, setup token,
   update-signing key) and the `caddy-data` volume (the CA). Losing the
   signing key strands agent self-update; losing the CA invalidates the
@@ -61,6 +68,20 @@ Operations:
 - Root certificate for browsers:
   `docker compose exec caddy cat /data/caddy/pki/authorities/local/root.crt`.
 - Logs: `docker compose logs -f hub`.
+
+## Smoke test
+
+`scripts/smoke/compose-enroll.sh` is the end-to-end gate for this stack. On
+a disposable Linux host with Docker, systemd, and passwordless sudo it
+brings the stack up, completes setup through the API, mints an install
+token, runs the generated Linux command on that same host so it enrolls as
+an agent, asserts the machine is online with the CA pinned, then removes
+the agent and the stack. CI runs it on pull requests that touch the
+container files and before publishing images on a tag. Locally:
+
+```bash
+SMOKE_CONFIRM_DISPOSABLE=1 HUB_HOST=<this host's IP> scripts/smoke/compose-enroll.sh
+```
 
 ## Images
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,13 +1,69 @@
-# Docker
+# Container images
 
-Docker packaging is not shipped yet.
+Two images cover the hub side of a deployment. Agents stay native
+services on every managed machine; they are not containerized.
 
-BloxOS currently runs as:
+| Image | Dockerfile | Contents | Port |
+|---|---|---|---|
+| hub | `Dockerfile.hub` | hub binary plus the agent binaries the hub serves | 4000 |
+| dashboard | `Dockerfile.dashboard` | Next.js standalone server | 3000 |
 
-- a Go hub process on `127.0.0.1:4000`
-- a Next.js dashboard process on `127.0.0.1:3000`
-- native Linux and Windows agent binaries
-- Caddy in front for LAN HTTPS and routing
+Both build from the repository root (the hub and agent modules share
+`proto/` through a local replace directive) and run as unprivileged users.
+Compose and published images are not part of this step.
 
-The previous `docker-compose.yml` referenced Dockerfiles that are not present in
-the repository, so it was removed to avoid advertising a broken install path.
+## Build
+
+```bash
+docker build -f Dockerfile.hub -t bloxos-hub .
+docker build -f Dockerfile.dashboard -t bloxos-dashboard .
+```
+
+The hub image builds the hub and both agents from the same commit with
+`CGO_ENABLED=0`, `-trimpath`, no VCS stamping, and stripped binaries, so a
+rebuild of the same commit yields the same served agent hash and does not
+trigger a fleet rollout.
+
+## Architecture
+
+The served Linux agent matches the image's own architecture: an arm64 image
+serves arm64 Linux agents, an amd64 image serves amd64 Linux agents. The
+served Windows agent is always amd64. One image therefore serves one Linux
+agent architecture; a fleet that mixes amd64 and arm64 Linux machines needs
+per-architecture resolution in the hub, which is not implemented yet.
+
+## Run the hub
+
+The hub refuses to start without an origin policy, so `PUBLIC_URL` (or
+`ALLOWED_ORIGINS`) is required. All state lives in one volume mounted at
+`/data`: `bloxos.db`, and `.bloxos/` holding the setup token, JWT secret and
+update-signing key.
+
+```bash
+docker run -d --name bloxos-hub -p 4000:4000 \
+  -e PUBLIC_URL=http://127.0.0.1:4000 \
+  -v bloxos-data:/data \
+  bloxos-hub
+docker exec bloxos-hub cat /data/.bloxos/setup-token
+```
+
+Inside the image the hub listens on `0.0.0.0:4000` and runs as uid 65532.
+The agent binaries are root-owned and read-only at
+`/usr/local/lib/bloxos/linux/bloxos-agent` and
+`/usr/local/lib/bloxos/windows/bloxos-agent.exe`, which are the resolver's
+default paths, so no `BLOXOS_AGENT_BINARY*` setting is needed. For a private
+CA, mount the CA certificate and point `BLOXOS_CA_CERT` at it. Back up the
+`/data` volume; losing the update-signing key strands agent self-update.
+
+## Run the dashboard
+
+```bash
+docker run -d --name bloxos-dashboard -p 3000:3000 bloxos-dashboard
+```
+
+The dashboard is built with an empty `NEXT_PUBLIC_HUB_URL`, so it expects
+to be served from the same origin as the hub API, which a reverse proxy in
+front of both provides. It runs as the `node` user.
+
+Both images carry a healthcheck against `/health` (hub) and `/login`
+(dashboard).

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,68 @@
-# Container images
+# Containers
 
-Two images cover the hub side of a deployment. Agents stay native
-services on every managed machine; they are not containerized.
+The hub side of a deployment runs as containers: Caddy for TLS, the hub API,
+and the dashboard. Agents stay native services on every managed machine;
+they are not containerized.
+
+## Compose: the supported hub deployment
+
+One required setting, three commands, from a clone of this repository:
+
+```bash
+cd docker
+cp .env.example .env      # set HUB_HOST to this machine's hostname or IP
+docker compose up -d --build
+```
+
+Then read the first-boot setup token and open the dashboard:
+
+```bash
+docker compose exec hub cat /data/.bloxos/setup-token
+```
+
+Open `https://<HUB_HOST>`, accept the browser warning for the internal CA
+(or install its root certificate, see below), enter the token, and create
+the admin account. Use **Add Machine** to enroll agents; the generated
+command carries the CA fingerprint, so agents verify the hub without any
+manual trust step.
+
+What the stack contains:
+
+- `caddy` serves `https://HUB_HOST` with its internal CA and forwards API,
+  WebSocket, installer, and download paths to the hub and everything else to
+  the dashboard. It runs unprivileged as the hub's uid so the hub can read
+  the CA it writes.
+- `hub` derives `PUBLIC_URL` from `HUB_HOST` and reads Caddy's root
+  certificate read-only from the `caddy-data` volume to pin it into install
+  commands.
+- `dashboard` is served same-origin behind Caddy.
+- `caddy-init` runs once to hand the Caddy volumes to the unprivileged uid.
+
+`HUB_HOST` is a bare hostname or IP address, no scheme, no port; the stack
+publishes 80 and 443. IP addresses work because Caddy is given a default
+SNI for clients that connect without one.
+
+Client addresses: Caddy forwards the client address to the hub and the hub
+accepts it from peers on the private Compose network, so per-address rate
+limits and the terminal audit see clients, not Caddy. The hub's port is not
+published, so only the stack's own containers can reach it. On rootless
+Docker the address Caddy sees is the port forwarder's, so all external
+clients share one address there; rootful Docker passes the real address.
+
+Operations:
+
+- Upgrade: `git pull` then `docker compose up -d --build`. The hub and the
+  agents it serves are rebuilt from the same commit; connected agents that
+  have pinned the update key self-update.
+- Back up the `bloxos-data` volume (database, secrets, setup token,
+  update-signing key) and the `caddy-data` volume (the CA). Losing the
+  signing key strands agent self-update; losing the CA invalidates the
+  certificate every enrolled agent pinned, and each must be re-enrolled.
+- Root certificate for browsers:
+  `docker compose exec caddy cat /data/caddy/pki/authorities/local/root.crt`.
+- Logs: `docker compose logs -f hub`.
+
+## Images
 
 | Image | Dockerfile | Contents | Port |
 |---|---|---|---|
@@ -10,9 +71,10 @@ services on every managed machine; they are not containerized.
 
 Both build from the repository root (the hub and agent modules share
 `proto/` through a local replace directive) and run as unprivileged users.
-Compose and published images are not part of this step.
+The sections below run them individually, without Caddy; published images
+are not part of this step.
 
-## Build
+### Build
 
 ```bash
 docker build -f Dockerfile.hub -t bloxos-hub .
@@ -24,7 +86,7 @@ The hub image builds the hub and both agents from the same commit with
 rebuild of the same commit yields the same served agent hash and does not
 trigger a fleet rollout.
 
-## Architecture
+### Architecture
 
 The served Linux agent matches the image's own architecture: an arm64 image
 serves arm64 Linux agents, an amd64 image serves amd64 Linux agents. The
@@ -32,7 +94,7 @@ served Windows agent is always amd64. One image therefore serves one Linux
 agent architecture; a fleet that mixes amd64 and arm64 Linux machines needs
 per-architecture resolution in the hub, which is not implemented yet.
 
-## Run the hub
+### Run the hub alone
 
 The hub refuses to start without an origin policy, so `PUBLIC_URL` (or
 `ALLOWED_ORIGINS`) is required. All state lives in one volume mounted at
@@ -55,7 +117,7 @@ default paths, so no `BLOXOS_AGENT_BINARY*` setting is needed. For a private
 CA, mount the CA certificate and point `BLOXOS_CA_CERT` at it. Back up the
 `/data` volume; losing the update-signing key strands agent self-update.
 
-## Run the dashboard
+### Run the dashboard alone
 
 ```bash
 docker run -d --name bloxos-dashboard -p 3000:3000 bloxos-dashboard

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,67 @@
+# BloxOS hub stack: Caddy (TLS with an internal CA) in front of the hub API and
+# the dashboard. Agents are native services on managed machines and are not
+# part of this stack.
+#
+# Required: HUB_HOST in docker/.env, the hostname or IP address that browsers
+# and agents will use. Everything is served from https://HUB_HOST; the hub's
+# PUBLIC_URL is derived from it.
+
+name: bloxos
+
+services:
+  hub:
+    build:
+      context: ..
+      dockerfile: Dockerfile.hub
+    image: bloxos-hub:local
+    restart: unless-stopped
+    environment:
+      PUBLIC_URL: https://${HUB_HOST:?set HUB_HOST in docker/.env to the hostname or IP of this machine}
+      # Caddy's internal CA, read-only, so the hub can pin it into the install
+      # commands it generates.
+      BLOXOS_CA_CERT: /caddy/caddy/pki/authorities/local/root.crt
+    volumes:
+      - bloxos-data:/data
+      - caddy-data:/caddy:ro
+
+  dashboard:
+    build:
+      context: ..
+      dockerfile: Dockerfile.dashboard
+    image: bloxos-dashboard:local
+    restart: unless-stopped
+
+  # One-shot. Caddy runs unprivileged as the hub's uid so that the CA files it
+  # writes are readable by the hub; fresh named volumes are root-owned, so
+  # hand them over once.
+  caddy-init:
+    image: alpine:3.22
+    command: chown -R 65532:65532 /data /config
+    volumes:
+      - caddy-data:/data
+      - caddy-config:/config
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    user: "65532:65532"
+    environment:
+      HUB_HOST: ${HUB_HOST:?set HUB_HOST in docker/.env to the hostname or IP of this machine}
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      caddy-init:
+        condition: service_completed_successfully
+      hub:
+        condition: service_healthy
+
+volumes:
+  bloxos-data:
+  caddy-data:
+  caddy-config:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -13,7 +13,9 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile.hub
-    image: bloxos-hub:local
+    # Published on version tags by .github/workflows/docker.yml; `docker
+    # compose pull` fetches it, `docker compose up -d --build` builds it here.
+    image: ghcr.io/bokiko/bloxos-hub:${BLOXOS_VERSION:-latest}
     restart: unless-stopped
     environment:
       PUBLIC_URL: https://${HUB_HOST:?set HUB_HOST in docker/.env to the hostname or IP of this machine}
@@ -28,7 +30,9 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile.dashboard
-    image: bloxos-dashboard:local
+    # Published on version tags by .github/workflows/docker.yml; `docker
+    # compose pull` fetches it, `docker compose up -d --build` builds it here.
+    image: ghcr.io/bokiko/bloxos-dashboard:${BLOXOS_VERSION:-latest}
     restart: unless-stopped
 
   # One-shot. Caddy runs unprivileged as the hub's uid so that the CA files it

--- a/scripts/caddy/Caddyfile
+++ b/scripts/caddy/Caddyfile
@@ -3,7 +3,11 @@
 }
 
 https://{$HUB_HOST} {
-	tls internal
+	# RSA-2048 leaf certificates: stock Windows PowerShell 5.1 clients do not
+	# accept Caddy's default ECDSA keys (see AGENTS.md).
+	tls internal {
+		key_type rsa2048
+	}
 
 	# Hub API routes
 	handle /api/* {

--- a/scripts/smoke/compose-enroll.sh
+++ b/scripts/smoke/compose-enroll.sh
@@ -18,7 +18,8 @@
 # builds only missing ones; run `docker compose --project-directory docker
 # build` first after changing a Dockerfile.
 #
-# Requires: docker compose, systemd, sudo without a password, curl, python3.
+# Requires: docker compose, systemd, sudo without a password, curl, openssl,
+# python3.
 set -euo pipefail
 
 if [[ "${SMOKE_CONFIRM_DISPOSABLE:-}" != "1" ]]; then
@@ -64,6 +65,11 @@ done
 curl -sk --max-time 3 "$HUB/health" | grep -q '"ok"' || fail "hub not healthy through Caddy"
 [[ "$(curl -sk -o /dev/null -w '%{http_code}' "$HUB/login")" == 200 ]] || fail "dashboard not served"
 [[ "$(curl -sk -o /dev/null -w '%{http_code}' "$HUB/install.ps1")" == 200 ]] || fail "Windows installer not served"
+
+echo "== served certificate key type"
+LEAF="$(openssl s_client -connect "$HUB_HOST:443" -servername "$HUB_HOST" </dev/null 2>/dev/null | openssl x509 -noout -text)"
+echo "$LEAF" | grep -q 'Public Key Algorithm: rsaEncryption' || fail "served certificate is not RSA (AGENTS.md requires RSA-2048 for Windows PowerShell 5.1 clients)"
+echo "$LEAF" | grep -q 'Public-Key: (2048 bit)' || fail "served RSA certificate is not 2048-bit"
 
 echo "== first-boot setup and login"
 PASSWORD="smoke-$(head -c 12 /dev/urandom | base64 | tr -dc 'A-Za-z0-9')"

--- a/scripts/smoke/compose-enroll.sh
+++ b/scripts/smoke/compose-enroll.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# End-to-end smoke test for the Compose hub stack on a disposable Linux host.
+#
+# Brings up docker/compose.yaml, completes first-boot setup through the API,
+# mints an install token, runs the generated Linux paste block ON THIS HOST
+# (so this host becomes an enrolled agent: it installs a systemd service,
+# /etc/bloxos, and /usr/local/bin/bloxos-agent), and asserts the machine
+# comes online with the CA pinned. Then it removes the agent and the stack.
+#
+# Run only on a host you can throw away (a CI runner, a Lima VM):
+#   SMOKE_CONFIRM_DISPOSABLE=1 scripts/smoke/compose-enroll.sh
+#
+# Environment:
+#   HUB_HOST   hostname or IP this host reaches the stack on (default 127.0.0.1)
+#   KEEP=1     leave the stack and the agent installed for inspection
+#
+# Uses the images named in docker/compose.yaml if they exist locally and
+# builds only missing ones; run `docker compose --project-directory docker
+# build` first after changing a Dockerfile.
+#
+# Requires: docker compose, systemd, sudo without a password, curl, python3.
+set -euo pipefail
+
+if [[ "${SMOKE_CONFIRM_DISPOSABLE:-}" != "1" ]]; then
+  echo "refusing: this installs an agent service on this host; set SMOKE_CONFIRM_DISPOSABLE=1 on a disposable host" >&2
+  exit 2
+fi
+
+HUB_HOST="${HUB_HOST:-127.0.0.1}"
+HUB="https://$HUB_HOST"
+COMPOSE_DIR="$(cd "$(dirname "$0")/../../docker" && pwd)"
+export HUB_HOST
+compose() { docker compose --project-directory "$COMPOSE_DIR" "$@"; }
+json() { python3 -c "import sys,json; d=json.load(sys.stdin); print($1)"; }
+fail() { echo "SMOKE FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  local rc=$?
+  if [[ $rc -ne 0 ]]; then
+    echo "== hub and caddy logs (last 60 lines) after failure"
+    compose logs --tail 60 hub caddy 2>/dev/null || true
+    sudo journalctl -u bloxos-agent --no-pager -n 20 2>/dev/null || true
+  fi
+  [[ "${KEEP:-}" == "1" ]] && { echo "KEEP=1: stack and agent left in place"; return; }
+  echo "== cleanup"
+  sudo systemctl disable --now bloxos-agent bloxos-agent-recover >/dev/null 2>&1 || true
+  sudo rm -f /etc/systemd/system/bloxos-agent.service /etc/systemd/system/bloxos-agent-recover.service \
+    /usr/local/bin/bloxos-agent /usr/local/bin/bloxos-agent-recover /usr/local/bin/bloxos-agent.prev \
+    /usr/local/bin/.bloxos-agent-updated-at
+  sudo rm -rf /etc/bloxos
+  sudo systemctl daemon-reload
+  compose down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "== up ($HUB)"
+compose up -d
+
+echo "== wait for health"
+for _ in $(seq 1 60); do
+  curl -sk --max-time 3 "$HUB/health" | grep -q '"ok"' && break
+  sleep 2
+done
+curl -sk --max-time 3 "$HUB/health" | grep -q '"ok"' || fail "hub not healthy through Caddy"
+[[ "$(curl -sk -o /dev/null -w '%{http_code}' "$HUB/login")" == 200 ]] || fail "dashboard not served"
+[[ "$(curl -sk -o /dev/null -w '%{http_code}' "$HUB/install.ps1")" == 200 ]] || fail "Windows installer not served"
+
+echo "== first-boot setup and login"
+PASSWORD="smoke-$(head -c 12 /dev/urandom | base64 | tr -dc 'A-Za-z0-9')"
+if curl -sk "$HUB/api/setup/status" | grep -q '"needs_setup":true'; then
+  SETUP_TOKEN="$(compose exec -T hub cat /data/.bloxos/setup-token)"
+  curl -sk -f -X POST "$HUB/api/setup" -H 'Content-Type: application/json' \
+    -d "{\"setup_token\":\"$SETUP_TOKEN\",\"username\":\"smoke\",\"password\":\"$PASSWORD\",\"pin\":\"1234\"}" >/dev/null \
+    || fail "setup rejected"
+else
+  fail "hub already set up; this harness expects a fresh stack"
+fi
+JWT="$(curl -sk -f -X POST "$HUB/api/auth/login" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"smoke\",\"password\":\"$PASSWORD\"}" | json 'd["token"]')"
+[[ -n "$JWT" ]] || fail "login returned no token"
+
+echo "== install token"
+TOKEN_JSON="$(curl -sk -f -X POST "$HUB/api/tokens" -H "Authorization: Bearer $JWT")"
+CA_SHA="$(echo "$TOKEN_JSON" | json 'd.get("ca_sha256","")')"
+[[ -n "$CA_SHA" ]] || fail "install command carries no CA fingerprint; hub could not read Caddy's CA"
+PASTE="$(mktemp)"
+echo "$TOKEN_JSON" | json 'd["command"]' > "$PASTE"
+
+echo "== enroll this host with the generated Linux command"
+bash "$PASTE" || fail "paste block failed"
+rm -f "$PASTE"
+
+echo "== verify"
+for _ in $(seq 1 30); do
+  curl -sk "$HUB/api/machines" -H "Authorization: Bearer $JWT" | grep -q '"status":"online"' && break
+  sleep 2
+done
+curl -sk "$HUB/api/machines" -H "Authorization: Bearer $JWT" | grep -q '"status":"online"' || fail "agent never came online"
+[[ "$(systemctl is-active bloxos-agent)" == active ]] || fail "agent service not active"
+[[ "$(sudo sha256sum /etc/bloxos/ca.crt | cut -c1-64)" == "$CA_SHA" ]] || fail "installed CA does not match the fingerprint in the install command"
+sudo test -s /etc/bloxos/agent-secret || fail "agent has no durable secret; enrollment did not commit"
+sudo test -s /etc/bloxos/agent-update.pub || fail "update key not pinned"
+
+echo "SMOKE PASS: agent enrolled through the Compose stack at $HUB"


### PR DESCRIPTION
## Summary

A supported one-setting install path for the hub. Three commits, no hub or agent behavior changes.

```bash
cd docker
cp .env.example .env      # set HUB_HOST to this machine's hostname or IP
docker compose up -d --build
```

Then `docker compose exec hub cat /data/.bloxos/setup-token`, open `https://<HUB_HOST>`, create the admin account, and use Add Machine. The generated install command carries Caddy's CA fingerprint, so agents verify the hub with no manual trust step. Agents stay native services on managed machines.

## What is in it

- **Images** (28fdbe7). `Dockerfile.hub` builds the hub and the agent binaries it serves from the same commit, deterministically (`-trimpath`, no VCS stamping, stripped), so a rebuild does not change the served agent hash or trigger a rollout. Runtime is Alpine as uid 65532 with all state on one `/data` volume and the agents root-owned 0755 at the resolver's default paths. `Dockerfile.dashboard` is the Next standalone server as the `node` user, built same-origin. One image serves one Linux agent architecture (the image's own) plus Windows amd64; mixed-architecture Linux fleets need per-arch resolution in the hub, documented as not implemented.
- **Compose stack** (6dfe4f2). Caddy with its internal CA, the hub, and the dashboard. `HUB_HOST` is the only required setting; the hub's `PUBLIC_URL` is derived from it and Caddy serves `https://HUB_HOST` with a default SNI so IP addresses work. Caddy runs unprivileged as the hub's uid so the hub can read the CA from a read-only mount and pin it into install commands; a one-shot init hands the Caddy volumes to that uid. Plain bridge networking, chosen after namespace sharing left one service unreachable whenever the other restarted.
- **Smoke gate and publishing** (29d8bee). `scripts/smoke/compose-enroll.sh` brings the stack up on a disposable Linux host, completes setup through the API, mints a token, runs the generated Linux command on that host so it enrolls as an agent, and asserts online status, CA fingerprint match, durable secret, and pinned key, then cleans up. `.github/workflows/docker.yml` runs it on pull requests touching container files and on every `v*` tag, and only on tags, after it passes, publishes `ghcr.io/bokiko/bloxos-hub` and `bloxos-dashboard` for amd64 and arm64. Compose names those images with a `BLOXOS_VERSION` override, so `docker compose pull && docker compose up -d` uses published images while `--build` builds from a clone. The dashboard build stage runs on the build platform and image optimization is declared off, since the dashboard never uses `next/image`; the emulated build hung.

## Local validation

Lima Docker VM on arm64 (Docker 29.8, rootless), builds from the mounted worktree:

- Images: hub 51.6 MB built in 40s cold, dashboard 285 MB in 33s; hub runs as uid 65532 with a root-owned 0755 chain from `/` to both agents; both agents resolved from default paths; downloaded agent hash equals the hash in the served installer; health checks healthy; state persisted across restart; a no-cache rebuild reproduced identical hub, Linux agent, and Windows agent hashes.
- Compose: config fails clearly without `HUB_HOST`; up in 16s with all services healthy; TLS, HTTP redirect, dashboard and API routing through Caddy; the hub reads the CA and mints install commands with its fingerprint.
- Enrollment: the VM enrolled itself through the stack end to end, including the deferred-commit confirmation; hub restart, Caddy restart, and a process-initiated hub exit each recovered within 5s with the agent reconnecting.
- Harness: passes in 11 to 18s against freshly built images and leaves no agent, containers, or volumes behind; shellcheck clean; actionlint clean on the workflow.
- Publish job dry run: multi-platform builds of both images to OCI archives list linux/amd64 and linux/arm64 (hub 58s, dashboard 39s); the emulated amd64 hub starts, resolves its agents, and answers health; the emulated amd64 dashboard serves `/login`.
- Hub `go vet` and `go test` pass; dashboard lint and build pass.

## After merge

The one remaining acceptance check for publishing is the first `v*` tag: the tag run must pass the smoke job, publish both images, and `docker compose pull && docker compose up -d` on a clean host must start the stack from GHCR. That run also gives the real CI timing for the emulated hub stage.

## Review notes

- The hub honors forwarded client addresses from private-network peers by default (echo's extractor), which this stack relies on and which is safe here because the hub's port is not published. On a native hub bound to a LAN address it would be a spoofing vector; a small hub-side trusted-proxy setting is the right follow-up.
- On rootless Docker the address Caddy sees is the port forwarder's; rootful Docker passes the real client address.
- On the very first start the hub creates its database 0644 before applying 0600; the volume is 0700 so nothing else can read it. Pre-existing hub behavior worth a one-line fix later.
- The main README still describes Docker as not shipped; the docs pass after this lands should point the quick start at the Compose path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vy4iwPBdbCJhubJVYXQGpn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New production deployment path (TLS, CA trust, agent enrollment) and automated GHCR publishing; core hub/agent logic in this diff is mostly wiring rather than behavioral changes.
> 
> **Overview**
> Adds a **supported hub deployment** via Docker Compose: set **`HUB_HOST`**, bring up Caddy (internal TLS), hub, and dashboard behind **`https://HUB_HOST`**, with the hub reading Caddy’s CA so install commands include a CA fingerprint.
> 
> New **`Dockerfile.hub`** and **`Dockerfile.dashboard`** build unprivileged runtime images (hub bundles served Linux/Windows agent binaries from the same commit; dashboard uses Next **`standalone`** with empty **`NEXT_PUBLIC_HUB_URL`** for same-origin proxying). **`docker/compose.yaml`**, **`docker/Caddyfile`**, and expanded **`docker/README.md`** document the stack; **`.dockerignore`** trims build context.
> 
> **`scripts/smoke/compose-enroll.sh`** is an end-to-end gate (setup, token, self-enroll, CA checks). **`.github/workflows/docker.yml`** runs it on container-related PRs and, after smoke on **`v*`** tags, publishes multi-arch **`bloxos-hub`** / **`bloxos-dashboard`** to GHCR with digest-first tagging so version/`latest` stay paired.
> 
> Caddy configs (**`docker/Caddyfile`** and **`scripts/caddy/Caddyfile`**) now use **RSA-2048** internal TLS leaves for Windows PowerShell 5.1 clients; the smoke script asserts that cert type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14aec8800250dde01b0438a2cd750657d72cb203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->