### PR TITLE
feat(hub+agent+ui): AI Sessions — read-only live visibility into AI coding tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,16 @@ Fleet management dashboard for AI machines. Go hub + agent, Next.js dashboard.
   trusted provisioning path.
 - The signature may come from a detached `<binary>.sig` produced offline, in
   which case the hub holds no private key — do not assume the hub signs.
+- **AI Sessions is metadata-only monitoring.** Agents report which supported
+  AI coding tools (Claude Code, Codex, Kimi) are running, reduced to the
+  contract in `proto/aisessions`: opaque id, tool, start time, project
+  **basename**, an explicitly-flagged model, and an inferred activity state,
+  each with its source and confidence. Never add prompts, responses,
+  transcripts, tool commands/output, environment variables, full argv, full
+  paths, or the OS username to that contract. The hub keeps live snapshots
+  only (no history) and re-sanitizes every frame. The admin switch defaults
+  to on; disabling it stops agent-side scanning via the `ai_sessions_config`
+  frame, and `BLOXOS_AI_SESSIONS=0` on an agent is a hard local opt-out.
 - Credentials NEVER committed — use env vars or local config
 - Dark mode is the default UI theme
 - Caddy TLS uses RSA-2048 keys, not ECDSA. Do not change without testing on stock Windows PowerShell 5.1.

--- a/agent/ai_sessions.go
+++ b/agent/ai_sessions.go
@@ -1,0 +1,137 @@
+package main
+
+// AI Sessions (checkpoint 1): read-only discovery of running AI coding
+// tools — Claude Code, Codex, Kimi — reported to the hub as metadata only.
+//
+// What leaves this machine is exactly aisessions.Session: an opaque id, the
+// tool name, start time, project basename, an explicitly-flagged model, and
+// a CPU-time activity inference. Classification and reduction live in the
+// platform-neutral aiscan package; this file only reads the live process
+// table (gopsutil, already a dependency) and sends the result. A monitored
+// process's environment is never read. Nothing is written or signalled.
+//
+// Scanning is gated (aiscan.Gate): it runs only after the hub has said the
+// feature is enabled on this connection, and never when the machine-local
+// BLOXOS_AI_SESSIONS opt-out is set.
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/bokiko/bloxos/agent/aiscan"
+	"github.com/bokiko/bloxos/proto/aisessions"
+	"github.com/gorilla/websocket"
+	"github.com/shirou/gopsutil/v4/process"
+)
+
+// listAIProcesses reads the live process table via gopsutil (already a
+// dependency of the agent). It reads only the executable name for every
+// process and fetches the remaining metadata solely for candidates that
+// could be an AI tool, keeping the scan cheap on busy hosts.
+func listAIProcesses(ctx context.Context) ([]aiscan.Process, error) {
+	procs, err := process.ProcessesWithContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]aiscan.Process, 0, 8)
+	for _, p := range procs {
+		name, err := p.NameWithContext(ctx)
+		if err != nil {
+			continue
+		}
+		if !aiscan.Candidate(name) {
+			continue
+		}
+		argv, err := p.CmdlineSliceWithContext(ctx)
+		if err != nil {
+			argv = nil
+		}
+		if _, ok := aiscan.Classify(name, argv); !ok {
+			continue
+		}
+		ap := aiscan.Process{PID: p.Pid, Name: name, Argv: argv}
+		if ppid, err := p.PpidWithContext(ctx); err == nil {
+			ap.PPID = ppid
+		}
+		if cwd, err := p.CwdWithContext(ctx); err == nil {
+			ap.Cwd = cwd
+		}
+		if user, err := p.UsernameWithContext(ctx); err == nil {
+			ap.Username = user
+		}
+		if start, err := p.CreateTimeWithContext(ctx); err == nil {
+			ap.StartMS = start
+		}
+		if times, err := p.TimesWithContext(ctx); err == nil {
+			ap.CPUSeconds = times.User + times.System
+		} else {
+			ap.CPUSeconds = -1
+		}
+		out = append(out, ap)
+	}
+	return out, nil
+}
+
+var (
+	aiScanner = aiscan.NewScanner()
+	// aiGate holds the hub's runtime enable/disable decision for the
+	// current connection; runAgent resets it on every connect.
+	aiGate aiscan.Gate
+)
+
+// aiSessionsConfigType is the hub→agent frame carrying the admin switch.
+// Agents built before this feature route it through handleCommand, which
+// ignores any frame without a command id — so it is safe to send to every
+// agent.
+const aiSessionsConfigType = "ai_sessions_config"
+
+// handleAISessionsConfig applies an ai_sessions_config frame. When the hub
+// newly enables the feature, one report is sent right away rather than
+// waiting for the next 30s tick.
+func handleAISessionsConfig(conn *websocket.Conn, mu *sync.Mutex, machineID string, msg []byte) {
+	var cfg struct {
+		Enabled bool   `json:"enabled"`
+		Rev     uint64 `json:"rev"`
+	}
+	if err := json.Unmarshal(msg, &cfg); err != nil {
+		log.Printf("invalid %s frame: %v", aiSessionsConfigType, err)
+		return
+	}
+	if aiGate.Apply(cfg.Enabled, cfg.Rev) {
+		go sendAISessions(conn, mu, machineID)
+	}
+}
+
+// sendAISessions scans and reports. Failures are logged and never abort the
+// connection: this is auxiliary metadata, and a broken process table must
+// not take metrics or auto-update down with it.
+func sendAISessions(conn *websocket.Conn, mu *sync.Mutex, machineID string) {
+	if !aiGate.Allowed(os.Getenv("BLOXOS_AI_SESSIONS")) {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("ai sessions: panic recovered: %v (continuing)", r)
+		}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	procs, err := listAIProcesses(ctx)
+	if err != nil {
+		log.Printf("ai sessions: process scan error: %v", err)
+		return
+	}
+	msg := aisessions.Sanitize(aisessions.Message{
+		Type:      aisessions.MessageType,
+		MachineID: machineID,
+		Schema:    aisessions.SchemaVersion,
+		Sessions:  aiScanner.Build(procs, time.Now()),
+	})
+	if err := writeJSON(conn, mu, msg); err != nil {
+		log.Printf("ai sessions: write error: %v", err)
+	}
+}

--- a/agent/ai_sessions_test.go
+++ b/agent/ai_sessions_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestHandleAISessionsConfigGatesScanning checks the wiring between the
+// hub's config frame and the scanner gate. A nil connection is fine: the
+// gate transition to "newly enabled" spawns sendAISessions, which we avoid
+// by applying enabled=true before the handler so nothing writes.
+func TestHandleAISessionsConfigGatesScanning(t *testing.T) {
+	t.Setenv("BLOXOS_AI_SESSIONS", "")
+	aiGate.Reset()
+	if aiGate.Allowed("") {
+		t.Fatal("gate must start closed")
+	}
+	handleAISessionsConfig(nil, nil, "m", []byte(`{"type":"ai_sessions_config","enabled":false,"rev":2}`))
+	if aiGate.Allowed("") {
+		t.Fatal("hub disable must close the gate")
+	}
+	// Reordered delivery: a stale rev 1 enable after the rev 2 disable.
+	handleAISessionsConfig(nil, nil, "m", []byte(`{"type":"ai_sessions_config","enabled":true,"rev":1}`))
+	if aiGate.Allowed("") {
+		t.Fatal("stale lower-revision enable must be ignored")
+	}
+	aiGate.Apply(true, 3) // pre-open so the handler below does not spawn a report on a nil conn
+	handleAISessionsConfig(nil, nil, "m", []byte(`{"type":"ai_sessions_config","enabled":true,"rev":3}`))
+	if !aiGate.Allowed("") {
+		t.Fatal("hub enable must open the gate")
+	}
+	if aiGate.Allowed("0") {
+		t.Fatal("local opt-out must override hub enable")
+	}
+	handleAISessionsConfig(nil, nil, "m", []byte(`not json`))
+	if !aiGate.Allowed("") {
+		t.Fatal("malformed frame must not change the gate")
+	}
+	aiGate.Reset()
+}

--- a/agent/aiscan/aiscan.go
+++ b/agent/aiscan/aiscan.go
@@ -1,0 +1,400 @@
+// Package aiscan classifies running processes as supported AI coding tools
+// (Claude Code, Codex, Kimi) and reduces them to aisessions.Session values.
+//
+// It is pure: it takes a process table and returns metadata, so it can be
+// tested on every platform. Reading the live process table is the caller's
+// job (see agent/ai_sessions.go).
+//
+// Privacy contract: the command line is used to classify the process and
+// to find an explicit --model flag, then discarded. The working directory is
+// reduced to a basename under aisessions.ProjectFromDir or dropped. Nothing
+// else about a process is retained.
+package aiscan
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/aisessions"
+)
+
+// Gate decides whether this agent may scan and report at all. Two controls
+// combine, and both must allow:
+//
+//   - The hub's runtime signal (an "ai_sessions_config" frame sent after
+//     registration and whenever an admin flips the switch). Until the hub
+//     has spoken on the current connection nothing is scanned — so an agent
+//     talking to a hub that predates the feature, or one whose admin turned
+//     it off, never reads a process table for it.
+//   - The machine-local BLOXOS_AI_SESSIONS opt-out, a hard override that a
+//     hub enable cannot defeat.
+type Gate struct {
+	mu      sync.Mutex
+	state   gateState
+	applied bool   // a hub decision has been applied on this connection
+	rev     uint64 // revision of that decision
+}
+
+type gateState int
+
+const (
+	gateUnknown gateState = iota
+	gateEnabled
+	gateDisabled
+)
+
+// Reset forgets the hub's decision and revision; call it when a
+// connection starts.
+func (g *Gate) Reset() {
+	g.mu.Lock()
+	g.state = gateUnknown
+	g.applied = false
+	g.rev = 0
+	g.mu.Unlock()
+}
+
+// Apply records the hub's decision and reports whether it newly enabled
+// scanning, so the caller can report promptly instead of waiting a tick.
+// rev is the hub's monotonic config revision: the hub's registration send
+// and its toggle broadcast travel on independent goroutines, so a stale
+// frame can arrive after a newer one. Once a decision has been applied on
+// this connection, only a strictly greater revision is accepted: a lower
+// one is a delayed stale frame, and an equal one with a different value
+// could only be a duplicate or a forgery, so neither may flip the gate.
+// This is what keeps a delayed "enabled" from undoing an admin's
+// "disabled".
+func (g *Gate) Apply(enabled bool, rev uint64) (newlyEnabled bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.applied && rev <= g.rev {
+		return false
+	}
+	g.applied = true
+	g.rev = rev
+	prev := g.state
+	if enabled {
+		g.state = gateEnabled
+	} else {
+		g.state = gateDisabled
+	}
+	return enabled && prev != gateEnabled
+}
+
+// Allowed reports whether a scan may run now. envValue is the agent's own
+// BLOXOS_AI_SESSIONS setting.
+func (g *Gate) Allowed(envValue string) bool {
+	if !EnabledByEnv(envValue) {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.state == gateEnabled
+}
+
+// EnabledByEnv interprets the BLOXOS_AI_SESSIONS value. Monitoring is on
+// by default; "0", "false", "off" or "no" turn this machine's reporting off.
+func EnabledByEnv(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "0", "false", "off", "no":
+		return false
+	}
+	return true
+}
+
+// Process is the subset of process metadata the classifier and session
+// builder consume. Argv and Cwd are inputs only; they never appear in the
+// output.
+type Process struct {
+	PID        int32
+	PPID       int32
+	Name       string   // executable name as the OS reports it (comm / image name)
+	Argv       []string // full command line; never leaves Build
+	Cwd        string   // full working directory; reduced to a basename or dropped
+	Username   string   // used only to withhold a project name equal to it
+	StartMS    int64    // process start, unix milliseconds
+	CPUSeconds float64  // user+system CPU time consumed so far
+}
+
+// toolTokens maps a normalized executable/script token to a tool.
+// Everything not listed here is not an AI session, full stop.
+var toolTokens = map[string]string{
+	"claude":      aisessions.ToolClaude,
+	"claude-code": aisessions.ToolClaude, // npm package dir @anthropic-ai/claude-code/cli.js
+	"codex":       aisessions.ToolCodex,  // native binary or @openai/codex/bin/codex.js
+	"kimi":        aisessions.ToolKimi,
+	"kimi-cli":    aisessions.ToolKimi, // pip/uv distribution name
+	"kimi_cli":    aisessions.ToolKimi, // python -m kimi_cli
+}
+
+// entryTokens are script basenames that say nothing about the tool; the
+// parent directory is consulted instead (…/claude-code/cli.js).
+var entryTokens = map[string]bool{"cli": true, "index": true, "main": true, "__main__": true, "bin": true}
+
+// ActivityCPURate is the CPU utilisation (CPU-seconds per wall second)
+// above which a session is inferred "active". Below it, "idle". Both are
+// inferences and are reported as such.
+const ActivityCPURate = 0.01
+
+// Candidate reports whether a process with this executable name could be
+// an AI tool at all — the name itself or an interpreter that may be running
+// one. Callers use it to avoid reading the command line of every process.
+func Candidate(name string) bool {
+	if _, known := toolTokens[normalizeToken(name)]; known {
+		return true
+	}
+	return isInterpreter(name)
+}
+
+// Classify decides whether a process is a supported AI tool. It looks
+// at the executable name, argv[0], and — when argv[0] is an interpreter —
+// the script or module being run. Matching is exact on normalized tokens;
+// substrings never match, so "claude-desktop" or "codex-server" do not.
+func Classify(name string, argv []string) (string, bool) {
+	tool, _, ok := classify(name, argv)
+	return tool, ok
+}
+
+// classify also reports the index in argv of the tool's entry point (the
+// binary, launcher script or -m module). Only arguments AFTER that index
+// belong to the tool; anything before it belongs to the interpreter or
+// wrapper and must not be read as a tool flag. entry is -1 when the tool
+// was recognized from the process name but no argv element identifies it.
+func classify(name string, argv []string) (tool string, entry int, ok bool) {
+	byName, nameOK := toolTokens[normalizeToken(name)]
+	if len(argv) == 0 {
+		if nameOK {
+			return byName, -1, true
+		}
+		return "", -1, false
+	}
+	if tool, ok := toolFromPath(argv[0]); ok {
+		return tool, 0, true
+	}
+	if isInterpreter(argv[0]) {
+		if idx := interpreterTargetIndex(argv); idx > 0 {
+			if tool, ok := toolFromPath(argv[idx]); ok {
+				return tool, idx, true
+			}
+		}
+	}
+	if !nameOK {
+		return "", -1, false
+	}
+	// Recognized by process name (e.g. a shebang wrapper whose comm is the
+	// script name while argv[0] is the shell). Find the launcher in argv so
+	// tool flags are parsed only after it.
+	for i := 1; i < len(argv); i++ {
+		if tool, ok := toolFromPath(argv[i]); ok && tool == byName {
+			return byName, i, true
+		}
+	}
+	return byName, -1, true
+}
+
+// toolFromPath classifies a path to an executable, script or module.
+func toolFromPath(p string) (string, bool) {
+	parts := splitPath(p)
+	if len(parts) == 0 {
+		return "", false
+	}
+	tok := normalizeToken(parts[len(parts)-1])
+	if tool, ok := toolTokens[tok]; ok {
+		return tool, true
+	}
+	if entryTokens[tok] && len(parts) >= 2 {
+		if tool, ok := toolTokens[normalizeToken(parts[len(parts)-2])]; ok {
+			return tool, true
+		}
+	}
+	return "", false
+}
+
+// interpreterTargetIndex returns the argv index of the script path or
+// module name an interpreter was asked to run: the first non-flag argument,
+// or the operand of -m / "--". 0 means none was found.
+func interpreterTargetIndex(argv []string) int {
+	for i := 1; i < len(argv); i++ {
+		a := argv[i]
+		if (a == "-m" || a == "--") && i+1 < len(argv) {
+			return i + 1
+		}
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		return i
+	}
+	return 0
+}
+
+func isInterpreter(argv0 string) bool {
+	tok := normalizeToken(basename(argv0))
+	switch tok {
+	case "node", "nodejs", "bun", "deno":
+		return true
+	}
+	return strings.HasPrefix(tok, "python")
+}
+
+// normalizeToken lower-cases and strips platform/launcher suffixes so
+// "Claude.exe", "codex.js" and "kimi" compare equal to their tool token.
+func normalizeToken(s string) string {
+	tok := strings.ToLower(strings.TrimSpace(s))
+	for _, suffix := range []string{".exe", ".cmd", ".bat", ".mjs", ".cjs", ".js", ".py"} {
+		if strings.HasSuffix(tok, suffix) {
+			tok = strings.TrimSuffix(tok, suffix)
+			break
+		}
+	}
+	return tok
+}
+
+func splitPath(p string) []string {
+	return strings.FieldsFunc(p, func(r rune) bool { return r == '/' || r == '\\' })
+}
+
+func basename(p string) string {
+	parts := splitPath(p)
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
+}
+
+// ModelFromArgv finds an explicit model flag among the tool's own
+// arguments — those after entry, the index of the tool's entry point in
+// argv. Interpreter and wrapper flags before it are never consulted, so
+// "python -m kimi_cli" does not yield a model of "kimi_cli". Only the
+// flag's operand is returned; the rest of argv is never surfaced.
+//
+// Rules are tool-aware: "--model X" and "--model=X" are accepted for every
+// tool; the short "-m X" only for codex, which documents it.
+func ModelFromArgv(tool string, argv []string, entry int) aisessions.Attr {
+	if entry < 0 || entry >= len(argv) {
+		return aisessions.Unknown()
+	}
+	shortOK := tool == aisessions.ToolCodex
+	for i := entry + 1; i < len(argv); i++ {
+		a := argv[i]
+		switch {
+		case a == "--model" || (shortOK && a == "-m"):
+			if i+1 < len(argv) {
+				return aisessions.ModelFromFlag(argv[i+1])
+			}
+			return aisessions.Unknown()
+		case strings.HasPrefix(a, "--model="):
+			return aisessions.ModelFromFlag(strings.TrimPrefix(a, "--model="))
+		}
+	}
+	return aisessions.Unknown()
+}
+
+// cpuSample is the per-process state carried between scans so activity
+// can be inferred from CPU time consumed since the previous scan.
+type cpuSample struct {
+	StartMS    int64
+	CPUSeconds float64
+	At         time.Time
+}
+
+// Scanner holds the inter-scan state. One instance lives for the
+// agent process; the map is pruned to the processes seen on each scan.
+type Scanner struct {
+	mu   sync.Mutex
+	prev map[int32]cpuSample
+}
+
+func NewScanner() *Scanner {
+	return &Scanner{prev: make(map[int32]cpuSample)}
+}
+
+// match is a classified process awaiting tree collapse.
+type match struct {
+	proc  Process
+	tool  string
+	entry int
+}
+
+// Build turns a process table into the sessions to report. It is pure
+// apart from the scanner's inter-scan CPU samples. Raw argv and cwd are
+// consumed here and do not appear in the result.
+func (sc *Scanner) Build(procs []Process, now time.Time) []aisessions.Session {
+	// Pass 1: classify, and index parents for the tree walk below.
+	matched := make(map[int32]match)
+	parents := make(map[int32]int32, len(procs))
+	order := make([]int32, 0)
+	for _, p := range procs {
+		if _, dup := parents[p.PID]; dup {
+			continue
+		}
+		parents[p.PID] = p.PPID
+		tool, entry, ok := classify(p.Name, p.Argv)
+		if !ok {
+			continue
+		}
+		matched[p.PID] = match{proc: p, tool: tool, entry: entry}
+		order = append(order, p.PID)
+	}
+
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	next := make(map[int32]cpuSample, len(matched))
+
+	// Pass 2: collapse process trees. A wrapper script whose name matches
+	// and the real binary it exec'd, or a tool re-launching itself through
+	// a shell, is one session: report the topmost matched ancestor of the
+	// same tool only.
+	out := make([]aisessions.Session, 0, len(order))
+	for _, pid := range order {
+		m := matched[pid]
+		if hasMatchedAncestor(m, matched, parents) {
+			continue
+		}
+		p := m.proc
+		s := aisessions.Session{
+			ID:       aisessions.SessionID(p.PID, p.StartMS),
+			Tool:     m.tool,
+			Project:  aisessions.Unknown(),
+			Model:    ModelFromArgv(m.tool, p.Argv, m.entry),
+			Activity: aisessions.Unknown(),
+		}
+		if p.StartMS > 0 {
+			s.StartedAt = time.UnixMilli(p.StartMS).UTC().Format(time.RFC3339)
+		}
+		if attr, ok := aisessions.ProjectFromDir(p.Cwd, p.Username); ok {
+			s.Project = attr
+		}
+		if prev, ok := sc.prev[p.PID]; ok && prev.StartMS == p.StartMS && p.CPUSeconds >= 0 && prev.CPUSeconds >= 0 {
+			if elapsed := now.Sub(prev.At).Seconds(); elapsed > 0 {
+				rate := (p.CPUSeconds - prev.CPUSeconds) / elapsed
+				state := aisessions.ActivityIdle
+				if rate >= ActivityCPURate {
+					state = aisessions.ActivityActive
+				}
+				s.Activity = aisessions.Attr{Value: state, Source: aisessions.SourceCPUTime, Confidence: aisessions.ConfidenceInferred}
+			}
+		}
+		next[p.PID] = cpuSample{StartMS: p.StartMS, CPUSeconds: p.CPUSeconds, At: now}
+		out = append(out, s)
+	}
+	sc.prev = next
+	return out
+}
+
+// hasMatchedAncestor walks the parent chain through the whole table
+// (bounded, so a cyclic or enormous fake table cannot spin) looking for a
+// matched process of the same tool.
+func hasMatchedAncestor(m match, matched map[int32]match, parents map[int32]int32) bool {
+	ppid := m.proc.PPID
+	for hop := 0; hop < 8 && ppid > 1; hop++ {
+		if parent, ok := matched[ppid]; ok && parent.tool == m.tool {
+			return true
+		}
+		next, ok := parents[ppid]
+		if !ok {
+			return false
+		}
+		ppid = next
+	}
+	return false
+}

--- a/agent/aiscan/aiscan_test.go
+++ b/agent/aiscan/aiscan_test.go
@@ -1,0 +1,480 @@
+package aiscan
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/aisessions"
+)
+
+func TestClassifyAIToolPositives(t *testing.T) {
+	cases := []struct {
+		name string
+		argv []string
+		want string
+	}{
+		// Native binaries and symlinked launchers.
+		{"claude", []string{"claude"}, aisessions.ToolClaude},
+		{"claude", []string{"/home/u/.local/bin/claude", "--resume"}, aisessions.ToolClaude},
+		{"Claude.exe", []string{`C:\Users\u\AppData\Local\Programs\claude\Claude.exe`}, aisessions.ToolClaude},
+		{"codex", []string{"codex", "-m", "gpt-5-codex"}, aisessions.ToolCodex},
+		{"codex.exe", nil, aisessions.ToolCodex},
+		{"kimi", []string{"/home/u/.local/bin/kimi"}, aisessions.ToolKimi},
+		// Name is the interpreter; the script decides.
+		{"node", []string{"node", "/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js"}, aisessions.ToolClaude},
+		{"node", []string{"/usr/bin/node", "--max-old-space-size=4096", "/usr/local/bin/claude"}, aisessions.ToolClaude},
+		{"node", []string{"node", `C:\Users\u\AppData\Roaming\npm\node_modules\@anthropic-ai\claude-code\cli.js`}, aisessions.ToolClaude},
+		{"bun", []string{"bun", "/opt/homebrew/lib/node_modules/@openai/codex/bin/codex.js"}, aisessions.ToolCodex},
+		{"node.exe", []string{`C:\Program Files\nodejs\node.exe`, `C:\npm\node_modules\@openai\codex\bin\codex.js`}, aisessions.ToolCodex},
+		{"python3", []string{"python3", "-m", "kimi_cli"}, aisessions.ToolKimi},
+		{"python3.12", []string{"/home/u/.venv/bin/python3.12", "/home/u/.local/bin/kimi", "--model", "kimi-k2"}, aisessions.ToolKimi},
+		{"python", []string{"python", "/site-packages/kimi_cli/__main__.py"}, aisessions.ToolKimi},
+		// Shebang wrapper: comm is the script name even though argv[0] is bash.
+		{"claude", []string{"/bin/bash", "/usr/local/bin/claude"}, aisessions.ToolClaude},
+		// Empty name, argv carries the answer.
+		{"", []string{"/usr/local/bin/codex"}, aisessions.ToolCodex},
+	}
+	for _, c := range cases {
+		got, ok := Classify(c.name, c.argv)
+		if !ok || got != c.want {
+			t.Errorf("Classify(%q, %q) = (%q,%v), want (%q,true)", c.name, c.argv, got, ok, c.want)
+		}
+	}
+}
+
+func TestClassifyAIToolNegatives(t *testing.T) {
+	cases := []struct {
+		name string
+		argv []string
+	}{
+		{"", nil},
+		{"bash", []string{"bash"}},
+		{"sshd", []string{"sshd: u@pts/0"}},
+		// Near-miss names never match by substring.
+		{"claude-desktop", []string{"claude-desktop"}},
+		{"claudette", []string{"claudette"}},
+		{"xclaude", nil},
+		{"codex-server", []string{"codex-server"}},
+		{"xcodex", nil},
+		{"kimi-desktop", nil},
+		{"kimidb", nil},
+		// A tool name appearing as an ARGUMENT to something else is not a session.
+		{"bash", []string{"bash", "-c", "claude -p 'summarize this'"}},
+		{"grep", []string{"grep", "-r", "claude", "."}},
+		{"vim", []string{"vim", "claude.md"}},
+		{"cat", []string{"cat", "/home/u/.claude/settings.json"}},
+		{"ssh", []string{"ssh", "host", "codex"}},
+		{"python3", []string{"python3", "train.py", "--model", "claude"}},
+		{"node", []string{"node", "/srv/app/claude-code-router/cli.js"}},
+		{"node", []string{"node", "-e", "require('claude')"}},
+		{"node", []string{"node"}},
+		{"node", []string{"node", "--version"}},
+		{"python3", []string{"python3", "-m", "kimi_cli_utils"}},
+		{"python3", []string{"python3", "-c", "import kimi"}},
+		// The agent itself, the hub, and unrelated AI tooling.
+		{"bloxos-agent", []string{"/usr/local/bin/bloxos-agent"}},
+		{"ollama", []string{"ollama", "run", "claude"}},
+		{"cursor", []string{"cursor"}},
+		{"aider", []string{"aider", "--model", "claude-opus-5"}},
+	}
+	for _, c := range cases {
+		if got, ok := Classify(c.name, c.argv); ok {
+			t.Errorf("Classify(%q, %q) = %q, want no match", c.name, c.argv, got)
+		}
+	}
+}
+
+func TestModelFromArgv(t *testing.T) {
+	exact := func(v string) aisessions.Attr {
+		return aisessions.Attr{Value: v, Source: aisessions.SourceArgvFlag, Confidence: aisessions.ConfidenceExact}
+	}
+	inferred := func(v string) aisessions.Attr {
+		return aisessions.Attr{Value: v, Source: aisessions.SourceArgvFlag, Confidence: aisessions.ConfidenceInferred}
+	}
+	cases := []struct {
+		name string
+		argv []string
+		want aisessions.Attr
+	}{
+		{"claude", []string{"claude", "--model", "claude-opus-5"}, exact("claude-opus-5")},
+		{"claude", []string{"claude", "--model=opus"}, inferred("opus")},
+		{"codex", []string{"codex", "-m", "gpt-5-codex", "resume"}, exact("gpt-5-codex")},
+		{"codex", []string{"codex", "--model", "gpt-5-codex"}, exact("gpt-5-codex")},
+		{"claude", []string{"claude"}, aisessions.Unknown()},
+		{"claude", []string{"claude", "--model"}, aisessions.Unknown()},
+		{"claude", []string{"claude", "--model", "/tmp/evil path"}, aisessions.Unknown()},
+		{"claude", []string{"claude", "-p", "--model is not a flag here"}, aisessions.Unknown()},
+		// -m is codex's short flag only; for other tools it is not a model.
+		{"claude", []string{"claude", "-m", "opus"}, aisessions.Unknown()},
+		{"kimi", []string{"kimi", "-m", "kimi-k2"}, aisessions.Unknown()},
+		// Regression: an interpreter's -m module flag is never a model.
+		{"python3", []string{"python3", "-m", "kimi_cli"}, aisessions.Unknown()},
+		{"python3", []string{"python3", "-m", "kimi_cli", "--model", "kimi-k2"}, exact("kimi-k2")},
+		{"python", []string{"/usr/bin/python3.12", "-u", "-m", "kimi_cli", "--model=kimi-k2-thinking"}, exact("kimi-k2-thinking")},
+		// Interpreter flags before the entry point are not tool flags either.
+		{"node", []string{"node", "--max-old-space-size=4096", "/usr/local/bin/claude", "--model", "sonnet"}, inferred("sonnet")},
+		{"node", []string{"node", "--title=--model", "/usr/local/bin/claude"}, aisessions.Unknown()},
+		// Recognized by name only (entry -1): nothing in argv is trusted as a tool flag.
+		{"claude", []string{"/bin/bash", "-c", "exec real-claude --model opus"}, aisessions.Unknown()},
+		// Shebang wrapper: flags after the launcher script count.
+		{"claude", []string{"/bin/bash", "/usr/local/bin/claude", "--model", "claude-sonnet-5"}, exact("claude-sonnet-5")},
+		{"claude", []string{"/bin/bash", "--model", "x", "/usr/local/bin/claude"}, aisessions.Unknown()},
+		// argv[0] alone is never a flag operand.
+		{"claude", []string{"--model"}, aisessions.Unknown()},
+	}
+	for _, c := range cases {
+		tool, entry, ok := classify(c.name, c.argv)
+		if !ok {
+			t.Errorf("classify(%q, %q) unexpectedly failed", c.name, c.argv)
+			continue
+		}
+		if got := ModelFromArgv(tool, c.argv, entry); got != c.want {
+			t.Errorf("ModelFromArgv(%q, %q, %d) = %+v, want %+v", tool, c.argv, entry, got, c.want)
+		}
+	}
+}
+
+func TestClassifyEntryIndex(t *testing.T) {
+	cases := []struct {
+		name  string
+		argv  []string
+		entry int
+	}{
+		{"claude", []string{"claude"}, 0},
+		{"claude", nil, -1},
+		{"claude", []string{"/bin/bash", "/usr/local/bin/claude"}, 1},
+		{"claude", []string{"/bin/bash", "-c", "something"}, -1},
+		{"node", []string{"node", "--flag", "/x/@anthropic-ai/claude-code/cli.js", "--model", "opus"}, 2},
+		{"python3", []string{"python3", "-m", "kimi_cli", "--model", "k"}, 2},
+		{"python3", []string{"python3", "--", "/home/u/.local/bin/kimi"}, 2},
+	}
+	for _, c := range cases {
+		_, entry, ok := classify(c.name, c.argv)
+		if !ok || entry != c.entry {
+			t.Errorf("classify(%q, %q) entry=%d ok=%v, want entry %d", c.name, c.argv, entry, ok, c.entry)
+		}
+	}
+}
+
+// TestAISessionsPrivacyRegression plants every category of forbidden data in
+// the process table and proves none of it reaches the wire.
+func TestAISessionsPrivacyRegression(t *testing.T) {
+	const (
+		apiKey   = "sk-ant-api03-PLANTEDSECRETVALUE"
+		prompt   = "tell me the production password hunter2"
+		fullPath = "/home/alice/work/secret-project"
+		username = "alice"
+		envVar   = "ANTHROPIC_API_KEY=PLANTEDENV"
+		toolOut  = "STDOUT-OF-A-TOOL-CALL"
+	)
+	procs := []Process{
+		{
+			PID: 4242, PPID: 1, Name: "claude",
+			Argv:     []string{"/home/alice/.local/bin/claude", "--model", "claude-opus-5", "-p", prompt, "--api-key", apiKey, "--env", envVar, "--", toolOut},
+			Cwd:      fullPath,
+			Username: username,
+			StartMS:  1_760_000_000_000,
+		},
+		{ // cwd IS the home directory: must not surface the username as a project.
+			PID: 4343, PPID: 1, Name: "codex",
+			Argv:     []string{"codex", "-m", "gpt-5-codex", "--danger-full-access", "--prompt", prompt},
+			Cwd:      "/home/" + username,
+			Username: username,
+			StartMS:  1_760_000_000_000,
+		},
+		{ // cwd basename equals the username elsewhere on disk.
+			PID: 4444, PPID: 1, Name: "kimi",
+			Argv:     []string{"kimi"},
+			Cwd:      "/srv/" + username,
+			Username: username,
+			StartMS:  1_760_000_000_000,
+		},
+	}
+	sc := NewScanner()
+	sessions := sc.Build(procs, time.Now())
+	if len(sessions) != 3 {
+		t.Fatalf("got %d sessions, want 3", len(sessions))
+	}
+	msg := aisessions.Sanitize(aisessions.Message{Type: aisessions.MessageType, MachineID: "m", Schema: aisessions.SchemaVersion, Sessions: sessions})
+	wire, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(wire)
+
+	for _, forbidden := range []string{
+		apiKey, "PLANTEDSECRET", prompt, "hunter2", "password",
+		fullPath, "/home/", "alice", envVar, "PLANTEDENV", "ANTHROPIC_API_KEY",
+		toolOut, "--danger-full-access", "--prompt", "\"pid\"", "\"argv\"", "\"cwd\":", "\"env\"", "\"username\"",
+	} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("wire payload leaks %q:\n%s", forbidden, out)
+		}
+	}
+	// What IS allowed came through, with its provenance.
+	if !strings.Contains(out, `"value":"secret-project","source":"cwd","confidence":"exact"`) {
+		t.Errorf("project basename missing from payload: %s", out)
+	}
+	if !strings.Contains(out, `"value":"claude-opus-5","source":"argv_flag","confidence":"exact"`) {
+		t.Errorf("explicit model missing from payload: %s", out)
+	}
+	if !strings.Contains(out, `"value":"gpt-5-codex","source":"argv_flag","confidence":"exact"`) {
+		t.Errorf("codex model missing from payload: %s", out)
+	}
+	// Home-dir and username-named cwds are withheld, not partially leaked.
+	if sessions[1].Project != aisessions.Unknown() || sessions[2].Project != aisessions.Unknown() {
+		t.Errorf("home/username cwd must yield Unknown project: %+v %+v", sessions[1].Project, sessions[2].Project)
+	}
+	// First scan: no activity evidence yet.
+	for _, s := range sessions {
+		if s.Activity != aisessions.Unknown() {
+			t.Errorf("first scan must not claim activity: %+v", s.Activity)
+		}
+	}
+}
+
+func TestBuildAISessionsCollapsesWrapperTrees(t *testing.T) {
+	procs := []Process{
+		// A shell wrapper named claude (comm=claude) that exec'd the real binary.
+		{PID: 10, PPID: 1, Name: "claude", Argv: []string{"/bin/bash", "/usr/local/bin/claude"}, StartMS: 1},
+		{PID: 11, PPID: 10, Name: "claude", Argv: []string{"/home/u/.local/share/claude/versions/2.1.0"}, StartMS: 2},
+		// Claude Code re-launching itself (e.g. a helper) two hops down.
+		{PID: 12, PPID: 11, Name: "sh", Argv: []string{"sh", "-c", "…"}, StartMS: 3},
+		{PID: 13, PPID: 12, Name: "claude", Argv: []string{"claude", "--print"}, StartMS: 4},
+		// A different tool under a claude process is its own session.
+		{PID: 20, PPID: 11, Name: "codex", Argv: []string{"codex"}, StartMS: 5},
+		// Independent sessions.
+		{PID: 30, PPID: 1, Name: "codex", Argv: []string{"codex"}, StartMS: 6},
+		{PID: 40, PPID: 30, Name: "kimi", Argv: []string{"kimi"}, StartMS: 7},
+	}
+	sc := NewScanner()
+	got := sc.Build(procs, time.Now())
+	ids := map[string]string{}
+	for _, s := range got {
+		ids[s.ID] = s.Tool
+	}
+	want := map[string]string{
+		aisessions.SessionID(10, 1): aisessions.ToolClaude,
+		aisessions.SessionID(20, 5): aisessions.ToolCodex,
+		aisessions.SessionID(30, 6): aisessions.ToolCodex,
+		aisessions.SessionID(40, 7): aisessions.ToolKimi,
+	}
+	if len(ids) != len(want) {
+		t.Fatalf("got %d sessions %v, want %d", len(ids), ids, len(want))
+	}
+	for id, tool := range want {
+		if ids[id] != tool {
+			t.Errorf("session %s: got tool %q, want %q", id, ids[id], tool)
+		}
+	}
+	// pid 13 (claude under sh under claude) collapsed via the 2-hop walk,
+	// pid 11 collapsed into its wrapper 10.
+	for _, pid := range []struct {
+		pid   int32
+		start int64
+	}{{11, 2}, {13, 4}} {
+		if _, present := ids[aisessions.SessionID(pid.pid, pid.start)]; present {
+			t.Errorf("pid %d should have collapsed into its ancestor", pid.pid)
+		}
+	}
+}
+
+func TestBuildAISessionsSurvivesParentCycle(t *testing.T) {
+	procs := []Process{
+		{PID: 5, PPID: 6, Name: "claude", StartMS: 1},
+		{PID: 6, PPID: 5, Name: "claude", StartMS: 2},
+	}
+	done := make(chan []aisessions.Session, 1)
+	go func() { done <- NewScanner().Build(procs, time.Now()) }()
+	select {
+	case got := <-done:
+		// Both collapse into each other; an empty answer is acceptable, an
+		// infinite loop is not.
+		if len(got) > 2 {
+			t.Fatalf("unexpected sessions: %+v", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ancestor walk did not terminate on a parent cycle")
+	}
+}
+
+func TestBuildAISessionsActivityInference(t *testing.T) {
+	sc := NewScanner()
+	t0 := time.Unix(1_760_000_000, 0)
+	base := Process{PID: 7, PPID: 1, Name: "claude", StartMS: 100, CPUSeconds: 10}
+
+	first := sc.Build([]Process{base}, t0)
+	if first[0].Activity != aisessions.Unknown() {
+		t.Fatalf("first scan: %+v, want unknown", first[0].Activity)
+	}
+
+	// 30s later, 3s of CPU consumed → 10% → active (inferred).
+	busy := base
+	busy.CPUSeconds = 13
+	second := sc.Build([]Process{busy}, t0.Add(30*time.Second))
+	wantActive := aisessions.Attr{Value: aisessions.ActivityActive, Source: aisessions.SourceCPUTime, Confidence: aisessions.ConfidenceInferred}
+	if second[0].Activity != wantActive {
+		t.Fatalf("busy scan: %+v, want %+v", second[0].Activity, wantActive)
+	}
+
+	// Another 30s, 0.1s of CPU → 0.3% → idle (inferred).
+	quiet := busy
+	quiet.CPUSeconds = 13.1
+	third := sc.Build([]Process{quiet}, t0.Add(60*time.Second))
+	wantIdle := aisessions.Attr{Value: aisessions.ActivityIdle, Source: aisessions.SourceCPUTime, Confidence: aisessions.ConfidenceInferred}
+	if third[0].Activity != wantIdle {
+		t.Fatalf("quiet scan: %+v, want %+v", third[0].Activity, wantIdle)
+	}
+
+	// PID reused by a new process (different start time): no inference.
+	reused := quiet
+	reused.StartMS = 999
+	reused.CPUSeconds = 50
+	fourth := sc.Build([]Process{reused}, t0.Add(90*time.Second))
+	if fourth[0].Activity != aisessions.Unknown() {
+		t.Fatalf("pid reuse: %+v, want unknown", fourth[0].Activity)
+	}
+	if fourth[0].ID == third[0].ID {
+		t.Fatal("pid reuse must produce a new session id")
+	}
+
+	// CPU time unavailable on this platform: never guess.
+	noCPU := reused
+	noCPU.CPUSeconds = -1
+	fifth := sc.Build([]Process{noCPU}, t0.Add(120*time.Second))
+	if fifth[0].Activity != aisessions.Unknown() {
+		t.Fatalf("no cpu evidence: %+v, want unknown", fifth[0].Activity)
+	}
+
+	// Inter-scan state is pruned to live processes.
+	sc.Build(nil, t0.Add(150*time.Second))
+	if len(sc.prev) != 0 {
+		t.Fatalf("scanner retained %d stale samples", len(sc.prev))
+	}
+}
+
+func TestBuildAISessionsStartedAtAndEmpty(t *testing.T) {
+	sc := NewScanner()
+	got := sc.Build([]Process{
+		{PID: 1, Name: "claude", StartMS: 1_760_000_000_000},
+		{PID: 2, Name: "codex", StartMS: 0},
+		{PID: 3, Name: "bash"},
+	}, time.Now())
+	if len(got) != 2 {
+		t.Fatalf("got %d sessions, want 2", len(got))
+	}
+	if got[0].StartedAt != time.UnixMilli(1_760_000_000_000).UTC().Format(time.RFC3339) {
+		t.Errorf("started_at = %q", got[0].StartedAt)
+	}
+	if got[1].StartedAt != "" {
+		t.Errorf("unknown start time must be empty, got %q", got[1].StartedAt)
+	}
+	if empty := sc.Build(nil, time.Now()); len(empty) != 0 {
+		t.Errorf("nil table should yield no sessions: %+v", empty)
+	}
+}
+
+func TestAISessionsLocalOptOut(t *testing.T) {
+	for _, c := range []struct {
+		val  string
+		want bool
+	}{{"", true}, {"1", true}, {"true", true}, {"anything", true}, {"0", false}, {"false", false}, {"OFF", false}, {" no ", false}} {
+		if got := EnabledByEnv(c.val); got != c.want {
+			t.Errorf("BLOXOS_AI_SESSIONS=%q → %v, want %v", c.val, got, c.want)
+		}
+	}
+}
+
+func TestGateRequiresHubSignalAndHonorsLocalOptOut(t *testing.T) {
+	var g Gate
+	// No hub signal yet: never scan, regardless of env.
+	if g.Allowed("") || g.Allowed("1") {
+		t.Fatal("gate must stay closed until the hub has spoken")
+	}
+	// Hub says enabled (the default hub setting): open.
+	if newly := g.Apply(true, 1); !newly {
+		t.Fatal("first enable must report newlyEnabled")
+	}
+	if !g.Allowed("") {
+		t.Fatal("gate should be open after hub enable")
+	}
+	if newly := g.Apply(true, 2); newly {
+		t.Fatal("repeated enable at a newer rev must not report newlyEnabled")
+	}
+	// Local hard opt-out wins over a hub enable.
+	for _, v := range []string{"0", "false", "off", "no"} {
+		if g.Allowed(v) {
+			t.Fatalf("BLOXOS_AI_SESSIONS=%q must override hub enable", v)
+		}
+	}
+	// Hub disable closes it.
+	if newly := g.Apply(false, 3); newly {
+		t.Fatal("disable must not report newlyEnabled")
+	}
+	if g.Allowed("") {
+		t.Fatal("gate should be closed after hub disable")
+	}
+	// Re-enable after disable is "newly enabled" again.
+	if newly := g.Apply(true, 4); !newly || !g.Allowed("") {
+		t.Fatal("re-enable after disable should open and report newlyEnabled")
+	}
+	// A new connection starts from unknown.
+	g.Reset()
+	if g.Allowed("") {
+		t.Fatal("Reset must close the gate until the hub speaks again")
+	}
+}
+
+// TestGateIgnoresStaleRevision is the reordering scenario: a disable at
+// rev 2 followed by a delayed enable at rev 1 must leave the gate closed.
+func TestGateIgnoresStaleRevision(t *testing.T) {
+	var g Gate
+	if newly := g.Apply(false, 2); newly || g.Allowed("") {
+		t.Fatal("rev 2 disable should close the gate")
+	}
+	if newly := g.Apply(true, 1); newly || g.Allowed("") {
+		t.Fatal("stale rev 1 enable must be ignored after rev 2 disable")
+	}
+	if newly := g.Apply(true, 3); !newly || !g.Allowed("") {
+		t.Fatal("rev 3 enable should open the gate")
+	}
+	// Equal revision is ignored: a duplicate changes nothing, and a
+	// conflicting value at the same revision cannot flip the gate.
+	if newly := g.Apply(true, 3); newly || !g.Allowed("") {
+		t.Fatal("duplicate rev 3 must change nothing")
+	}
+	if newly := g.Apply(false, 3); newly || !g.Allowed("") {
+		t.Fatal("conflicting value at equal rev 3 must not close the gate")
+	}
+	// A new connection starts over: rev 1 is fresh again.
+	g.Reset()
+	if g.Allowed("") {
+		t.Fatal("Reset must close the gate")
+	}
+	if newly := g.Apply(true, 1); !newly || !g.Allowed("") {
+		t.Fatal("after Reset a low revision is valid again")
+	}
+}
+
+// TestGateEqualRevisionConflictCannotFlip pins the equal-revision rule in
+// both directions: whichever value arrived first at a revision stands.
+func TestGateEqualRevisionConflictCannotFlip(t *testing.T) {
+	var g Gate
+	g.Apply(false, 2)
+	if g.Apply(true, 2) || g.Allowed("") {
+		t.Fatal("equal-rev enable must not reopen a gate closed at that rev")
+	}
+	g.Reset()
+	if !g.Apply(true, 2) || !g.Allowed("") {
+		t.Fatal("first decision at rev 2 should open the gate")
+	}
+	if g.Apply(false, 2) || !g.Allowed("") {
+		t.Fatal("equal-rev disable must not close a gate opened at that rev")
+	}
+	// Strictly greater still wins.
+	if g.Apply(false, 3) || g.Allowed("") {
+		t.Fatal("rev 3 disable should close the gate")
+	}
+}

--- a/agent/main.go
+++ b/agent/main.go
@@ -602,6 +602,10 @@ func runAgent(machineID string) (authOutcome, error) {
 	// Mutex for concurrent writes to WebSocket.
 	var writeMu sync.Mutex
 
+	// AI Sessions scanning stays off until this hub says otherwise on this
+	// connection (an older hub never will).
+	aiGate.Reset()
+
 	// Liveness: require a hub frame (data or pong) within pongWait, and refresh
 	// the deadline whenever one arrives. A silently dead TCP connection now
 	// surfaces within ~pongWait instead of hanging on the OS keepalive (~2h).
@@ -693,6 +697,10 @@ func runAgent(machineID string) (authOutcome, error) {
 				// flow in its own goroutine internally.
 				handleAgentVersion(msg)
 
+			case aiSessionsConfigType:
+				// Admin switch for AI Sessions reporting (see ai_sessions.go).
+				handleAISessionsConfig(conn, &writeMu, machineID, msg)
+
 			default:
 				// Anything else is a command (restart_service, refresh_metrics, etc.)
 				go handleCommand(conn, &writeMu, msg)
@@ -761,6 +769,7 @@ func sendAll(conn *websocket.Conn, mu *sync.Mutex, machineID string) error {
 	}
 	sendServices(conn, mu, machineID)
 	sendContainers(conn, mu, machineID)
+	sendAISessions(conn, mu, machineID)
 	return nil
 }
 

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { BrandingProvider } from "@/contexts/BrandingContext";
 import { PreferencesProvider } from "@/contexts/PreferencesContext";
 import { VersionsProvider } from "@/contexts/VersionsContext";
 import { InventoryProvider } from "@/contexts/InventoryContext";
+import { AISessionsProvider } from "@/contexts/AISessionsContext";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Geist, Geist_Mono } from "next/font/google";
@@ -106,9 +107,13 @@ export default function RootLayout({
                   <SSEProvider>
                     <VersionsProvider>
                       <InventoryProvider>
-                        <TooltipProvider>
-                          <ToastProvider>{children}</ToastProvider>
-                        </TooltipProvider>
+                        {/* AI Sessions rides the shared SSE stream (subscribe)
+                            and bootstraps from GET on every reconnect. */}
+                        <AISessionsProvider>
+                          <TooltipProvider>
+                            <ToastProvider>{children}</ToastProvider>
+                          </TooltipProvider>
+                        </AISessionsProvider>
                       </InventoryProvider>
                     </VersionsProvider>
                   </SSEProvider>

--- a/dashboard/src/app/machine/[id]/page.tsx
+++ b/dashboard/src/app/machine/[id]/page.tsx
@@ -13,6 +13,8 @@ import { RebootModal } from "@/components/RebootModal";
 import { MetricCharts } from "@/components/MetricCharts";
 import { HardwareCard, type HardwareInfo } from "@/components/HardwareCard";
 import { MachineNotes } from "@/components/MachineNotes";
+import { AISessionsPanel } from "@/components/AISessionsPanel";
+import { useAISessions } from "@/contexts/AISessionsContext";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -27,13 +29,13 @@ import {
   Activity, Zap, Terminal as TerminalIcon, RotateCcw,
   Lock, Unlock, X, Maximize2, Minimize2, Wifi, BarChart3, Trash2,
   LayoutDashboard, Box, Container as ContainerIcon, StickyNote, KeyRound,
-  RefreshCw, Copy, Check,
+  RefreshCw, Copy, Check, Bot,
 } from "lucide-react";
 import { HUB_URL, getAuthHeaders } from "@/lib/session";
 import { useAuth } from "@/contexts/AuthContext";
 
-type DetailTab = "overview" | "services" | "containers" | "metrics" | "notes" | "terminal";
-const DETAIL_TABS: readonly DetailTab[] = ["overview", "services", "containers", "metrics", "notes", "terminal"] as const;
+type DetailTab = "overview" | "services" | "containers" | "metrics" | "ai-sessions" | "notes" | "terminal";
+const DETAIL_TABS: readonly DetailTab[] = ["overview", "services", "containers", "metrics", "ai-sessions", "notes", "terminal"] as const;
 function parseTab(raw: string | null): DetailTab {
   return DETAIL_TABS.includes(raw as DetailTab) ? (raw as DetailTab) : "overview";
 }
@@ -147,6 +149,8 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
   } | null>(null);
   const [reenrollCopied, setReenrollCopied] = useState<"command" | "sha" | null>(null);
   const { hasScope, authFetch } = useAuth();
+  const aiSessions = useAISessions();
+  const aiSessionCount = aiSessions.enabled === false ? 0 : (aiSessions.getMachine(id)?.sessions.length ?? 0);
   const canDelete = hasScope("fleet.admin");
   const canControl = hasScope("fleet.control");
   const router = useRouter();
@@ -783,6 +787,15 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
               <BarChart3 className="w-4 h-4" />
               Metrics
             </TabsTrigger>
+            {!isAPIMachine && (
+              <TabsTrigger value="ai-sessions" className="px-4 py-1.5 gap-1.5 text-sm">
+                <Bot className="w-4 h-4" />
+                AI Sessions
+                {aiSessionCount > 0 && (
+                  <span className="ml-1 text-[10px] font-mono tabular-nums text-blox-muted">{aiSessionCount}</span>
+                )}
+              </TabsTrigger>
+            )}
             <TabsTrigger value="notes" className="px-4 py-1.5 gap-1.5 text-sm">
               <StickyNote className="w-4 h-4" />
               Notes
@@ -976,6 +989,14 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
               <MetricCharts machineId={id} hasGpu={hasGpu} />
             </motion.div>
           </TabsContent>
+
+          {!isAPIMachine && (
+            <TabsContent value="ai-sessions" className="mt-6">
+              <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.05 }}>
+                <AISessionsPanel machineId={id} />
+              </motion.div>
+            </TabsContent>
+          )}
 
           <TabsContent value="notes" className="mt-6">
             <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.05 }}>

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -34,7 +34,7 @@ import {
   Plus, WifiOff, Search, LayoutGrid, List,
   ChevronDown, Square, CheckSquare, RotateCcw, Trash2, Pencil,
   ArrowUpDown, Filter, Monitor, Server, RefreshCw, Boxes,
-  GitCompareArrows,
+  GitCompareArrows, Bot,
 } from "lucide-react";
 import Link from "next/link";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -419,6 +419,15 @@ export default function Home() {
               aria-label="Agent versions"
             >
               <GitCompareArrows className="w-4 h-4" />
+            </Link>
+
+            <Link
+              href="/sessions"
+              className="inline-flex items-center justify-center rounded-md w-8 h-8 text-blox-muted hover:text-blox-text hover:bg-blox-border/50 transition-colors"
+              title="AI Sessions"
+              aria-label="AI Sessions"
+            >
+              <Bot className="w-4 h-4" />
             </Link>
 
             {/* Vertical divider — separates utility icons from create actions */}

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+// AI Sessions — fleet-wide live view. Read-only.
+//
+// Groups the live snapshot by machine. Truth comes from the AISessions
+// context (GET on connect, SSE deltas after); this page adds no fetching.
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { motion } from "framer-motion";
+import { ArrowLeft, Bot, RefreshCw, WifiOff } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useAISessions, useNow } from "@/contexts/AISessionsContext";
+import { useSSE } from "@/contexts/SSEContext";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  SessionList,
+  SessionsDisabledNotice,
+  SessionsEmpty,
+  SessionsErrorNotice,
+  SessionsLegend,
+  SessionsSkeleton,
+  StaleNotice,
+} from "@/components/AISessionsList";
+import { isSnapshotStale, sortMachines, summarize } from "@/lib/ai-sessions";
+import { cn } from "@/lib/utils";
+
+export default function SessionsPage() {
+  const { enabled, hasLoaded, loading, error, staleAfterSeconds, machines, refresh } = useAISessions();
+  const { connected } = useSSE();
+  const { hasScope } = useAuth();
+  const now = useNow();
+
+  const ordered = useMemo(() => sortMachines(Array.from(machines.values())), [machines]);
+  const withSessions = useMemo(() => ordered.filter((m) => m.sessions.length > 0), [ordered]);
+  const totals = useMemo(() => summarize(ordered), [ordered]);
+
+  let body: React.ReactNode;
+  if (!hasLoaded) {
+    body = (
+      <div className="bg-blox-card border border-blox-border rounded-xl p-5">
+        <SessionsSkeleton rows={4} />
+      </div>
+    );
+  } else if (error && machines.size === 0) {
+    body = <SessionsErrorNotice error={error} onRetry={() => void refresh()} />;
+  } else if (enabled === false) {
+    body = (
+      <div className="bg-blox-card border border-blox-border rounded-xl p-5">
+        <SessionsDisabledNotice canManage={hasScope("fleet.admin")} />
+      </div>
+    );
+  } else if (withSessions.length === 0) {
+    body = (
+      <div className="bg-blox-card border border-blox-border rounded-xl p-5">
+        <SessionsEmpty scope="fleet" />
+        {totals.reporting > 0 && (
+          <p className="text-center text-[11px] text-blox-muted -mt-4 pb-4">
+            {totals.reporting} machine{totals.reporting === 1 ? "" : "s"} reporting, none with a session.
+          </p>
+        )}
+      </div>
+    );
+  } else {
+    body = (
+      <div className="space-y-4">
+        {withSessions.map((m) => {
+          const stale = isSnapshotStale(m.receivedAtLocal, now, staleAfterSeconds);
+          return (
+            <section
+              key={m.machineId}
+              aria-labelledby={`ai-sessions-${m.machineId}`}
+              className={cn(
+                "bg-blox-card border rounded-xl p-5 transition-opacity",
+                stale ? "border-status-stale/30 opacity-80" : "border-blox-border",
+              )}
+              data-testid="ai-sessions-machine"
+            >
+              <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
+                <div className="flex items-center gap-2 min-w-0">
+                  <h2 id={`ai-sessions-${m.machineId}`} className="text-sm font-semibold text-blox-text truncate">
+                    <Link href={`/machine/${encodeURIComponent(m.machineId)}?tab=ai-sessions`} className="hover:underline">
+                      {m.hostname || m.machineId}
+                    </Link>
+                  </h2>
+                  <span className="text-[10px] text-blox-muted font-mono tabular-nums">
+                    ({m.sessions.length})
+                  </span>
+                </div>
+                <StaleNotice machine={m} now={now} staleAfterSeconds={staleAfterSeconds} />
+              </div>
+              <SessionList sessions={m.sessions} now={now} />
+            </section>
+          );
+        })}
+        <div className="px-1">
+          <SessionsLegend />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+      className="min-h-screen bg-blox-bg"
+    >
+      <header className="sticky top-0 z-50 bg-blox-bg/80 backdrop-blur-xl border-b border-blox-border/50">
+        <div className="max-w-[1200px] mx-auto px-4 sm:px-6 h-12 flex items-center justify-between">
+          <Link
+            href="/"
+            className="flex items-center gap-1.5 text-blox-muted hover:text-blox-text transition-colors text-xs"
+          >
+            <ArrowLeft className="w-3.5 h-3.5" aria-hidden />
+            <span>Fleet</span>
+          </Link>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void refresh()}
+            disabled={loading}
+            className="text-xs text-blox-muted hover:text-blox-text gap-1.5 h-8"
+          >
+            <RefreshCw className={cn("w-3.5 h-3.5", loading && "animate-spin")} aria-hidden />
+            Refresh
+          </Button>
+        </div>
+      </header>
+
+      <section className="border-b border-blox-border/50 bg-blox-bg/40">
+        <div className="max-w-[1200px] mx-auto px-4 sm:px-6 py-6">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h1 className="text-xl sm:text-2xl font-semibold text-blox-text tracking-tight inline-flex items-center gap-2">
+              <Bot className="w-5 h-5 text-blox-blue" aria-hidden />
+              AI Sessions
+            </h1>
+            {hasLoaded && enabled !== false && (
+              <Badge variant="outline" className="border-blox-border text-blox-muted text-[10px] tabular-nums">
+                {totals.sessions} session{totals.sessions === 1 ? "" : "s"} · {totals.machines} machine
+                {totals.machines === 1 ? "" : "s"}
+              </Badge>
+            )}
+            {hasLoaded && enabled === false && (
+              <Badge variant="outline" className="border-blox-border text-blox-muted text-[10px]">
+                off
+              </Badge>
+            )}
+            {!connected && (
+              <span className="inline-flex items-center gap-1 text-[11px] text-status-warning" role="status">
+                <WifiOff className="w-3 h-3" aria-hidden />
+                live updates paused
+              </span>
+            )}
+          </div>
+          <p className="text-[12px] text-blox-muted mt-1.5 max-w-2xl">
+            Claude Code, Codex and Kimi sessions currently running across the fleet. Metadata only: the
+            tool, an explicitly chosen model, the project folder name, and how long the process has run.
+            Live only — nothing is kept once a session ends.
+          </p>
+        </div>
+      </section>
+
+      <main className="max-w-[1200px] mx-auto px-4 sm:px-6 py-6 space-y-6">{body}</main>
+    </motion.div>
+  );
+}

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -7,6 +7,7 @@
 // 10), and Branding (Phase 10, admin only).
 
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { ChevronLeft } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import {
@@ -19,11 +20,23 @@ import { ThemeSettings } from "@/components/settings/ThemeSettings";
 import { BrandingSettings } from "@/components/settings/BrandingSettings";
 import { ProfileSettings } from "@/components/settings/ProfileSettings";
 import { PreferencesSettings } from "@/components/settings/PreferencesSettings";
+import { AISessionsSettings } from "@/components/settings/AISessionsSettings";
+
+const SETTINGS_TABS = ["profile", "preferences", "theme", "branding", "ai-sessions"] as const;
+type SettingsTab = (typeof SETTINGS_TABS)[number];
 
 export default function SettingsPage() {
   const { hasScope } = useAuth();
+  const searchParams = useSearchParams();
   const canEditBranding = hasScope("branding.admin");
-  const defaultTab = "profile";
+  const canManageAISessions = hasScope("fleet.admin");
+  const requested = searchParams.get("tab") as SettingsTab | null;
+  const defaultTab: SettingsTab =
+    requested && SETTINGS_TABS.includes(requested) &&
+    (requested !== "branding" || canEditBranding) &&
+    (requested !== "ai-sessions" || canManageAISessions)
+      ? requested
+      : "profile";
 
   return (
     <div className="min-h-screen bg-blox-bg">
@@ -43,7 +56,7 @@ export default function SettingsPage() {
         <section className="mb-8">
           <h1 className="text-2xl font-bold tracking-tight text-blox-text">Settings</h1>
           <p className="text-sm text-blox-muted mt-1">
-            Personal preferences and (for admins) instance branding.
+            Personal preferences and (for admins) instance branding and monitoring.
           </p>
         </section>
 
@@ -53,6 +66,7 @@ export default function SettingsPage() {
             <TabsTrigger value="preferences">Preferences</TabsTrigger>
             <TabsTrigger value="theme">Theme</TabsTrigger>
             {canEditBranding && <TabsTrigger value="branding">Branding</TabsTrigger>}
+            {canManageAISessions && <TabsTrigger value="ai-sessions">AI Sessions</TabsTrigger>}
           </TabsList>
 
           <TabsContent value="profile" className="mt-6">
@@ -70,6 +84,12 @@ export default function SettingsPage() {
           {canEditBranding && (
             <TabsContent value="branding" className="mt-6">
               <BrandingSettings />
+            </TabsContent>
+          )}
+
+          {canManageAISessions && (
+            <TabsContent value="ai-sessions" className="mt-6">
+              <AISessionsSettings />
             </TabsContent>
           )}
         </Tabs>

--- a/dashboard/src/components/AISessionsList.tsx
+++ b/dashboard/src/components/AISessionsList.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+// AI Sessions — shared presentation for one machine's session list plus the
+// empty / disabled / loading / stale states. Used by the machine detail tab
+// and the fleet-wide /sessions page so both read the contract identically.
+//
+// Read-only by design: there is nothing here that acts on a session.
+
+import Link from "next/link";
+import { Bot, Clock, FolderGit2, Info, PowerOff, WifiOff } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  type AIAttr,
+  type AISession,
+  type AISessionsMachine,
+  activityLabel,
+  confidenceLabel,
+  formatRunningFor,
+  isSnapshotStale,
+  snapshotAgeSeconds,
+  sortSessions,
+  toolChipClass,
+  toolLabel,
+} from "@/lib/ai-sessions";
+import { cn } from "@/lib/utils";
+
+/* ---------------------------------------------------------------------------
+ * Attribute rendering — value + explicit confidence. Never colour alone.
+ * ------------------------------------------------------------------------- */
+
+function ConfidenceMark({ confidence }: { confidence: string }) {
+  const label = confidenceLabel(confidence);
+  const cls =
+    confidence === "exact"
+      ? "text-emerald-400 border-emerald-500/30"
+      : confidence === "inferred"
+        ? "text-amber-400 border-amber-500/30"
+        : "text-blox-muted border-blox-border";
+  const help =
+    confidence === "exact"
+      ? "Observed verbatim from the process."
+      : confidence === "inferred"
+        ? "Derived from indirect evidence; treat as a hint."
+        : "No evidence available.";
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            className={cn(
+              "inline-flex items-center rounded-sm border px-1 py-px text-[9px] font-medium uppercase tracking-[0.08em] leading-none",
+              cls,
+            )}
+            aria-label={`confidence ${label}`}
+          />
+        }
+      >
+        {label}
+      </TooltipTrigger>
+      <TooltipContent side="top">{help}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function ModelCell({ model }: { model: AIAttr }) {
+  if (!model.value || model.confidence === "unknown") {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-blox-muted">
+        <span className="text-xs">model unknown</span>
+        <ConfidenceMark confidence="unknown" />
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 min-w-0">
+      <span className="text-xs font-mono text-blox-text truncate" title={model.value}>
+        {model.value}
+      </span>
+      <ConfidenceMark confidence={model.confidence} />
+    </span>
+  );
+}
+
+export function ProjectCell({ project }: { project: AIAttr }) {
+  if (!project.value) {
+    return <span className="text-xs text-blox-muted">no project</span>;
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 min-w-0" title="Working directory name">
+      <FolderGit2 className="w-3 h-3 text-blox-muted shrink-0" aria-hidden />
+      <span className="text-xs font-mono text-blox-text truncate">{project.value}</span>
+    </span>
+  );
+}
+
+export function ActivityCell({ activity }: { activity: AIAttr }) {
+  const label = activityLabel(activity);
+  const known = activity.confidence !== "unknown" && !!activity.value;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 text-xs",
+        known ? "text-blox-text" : "text-blox-muted",
+      )}
+    >
+      <span
+        className={cn(
+          "inline-block w-1.5 h-1.5 rounded-full shrink-0",
+          !known ? "bg-blox-muted/40" : activity.value === "active" ? "bg-blox-blue" : "bg-blox-muted/60",
+        )}
+        aria-hidden
+      />
+      <span>{label}</span>
+    </span>
+  );
+}
+
+/** The one definitive state: a session exists because its process does. */
+export function RunningBadge() {
+  return (
+    <Badge
+      variant="outline"
+      className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-[10px] gap-1 h-auto py-0 px-1.5"
+    >
+      <span className="relative inline-flex h-1.5 w-1.5" aria-hidden>
+        <span className="absolute inset-0 rounded-full bg-emerald-400 opacity-60 animate-status-pulse" />
+        <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-400" />
+      </span>
+      Running
+    </Badge>
+  );
+}
+
+export function ToolChip({ tool }: { tool: string }) {
+  return (
+    <Badge variant="outline" className={cn("text-[10px] h-auto py-0 px-1.5", toolChipClass(tool))}>
+      {toolLabel(tool)}
+    </Badge>
+  );
+}
+
+/* ---------------------------------------------------------------------------
+ * One session row.
+ * ------------------------------------------------------------------------- */
+
+export function SessionRow({ session, now }: { session: AISession; now: number }) {
+  const running = formatRunningFor(session.started_at, now);
+  return (
+    <li
+      className="flex flex-col gap-1.5 sm:grid sm:grid-cols-[6.5rem_minmax(0,1.4fr)_minmax(0,1fr)_5rem_minmax(0,1fr)] sm:items-center sm:gap-x-3 sm:gap-y-0 px-2 py-2 rounded-lg hover:bg-blox-border/20 transition-colors"
+      data-session-id={session.id}
+    >
+      {/* On phones this is one line (chip + model); on wider screens the
+          two children become their own grid cells. */}
+      <div className="flex items-center gap-2 min-w-0 sm:contents">
+        <ToolChip tool={session.tool} />
+        <div className="min-w-0">
+          <ModelCell model={session.model} />
+        </div>
+      </div>
+      <div className="min-w-0">
+        <ProjectCell project={session.project} />
+      </div>
+      <div className="inline-flex items-center gap-1 text-xs text-blox-muted tabular-nums" title="Running for">
+        <Clock className="w-3 h-3 shrink-0" aria-hidden />
+        {session.started_at ? (
+          <time dateTime={session.started_at}>{running}</time>
+        ) : (
+          <span>{running}</span>
+        )}
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <ActivityCell activity={session.activity} />
+        <RunningBadge />
+      </div>
+    </li>
+  );
+}
+
+/* ---------------------------------------------------------------------------
+ * A machine's session group (used on /sessions) and its stale marker.
+ * ------------------------------------------------------------------------- */
+
+export function StaleNotice({ machine, now, staleAfterSeconds }: { machine: AISessionsMachine; now: number; staleAfterSeconds: number }) {
+  if (!isSnapshotStale(machine.receivedAtLocal, now, staleAfterSeconds)) return null;
+  const age = snapshotAgeSeconds(machine.receivedAtLocal, now);
+  return (
+    <span
+      className="inline-flex items-center gap-1 text-[10px] text-status-stale uppercase tracking-[0.06em]"
+      role="status"
+    >
+      <WifiOff className="w-3 h-3" aria-hidden />
+      stale · last report {age >= 120 ? `${Math.floor(age / 60)}m` : `${age}s`} ago
+    </span>
+  );
+}
+
+export function SessionList({ sessions, now }: { sessions: AISession[]; now: number }) {
+  const sorted = sortSessions(sessions);
+  return (
+    <ul className="space-y-0.5" aria-label="AI coding sessions">
+      {sorted.map((s) => (
+        <SessionRow key={s.id} session={s} now={now} />
+      ))}
+    </ul>
+  );
+}
+
+/* ---------------------------------------------------------------------------
+ * States.
+ * ------------------------------------------------------------------------- */
+
+export function SessionsSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <div className="space-y-1.5" aria-busy="true" aria-label="Loading AI sessions">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="h-9 rounded-lg bg-blox-border/30 animate-shimmer" />
+      ))}
+    </div>
+  );
+}
+
+export function SessionsDisabledNotice({ canManage }: { canManage: boolean }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-8 text-center text-blox-muted">
+      <PowerOff className="w-8 h-8 mb-2 opacity-30" aria-hidden />
+      <p className="text-sm text-blox-text">AI Sessions monitoring is turned off</p>
+      <p className="text-xs mt-1 max-w-sm">
+        An administrator disabled it for this hub. Agents stop scanning and nothing is reported.
+      </p>
+      {canManage && (
+        <Link href="/settings?tab=ai-sessions" className="text-xs text-blox-blue hover:underline mt-3">
+          Manage in Settings
+        </Link>
+      )}
+    </div>
+  );
+}
+
+export function SessionsEmpty({ scope }: { scope: "machine" | "fleet" }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-8 text-center text-blox-muted">
+      <Bot className="w-8 h-8 mb-2 opacity-20" aria-hidden />
+      <p className="text-sm text-blox-text">No AI coding sessions running</p>
+      <p className="text-xs mt-1 max-w-sm">
+        {scope === "fleet"
+          ? "Claude Code, Codex and Kimi sessions appear here while they run on any connected machine."
+          : "Claude Code, Codex and Kimi sessions appear here while they run on this machine."}
+      </p>
+    </div>
+  );
+}
+
+export function SessionsNotReporting() {
+  return (
+    <div className="flex flex-col items-center justify-center py-8 text-center text-blox-muted">
+      <Info className="w-8 h-8 mb-2 opacity-20" aria-hidden />
+      <p className="text-sm text-blox-text">No session report from this machine</p>
+      <p className="text-xs mt-1 max-w-sm">
+        Reporting needs a connected agent that supports AI Sessions. Offline machines and older agents show nothing here.
+      </p>
+    </div>
+  );
+}
+
+export function SessionsErrorNotice({ error, onRetry }: { error: string; onRetry?: () => void }) {
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2.5" role="alert">
+      <Info className="w-4 h-4 text-red-400 mt-0.5 shrink-0" aria-hidden />
+      <div className="flex-1 text-xs">
+        <p className="text-blox-text">Could not load AI sessions</p>
+        <p className="text-blox-muted mt-0.5">{error}</p>
+      </div>
+      {onRetry && (
+        <button type="button" onClick={onRetry} className="text-xs text-blox-blue hover:underline">
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** Small legend explaining the markers; shown once per surface. */
+export function SessionsLegend() {
+  return (
+    <p className="text-[11px] text-blox-muted">
+      <span className="text-blox-text">Running</span> means the tool&apos;s process exists on the machine.
+      Model and activity carry a confidence mark: <span className="text-emerald-400">exact</span> was observed
+      directly, <span className="text-amber-400">inferred</span> is a hint, <span>unknown</span> has no evidence.
+      Idle is an inferred CPU reading, not a sign the session ended.
+    </p>
+  );
+}

--- a/dashboard/src/components/AISessionsPanel.tsx
+++ b/dashboard/src/components/AISessionsPanel.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+// AI Sessions — per-machine panel rendered in the machine detail "AI
+// Sessions" tab. Read-only.
+
+import { Bot } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useAISessions, useNow } from "@/contexts/AISessionsContext";
+import { useSSE } from "@/contexts/SSEContext";
+import {
+  SessionList,
+  SessionsDisabledNotice,
+  SessionsEmpty,
+  SessionsErrorNotice,
+  SessionsLegend,
+  SessionsNotReporting,
+  SessionsSkeleton,
+  StaleNotice,
+} from "@/components/AISessionsList";
+
+export function AISessionsPanel({ machineId }: { machineId: string }) {
+  const { enabled, hasLoaded, error, staleAfterSeconds, getMachine, refresh } = useAISessions();
+  const { connected } = useSSE();
+  const { hasScope } = useAuth();
+  const now = useNow();
+  const machine = getMachine(machineId);
+  const count = machine?.sessions.length ?? 0;
+
+  let body: React.ReactNode;
+  if (!hasLoaded) {
+    body = <SessionsSkeleton />;
+  } else if (error && !machine) {
+    body = <SessionsErrorNotice error={error} onRetry={() => void refresh()} />;
+  } else if (enabled === false) {
+    body = <SessionsDisabledNotice canManage={hasScope("fleet.admin")} />;
+  } else if (!machine) {
+    body = <SessionsNotReporting />;
+  } else if (count === 0) {
+    body = <SessionsEmpty scope="machine" />;
+  } else {
+    body = <SessionList sessions={machine.sessions} now={now} />;
+  }
+
+  return (
+    <div className="bg-blox-card border border-blox-border rounded-xl p-5" data-testid="ai-sessions-panel">
+      <div className="flex items-center justify-between gap-3 mb-4 flex-wrap">
+        <div className="flex items-center gap-2.5">
+          <div className="p-1.5 rounded-lg bg-blox-blue/10">
+            <Bot className="w-3.5 h-3.5 text-blox-blue" aria-hidden />
+          </div>
+          <h3 className="text-sm font-semibold text-blox-text">AI Sessions</h3>
+          {enabled !== false && machine && (
+            <span className="text-[10px] text-blox-muted font-mono tabular-nums">({count})</span>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          {machine && <StaleNotice machine={machine} now={now} staleAfterSeconds={staleAfterSeconds} />}
+          {!connected && (
+            <span className="text-[10px] text-status-warning uppercase tracking-[0.06em]" role="status">
+              live updates paused
+            </span>
+          )}
+        </div>
+      </div>
+      {body}
+      {enabled !== false && count > 0 && (
+        <div className="mt-4 pt-3 border-t border-blox-border/60">
+          <SessionsLegend />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/CommandPalette.tsx
+++ b/dashboard/src/components/CommandPalette.tsx
@@ -25,7 +25,7 @@ import {
   ArrowRight,
   GitBranch,
   Boxes,
-  Settings,
+  Settings, Bot
 } from "lucide-react";
 
 interface CommandPaletteProps {
@@ -122,6 +122,13 @@ export function CommandPalette({
               >
                 <GitBranch />
                 <span>Agent versions</span>
+              </Command.Item>
+              <Command.Item
+                value="ai sessions claude codex kimi coding"
+                onSelect={() => runCommand(() => router.push("/sessions"))}
+              >
+                <Bot />
+                <span>AI Sessions</span>
               </Command.Item>
               {onOpenAlerts && (
                 <Command.Item

--- a/dashboard/src/components/FleetPulse.tsx
+++ b/dashboard/src/components/FleetPulse.tsx
@@ -2,15 +2,18 @@
 
 import { useMemo } from "react";
 import { motion } from "framer-motion";
+import { useRouter } from "next/navigation";
 import { useSSE } from "@/contexts/SSEContext";
+import { useAISessions } from "@/contexts/AISessionsContext";
 import type { MachineMetrics } from "@/lib/demo-data";
-import { Cpu, MemoryStick, Thermometer, AlertTriangle, Activity, WifiOff } from "lucide-react";
+import { summarize } from "@/lib/ai-sessions";
+import { Cpu, MemoryStick, Thermometer, AlertTriangle, Activity, WifiOff, Bot } from "lucide-react";
 import { classifyMachine } from "@/components/StatusBadge";
 
 /* ============================================================================
  * FleetPulse — top-of-page health strip.
  *
- * One hero cell (FLEET) + four supporting cells (CPU / RAM / GPU / ALERTS).
+ * One hero cell (FLEET) + five supporting cells (CPU / RAM / GPU / AI / ALERTS).
  * Every cell uses the same locked anatomy via <StatCell>:
  *
  *     ┌───────────────────────────────────────┐
@@ -99,6 +102,9 @@ interface FleetPulseProps {
 export function FleetPulse({ onAlertsClick }: FleetPulseProps) {
   const { machines, alertCount, alerts, connected, hasReceivedData } = useSSE();
   const stats = useMemo(() => computeStats(machines), [machines]);
+  const router = useRouter();
+  const ai = useAISessions();
+  const aiTotals = useMemo(() => summarize(ai.machines.values()), [ai.machines]);
 
   // Fleet severity = aggregate of the worst state present.
   const fleetSeverity: Severity =
@@ -126,7 +132,7 @@ export function FleetPulse({ onAlertsClick }: FleetPulseProps) {
       <div className="border-b border-border-subtle bg-surface-base">
         <div className="max-w-[1600px] mx-auto px-4 sm:px-6 py-3">
           <StatRow>
-            {Array.from({ length: 5 }).map((_, i) => (
+            {Array.from({ length: 6 }).map((_, i) => (
               <StatCell
                 key={i}
                 label="…"
@@ -242,7 +248,41 @@ export function FleetPulse({ onAlertsClick }: FleetPulseProps) {
             />
           )}
 
-          {/* 5 · ALERTS ─────────────────────────────────────────────── */}
+          {/* 5 · AI SESSIONS ─────────────────────────────────────────── */}
+          <StatCell
+            label="AI Sessions"
+            icon={<Bot className="h-3 w-3" />}
+            severity="neutral"
+            onClick={() => router.push("/sessions")}
+            className="hidden md:flex"
+            primary={
+              ai.enabled === false ? (
+                <span className="metric-value text-2xl text-text-disabled">off</span>
+              ) : !ai.hasLoaded ? (
+                <span className="metric-value text-2xl text-text-disabled">—</span>
+              ) : (
+                <span className="inline-flex items-baseline gap-1.5">
+                  <span className="metric-value text-2xl text-text-primary">{aiTotals.sessions}</span>
+                  <span className="metric-unit text-xs">
+                    on {aiTotals.machines} machine{aiTotals.machines === 1 ? "" : "s"}
+                  </span>
+                </span>
+              )
+            }
+            context={
+              <span className="metric-figure text-text-tertiary text-[11px]">
+                {ai.enabled === false
+                  ? "disabled by admin"
+                  : !ai.hasLoaded
+                    ? "loading"
+                    : aiTotals.sessions === 0
+                      ? "no coding sessions"
+                      : "running now · live"}
+              </span>
+            }
+          />
+
+          {/* 6 · ALERTS ─────────────────────────────────────────────── */}
           <StatCell
             label="Alerts"
             icon={<AlertTriangle className="h-3 w-3" />}
@@ -284,14 +324,15 @@ export function FleetPulse({ onAlertsClick }: FleetPulseProps) {
 }
 
 /* ============================================================================
- * Layout — asymmetric grid. Hero claims 5fr, four supporting cells share
- * 4fr each (totaling 16fr → 21fr). On mobile the row collapses to 2-col.
+ * Layout — asymmetric grid. Hero claims 5fr, supporting cells 3fr each. On
+ * mobile the row collapses to 2-col; the AI cell hides below md so the
+ * strip never exceeds one row of five on tablets.
  * ============================================================================ */
 
 function StatRow({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="grid grid-cols-2 sm:grid-cols-[5fr_3fr_3fr_3fr_3fr] gap-px overflow-hidden rounded-lg bg-border-subtle ring-1 ring-border-subtle"
+      className="grid grid-cols-2 sm:grid-cols-[5fr_3fr_3fr_3fr_3fr] md:grid-cols-[5fr_3fr_3fr_3fr_3fr_3fr] gap-px overflow-hidden rounded-lg bg-border-subtle ring-1 ring-border-subtle"
     >
       {children}
     </div>

--- a/dashboard/src/components/settings/AISessionsSettings.tsx
+++ b/dashboard/src/components/settings/AISessionsSettings.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+// AI Sessions — admin switch. Rendered only for fleet.admin (the settings
+// page gates the tab); the hub enforces the same scope on PATCH.
+
+import { useState } from "react";
+import { Bot, ShieldCheck } from "lucide-react";
+import { useAISessions } from "@/contexts/AISessionsContext";
+import { useToast } from "@/components/Toast";
+import { cn } from "@/lib/utils";
+
+export function AISessionsSettings() {
+  const { enabled, hasLoaded, setEnabled } = useAISessions();
+  const { addToast } = useToast();
+  const [saving, setSaving] = useState(false);
+  const isOn = enabled === true;
+
+  const toggle = async () => {
+    if (saving || enabled === null) return;
+    setSaving(true);
+    try {
+      await setEnabled(!isOn);
+      addToast("success", !isOn ? "AI Sessions monitoring enabled" : "AI Sessions monitoring disabled");
+    } catch (e) {
+      addToast("error", e instanceof Error ? e.message : "Failed to update AI Sessions");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-xl border border-blox-border bg-blox-card p-5">
+        <div className="flex items-start justify-between gap-6 flex-wrap">
+          <div className="min-w-0 max-w-2xl">
+            <h2 className="text-sm font-semibold text-blox-text mb-1 inline-flex items-center gap-2">
+              <Bot className="w-4 h-4 text-blox-blue" aria-hidden />
+              AI Sessions monitoring
+            </h2>
+            <p className="text-xs text-blox-muted">
+              Show which AI coding tools (Claude Code, Codex, Kimi) are running on fleet machines.
+            </p>
+            <ul className="mt-3 space-y-1.5 text-xs text-blox-muted">
+              <li className="flex gap-2">
+                <ShieldCheck className="w-3.5 h-3.5 text-emerald-400 mt-px shrink-0" aria-hidden />
+                <span>
+                  <span className="text-blox-text">Metadata only.</span> The tool, an explicitly chosen model,
+                  the project folder name, start time and a coarse CPU-based activity hint. Never prompts,
+                  responses, transcripts, commands, environment variables, full paths or usernames.
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <ShieldCheck className="w-3.5 h-3.5 text-emerald-400 mt-px shrink-0" aria-hidden />
+                <span>
+                  <span className="text-blox-text">Live only.</span> Sessions disappear when the process
+                  ends or the machine disconnects. Nothing is stored.
+                </span>
+              </li>
+            </ul>
+          </div>
+
+          <button
+            type="button"
+            role="switch"
+            aria-checked={isOn}
+            aria-label="AI Sessions monitoring"
+            disabled={!hasLoaded || saving}
+            onClick={() => void toggle()}
+            className={cn(
+              "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blox-blue/50",
+              "disabled:opacity-50 disabled:cursor-not-allowed",
+              isOn ? "bg-blox-blue border-blox-blue" : "bg-blox-bg border-blox-border",
+            )}
+          >
+            <span
+              className={cn(
+                "inline-block h-4.5 w-4.5 rounded-full bg-white shadow transition-transform",
+                isOn ? "translate-x-[22px]" : "translate-x-[2px]",
+              )}
+              aria-hidden
+            />
+          </button>
+        </div>
+
+        <div className="mt-4 flex items-center gap-2 text-xs">
+          <span className="text-blox-muted">Status:</span>
+          <span className={cn("font-medium", isOn ? "text-emerald-400" : "text-blox-muted")}>
+            {!hasLoaded ? "loading…" : isOn ? "On — agents report live sessions" : "Off — agents do not scan"}
+          </span>
+        </div>
+
+        <p className="mt-4 text-[11px] text-blox-muted">
+          Turning this off is pushed to every connected agent, which stops scanning immediately. A machine
+          can also opt out on its own by setting <code className="font-mono text-blox-text">BLOXOS_AI_SESSIONS=0</code> in
+          the agent&apos;s environment; that local opt-out cannot be overridden from here.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/dashboard/src/contexts/AISessionsContext.tsx
+++ b/dashboard/src/contexts/AISessionsContext.tsx
@@ -149,14 +149,16 @@ export function AISessionsProvider({ children }: { children: ReactNode }) {
         const view = JSON.parse(data) as AISessionsMachineView;
         if (!view || typeof view.machine_id !== "string" || !view.machine_id) return;
         const localNow = Date.now();
+        // Invalidate in-flight GET so it doesn't overwrite this newer SSE.
+        refreshSeqRef.current++;
         setMachines((prev) => {
           const next = new Map(prev);
           // A freshly received event is, by construction, "now" on the hub.
           next.set(view.machine_id, viewToMachine(view, localNow, localNow));
           return next;
         });
-        // Anything arriving means the feature is on.
-        setEnabledState((e) => (e === false ? true : e ?? true));
+        // Do NOT infer enabled=true from snapshot events. Trust only
+        // ai_sessions_config SSE and GET /api/ai-sessions for the switch.
       } catch {
         // ignore malformed frames
       }
@@ -165,6 +167,8 @@ export function AISessionsProvider({ children }: { children: ReactNode }) {
       try {
         const msg = JSON.parse(data) as { machine_id?: string };
         if (!msg?.machine_id) return;
+        // Invalidate in-flight GET so it doesn't overwrite this removal.
+        refreshSeqRef.current++;
         setMachines((prev) => {
           if (!prev.has(msg.machine_id!)) return prev;
           const next = new Map(prev);
@@ -179,6 +183,8 @@ export function AISessionsProvider({ children }: { children: ReactNode }) {
       try {
         const msg = JSON.parse(data) as { enabled?: boolean };
         if (typeof msg?.enabled !== "boolean") return;
+        // Invalidate in-flight GET so it doesn't overwrite this config change.
+        refreshSeqRef.current++;
         setEnabledState(msg.enabled);
         if (!msg.enabled) setMachines(new Map());
       } catch {

--- a/dashboard/src/contexts/AISessionsContext.tsx
+++ b/dashboard/src/contexts/AISessionsContext.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+// AI Sessions — the single client-side store for live AI coding sessions.
+//
+// Truth comes from GET /api/ai-sessions on every SSE (re)connect; deltas
+// arrive over the shared SSE stream (ai_sessions / ai_sessions_removed /
+// ai_sessions_config) through SSEProvider.subscribe. There is no polling
+// and no second EventSource. Everything held here is the sanitized
+// contract from proto/aisessions — nothing else exists to hold.
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useAuth } from "./AuthContext";
+import { useSSE } from "./SSEContext";
+import { HUB_URL } from "@/lib/session";
+import {
+  type AISessionsMachine,
+  type AISessionsMachineView,
+  type AISessionsResponse,
+  toLocalReceivedAt,
+} from "@/lib/ai-sessions";
+
+const DEFAULT_STALE_AFTER_SECONDS = 90;
+
+interface AISessionsContextValue {
+  /** null until the first bootstrap has answered. */
+  enabled: boolean | null;
+  /** True once GET has answered at least once (success or failure). */
+  hasLoaded: boolean;
+  loading: boolean;
+  error: string | null;
+  staleAfterSeconds: number;
+  machines: Map<string, AISessionsMachine>;
+  getMachine: (machineId: string) => AISessionsMachine | undefined;
+  refresh: () => Promise<void>;
+  /** Admin only (fleet.admin). Persists the switch and returns the new state. */
+  setEnabled: (enabled: boolean) => Promise<void>;
+}
+
+const AISessionsContext = createContext<AISessionsContextValue | null>(null);
+
+export function useAISessions() {
+  const ctx = useContext(AISessionsContext);
+  if (!ctx) throw new Error("useAISessions must be used within AISessionsProvider");
+  return ctx;
+}
+
+function viewToMachine(view: AISessionsMachineView, hubNowMs: number, localNowMs: number): AISessionsMachine {
+  return {
+    machineId: view.machine_id,
+    hostname: view.hostname || "",
+    sessions: Array.isArray(view.sessions) ? view.sessions : [],
+    receivedAtLocal: toLocalReceivedAt(view.received_at, hubNowMs, localNowMs),
+  };
+}
+
+export function AISessionsProvider({ children }: { children: ReactNode }) {
+  const { authFetch, isAuthenticated } = useAuth();
+  const { subscribe, connected } = useSSE();
+  const [enabled, setEnabledState] = useState<boolean | null>(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [staleAfterSeconds, setStaleAfterSeconds] = useState(DEFAULT_STALE_AFTER_SECONDS);
+  const [machines, setMachines] = useState<Map<string, AISessionsMachine>>(new Map());
+  const mountedRef = useRef(true);
+  // Serialize overlapping bootstraps: only the newest response may win.
+  const refreshSeqRef = useRef(0);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!isAuthenticated) return;
+    const seq = ++refreshSeqRef.current;
+    setLoading(true);
+    try {
+      const res = await authFetch(`${HUB_URL}/api/ai-sessions`);
+      if (!mountedRef.current || seq !== refreshSeqRef.current) return;
+      if (!res.ok) {
+        setError(`Hub returned ${res.status}`);
+        return;
+      }
+      const json: AISessionsResponse = await res.json();
+      if (!mountedRef.current || seq !== refreshSeqRef.current) return;
+      const localNow = Date.now();
+      const hubNow = json.now ? Date.parse(json.now) : localNow;
+      const next = new Map<string, AISessionsMachine>();
+      if (json.enabled) {
+        for (const view of json.machines ?? []) {
+          if (!view.machine_id) continue;
+          next.set(view.machine_id, viewToMachine(view, hubNow, localNow));
+        }
+      }
+      setEnabledState(Boolean(json.enabled));
+      if (typeof json.stale_after_seconds === "number" && json.stale_after_seconds > 0) {
+        setStaleAfterSeconds(json.stale_after_seconds);
+      }
+      setMachines(next);
+      setError(null);
+    } catch (err) {
+      if (!mountedRef.current || seq !== refreshSeqRef.current) return;
+      setError(err instanceof Error ? err.message : "Cannot reach hub");
+    } finally {
+      if (mountedRef.current && seq === refreshSeqRef.current) {
+        setLoading(false);
+        setHasLoaded(true);
+      }
+    }
+  }, [authFetch, isAuthenticated]);
+
+  // Bootstrap on auth, and re-bootstrap on every SSE (re)connect: events
+  // missed while disconnected are not replayed, so GET is the truth again.
+  useEffect(() => {
+    // Deferred to the next tick (as VersionsContext does) so React 19's
+    // set-state-in-effect rule is not tripped by a synchronous reset.
+    const t = setTimeout(() => {
+      if (!isAuthenticated) {
+        // Logout: nothing of this user's may linger for the next one.
+        refreshSeqRef.current++;
+        setMachines(new Map());
+        setEnabledState(null);
+        setHasLoaded(false);
+        setError(null);
+        return;
+      }
+      void refresh();
+    }, 0);
+    return () => clearTimeout(t);
+  }, [isAuthenticated, connected, refresh]);
+
+  // Live deltas.
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    const offSnapshot = subscribe("ai_sessions", (data) => {
+      try {
+        const view = JSON.parse(data) as AISessionsMachineView;
+        if (!view || typeof view.machine_id !== "string" || !view.machine_id) return;
+        const localNow = Date.now();
+        setMachines((prev) => {
+          const next = new Map(prev);
+          // A freshly received event is, by construction, "now" on the hub.
+          next.set(view.machine_id, viewToMachine(view, localNow, localNow));
+          return next;
+        });
+        // Anything arriving means the feature is on.
+        setEnabledState((e) => (e === false ? true : e ?? true));
+      } catch {
+        // ignore malformed frames
+      }
+    });
+    const offRemoved = subscribe("ai_sessions_removed", (data) => {
+      try {
+        const msg = JSON.parse(data) as { machine_id?: string };
+        if (!msg?.machine_id) return;
+        setMachines((prev) => {
+          if (!prev.has(msg.machine_id!)) return prev;
+          const next = new Map(prev);
+          next.delete(msg.machine_id!);
+          return next;
+        });
+      } catch {
+        // ignore
+      }
+    });
+    const offConfig = subscribe("ai_sessions_config", (data) => {
+      try {
+        const msg = JSON.parse(data) as { enabled?: boolean };
+        if (typeof msg?.enabled !== "boolean") return;
+        setEnabledState(msg.enabled);
+        if (!msg.enabled) setMachines(new Map());
+      } catch {
+        // ignore
+      }
+    });
+    return () => {
+      offSnapshot();
+      offRemoved();
+      offConfig();
+    };
+  }, [isAuthenticated, subscribe]);
+
+  const setEnabled = useCallback(
+    async (next: boolean) => {
+      const res = await authFetch(`${HUB_URL}/api/ai-sessions/settings`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: next }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => null);
+        throw new Error(json?.error || `Failed to update AI Sessions (${res.status})`);
+      }
+      const json = (await res.json().catch(() => null)) as { enabled?: boolean } | null;
+      const applied = typeof json?.enabled === "boolean" ? json.enabled : next;
+      setEnabledState(applied);
+      if (!applied) setMachines(new Map());
+    },
+    [authFetch],
+  );
+
+  const getMachine = useCallback((machineId: string) => machines.get(machineId), [machines]);
+
+  const value = useMemo<AISessionsContextValue>(
+    () => ({
+      enabled,
+      hasLoaded,
+      loading,
+      error,
+      staleAfterSeconds,
+      machines,
+      getMachine,
+      refresh,
+      setEnabled,
+    }),
+    [enabled, hasLoaded, loading, error, staleAfterSeconds, machines, getMachine, refresh, setEnabled],
+  );
+
+  return <AISessionsContext.Provider value={value}>{children}</AISessionsContext.Provider>;
+}
+
+/**
+ * Coarse clock for durations and staleness. Ticks only while mounted, so a
+ * page without sessions on screen costs nothing.
+ */
+export function useNow(intervalMs = 10_000): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}

--- a/dashboard/src/contexts/SSEContext.tsx
+++ b/dashboard/src/contexts/SSEContext.tsx
@@ -18,9 +18,19 @@ import {
 import { readCache, clearCache, makeDebouncedWriter } from "@/lib/metrics-cache";
 import { parseServerTimestamp } from "@/lib/timestamps";
 
+/** Handler for a raw named SSE event's `data` string. */
+export type SSEEventHandler = (data: string) => void;
+
 interface SSEContextType {
   machines: MachineMetrics[];
   getMachine: (id: string) => MachineMetrics | undefined;
+  /**
+   * Subscribe to a named SSE event on the single shared EventSource. The
+   * subscription survives reconnects (listeners are re-attached to every
+   * new EventSource). Returns an unsubscribe function. Feature contexts
+   * (e.g. AI Sessions) use this instead of opening a second stream.
+   */
+  subscribe: (event: string, handler: SSEEventHandler) => () => void;
   connected: boolean;
   hasReceivedData: boolean;
   alertCount: number;
@@ -73,6 +83,53 @@ export function SSEProvider({ children }: { children: ReactNode }) {
   const connectRef = useRef<() => void>(() => {});
   // Generation counter to serialize overlapping async connect() calls.
   const connectSeqRef = useRef(0);
+  // Named-event subscriptions from feature contexts. Keyed by event name;
+  // each EventSource gets one DOM listener per name that fans out to the
+  // current handler set, so handlers can come and go without touching
+  // the connection.
+  const subscriptionsRef = useRef<Map<string, Set<SSEEventHandler>>>(new Map());
+  const attachedRef = useRef<WeakMap<EventSource, Set<string>>>(new WeakMap());
+
+  const attachSubscription = useCallback((es: EventSource, event: string) => {
+    let attached = attachedRef.current.get(es);
+    if (!attached) {
+      attached = new Set();
+      attachedRef.current.set(es, attached);
+    }
+    if (attached.has(event)) return;
+    attached.add(event);
+    es.addEventListener(event, (e) => {
+      if (!mountedRef.current) return;
+      const handlers = subscriptionsRef.current.get(event);
+      if (!handlers) return;
+      for (const h of handlers) {
+        try {
+          h((e as MessageEvent).data);
+        } catch {
+          // a misbehaving subscriber must not break the stream
+        }
+      }
+    });
+  }, []);
+
+  const subscribe = useCallback(
+    (event: string, handler: SSEEventHandler) => {
+      let handlers = subscriptionsRef.current.get(event);
+      if (!handlers) {
+        handlers = new Set();
+        subscriptionsRef.current.set(event, handlers);
+      }
+      handlers.add(handler);
+      if (esRef.current) attachSubscription(esRef.current, event);
+      return () => {
+        const set = subscriptionsRef.current.get(event);
+        if (!set) return;
+        set.delete(handler);
+        if (set.size === 0) subscriptionsRef.current.delete(event);
+      };
+    },
+    [attachSubscription],
+  );
 
   // Phase 7: localStorage-backed cache for instant rehydration on reload.
   const userIDRef = useRef<string | null>(null);
@@ -151,6 +208,9 @@ export function SSEProvider({ children }: { children: ReactNode }) {
       return;
     }
     esRef.current = es;
+    for (const event of subscriptionsRef.current.keys()) {
+      attachSubscription(es, event);
+    }
 
     es.onopen = () => {
       if (!mountedRef.current) return;
@@ -306,7 +366,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
       backoffRef.current = Math.min(backoffRef.current * 2, 30000);
       reconnectTimer.current = setTimeout(() => connectRef.current(), delay);
     };
-  }, [disconnect]);
+  }, [disconnect, attachSubscription]);
 
   useEffect(() => {
     connectRef.current = () => {
@@ -424,6 +484,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
       value={{
         machines,
         getMachine,
+        subscribe,
         connected,
         hasReceivedData,
         alertCount,

--- a/dashboard/src/lib/ai-sessions.ts
+++ b/dashboard/src/lib/ai-sessions.ts
@@ -1,0 +1,163 @@
+/**
+ * AI Sessions — client-side contract types and pure display helpers.
+ *
+ * The types mirror proto/aisessions exactly. Everything the dashboard shows
+ * about a session comes from these fields; there is nothing else to show.
+ */
+
+export type AITool = "claude" | "codex" | "kimi";
+
+export type AIConfidence = "exact" | "inferred" | "unknown";
+
+export interface AIAttr {
+  value: string;
+  source: string;
+  confidence: AIConfidence | string;
+}
+
+export interface AISession {
+  id: string;
+  tool: AITool | string;
+  started_at?: string;
+  project: AIAttr;
+  model: AIAttr;
+  activity: AIAttr;
+}
+
+/** One machine's snapshot as delivered by GET /api/ai-sessions and SSE. */
+export interface AISessionsMachineView {
+  machine_id: string;
+  hostname: string;
+  received_at: string;
+  sessions: AISession[];
+}
+
+export interface AISessionsResponse {
+  enabled: boolean;
+  stale_after_seconds: number;
+  now?: string;
+  machines: AISessionsMachineView[];
+}
+
+/** A machine snapshot re-keyed to the browser clock. */
+export interface AISessionsMachine {
+  machineId: string;
+  hostname: string;
+  sessions: AISession[];
+  /** Browser-clock instant that corresponds to the hub's received_at. */
+  receivedAtLocal: number;
+}
+
+export const TOOL_LABELS: Record<AITool, string> = {
+  claude: "Claude Code",
+  codex: "Codex",
+  kimi: "Kimi",
+};
+
+export function toolLabel(tool: string): string {
+  return TOOL_LABELS[tool as AITool] ?? tool;
+}
+
+/** Tailwind classes for the tool chip. Muted, consistent with badge palette. */
+export function toolChipClass(tool: string): string {
+  switch (tool) {
+    case "claude":
+      return "border-amber-500/30 bg-amber-500/10 text-amber-400";
+    case "codex":
+      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-400";
+    case "kimi":
+      return "border-sky-500/30 bg-sky-500/10 text-sky-400";
+    default:
+      return "border-blox-border bg-blox-card text-blox-muted";
+  }
+}
+
+/**
+ * Format the time a process has been running. Coarse on purpose: a session
+ * list is scanned, not read, and seconds-level churn is noise.
+ */
+export function formatRunningFor(startedAt: string | undefined, nowMs: number): string {
+  if (!startedAt) return "unknown";
+  const start = Date.parse(startedAt);
+  if (!isFinite(start)) return "unknown";
+  const sec = Math.max(0, Math.floor((nowMs - start) / 1000));
+  if (sec < 60) return "<1m";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  const remMin = min % 60;
+  if (hr < 24) return remMin ? `${hr}h ${remMin}m` : `${hr}h`;
+  const day = Math.floor(hr / 24);
+  const remHr = hr % 24;
+  return remHr ? `${day}d ${remHr}h` : `${day}d`;
+}
+
+/** Seconds since the hub last heard from this machine's agent about sessions. */
+export function snapshotAgeSeconds(receivedAtLocal: number, nowMs: number): number {
+  return Math.max(0, Math.floor((nowMs - receivedAtLocal) / 1000));
+}
+
+export function isSnapshotStale(receivedAtLocal: number, nowMs: number, staleAfterSeconds: number): boolean {
+  return snapshotAgeSeconds(receivedAtLocal, nowMs) > staleAfterSeconds;
+}
+
+/**
+ * Convert a hub-clock received_at to a browser-clock instant. `hubNowMs` is
+ * the hub clock at the moment the payload was produced and `localNowMs` the
+ * browser clock when it arrived; the difference is the offset to apply so
+ * ageing never depends on the two clocks agreeing.
+ */
+export function toLocalReceivedAt(receivedAt: string, hubNowMs: number, localNowMs: number): number {
+  const received = Date.parse(receivedAt);
+  if (!isFinite(received) || !isFinite(hubNowMs)) return localNowMs;
+  return localNowMs - Math.max(0, hubNowMs - received);
+}
+
+/** Human labels for the attribute confidence marker. */
+export function confidenceLabel(confidence: string): string {
+  switch (confidence) {
+    case "exact":
+      return "exact";
+    case "inferred":
+      return "inferred";
+    default:
+      return "unknown";
+  }
+}
+
+export function activityLabel(activity: AIAttr): string {
+  if (activity.confidence === "unknown" || !activity.value) return "activity unknown";
+  return `${activity.value} (inferred)`;
+}
+
+/** Total sessions across machines plus how many machines carry at least one. */
+export function summarize(machines: Iterable<AISessionsMachine>): { sessions: number; machines: number; reporting: number } {
+  let sessions = 0;
+  let withSessions = 0;
+  let reporting = 0;
+  for (const m of machines) {
+    reporting++;
+    if (m.sessions.length > 0) {
+      withSessions++;
+      sessions += m.sessions.length;
+    }
+  }
+  return { sessions, machines: withSessions, reporting };
+}
+
+/** Stable ordering: hostname, then machine id, then session start (oldest first). */
+export function sortMachines(machines: AISessionsMachine[]): AISessionsMachine[] {
+  return [...machines].sort((a, b) => {
+    const h = (a.hostname || a.machineId).localeCompare(b.hostname || b.machineId);
+    return h !== 0 ? h : a.machineId.localeCompare(b.machineId);
+  });
+}
+
+export function sortSessions(sessions: AISession[]): AISession[] {
+  return [...sessions].sort((a, b) => {
+    const sa = a.started_at ? Date.parse(a.started_at) : Number.POSITIVE_INFINITY;
+    const sb = b.started_at ? Date.parse(b.started_at) : Number.POSITIVE_INFINITY;
+    if (sa !== sb) return sa - sb;
+    return a.id.localeCompare(b.id);
+  });
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,6 +111,58 @@ It uses:
 With `NEXT_PUBLIC_HUB_URL` unset, the dashboard uses same-origin API calls,
 which is the intended Caddy-backed production mode.
 
+## AI Sessions
+
+AI Sessions is read-only, live-only visibility into which supported AI coding
+tools (Claude Code, Codex, Kimi) are running on each agent machine.
+
+The wire contract lives in `proto/aisessions` and is shared by both sides so
+the whitelist and sanitization rules cannot drift. A session carries an opaque
+id, the tool, the process start time, and three attributes — project, model,
+activity — each as `{value, source, confidence}`:
+
+- `project` is the working directory's **basename** only, withheld when the
+  directory is the filesystem root, a top-level directory, a home directory,
+  or named after the OS user.
+- `model` is set only from an explicit `--model` (or Codex `-m`) flag among
+  the tool's own arguments. A full id is `exact`; an alias such as `opus` is
+  `inferred`. It is never read from the environment.
+- `activity` is `active`/`idle` inferred from CPU time between two scans, or
+  `unknown` on the first scan. It is never reported as exact.
+
+Agent side, `agent/aiscan` is the pure classifier and reducer (tested on every
+platform); `agent/ai_sessions.go` reads the process table through gopsutil and
+sends an `ai_sessions` frame with the 30s metrics cadence. Classification is an
+exact match on the executable name, `argv[0]`, or the script/module an
+interpreter is running; substrings never match. Wrapper scripts and self-
+spawned children collapse into one session. Argv and the full cwd are consumed
+in the reducer and discarded.
+
+Scanning is gated. After registration the hub sends `ai_sessions_config`
+carrying the admin switch, and broadcasts changes to every connected agent. The
+hub keeps the switch and a per-process monotonic revision as one cached pair;
+every frame is built from a single atomic snapshot of it and carries `rev`.
+The registration send and a toggle broadcast run on independent goroutines, so
+once an agent has applied a decision on its current connection it accepts only
+a strictly greater revision, so neither a delayed stale frame nor a duplicate
+or forged equal-revision frame can flip the gate; a hub restart is safe because
+the gate resets on every connection. An agent scans only after hearing "enabled" on its current
+connection — so an agent talking to an older hub never scans — and
+`BLOXOS_AI_SESSIONS=0` in the agent's environment is a hard local opt-out no
+hub setting can override.
+Agents built before the feature route the config frame through their command
+handler, which ignores frames without a command id.
+
+Hub side, `hub/ai_sessions.go` keeps one in-memory snapshot per machine, keyed
+by the identity the socket authenticated as (the frame's own `machine_id` is
+ignored) and accepted only from the registered connection. Every frame is
+re-sanitized. Snapshots are removed when the socket unregisters or the machine
+is deleted, and expire lazily after 90s without a report. `GET
+/api/ai-sessions` (fleet.read) returns the live view; `PATCH
+/api/ai-sessions/settings` (fleet.admin) flips the switch, which is persisted
+in `hub_settings` and defaults to enabled when no row exists. Disabling clears
+all snapshots and tells agents to stop.
+
 ## Update Flow
 
 The hub hashes the configured agent binaries and announces the expected SHA to

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,6 +163,17 @@ is deleted, and expire lazily after 90s without a report. `GET
 in `hub_settings` and defaults to enabled when no row exists. Disabling clears
 all snapshots and tells agents to stop.
 
+Dashboards get live updates on the existing `/api/events` stream: `ai_sessions`
+carries one machine's sanitized snapshot (the same shape as a GET entry),
+`ai_sessions_removed` names a machine whose socket went away or was deleted,
+and `ai_sessions_config` announces the switch. The dashboard's
+`AISessionsContext` bootstraps from GET on every SSE (re)connect and applies
+those deltas through the SSE provider's `subscribe` hook; there is no second
+stream and no polling. The GET response includes the hub clock (`now`) so the
+client ages `received_at` without depending on clock agreement. Surfaces: a
+cell in the fleet pulse strip, `/sessions`, an "AI Sessions" tab on each
+agent machine, and an admin-only switch under Settings.
+
 ## Update Flow
 
 The hub hashes the configured agent binaries and announces the expected SHA to

--- a/hub/agent_connection_cleanup_test.go
+++ b/hub/agent_connection_cleanup_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -31,6 +32,26 @@ func machineStatus(t *testing.T, s *Server, machineID string) string {
 		t.Fatalf("read status for %s: %v", machineID, err)
 	}
 	return status
+}
+
+// expectConnectionClosed reads until the hub closes the socket. The only
+// frame tolerated on the way is the post-registration ai_sessions_config
+// notice; anything else means the hub kept talking instead of closing.
+func expectConnectionClosed(t *testing.T, conn *websocket.Conn, msg string) {
+	t.Helper()
+	for {
+		_, frame, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(frame, &envelope) == nil && envelope.Type == aiSessionsConfigType {
+			continue
+		}
+		t.Fatalf("%s (got frame %s)", msg, frame)
+	}
 }
 
 func agentMapHasEntry(s *Server, machineID string) bool {
@@ -92,9 +113,7 @@ func TestEnrollmentCommittedWithNoStagedStateUnregisters(t *testing.T) {
 
 	// The hub must close the connection (no matching staged state).
 	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
-	if _, _, err := conn.ReadMessage(); err == nil {
-		t.Fatal("expected the connection to be closed after enrollment_committed with no staged state")
-	}
+	expectConnectionClosed(t, conn, "expected the connection to be closed after enrollment_committed with no staged state")
 	waitForAgentMapAbsence(t, s, machineID, 5*time.Second)
 }
 
@@ -118,9 +137,7 @@ func TestPromotionMismatchUnregisters(t *testing.T) {
 	}
 
 	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
-	if _, _, err := conn.ReadMessage(); err == nil {
-		t.Fatal("expected the connection to be closed after a mismatched promotion")
-	}
+	expectConnectionClosed(t, conn, "expected the connection to be closed after a mismatched promotion")
 	waitForAgentMapAbsence(t, s, "promo-mismatch-cleanup", 5*time.Second)
 }
 
@@ -146,9 +163,7 @@ func TestPromotionExpiredDuringCommitUnregisters(t *testing.T) {
 	}
 
 	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
-	if _, _, err := conn.ReadMessage(); err == nil {
-		t.Fatal("expected the connection to be closed after committing an expired pending credential")
-	}
+	expectConnectionClosed(t, conn, "expected the connection to be closed after committing an expired pending credential")
 	waitForAgentMapAbsence(t, s, machineID, 5*time.Second)
 }
 

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bokiko/bloxos/proto/aisessions"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
@@ -80,6 +81,7 @@ func (s *Server) registerAgentConnection(machineID string, agent *ConnectedAgent
 		_ = displaced.Conn.Close()
 	}
 	s.goTracked(func() { s.announceVersionToAgent(machineID, agent) })
+	s.goTracked(func() { s.sendAISessionsConfig(machineID, agent) })
 }
 
 // unregisterAgentConnection is the symmetric cleanup for
@@ -102,6 +104,9 @@ func (s *Server) unregisterAgentConnection(machineID string, agent *ConnectedAge
 	s.agentsMu.Unlock()
 	if stillOurs {
 		s.markOffline(machineID)
+		// Live sessions only: a machine that is no longer connected has no
+		// sessions to show.
+		s.aiSessions.remove(machineID)
 	}
 }
 
@@ -1081,6 +1086,11 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 					KeyPinned:      versionMsg.UpdateKeyPinned,
 				})
 			}
+
+		case aisessions.MessageType:
+			// Read-only AI tool session metadata. Bound to the authenticated
+			// machine and to the registered socket; see ingestAISessions.
+			s.ingestAISessions(machineID, agent, msg)
 
 		case "command_response":
 			var resp CommandResponse

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -106,7 +106,7 @@ func (s *Server) unregisterAgentConnection(machineID string, agent *ConnectedAge
 		s.markOffline(machineID)
 		// Live sessions only: a machine that is no longer connected has no
 		// sessions to show.
-		s.aiSessions.remove(machineID)
+		s.removeAISessions(machineID)
 	}
 }
 

--- a/hub/ai_sessions.go
+++ b/hub/ai_sessions.go
@@ -271,13 +271,12 @@ func broadcastAISessionsConfigSSE(enabled bool) {
 	broadcastSSE(sseFrame("ai_sessions_config", map[string]bool{"enabled": enabled}))
 }
 
-// removeAISessions drops a machine's snapshot and tells dashboards, but only
-// announces when there was something to drop, so an unrelated disconnect
-// does not spray events.
+// removeAISessions drops a machine's snapshot and tells dashboards. Always
+// broadcasts the removal, even if the store had no entry, to ensure stale
+// sessions lazily evicted by live() are also removed from dashboards.
 func (s *Server) removeAISessions(machineID string) {
-	if s.aiSessions.removeIfPresent(machineID) {
-		broadcastAISessionsRemoved(machineID)
-	}
+	s.aiSessions.remove(machineID)
+	broadcastAISessionsRemoved(machineID)
 }
 
 // --- ingest (agent WebSocket) ---
@@ -293,16 +292,27 @@ func (s *Server) ingestAISessions(machineID string, agent *ConnectedAgent, raw [
 	if machineID == "" || !s.isRegisteredConnection(machineID, agent) {
 		return
 	}
-	if !s.aiSessionsEnabled() {
-		s.aiSessions.remove(machineID)
-		return
-	}
 	var msg aisessions.Message
 	if err := json.Unmarshal(raw, &msg); err != nil {
 		log.Printf("invalid ai_sessions JSON from %s: %v", machineID, err)
 		return
 	}
 	clean := aisessions.Sanitize(msg)
+	// Serialize the enabled check and store+broadcast together against the
+	// disable path to prevent races where a concurrent disable clears the
+	// store but this ingest still publishes a fresh snapshot.
+	c := &s.aiSessionsCfg
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.loaded {
+		c.enabled = s.loadAISessionsEnabled()
+		c.rev = 1
+		c.loaded = true
+	}
+	if !c.enabled {
+		s.aiSessions.remove(machineID)
+		return
+	}
 	receivedAt := s.aiSessions.putAt(machineID, clean.Sessions)
 	s.broadcastAISessionsView(s.aiSessionsMachineView(machineID, clean.Sessions, receivedAt))
 }

--- a/hub/ai_sessions.go
+++ b/hub/ai_sessions.go
@@ -63,6 +63,24 @@ func (st *aiSessionStore) remove(machineID string) {
 	st.mu.Unlock()
 }
 
+// removeIfPresent is remove that reports whether an entry existed.
+func (st *aiSessionStore) removeIfPresent(machineID string) bool {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	_, ok := st.byMachine[machineID]
+	delete(st.byMachine, machineID)
+	return ok
+}
+
+// putAt stores a snapshot and returns the receipt time used.
+func (st *aiSessionStore) putAt(machineID string, sessions []aisessions.Session) time.Time {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	now := st.now()
+	st.byMachine[machineID] = aiSessionSnapshot{Sessions: sessions, ReceivedAt: now}
+	return now
+}
+
 func (st *aiSessionStore) clear() {
 	st.mu.Lock()
 	st.byMachine = make(map[string]aiSessionSnapshot)
@@ -220,7 +238,46 @@ func (s *Server) setAISessionsEnabled(enabled bool) error {
 		s.aiSessions.clear()
 	}
 	s.broadcastAISessionsConfig(enabled, rev)
+	broadcastAISessionsConfigSSE(enabled)
 	return nil
+}
+
+// --- live delivery (dashboard SSE) ---
+//
+// Three events, all built from the sanitized contract only:
+//   ai_sessions          one machine's current snapshot (same shape as a
+//                        GET /api/ai-sessions machine entry)
+//   ai_sessions_removed  {"machine_id"} — the machine's socket went away or
+//                        the machine was deleted; drop its sessions
+//   ai_sessions_config   {"enabled"} — the admin switch changed; when false
+//                        every snapshot is gone
+// The dashboard bootstraps from GET on every (re)connect, so no SSE
+// snapshot of sessions is needed at stream start.
+
+func sseFrame(event string, v any) []byte {
+	data, _ := json.Marshal(v)
+	return []byte(fmt.Sprintf("event: %s\ndata: %s\n\n", event, data))
+}
+
+func (s *Server) broadcastAISessionsView(view aiSessionsMachineView) {
+	broadcastSSE(sseFrame("ai_sessions", view))
+}
+
+func broadcastAISessionsRemoved(machineID string) {
+	broadcastSSE(sseFrame("ai_sessions_removed", map[string]string{"machine_id": machineID}))
+}
+
+func broadcastAISessionsConfigSSE(enabled bool) {
+	broadcastSSE(sseFrame("ai_sessions_config", map[string]bool{"enabled": enabled}))
+}
+
+// removeAISessions drops a machine's snapshot and tells dashboards, but only
+// announces when there was something to drop, so an unrelated disconnect
+// does not spray events.
+func (s *Server) removeAISessions(machineID string) {
+	if s.aiSessions.removeIfPresent(machineID) {
+		broadcastAISessionsRemoved(machineID)
+	}
 }
 
 // --- ingest (agent WebSocket) ---
@@ -246,7 +303,24 @@ func (s *Server) ingestAISessions(machineID string, agent *ConnectedAgent, raw [
 		return
 	}
 	clean := aisessions.Sanitize(msg)
-	s.aiSessions.put(machineID, clean.Sessions)
+	receivedAt := s.aiSessions.putAt(machineID, clean.Sessions)
+	s.broadcastAISessionsView(s.aiSessionsMachineView(machineID, clean.Sessions, receivedAt))
+}
+
+// aiSessionsMachineView builds the wire view for one machine. Hostname is
+// display sugar; a missing row (machine deleted while its socket lingers)
+// is not an error.
+func (s *Server) aiSessionsMachineView(machineID string, sessions []aisessions.Session, receivedAt time.Time) aiSessionsMachineView {
+	view := aiSessionsMachineView{
+		MachineID:  machineID,
+		ReceivedAt: receivedAt.UTC().Format(time.RFC3339),
+		Sessions:   sessions,
+	}
+	if view.Sessions == nil {
+		view.Sessions = []aisessions.Session{}
+	}
+	_ = s.db.QueryRow(`SELECT hostname FROM machines WHERE id = ?`, machineID).Scan(&view.Hostname)
+	return view
 }
 
 // isRegisteredConnection reports whether agent is the live registry entry
@@ -268,9 +342,12 @@ type aiSessionsMachineView struct {
 }
 
 type aiSessionsResponse struct {
-	Enabled           bool                    `json:"enabled"`
-	StaleAfterSeconds int                     `json:"stale_after_seconds"`
-	Machines          []aiSessionsMachineView `json:"machines"`
+	Enabled           bool `json:"enabled"`
+	StaleAfterSeconds int  `json:"stale_after_seconds"`
+	// Now is the hub clock at response time, so a client can age
+	// received_at against the same clock instead of its own.
+	Now      string                  `json:"now"`
+	Machines []aiSessionsMachineView `json:"machines"`
 }
 
 // handleListAISessions returns the live snapshot for every reporting
@@ -279,6 +356,7 @@ func (s *Server) handleListAISessions(c echo.Context) error {
 	resp := aiSessionsResponse{
 		Enabled:           s.aiSessionsEnabled(),
 		StaleAfterSeconds: int(aiSessionsStaleAfter / time.Second),
+		Now:               s.aiSessions.now().UTC().Format(time.RFC3339),
 		Machines:          []aiSessionsMachineView{},
 	}
 	if !resp.Enabled {
@@ -287,18 +365,7 @@ func (s *Server) handleListAISessions(c echo.Context) error {
 	}
 	live := s.aiSessions.live()
 	for id, snap := range live {
-		view := aiSessionsMachineView{
-			MachineID:  id,
-			ReceivedAt: snap.ReceivedAt.UTC().Format(time.RFC3339),
-			Sessions:   snap.Sessions,
-		}
-		if view.Sessions == nil {
-			view.Sessions = []aisessions.Session{}
-		}
-		// Hostname is display sugar; a missing row (machine deleted while
-		// its socket lingers) is not an error.
-		_ = s.db.QueryRow(`SELECT hostname FROM machines WHERE id = ?`, id).Scan(&view.Hostname)
-		resp.Machines = append(resp.Machines, view)
+		resp.Machines = append(resp.Machines, s.aiSessionsMachineView(id, snap.Sessions, snap.ReceivedAt))
 	}
 	sort.Slice(resp.Machines, func(i, j int) bool {
 		a, b := resp.Machines[i], resp.Machines[j]

--- a/hub/ai_sessions.go
+++ b/hub/ai_sessions.go
@@ -1,0 +1,326 @@
+package main
+
+// AI Sessions (checkpoint 1) — hub side.
+//
+// The hub keeps ONLY the latest snapshot of AI tool sessions per machine, in
+// memory, keyed by the machine the reporting socket authenticated as. There
+// is no history table: when a socket closes, or a snapshot goes stale, the
+// sessions disappear. Reads are served to anyone with fleet.read; the
+// feature-wide switch is persisted in hub_settings and defaults to enabled,
+// so a fresh install needs no configuration. Turning it off drops every
+// snapshot immediately and makes the hub discard further reports.
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/aisessions"
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+)
+
+// aiSessionsStaleAfter bounds how long a snapshot is served without a fresh
+// report. Agents report every 30s alongside metrics, so three missed
+// reports means the machine's socket is gone or wedged.
+const aiSessionsStaleAfter = 90 * time.Second
+
+const aiSessionsEnabledSettingKey = "ai_sessions.enabled"
+
+// aiSessionSnapshot is one machine's latest report.
+type aiSessionSnapshot struct {
+	Sessions   []aisessions.Session
+	ReceivedAt time.Time
+}
+
+// aiSessionStore is the in-memory registry of snapshots. It owns its own
+// lock rather than piggybacking on agentsMu so ingest never contends with
+// registration, and its clock is injectable for stale-expiry tests.
+type aiSessionStore struct {
+	mu        sync.RWMutex
+	byMachine map[string]aiSessionSnapshot
+	now       func() time.Time
+}
+
+func newAISessionStore() *aiSessionStore {
+	return &aiSessionStore{byMachine: make(map[string]aiSessionSnapshot), now: time.Now}
+}
+
+func (st *aiSessionStore) put(machineID string, sessions []aisessions.Session) {
+	st.mu.Lock()
+	st.byMachine[machineID] = aiSessionSnapshot{Sessions: sessions, ReceivedAt: st.now()}
+	st.mu.Unlock()
+}
+
+func (st *aiSessionStore) remove(machineID string) {
+	st.mu.Lock()
+	delete(st.byMachine, machineID)
+	st.mu.Unlock()
+}
+
+func (st *aiSessionStore) clear() {
+	st.mu.Lock()
+	st.byMachine = make(map[string]aiSessionSnapshot)
+	st.mu.Unlock()
+}
+
+// live returns the fresh snapshots and evicts stale ones. Eviction happens
+// here, lazily, so no sweeper goroutine is needed: a stale entry costs a
+// few hundred bytes until the next read.
+func (st *aiSessionStore) live() map[string]aiSessionSnapshot {
+	cutoff := st.now().Add(-aiSessionsStaleAfter)
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	out := make(map[string]aiSessionSnapshot, len(st.byMachine))
+	for id, snap := range st.byMachine {
+		if snap.ReceivedAt.Before(cutoff) {
+			delete(st.byMachine, id)
+			continue
+		}
+		out[id] = snap
+	}
+	return out
+}
+
+// --- feature switch ---
+
+// aiSessionsConfig is the hub's single in-memory source of truth for the
+// switch: the enabled flag and a monotonic revision that advances on every
+// change. Every config frame is built from one atomic snapshot of this
+// pair, so two sends racing on the network (a registration send and a
+// toggle broadcast) can be ordered by the agent: a lower revision is
+// stale and is ignored. The revision is per hub process; a restart is
+// fine because agents reset their gate on every connection.
+type aiSessionsConfig struct {
+	mu      sync.Mutex
+	loaded  bool
+	enabled bool
+	rev     uint64
+}
+
+// aiSessionsConfigSnapshot returns the current (enabled, rev) pair,
+// loading the persisted switch on first use. A missing row is "enabled":
+// the default requires no setup. A database error fails closed (disabled)
+// and is logged, so an unreadable settings table never turns monitoring
+// on by accident.
+func (s *Server) aiSessionsConfigSnapshot() (enabled bool, rev uint64) {
+	c := &s.aiSessionsCfg
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.loaded {
+		c.enabled = s.loadAISessionsEnabled()
+		c.rev = 1
+		c.loaded = true
+	}
+	return c.enabled, c.rev
+}
+
+func (s *Server) loadAISessionsEnabled() bool {
+	var value string
+	err := s.db.QueryRow(`SELECT value FROM hub_settings WHERE key = ?`, aiSessionsEnabledSettingKey).Scan(&value)
+	switch {
+	case err == sql.ErrNoRows:
+		return true
+	case err != nil:
+		log.Printf("ai sessions: read setting: %v", err)
+		return false
+	}
+	return value != "false"
+}
+
+// aiSessionsEnabled is the cached switch state.
+func (s *Server) aiSessionsEnabled() bool {
+	enabled, _ := s.aiSessionsConfigSnapshot()
+	return enabled
+}
+
+// aiSessionsConfigType is the hub→agent frame that carries the switch.
+// Agents built before this feature route it through their generic command
+// handler, which ignores any frame without a command id, so sending it to
+// every connected agent is safe.
+const aiSessionsConfigType = "ai_sessions_config"
+
+func aiSessionsConfigFrame(enabled bool, rev uint64) []byte {
+	data, _ := json.Marshal(map[string]any{"type": aiSessionsConfigType, "enabled": enabled, "rev": rev})
+	return data
+}
+
+// sendAISessionsConfig tells one agent the current switch state. Called
+// from registerAgentConnection (via goTracked) so every authenticated
+// socket learns the state before its first scheduled scan; an agent that
+// never hears it never scans. The frame carries the revision captured
+// with the state, so if this write lands after a newer broadcast the
+// agent discards it.
+func (s *Server) sendAISessionsConfig(machineID string, agent *ConnectedAgent) {
+	if agent.Conn == nil {
+		return
+	}
+	enabled, rev := s.aiSessionsConfigSnapshot()
+	if err := agent.writeLocked(websocket.TextMessage, aiSessionsConfigFrame(enabled, rev)); err != nil {
+		log.Printf("ai sessions: config to %s: %v", machineID, err)
+	}
+}
+
+// broadcastAISessionsConfig pushes a changed switch state to every
+// connected agent. Each write runs on its own tracked goroutine so one
+// slow socket cannot stall the admin request or the other agents.
+func (s *Server) broadcastAISessionsConfig(enabled bool, rev uint64) {
+	frame := aiSessionsConfigFrame(enabled, rev)
+	s.agentsMu.RLock()
+	targets := make(map[string]*ConnectedAgent, len(s.agents))
+	for id, a := range s.agents {
+		targets[id] = a
+	}
+	s.agentsMu.RUnlock()
+	for id, a := range targets {
+		if a.Conn == nil {
+			continue
+		}
+		s.goTracked(func() {
+			if err := a.writeLocked(websocket.TextMessage, frame); err != nil {
+				log.Printf("ai sessions: config broadcast to %s: %v", id, err)
+			}
+		})
+	}
+}
+
+// setAISessionsEnabled persists the switch and advances the cached state
+// and revision as one step under the config lock, so concurrent toggles
+// are serialized and the persisted order always matches revision order.
+// The broadcast uses exactly the pair captured here.
+func (s *Server) setAISessionsEnabled(enabled bool) error {
+	value := "true"
+	if !enabled {
+		value = "false"
+	}
+	c := &s.aiSessionsCfg
+	c.mu.Lock()
+	_, err := s.db.Exec(`
+		INSERT INTO hub_settings (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP`,
+		aiSessionsEnabledSettingKey, value)
+	if err != nil {
+		c.mu.Unlock()
+		return err
+	}
+	if !c.loaded {
+		c.rev = 1
+		c.loaded = true
+	}
+	c.enabled = enabled
+	c.rev++
+	rev := c.rev
+	c.mu.Unlock()
+	if !enabled {
+		s.aiSessions.clear()
+	}
+	s.broadcastAISessionsConfig(enabled, rev)
+	return nil
+}
+
+// --- ingest (agent WebSocket) ---
+
+// ingestAISessions handles one ai_sessions frame. machineID is the identity
+// the socket authenticated as — the frame's own machine_id is ignored for
+// keying, so a compromised agent cannot plant sessions on another machine.
+// Frames from a socket that is not the registered connection for that
+// machine (an enrollment that has not committed, or a displaced socket) are
+// dropped. Every session is re-sanitized: the hub trusts the contract, not
+// the agent.
+func (s *Server) ingestAISessions(machineID string, agent *ConnectedAgent, raw []byte) {
+	if machineID == "" || !s.isRegisteredConnection(machineID, agent) {
+		return
+	}
+	if !s.aiSessionsEnabled() {
+		s.aiSessions.remove(machineID)
+		return
+	}
+	var msg aisessions.Message
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		log.Printf("invalid ai_sessions JSON from %s: %v", machineID, err)
+		return
+	}
+	clean := aisessions.Sanitize(msg)
+	s.aiSessions.put(machineID, clean.Sessions)
+}
+
+// isRegisteredConnection reports whether agent is the live registry entry
+// for machineID.
+func (s *Server) isRegisteredConnection(machineID string, agent *ConnectedAgent) bool {
+	s.agentsMu.RLock()
+	current, ok := s.agents[machineID]
+	s.agentsMu.RUnlock()
+	return ok && current == agent
+}
+
+// --- read API ---
+
+type aiSessionsMachineView struct {
+	MachineID  string               `json:"machine_id"`
+	Hostname   string               `json:"hostname"`
+	ReceivedAt string               `json:"received_at"`
+	Sessions   []aisessions.Session `json:"sessions"`
+}
+
+type aiSessionsResponse struct {
+	Enabled           bool                    `json:"enabled"`
+	StaleAfterSeconds int                     `json:"stale_after_seconds"`
+	Machines          []aiSessionsMachineView `json:"machines"`
+}
+
+// handleListAISessions returns the live snapshot for every reporting
+// machine. Requires fleet.read.
+func (s *Server) handleListAISessions(c echo.Context) error {
+	resp := aiSessionsResponse{
+		Enabled:           s.aiSessionsEnabled(),
+		StaleAfterSeconds: int(aiSessionsStaleAfter / time.Second),
+		Machines:          []aiSessionsMachineView{},
+	}
+	if !resp.Enabled {
+		s.aiSessions.clear()
+		return c.JSON(http.StatusOK, resp)
+	}
+	live := s.aiSessions.live()
+	for id, snap := range live {
+		view := aiSessionsMachineView{
+			MachineID:  id,
+			ReceivedAt: snap.ReceivedAt.UTC().Format(time.RFC3339),
+			Sessions:   snap.Sessions,
+		}
+		if view.Sessions == nil {
+			view.Sessions = []aisessions.Session{}
+		}
+		// Hostname is display sugar; a missing row (machine deleted while
+		// its socket lingers) is not an error.
+		_ = s.db.QueryRow(`SELECT hostname FROM machines WHERE id = ?`, id).Scan(&view.Hostname)
+		resp.Machines = append(resp.Machines, view)
+	}
+	sort.Slice(resp.Machines, func(i, j int) bool {
+		a, b := resp.Machines[i], resp.Machines[j]
+		if a.Hostname != b.Hostname {
+			return a.Hostname < b.Hostname
+		}
+		return a.MachineID < b.MachineID
+	})
+	return c.JSON(http.StatusOK, resp)
+}
+
+// handleUpdateAISessionsSettings flips the feature switch. Requires
+// fleet.admin. Disabling clears every snapshot immediately.
+func (s *Server) handleUpdateAISessionsSettings(c echo.Context) error {
+	var body struct {
+		Enabled *bool `json:"enabled"`
+	}
+	if err := c.Bind(&body); err != nil || body.Enabled == nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "enabled (boolean) is required"})
+	}
+	if err := s.setAISessionsEnabled(*body.Enabled); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("save setting: %v", err)})
+	}
+	return c.JSON(http.StatusOK, map[string]bool{"enabled": *body.Enabled})
+}

--- a/hub/ai_sessions_test.go
+++ b/hub/ai_sessions_test.go
@@ -1024,14 +1024,12 @@ func TestAISessionsSSERemovalAndConfigBroadcasts(t *testing.T) {
 	if removed["machine_id"] != "m-rm" {
 		t.Fatalf("removal event for wrong machine: %v", removed)
 	}
-	// Nothing left to remove: no second announcement.
+	// A second call to removeAISessions still broadcasts removal to ensure
+	// dashboards get the removal even if the store was lazily evicted earlier.
 	s.removeAISessions("m-rm")
-	select {
-	case frame := <-ch:
-		if strings.HasPrefix(string(frame), "event: ai_sessions_removed") {
-			t.Fatalf("duplicate removal announced: %s", frame)
-		}
-	case <-time.After(100 * time.Millisecond):
+	_, removed = nextSSEEvent(t, ch, "ai_sessions_removed")
+	if removed["machine_id"] != "m-rm" {
+		t.Fatalf("second removal event for wrong machine: %v", removed)
 	}
 
 	// Machine delete path.

--- a/hub/ai_sessions_test.go
+++ b/hub/ai_sessions_test.go
@@ -1,0 +1,895 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/aisessions"
+	"github.com/gorilla/websocket"
+)
+
+// aiSessionsGet performs GET /api/ai-sessions with the given JWT.
+func aiSessionsGet(t *testing.T, e http.Handler, token string) (int, aiSessionsResponse, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/ai-sessions", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	var resp aiSessionsResponse
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode ai-sessions response: %v: %s", err, rec.Body.String())
+		}
+	}
+	return rec.Code, resp, rec.Body.String()
+}
+
+func aiSessionsPatch(t *testing.T, e http.Handler, token, body string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPatch, "/api/ai-sessions/settings", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec.Code, rec.Body.String()
+}
+
+func writeFrame(t *testing.T, conn *websocket.Conn, v any) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("write frame: %v", err)
+	}
+}
+
+// sendSentinelMetrics sends a metrics frame with a distinctive hostname and
+// waits until the hub has persisted it. Frames on one socket are processed
+// in order, so once the sentinel is visible every earlier frame was handled.
+func (s *Server) sendSentinelMetrics(t *testing.T, conn *websocket.Conn, machineID, hostname string) {
+	t.Helper()
+	writeFrame(t, conn, map[string]any{
+		"type": "metrics", "machine_id": machineID, "hostname": hostname, "ip": "10.0.0.1", "os": "linux",
+		"cpu_percent": 1.0, "ram_used_bytes": 1, "ram_total_bytes": 2, "disk_used_bytes": 1, "disk_total_bytes": 2,
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	})
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var got string
+		if s.db.QueryRow(`SELECT hostname FROM machines WHERE id = ?`, machineID).Scan(&got) == nil && got == hostname {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("hub never persisted sentinel metrics for %s", machineID)
+}
+
+func aiSessionsFrame(machineID string, sessions ...map[string]any) map[string]any {
+	if sessions == nil {
+		sessions = []map[string]any{}
+	}
+	return map[string]any{"type": aisessions.MessageType, "machine_id": machineID, "schema": 1, "sessions": sessions}
+}
+
+func validSession(id, tool string) map[string]any {
+	return map[string]any{
+		"id": id, "tool": tool, "started_at": "2026-09-05T10:00:00Z",
+		"project":  map[string]any{"value": "bloxos", "source": "cwd", "confidence": "exact"},
+		"model":    map[string]any{"value": "claude-opus-5", "source": "argv_flag", "confidence": "exact"},
+		"activity": map[string]any{"value": "active", "source": "cpu_time", "confidence": "inferred"},
+	}
+}
+
+// enrollAgentSecret enrolls machineID through a fresh install token and
+// returns its durable secret.
+func (s *Server) enrollAgentSecret(t *testing.T, server *httptest.Server, machineID string) string {
+	t.Helper()
+	if _, err := s.db.Exec(`DELETE FROM tokens`); err != nil {
+		t.Fatal(err)
+	}
+	token := s.seedValidToken(t)
+	return s.enrollAndCaptureSecret(t, server, token, machineID)
+}
+
+// connectEnrolledAgent enrolls machineID and returns a live, registered
+// socket authenticated with its durable secret.
+func (s *Server) connectEnrolledAgent(t *testing.T, server *httptest.Server, machineID string) *websocket.Conn {
+	t.Helper()
+	secret := s.enrollAgentSecret(t, server, machineID)
+	conn, err := wsDialAgent(t, server, "secret="+secret)
+	if err != nil {
+		t.Fatalf("reconnect %s: %v", machineID, err)
+	}
+	return conn
+}
+
+func TestAISessionsIngestAndRead(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	// Default: enabled, nothing reporting.
+	code, resp, body := aiSessionsGet(t, e, adminToken)
+	if code != http.StatusOK || !resp.Enabled || len(resp.Machines) != 0 {
+		t.Fatalf("initial read: %d %s", code, body)
+	}
+	if !strings.Contains(body, `"machines":[]`) {
+		t.Fatalf("empty machines must serialize as []: %s", body)
+	}
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	writeFrame(t, conn, aiSessionsFrame("machine-A", validSession("aaaa0001", "claude"), validSession("aaaa0002", "codex")))
+	s.sendSentinelMetrics(t, conn, "machine-A", "host-a")
+
+	code, resp, body = aiSessionsGet(t, e, adminToken)
+	if code != http.StatusOK || len(resp.Machines) != 1 {
+		t.Fatalf("read after ingest: %d %s", code, body)
+	}
+	m := resp.Machines[0]
+	if m.MachineID != "machine-A" || m.Hostname != "host-a" || len(m.Sessions) != 2 {
+		t.Fatalf("unexpected machine view: %+v", m)
+	}
+	if m.Sessions[0].Tool != "claude" || m.Sessions[0].Project.Value != "bloxos" || m.Sessions[0].Model.Confidence != "exact" || m.Sessions[0].Activity.Value != "active" {
+		t.Fatalf("session attrs not preserved: %+v", m.Sessions[0])
+	}
+	if resp.StaleAfterSeconds != int(aiSessionsStaleAfter/time.Second) {
+		t.Fatalf("stale_after_seconds = %d", resp.StaleAfterSeconds)
+	}
+
+	// A later report replaces, never accumulates: an empty list means no sessions.
+	writeFrame(t, conn, aiSessionsFrame("machine-A"))
+	s.sendSentinelMetrics(t, conn, "machine-A", "host-a2")
+	_, resp, _ = aiSessionsGet(t, e, adminToken)
+	if len(resp.Machines) != 1 || len(resp.Machines[0].Sessions) != 0 {
+		t.Fatalf("empty report should clear sessions but keep the machine: %+v", resp.Machines)
+	}
+
+	// Disconnect: live sessions only, so the machine disappears.
+	conn.Close()
+	s.waitAgentDrain(t, "machine-A", 2*time.Second)
+	_, resp, _ = aiSessionsGet(t, e, adminToken)
+	if len(resp.Machines) != 0 {
+		t.Fatalf("disconnected machine still listed: %+v", resp.Machines)
+	}
+}
+
+// TestAISessionsPrivacyRegressionHub proves that anything outside the
+// contract sent by an agent — planted prompts, secrets, full paths, argv,
+// env — never reaches the read API, even inside otherwise-valid sessions.
+func TestAISessionsPrivacyRegressionHub(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	const (
+		// Real API keys carry characters outside the model-id charset
+		// (here "/" and "+"), which is what the hub can enforce. An
+		// identifier-shaped string planted in the model field is
+		// indistinguishable from a model id and passes by design — see
+		// TestAISessionsModelFieldIsShapeCheckedOnly.
+		secret   = "sk-ant-api03-PLANTED/SECRET+VALUE"
+		prompt   = "please rotate the prod password hunter2"
+		fullPath = "/home/alice/work/secret-project"
+		fullArgv = "claude --dangerously-skip-permissions -p"
+	)
+	conn := s.connectEnrolledAgent(t, server, "machine-P")
+	defer conn.Close()
+
+	frame := aiSessionsFrame("machine-P",
+		map[string]any{
+			"id": "abcd1234", "tool": "claude",
+			"pid": 4242, "cwd": fullPath, "argv": []string{"claude", "-p", prompt}, "cmdline": fullArgv,
+			"env": map[string]string{"ANTHROPIC_API_KEY": secret}, "username": "alice", "prompt": prompt,
+			"transcript": "user: " + prompt,
+			"project":    map[string]any{"value": fullPath, "source": "cwd", "confidence": "exact", "path": fullPath},
+			"model":      map[string]any{"value": secret, "source": "argv_flag", "confidence": "exact"},
+			"activity":   map[string]any{"value": "typing: " + prompt, "source": "cpu_time", "confidence": "inferred"},
+		},
+		// Attribute values that are individually acceptable but overclaim confidence
+		// or cite a source the contract does not allow.
+		map[string]any{
+			"id": "abcd5678", "tool": "codex",
+			"project":  map[string]any{"value": "alice", "source": "transcript", "confidence": "exact"},
+			"model":    map[string]any{"value": "gpt-5-codex", "source": "env", "confidence": "exact"},
+			"activity": map[string]any{"value": "active", "source": "cpu_time", "confidence": "exact"},
+		},
+		map[string]any{"id": "abcd9999", "tool": "cursor", "prompt": prompt},
+	)
+	frame["prompt"] = prompt
+	frame["env"] = map[string]string{"SECRET": secret}
+	writeFrame(t, conn, frame)
+	s.sendSentinelMetrics(t, conn, "machine-P", "host-p")
+
+	code, resp, body := aiSessionsGet(t, e, adminToken)
+	if code != http.StatusOK {
+		t.Fatalf("read: %d %s", code, body)
+	}
+	for _, forbidden := range []string{
+		secret, "PLANTED", prompt, "hunter2", fullPath, "/home/", "alice", fullArgv,
+		"dangerously", "transcript", "typing", "4242", `"pid"`, `"argv"`, `"cwd":`, `"env"`, `"username"`, `"cmdline"`, `"path"`, "cursor",
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Errorf("read API leaks %q:\n%s", forbidden, body)
+		}
+	}
+	if len(resp.Machines) != 1 || len(resp.Machines[0].Sessions) != 2 {
+		t.Fatalf("expected the two whitelisted sessions to survive: %+v", resp.Machines)
+	}
+	for _, sess := range resp.Machines[0].Sessions {
+		if sess.Project != aisessions.Unknown() || sess.Model != aisessions.Unknown() || sess.Activity != aisessions.Unknown() {
+			t.Errorf("attrs outside the contract must collapse to unknown: %+v", sess)
+		}
+	}
+}
+
+// TestAISessionsModelFieldIsShapeCheckedOnly documents a residual risk
+// rather than hiding it: the model attribute is a free identifier (letters,
+// digits, ".", "_", ":", "-", at most 64 chars) because model ids are not
+// enumerable. A compromised agent can therefore push any identifier-shaped
+// string there. Values with path separators, spaces or other characters
+// are rejected, which is what keeps paths, prompts and typical secrets out.
+func TestAISessionsModelFieldIsShapeCheckedOnly(t *testing.T) {
+	_, s := setupTestServer(t)
+	agent := &ConnectedAgent{}
+	s.agentsMu.Lock()
+	s.agents["m-shape"] = agent
+	s.agentsMu.Unlock()
+	t.Cleanup(func() {
+		s.agentsMu.Lock()
+		delete(s.agents, "m-shape")
+		s.agentsMu.Unlock()
+	})
+	frame := func(model string) []byte {
+		raw, _ := json.Marshal(aiSessionsFrame("m-shape", map[string]any{
+			"id": "01", "tool": "claude",
+			"model": map[string]any{"value": model, "source": "argv_flag", "confidence": "exact"},
+		}))
+		return raw
+	}
+	s.ingestAISessions("m-shape", agent, frame("identifier-shaped-but-not-a-model-123"))
+	if got := s.aiSessions.live()["m-shape"].Sessions[0].Model.Value; got != "identifier-shaped-but-not-a-model-123" {
+		t.Fatalf("identifier-shaped value should pass shape check, got %q", got)
+	}
+	for _, bad := range []string{"/etc/passwd", "opus sonnet", "sk-ant/key+", "a=b", strings.Repeat("x", 65), "$HOME"} {
+		s.ingestAISessions("m-shape", agent, frame(bad))
+		if got := s.aiSessions.live()["m-shape"].Sessions[0].Model; got != aisessions.Unknown() {
+			t.Errorf("model %q should be rejected, got %+v", bad, got)
+		}
+	}
+}
+
+// TestAISessionsBoundToAuthenticatedMachine covers spoofing: a socket
+// authenticated as A cannot plant sessions on B, and a frame's own
+// machine_id (even empty) never overrides the authenticated identity.
+func TestAISessionsBoundToAuthenticatedMachine(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	connB := s.connectEnrolledAgent(t, server, "machine-B")
+	defer connB.Close()
+	s.sendSentinelMetrics(t, connB, "machine-B", "host-b")
+
+	connA := s.connectEnrolledAgent(t, server, "machine-A")
+	defer connA.Close()
+
+	// Cross-machine claim: dropped entirely.
+	writeFrame(t, connA, aiSessionsFrame("machine-B", validSession("b0b0b0b0", "codex")))
+	// Empty machine_id: bound to A, not rejected and not orphaned.
+	writeFrame(t, connA, aiSessionsFrame("", validSession("a0a0a0a0", "claude")))
+	s.sendSentinelMetrics(t, connA, "machine-A", "host-a")
+
+	_, resp, body := aiSessionsGet(t, e, adminToken)
+	byID := map[string]aiSessionsMachineView{}
+	for _, m := range resp.Machines {
+		byID[m.MachineID] = m
+	}
+	if b, ok := byID["machine-B"]; ok && len(b.Sessions) != 0 {
+		t.Fatalf("spoofed sessions landed on machine-B: %s", body)
+	}
+	a, ok := byID["machine-A"]
+	if !ok || len(a.Sessions) != 1 || a.Sessions[0].ID != "a0a0a0a0" {
+		t.Fatalf("frame with empty machine_id should bind to the authenticated machine: %s", body)
+	}
+	if strings.Contains(body, "b0b0b0b0") {
+		t.Fatalf("cross-machine session leaked somewhere: %s", body)
+	}
+}
+
+// TestAISessionsRequireRegisteredConnection: a token-enrolling socket that
+// has sent metrics (so machineID is known) but has not committed enrollment
+// is not registered and must not be able to publish sessions.
+func TestAISessionsRequireRegisteredConnection(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	token := s.seedValidToken(t)
+	conn, err := wsDialAgent(t, server, "token="+token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	sendMetricsMsg(t, conn, "machine-U")
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	readFrameType(t, conn, "enrolled") // secret issued, NOT committed → not registered
+	writeFrame(t, conn, aiSessionsFrame("machine-U", validSession("u0u0u0u0", "kimi")))
+	s.sendSentinelMetrics(t, conn, "machine-U", "host-u")
+
+	_, _, body := aiSessionsGet(t, e, adminToken)
+	if strings.Contains(body, "machine-U") || strings.Contains(body, "u0u0u0u0") {
+		t.Fatalf("uncommitted enrollment published sessions: %s", body)
+	}
+
+	// Direct unit check of the guard against a socket that is not the registered one.
+	s.ingestAISessions("machine-U", &ConnectedAgent{}, []byte(`{"type":"ai_sessions","sessions":[{"id":"ff","tool":"claude"}]}`))
+	if live := s.aiSessions.live(); len(live) != 0 {
+		t.Fatalf("unregistered agent wrote a snapshot: %+v", live)
+	}
+	s.ingestAISessions("", &ConnectedAgent{}, []byte(`{"type":"ai_sessions","sessions":[{"id":"ff","tool":"claude"}]}`))
+	if live := s.aiSessions.live(); len(live) != 0 {
+		t.Fatalf("empty machine id wrote a snapshot: %+v", live)
+	}
+}
+
+func TestAISessionsStaleSnapshotExpires(t *testing.T) {
+	_, s := setupTestServer(t)
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	s.aiSessions.now = func() time.Time { return now }
+
+	s.aiSessions.put("fresh", []aisessions.Session{{ID: "01", Tool: "claude"}})
+	now = now.Add(aiSessionsStaleAfter - time.Second)
+	s.aiSessions.put("recent", []aisessions.Session{{ID: "02", Tool: "codex"}})
+
+	live := s.aiSessions.live()
+	if len(live) != 2 {
+		t.Fatalf("both snapshots should be live: %v", live)
+	}
+	now = now.Add(2 * time.Second) // fresh is now > stale window old; recent is 2s old
+	live = s.aiSessions.live()
+	if _, ok := live["fresh"]; ok {
+		t.Fatalf("stale snapshot still served: %v", live)
+	}
+	if _, ok := live["recent"]; !ok {
+		t.Fatalf("recent snapshot dropped: %v", live)
+	}
+	// Eviction is real, not just filtered from one read.
+	s.aiSessions.mu.RLock()
+	_, stillStored := s.aiSessions.byMachine["fresh"]
+	s.aiSessions.mu.RUnlock()
+	if stillStored {
+		t.Fatal("stale snapshot was filtered but not evicted")
+	}
+	// A fresh report resurrects the machine.
+	s.aiSessions.put("fresh", nil)
+	if _, ok := s.aiSessions.live()["fresh"]; !ok {
+		t.Fatal("new report after expiry not served")
+	}
+}
+
+func TestAISessionsRBAC(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	s.seedTestUser(t, "viewer-ai", "viewerpass123", "1234", RoleViewer, true, true)
+	s.seedTestUser(t, "operator-ai", "operatorpass123", "1234", RoleOperator, true, true)
+	viewer := loginAndGetTokenForCredentials(t, e, "viewer-ai", "viewerpass123")
+	operator := loginAndGetTokenForCredentials(t, e, "operator-ai", "operatorpass123")
+	admin := loginAndGetToken(t, e)
+
+	if code, _, body := aiSessionsGet(t, e, ""); code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated read: %d %s", code, body)
+	}
+	if code, body := aiSessionsPatch(t, e, "", `{"enabled":false}`); code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated patch: %d %s", code, body)
+	}
+	for name, tok := range map[string]string{"viewer": viewer, "operator": operator, "admin": admin} {
+		if code, _, body := aiSessionsGet(t, e, tok); code != http.StatusOK {
+			t.Fatalf("%s read: %d %s", name, code, body)
+		}
+	}
+	for name, tok := range map[string]string{"viewer": viewer, "operator": operator} {
+		code, body := aiSessionsPatch(t, e, tok, `{"enabled":false}`)
+		if code != http.StatusForbidden || !strings.Contains(body, scopeFleetAdmin) {
+			t.Fatalf("%s patch should be forbidden citing %s: %d %s", name, scopeFleetAdmin, code, body)
+		}
+	}
+	if code, body := aiSessionsPatch(t, e, admin, `{"enabled":false}`); code != http.StatusOK || !strings.Contains(body, `"enabled":false`) {
+		t.Fatalf("admin patch: %d %s", code, body)
+	}
+	if code, body := aiSessionsPatch(t, e, admin, `{}`); code != http.StatusBadRequest {
+		t.Fatalf("patch without enabled should be 400: %d %s", code, body)
+	}
+	if code, body := aiSessionsPatch(t, e, admin, `{"enabled":"yes"}`); code != http.StatusBadRequest {
+		t.Fatalf("patch with non-boolean should be 400: %d %s", code, body)
+	}
+}
+
+func TestAISessionsAdminSwitchDisablesAndClears(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	admin := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-S")
+	defer conn.Close()
+	writeFrame(t, conn, aiSessionsFrame("machine-S", validSession("50505050", "claude")))
+	s.sendSentinelMetrics(t, conn, "machine-S", "host-s")
+	if _, resp, _ := aiSessionsGet(t, e, admin); len(resp.Machines) != 1 {
+		t.Fatalf("precondition: expected one machine, got %+v", resp.Machines)
+	}
+
+	// Disable: existing snapshot gone at once, persisted across a "restart"
+	// of the in-memory view, and new reports are discarded.
+	if code, body := aiSessionsPatch(t, e, admin, `{"enabled":false}`); code != http.StatusOK {
+		t.Fatalf("disable: %d %s", code, body)
+	}
+	if live := s.aiSessions.live(); len(live) != 0 {
+		t.Fatalf("disable must clear snapshots immediately: %+v", live)
+	}
+	if s.aiSessionsEnabled() {
+		t.Fatal("setting not persisted")
+	}
+	writeFrame(t, conn, aiSessionsFrame("machine-S", validSession("50505051", "codex")))
+	s.sendSentinelMetrics(t, conn, "machine-S", "host-s2")
+	code, resp, body := aiSessionsGet(t, e, admin)
+	if code != http.StatusOK || resp.Enabled || len(resp.Machines) != 0 {
+		t.Fatalf("disabled read: %d %s", code, body)
+	}
+	if live := s.aiSessions.live(); len(live) != 0 {
+		t.Fatalf("report accepted while disabled: %+v", live)
+	}
+
+	// Re-enable: the next report shows up again.
+	if code, body := aiSessionsPatch(t, e, admin, `{"enabled":true}`); code != http.StatusOK {
+		t.Fatalf("enable: %d %s", code, body)
+	}
+	writeFrame(t, conn, aiSessionsFrame("machine-S", validSession("50505052", "kimi")))
+	s.sendSentinelMetrics(t, conn, "machine-S", "host-s3")
+	_, resp, body = aiSessionsGet(t, e, admin)
+	if !resp.Enabled || len(resp.Machines) != 1 || resp.Machines[0].Sessions[0].ID != "50505052" {
+		t.Fatalf("re-enabled read: %s", body)
+	}
+}
+
+func TestAISessionsSettingDefaultsEnabledWithoutRow(t *testing.T) {
+	_, s := setupTestServer(t)
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM hub_settings`).Scan(&n); err != nil {
+		t.Fatalf("hub_settings table missing: %v", err)
+	}
+	if n != 0 || !s.aiSessionsEnabled() {
+		t.Fatalf("fresh install must be enabled with no rows (rows=%d)", n)
+	}
+}
+
+// TestAISessionsProtocolCompatibility: frames from older agents (which
+// never send ai_sessions) keep working unchanged; frames from newer agents
+// with a higher schema and unknown fields are accepted with the known
+// fields only; a malformed frame is ignored without disturbing the socket.
+func TestAISessionsProtocolCompatibility(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	admin := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-C")
+	defer conn.Close()
+
+	// Old-agent traffic: services/containers frames as before.
+	writeFrame(t, conn, map[string]any{"type": "services", "machine_id": "machine-C",
+		"services": []map[string]any{{"name": "sshd", "status": "running", "description": "ok"}}})
+	// Malformed ai_sessions payload (sessions is not an array).
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"ai_sessions","machine_id":"machine-C","sessions":"nope"}`)); err != nil {
+		t.Fatal(err)
+	}
+	// Future-schema frame with unknown fields at every level.
+	writeFrame(t, conn, map[string]any{
+		"type": "ai_sessions", "machine_id": "machine-C", "schema": 7, "future_top": true,
+		"sessions": []map[string]any{{
+			"id": "c0c0c0c0", "tool": "claude", "future_field": "x",
+			"project":  map[string]any{"value": "bloxos", "source": "cwd", "confidence": "exact", "future": 1},
+			"model":    map[string]any{"value": "", "source": "none", "confidence": "unknown"},
+			"activity": map[string]any{"value": "idle", "source": "cpu_time", "confidence": "inferred"},
+			"tokens":   map[string]any{"in": 10},
+		}},
+	})
+	s.sendSentinelMetrics(t, conn, "machine-C", "host-c")
+
+	_, resp, body := aiSessionsGet(t, e, admin)
+	if len(resp.Machines) != 1 || len(resp.Machines[0].Sessions) != 1 {
+		t.Fatalf("future-schema frame not accepted: %s", body)
+	}
+	if strings.Contains(body, "future") || strings.Contains(body, "tokens") {
+		t.Fatalf("unknown fields leaked through: %s", body)
+	}
+	sess := resp.Machines[0].Sessions[0]
+	if sess.Project.Value != "bloxos" || sess.Activity.Value != "idle" || sess.Model != aisessions.Unknown() {
+		t.Fatalf("known fields mangled: %+v", sess)
+	}
+	// The socket is still healthy and the old-agent frame was stored.
+	var svc int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM services WHERE machine_id = 'machine-C'`).Scan(&svc); err != nil || svc != 1 {
+		t.Fatalf("services frame lost: n=%d err=%v", svc, err)
+	}
+}
+
+// TestAISessionsConcurrentIngestReadToggle exercises the store under the race
+// detector: many machines reporting while readers list and an admin toggles.
+func TestAISessionsConcurrentIngestReadToggle(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	admin := loginAndGetToken(t, e)
+
+	const machines = 8
+	agents := make([]*ConnectedAgent, machines)
+	for i := range agents {
+		agents[i] = &ConnectedAgent{}
+		s.agentsMu.Lock()
+		s.agents[fmt.Sprintf("m%d", i)] = agents[i]
+		s.agentsMu.Unlock()
+	}
+	t.Cleanup(func() {
+		s.agentsMu.Lock()
+		for i := range agents {
+			delete(s.agents, fmt.Sprintf("m%d", i))
+		}
+		s.agentsMu.Unlock()
+	})
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < machines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := fmt.Sprintf("m%d", i)
+			for n := 0; ; n++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				raw, _ := json.Marshal(aiSessionsFrame(id, validSession(fmt.Sprintf("%08x", n), "claude")))
+				s.ingestAISessions(id, agents[i], raw)
+				if n%7 == 0 {
+					s.aiSessions.remove(id)
+				}
+			}
+		}(i)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for n := 0; n < 20; n++ {
+			if code, body := aiSessionsPatch(t, e, admin, fmt.Sprintf(`{"enabled":%v}`, n%2 == 0)); code != http.StatusOK {
+				t.Errorf("toggle: %d %s", code, body)
+			}
+		}
+	}()
+	for n := 0; n < 50; n++ {
+		if code, _, body := aiSessionsGet(t, e, admin); code != http.StatusOK {
+			t.Errorf("read: %d %s", code, body)
+		}
+	}
+	close(stop)
+	wg.Wait()
+	// Leave the switch on for a final consistency check.
+	if code, _ := aiSessionsPatch(t, e, admin, `{"enabled":true}`); code != http.StatusOK {
+		t.Fatal("final enable failed")
+	}
+	if code, _, _ := aiSessionsGet(t, e, admin); code != http.StatusOK {
+		t.Fatal("final read failed")
+	}
+}
+
+func TestAISessionsDisplacedSocketCannotReport(t *testing.T) {
+	_, s := setupTestServer(t)
+	old := &ConnectedAgent{}
+	fresh := &ConnectedAgent{}
+	s.agentsMu.Lock()
+	s.agents["m-d"] = fresh
+	s.agentsMu.Unlock()
+	t.Cleanup(func() {
+		s.agentsMu.Lock()
+		delete(s.agents, "m-d")
+		s.agentsMu.Unlock()
+	})
+	raw, _ := json.Marshal(aiSessionsFrame("m-d", validSession("d0d0d0d0", "claude")))
+	s.ingestAISessions("m-d", old, raw)
+	if len(s.aiSessions.live()) != 0 {
+		t.Fatal("displaced socket wrote a snapshot")
+	}
+	s.ingestAISessions("m-d", fresh, raw)
+	if len(s.aiSessions.live()) != 1 {
+		t.Fatal("registered socket could not write a snapshot")
+	}
+	// Unregistering the displaced socket must not wipe the fresh one's snapshot.
+	s.unregisterAgentConnection("m-d", old)
+	if len(s.aiSessions.live()) != 1 {
+		t.Fatal("unregister of a displaced socket removed the live snapshot")
+	}
+	s.unregisterAgentConnection("m-d", fresh)
+	if len(s.aiSessions.live()) != 0 {
+		t.Fatal("unregister of the registered socket left its snapshot behind")
+	}
+}
+
+func TestDeleteMachineRemovesAISessions(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	admin := loginAndGetToken(t, e)
+	s.seedTestMachine(t, "m-del")
+	s.aiSessions.put("m-del", []aisessions.Session{{ID: "01", Tool: "claude"}})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/machines/m-del", nil)
+	req.Header.Set("Authorization", "Bearer "+admin)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete: %d %s", rec.Code, rec.Body.String())
+	}
+	if len(s.aiSessions.live()) != 0 {
+		t.Fatal("deleted machine still has an AI sessions snapshot")
+	}
+}
+
+// readAISessionsConfig drains frames until an ai_sessions_config arrives and
+// returns its enabled flag.
+func readAISessionsConfig(t *testing.T, conn *websocket.Conn) bool {
+	t.Helper()
+	enabled, _ := readAISessionsConfigRev(t, conn)
+	return enabled
+}
+
+// readAISessionsConfigRev is readAISessionsConfig returning the revision too.
+func readAISessionsConfigRev(t *testing.T, conn *websocket.Conn) (bool, uint64) {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("waiting for %s: %v", aiSessionsConfigType, err)
+		}
+		var frame struct {
+			Type    string  `json:"type"`
+			Enabled *bool   `json:"enabled"`
+			Rev     *uint64 `json:"rev"`
+		}
+		if json.Unmarshal(msg, &frame) == nil && frame.Type == aiSessionsConfigType {
+			if frame.Enabled == nil || frame.Rev == nil || *frame.Rev == 0 {
+				t.Fatalf("config frame must carry enabled and a non-zero rev: %s", msg)
+			}
+			return *frame.Enabled, *frame.Rev
+		}
+	}
+}
+
+// TestAISessionsConfigRevisionAdvancesAndIsOrderable: each toggle advances
+// the revision and frames carry it, so an agent can discard a registration
+// frame that lands after a newer toggle broadcast.
+func TestAISessionsConfigRevisionAdvancesAndIsOrderable(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	admin := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-R")
+	defer conn.Close()
+	enabled, rev1 := readAISessionsConfigRev(t, conn)
+	if !enabled {
+		t.Fatal("default must be enabled")
+	}
+	if code, _ := aiSessionsPatch(t, e, admin, `{"enabled":false}`); code != http.StatusOK {
+		t.Fatal("disable failed")
+	}
+	enabled, rev2 := readAISessionsConfigRev(t, conn)
+	if enabled || rev2 <= rev1 {
+		t.Fatalf("disable must advance rev: got enabled=%v rev %d after %d", enabled, rev2, rev1)
+	}
+	if code, _ := aiSessionsPatch(t, e, admin, `{"enabled":true}`); code != http.StatusOK {
+		t.Fatal("enable failed")
+	}
+	enabled, rev3 := readAISessionsConfigRev(t, conn)
+	if !enabled || rev3 <= rev2 {
+		t.Fatalf("enable must advance rev: got enabled=%v rev %d after %d", enabled, rev3, rev2)
+	}
+	if got := string(aiSessionsConfigFrame(false, rev2)); !strings.Contains(got, fmt.Sprintf(`"rev":%d`, rev2)) {
+		t.Fatalf("frame must embed rev: %s", got)
+	}
+}
+
+// TestAISessionsConfigSnapshotConsistentUnderConcurrentToggle: sends racing
+// with toggles always observe a consistent (enabled, rev) pair — one rev
+// never reports two different states — and revs are monotonic.
+func TestAISessionsConfigSnapshotConsistentUnderConcurrentToggle(t *testing.T) {
+	_, s := setupTestServer(t)
+	// Load the persisted default (rev 1, enabled) before any toggle so the
+	// revision→state mapping below is deterministic.
+	if enabled, rev := s.aiSessionsConfigSnapshot(); !enabled || rev != 1 {
+		t.Fatalf("initial snapshot enabled=%v rev=%d, want true/1", enabled, rev)
+	}
+	var mu sync.Mutex
+	seen := map[uint64]bool{}
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var last uint64
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				enabled, rev := s.aiSessionsConfigSnapshot()
+				if rev < last {
+					t.Errorf("revision went backwards: %d after %d", rev, last)
+				}
+				last = rev
+				mu.Lock()
+				if prev, ok := seen[rev]; ok && prev != enabled {
+					t.Errorf("rev %d observed as both %v and %v", rev, prev, enabled)
+				}
+				seen[rev] = enabled
+				mu.Unlock()
+			}
+		}()
+	}
+	for n := 0; n < 40; n++ {
+		if err := s.setAISessionsEnabled(n%2 == 1); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(stop)
+	wg.Wait()
+	enabled, rev := s.aiSessionsConfigSnapshot()
+	if rev != 41 || !enabled { // rev 1 initial + 40 toggles; the last (n=39) enabled
+		t.Fatalf("final snapshot enabled=%v rev=%d, want true/41", enabled, rev)
+	}
+	// Toggle n lands at rev n+2 and sets enabled = (n odd), so odd revs
+	// (including the initial rev 1) are enabled and even revs are disabled.
+	for r, en := range seen {
+		want := r%2 == 1
+		if en != want {
+			t.Errorf("rev %d observed enabled=%v, want %v", r, en, want)
+		}
+	}
+}
+
+// TestAISessionsConfigSentOnRegistrationAndBroadcast covers the runtime
+// signal: default-on after registration, a disable pushed to connected
+// agents, and a reconnect receiving the current (disabled) state.
+func TestAISessionsConfigSentOnRegistrationAndBroadcast(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	admin := loginAndGetToken(t, e)
+
+	secret := s.enrollAgentSecret(t, server, "machine-G")
+	conn, err := wsDialAgent(t, server, "secret="+secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if !readAISessionsConfig(t, conn) {
+		t.Fatal("default state after registration must be enabled")
+	}
+
+	if code, body := aiSessionsPatch(t, e, admin, `{"enabled":false}`); code != http.StatusOK {
+		t.Fatalf("disable: %d %s", code, body)
+	}
+	if readAISessionsConfig(t, conn) {
+		t.Fatal("connected agent must receive the disable")
+	}
+
+	// Reconnect the same machine while disabled: the fresh socket hears
+	// "disabled" up front, before any scheduled scan could run.
+	conn.Close()
+	s.waitAgentDrain(t, "machine-G", 2*time.Second)
+	conn2, err := wsDialAgent(t, server, "secret="+secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn2.Close()
+	if readAISessionsConfig(t, conn2) {
+		t.Fatal("agent reconnecting while disabled must be told disabled")
+	}
+
+	if code, body := aiSessionsPatch(t, e, admin, `{"enabled":true}`); code != http.StatusOK {
+		t.Fatalf("enable: %d %s", code, body)
+	}
+	if !readAISessionsConfig(t, conn2) {
+		t.Fatal("connected agent must receive the re-enable")
+	}
+}
+
+// TestAISessionsConfigIgnoredByOldAgent simulates a pre-feature agent: it
+// treats the config frame as a command, finds no id, and ignores it. The
+// hub must keep serving that socket normally and must not expect a reply.
+func TestAISessionsConfigIgnoredByOldAgent(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	admin := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-O")
+	defer conn.Close()
+	readAISessionsConfig(t, conn) // arrives; an old agent would drop it
+	if code, _ := aiSessionsPatch(t, e, admin, `{"enabled":false}`); code != http.StatusOK {
+		t.Fatal("disable failed")
+	}
+	readAISessionsConfig(t, conn)
+	// An old agent keeps sending its usual traffic and never ai_sessions.
+	s.sendSentinelMetrics(t, conn, "machine-O", "host-o")
+	var status string
+	if err := s.db.QueryRow(`SELECT status FROM machines WHERE id = 'machine-O'`).Scan(&status); err != nil || status != "online" {
+		t.Fatalf("old agent socket disturbed: status=%q err=%v", status, err)
+	}
+	if !s.isRegisteredConnection("machine-O", s.registeredAgent("machine-O")) {
+		t.Fatal("old agent lost its registration")
+	}
+	if _, resp, _ := aiSessionsGet(t, e, admin); len(resp.Machines) != 0 {
+		t.Fatalf("old agent should have no snapshot: %+v", resp.Machines)
+	}
+}
+
+func (s *Server) registeredAgent(machineID string) *ConnectedAgent {
+	s.agentsMu.RLock()
+	defer s.agentsMu.RUnlock()
+	return s.agents[machineID]
+}
+
+// TestAISessionsConcurrentTogglesKeepDBAndCacheConsistent: many admin
+// toggles racing each other must leave the persisted value equal to the
+// cached value, because both are updated under one lock in one order.
+func TestAISessionsConcurrentTogglesKeepDBAndCacheConsistent(t *testing.T) {
+	_, s := setupTestServer(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for n := 0; n < 25; n++ {
+				if err := s.setAISessionsEnabled((i+n)%2 == 0); err != nil {
+					t.Errorf("toggle: %v", err)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+	cached, rev := s.aiSessionsConfigSnapshot()
+	if rev != 1+16*25 {
+		t.Fatalf("rev = %d, want %d", rev, 1+16*25)
+	}
+	if persisted := s.loadAISessionsEnabled(); persisted != cached {
+		t.Fatalf("persisted=%v cached=%v after concurrent toggles", persisted, cached)
+	}
+}

--- a/hub/ai_sessions_test.go
+++ b/hub/ai_sessions_test.go
@@ -893,3 +893,184 @@ func TestAISessionsConcurrentTogglesKeepDBAndCacheConsistent(t *testing.T) {
 		t.Fatalf("persisted=%v cached=%v after concurrent toggles", persisted, cached)
 	}
 }
+
+// subscribeSSE registers a test channel with the global SSE client set and
+// returns it plus a cleanup that removes it.
+func subscribeSSE(t *testing.T) chan []byte {
+	t.Helper()
+	ch := make(chan []byte, 64)
+	sseClientsMu.Lock()
+	sseClients[ch] = struct{}{}
+	sseClientsMu.Unlock()
+	t.Cleanup(func() {
+		sseClientsMu.Lock()
+		delete(sseClients, ch)
+		sseClientsMu.Unlock()
+	})
+	return ch
+}
+
+// nextSSEEvent waits for the next frame of the named event and returns its
+// decoded data. Frames for other events are skipped.
+func nextSSEEvent(t *testing.T, ch chan []byte, event string) (string, map[string]any) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case frame := <-ch:
+			text := string(frame)
+			if !strings.HasPrefix(text, "event: "+event+"\n") {
+				continue
+			}
+			payload := strings.TrimSuffix(strings.TrimPrefix(text, "event: "+event+"\ndata: "), "\n\n")
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+				t.Fatalf("decode %s payload %q: %v", event, payload, err)
+			}
+			return payload, decoded
+		case <-deadline:
+			t.Fatalf("no %s SSE event within 5s", event)
+		}
+	}
+}
+
+// TestAISessionsSSEEventShapeAndPrivacy: an accepted report is broadcast as
+// one ai_sessions event carrying exactly the GET view shape, sanitized.
+func TestAISessionsSSEEventShapeAndPrivacy(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedTestMachine(t, "m-sse")
+	agent := &ConnectedAgent{}
+	s.agentsMu.Lock()
+	s.agents["m-sse"] = agent
+	s.agentsMu.Unlock()
+	t.Cleanup(func() {
+		s.agentsMu.Lock()
+		delete(s.agents, "m-sse")
+		s.agentsMu.Unlock()
+	})
+	ch := subscribeSSE(t)
+
+	const secret = "sk-ant/PLANTED+SECRET"
+	frame := aiSessionsFrame("m-sse",
+		validSession("5e5e0001", "claude"),
+		map[string]any{"id": "5e5e0002", "tool": "codex", "prompt": secret, "cwd": "/home/alice/x",
+			"model": map[string]any{"value": secret, "source": "argv_flag", "confidence": "exact"}},
+		map[string]any{"id": "5e5e0003", "tool": "cursor"},
+	)
+	frame["env"] = map[string]string{"KEY": secret}
+	raw, _ := json.Marshal(frame)
+	s.ingestAISessions("m-sse", agent, raw)
+
+	payload, decoded := nextSSEEvent(t, ch, "ai_sessions")
+	for _, forbidden := range []string{secret, "PLANTED", "/home/", "alice", `"prompt"`, `"cwd":`, `"env"`, "cursor"} {
+		if strings.Contains(payload, forbidden) {
+			t.Errorf("SSE payload leaks %q: %s", forbidden, payload)
+		}
+	}
+	wantKeys := map[string]bool{"machine_id": true, "hostname": true, "received_at": true, "sessions": true}
+	for k := range decoded {
+		if !wantKeys[k] {
+			t.Errorf("unexpected top-level key %q in ai_sessions event", k)
+		}
+	}
+	if decoded["machine_id"] != "m-sse" || decoded["hostname"] != "machine-m-sse" {
+		t.Fatalf("machine identity wrong: %s", payload)
+	}
+	sessions := decoded["sessions"].([]any)
+	if len(sessions) != 2 {
+		t.Fatalf("expected 2 whitelisted sessions, got %d: %s", len(sessions), payload)
+	}
+	for _, raw := range sessions {
+		sess := raw.(map[string]any)
+		for k := range sess {
+			switch k {
+			case "id", "tool", "started_at", "project", "model", "activity":
+			default:
+				t.Errorf("unexpected session key %q", k)
+			}
+		}
+	}
+	second := sessions[1].(map[string]any)
+	if second["model"].(map[string]any)["value"] != "" {
+		t.Errorf("secret-shaped model value must be dropped: %v", second["model"])
+	}
+	if _, err := time.Parse(time.RFC3339, decoded["received_at"].(string)); err != nil {
+		t.Errorf("received_at not RFC3339: %v", decoded["received_at"])
+	}
+}
+
+// TestAISessionsSSERemovalAndConfigBroadcasts: unregistering the reporting
+// socket announces removal once; deleting a machine does too; toggling the
+// switch announces the new state and disable clears everything.
+func TestAISessionsSSERemovalAndConfigBroadcasts(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	admin := loginAndGetToken(t, e)
+	ch := subscribeSSE(t)
+
+	agent := &ConnectedAgent{}
+	s.agentsMu.Lock()
+	s.agents["m-rm"] = agent
+	s.agentsMu.Unlock()
+	raw, _ := json.Marshal(aiSessionsFrame("m-rm", validSession("0a0a0a0a", "kimi")))
+	s.ingestAISessions("m-rm", agent, raw)
+	nextSSEEvent(t, ch, "ai_sessions")
+
+	// A displaced (non-registered) socket unregistering must not announce.
+	s.unregisterAgentConnection("m-rm", &ConnectedAgent{})
+	// The registered socket going away does.
+	s.unregisterAgentConnection("m-rm", agent)
+	_, removed := nextSSEEvent(t, ch, "ai_sessions_removed")
+	if removed["machine_id"] != "m-rm" {
+		t.Fatalf("removal event for wrong machine: %v", removed)
+	}
+	// Nothing left to remove: no second announcement.
+	s.removeAISessions("m-rm")
+	select {
+	case frame := <-ch:
+		if strings.HasPrefix(string(frame), "event: ai_sessions_removed") {
+			t.Fatalf("duplicate removal announced: %s", frame)
+		}
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Machine delete path.
+	s.seedTestMachine(t, "m-del2")
+	s.aiSessions.put("m-del2", []aisessions.Session{{ID: "01", Tool: "claude"}})
+	req := httptest.NewRequest(http.MethodDelete, "/api/machines/m-del2", nil)
+	req.Header.Set("Authorization", "Bearer "+admin)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete: %d %s", rec.Code, rec.Body.String())
+	}
+	if _, removed := nextSSEEvent(t, ch, "ai_sessions_removed"); removed["machine_id"] != "m-del2" {
+		t.Fatalf("delete removal event wrong: %v", removed)
+	}
+
+	// Admin switch.
+	if code, body := aiSessionsPatch(t, e, admin, `{"enabled":false}`); code != http.StatusOK {
+		t.Fatalf("disable: %d %s", code, body)
+	}
+	if _, cfg := nextSSEEvent(t, ch, "ai_sessions_config"); cfg["enabled"] != false {
+		t.Fatalf("config event should say disabled: %v", cfg)
+	}
+	if code, body := aiSessionsPatch(t, e, admin, `{"enabled":true}`); code != http.StatusOK {
+		t.Fatalf("enable: %d %s", code, body)
+	}
+	if _, cfg := nextSSEEvent(t, ch, "ai_sessions_config"); cfg["enabled"] != true {
+		t.Fatalf("config event should say enabled: %v", cfg)
+	}
+}
+
+func TestAISessionsReadIncludesHubClock(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	admin := loginAndGetToken(t, e)
+	fixed := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	s.aiSessions.now = func() time.Time { return fixed }
+	_, _, body := aiSessionsGet(t, e, admin)
+	if !strings.Contains(body, `"now":"2026-09-05T12:00:00Z"`) {
+		t.Fatalf("response must carry the hub clock: %s", body)
+	}
+}

--- a/hub/main.go
+++ b/hub/main.go
@@ -738,7 +738,7 @@ func (s *Server) handleDeleteMachine(c echo.Context) error {
 	machineLatencyMu.Lock()
 	delete(machineLatency, id)
 	machineLatencyMu.Unlock()
-	s.aiSessions.remove(id)
+	s.removeAISessions(id)
 
 	log.Printf("machine deleted: %s (%s)", hostname, id)
 	return c.JSON(http.StatusOK, map[string]string{"status": "deleted", "hostname": hostname})

--- a/hub/main.go
+++ b/hub/main.go
@@ -307,6 +307,10 @@ func (s *Server) registerRoutes(e *echo.Echo) {
 
 	api.GET("/api/inventory", s.handleInventory)
 
+	// AI Sessions (read-only live metadata) + admin feature switch.
+	api.GET("/api/ai-sessions", s.handleListAISessions)
+	api.PATCH("/api/ai-sessions/settings", s.handleUpdateAISessionsSettings)
+
 	api.GET("/api/api-machines", s.handleListAPIMachines)
 	api.POST("/api/api-machines", s.handleCreateAPIMachine)
 	api.PATCH("/api/api-machines/:id", s.handleUpdateAPIMachine)
@@ -734,6 +738,7 @@ func (s *Server) handleDeleteMachine(c echo.Context) error {
 	machineLatencyMu.Lock()
 	delete(machineLatency, id)
 	machineLatencyMu.Unlock()
+	s.aiSessions.remove(id)
 
 	log.Printf("machine deleted: %s (%s)", hostname, id)
 	return c.JSON(http.StatusOK, map[string]string{"status": "deleted", "hostname": hostname})

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -1628,16 +1628,22 @@ func TestAgentVersionAnnouncedOnReconnect(t *testing.T) {
 	}
 
 	conn2.SetReadDeadline(time.Now().Add(3 * time.Second))
-	_, msg, err := conn2.ReadMessage()
-	if err != nil {
-		t.Fatalf("expected agent_version frame on reconnect, read err: %v", err)
-	}
+	var msg []byte
 	var versionMsg struct {
 		Type   string `json:"type"`
 		SHA256 string `json:"sha256"`
 	}
-	if err := json.Unmarshal(msg, &versionMsg); err != nil {
-		t.Fatalf("parse version frame: %v (raw=%q)", err, string(msg))
+	// Registration also emits ai_sessions_config on its own goroutine; the
+	// two post-registration frames have no ordering guarantee.
+	for versionMsg.Type == "" || versionMsg.Type == aiSessionsConfigType {
+		var err error
+		_, msg, err = conn2.ReadMessage()
+		if err != nil {
+			t.Fatalf("expected agent_version frame on reconnect, read err: %v", err)
+		}
+		if err := json.Unmarshal(msg, &versionMsg); err != nil {
+			t.Fatalf("parse version frame: %v (raw=%q)", err, string(msg))
+		}
 	}
 	if versionMsg.Type != "agent_version" {
 		t.Fatalf("expected type=agent_version, got %q (raw=%q)", versionMsg.Type, string(msg))

--- a/hub/migrations.go
+++ b/hub/migrations.go
@@ -392,6 +392,18 @@ var migrations = []migration{
 			return nil
 		},
 	},
+	{
+		description: "create hub_settings key/value table (AI Sessions feature switch)",
+		apply: func(tx *sql.Tx) error {
+			_, err := tx.Exec(`
+			CREATE TABLE IF NOT EXISTS hub_settings (
+				key TEXT PRIMARY KEY,
+				value TEXT NOT NULL,
+				updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+			)`)
+			return err
+		},
+	},
 }
 
 // isDuplicateColumnErr returns true when SQLite rejects an ALTER TABLE ADD

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -81,6 +81,8 @@ var roleScopes = map[UserRole][]string{
 var routeScopeRequirements = map[string]string{
 	routeScopeKey(http.MethodGet, "/api/events"):                               scopeFleetRead,
 	routeScopeKey(http.MethodGet, "/api/inventory"):                            scopeFleetRead,
+	routeScopeKey(http.MethodGet, "/api/ai-sessions"):                          scopeFleetRead,
+	routeScopeKey(http.MethodPatch, "/api/ai-sessions/settings"):               scopeFleetAdmin,
 	routeScopeKey(http.MethodGet, "/api/machines"):                             scopeFleetRead,
 	routeScopeKey(http.MethodGet, "/api/machines/:id"):                         scopeFleetRead,
 	routeScopeKey(http.MethodGet, "/api/machines/:id/services"):                scopeFleetRead,

--- a/hub/server.go
+++ b/hub/server.go
@@ -20,6 +20,11 @@ type Server struct {
 	// Serializes agent authentication/registration with credential revocation.
 	agentAuthMu sync.RWMutex
 
+	// Latest AI Sessions snapshot per connected machine, and the cached
+	// feature switch with its revision (see ai_sessions.go).
+	aiSessions    *aiSessionStore
+	aiSessionsCfg aiSessionsConfig
+
 	// Tracks background work this server spawned, so a caller can wait for
 	// it to finish before tearing the server down. See goTracked/Shutdown.
 	//
@@ -36,8 +41,9 @@ type Server struct {
 // newServer returns a Server backed by db with an empty agent registry.
 func newServer(db *sql.DB) *Server {
 	return &Server{
-		db:     db,
-		agents: make(map[string]*ConnectedAgent),
+		db:         db,
+		agents:     make(map[string]*ConnectedAgent),
+		aiSessions: newAISessionStore(),
 	}
 }
 

--- a/proto/aisessions/aisessions.go
+++ b/proto/aisessions/aisessions.go
@@ -157,7 +157,7 @@ func ProjectFromDir(dir, username string) (Attr, bool) {
 		}
 	}
 	base := parts[len(parts)-1]
-	if username != "" && strings.EqualFold(base, username) {
+	if username != "" && strings.EqualFold(base, normalizeUsername(username)) {
 		return Unknown(), false
 	}
 	name, ok := cleanProjectName(base)
@@ -165,6 +165,20 @@ func ProjectFromDir(dir, username string) (Attr, bool) {
 		return Unknown(), false
 	}
 	return Attr{Value: name, Source: SourceCwd, Confidence: ConfidenceExact}, true
+}
+
+// normalizeUsername extracts the account name from domain-qualified usernames
+// (DOMAIN\alice, COMPUTER\alice, or user@DOMAIN) for privacy checks.
+func normalizeUsername(username string) string {
+	// Handle DOMAIN\user or COMPUTER\user (Windows)
+	if idx := strings.LastIndexAny(username, "\\/"); idx >= 0 {
+		username = username[idx+1:]
+	}
+	// Handle user@DOMAIN
+	if idx := strings.IndexByte(username, '@'); idx >= 0 {
+		username = username[:idx]
+	}
+	return username
 }
 
 // ModelFromFlag derives the model attribute from the value of an explicit

--- a/proto/aisessions/aisessions.go
+++ b/proto/aisessions/aisessions.go
@@ -1,0 +1,330 @@
+// Package aisessions is the wire contract for the read-only "AI Sessions"
+// feature: an agent reports which supported AI coding tools are running on
+// its machine, and the hub keeps only the latest snapshot per machine.
+//
+// Privacy is the design constraint, not an afterthought. A session carries
+// ONLY the fields defined here. It never carries prompts, responses,
+// transcript contents, tool commands or output, environment variables, the
+// full command line, the full working directory, or the OS username. The
+// agent derives the fields below from process metadata and discards the
+// raw material; the hub re-applies Sanitize on every inbound message so a
+// misbehaving or older agent cannot smuggle anything else through.
+//
+// Both sides import this package so the whitelist, caps and normalization
+// rules cannot drift apart.
+package aisessions
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// MessageType is the agent→hub WebSocket frame type.
+const MessageType = "ai_sessions"
+
+// SchemaVersion is the version of the session payload shape. A hub accepts
+// any version it can decode; unknown fields are dropped by Sanitize.
+const SchemaVersion = 1
+
+// Supported tools. The classifier on the agent and Sanitize on the hub both
+// reject anything outside this set.
+const (
+	ToolClaude = "claude"
+	ToolCodex  = "codex"
+	ToolKimi   = "kimi"
+)
+
+// Confidence describes how much precision an attribute's value carries.
+//
+//   - exact: the value was observed verbatim (e.g. a --model flag with a full
+//     model id, a directory basename that exists).
+//   - inferred: derived from indirect evidence (a model alias, a CPU-time
+//     heuristic). Do not present it as fact.
+//   - unknown: no evidence. Value is empty.
+const (
+	ConfidenceExact    = "exact"
+	ConfidenceInferred = "inferred"
+	ConfidenceUnknown  = "unknown"
+)
+
+// Source names the evidence an attribute was derived from.
+const (
+	SourceNone     = "none"
+	SourceArgvFlag = "argv_flag" // model: a --model / -m flag on the command line
+	SourceCwd      = "cwd"       // project: basename of the working directory
+	SourceCPUTime  = "cpu_time"  // activity: CPU time consumed between two scans
+)
+
+// Activity states. "active" and "idle" are only ever inferred.
+const (
+	ActivityActive  = "active"
+	ActivityIdle    = "idle"
+	ActivityUnknown = "unknown"
+)
+
+// Caps applied by Sanitize. They bound both wire size and what a hostile
+// agent can push into hub memory.
+const (
+	MaxSessionsPerMachine = 64
+	MaxValueRunes         = 64
+	maxIDHexLen           = 32
+)
+
+// Attr is a value together with an explicit statement of where it came from
+// and how precise it is. Consumers must render Confidence, never just Value.
+type Attr struct {
+	Value      string `json:"value"`
+	Source     string `json:"source"`
+	Confidence string `json:"confidence"`
+}
+
+// Session is the normalized metadata for one running AI tool process.
+type Session struct {
+	// ID is opaque and stable for the lifetime of the process. It is not
+	// the PID.
+	ID string `json:"id"`
+	// Tool is one of ToolClaude, ToolCodex, ToolKimi.
+	Tool string `json:"tool"`
+	// StartedAt is the process start time in RFC 3339 UTC, or empty.
+	StartedAt string `json:"started_at,omitempty"`
+	// Project is the basename of the working directory when one is safely
+	// derivable. Never a path, never a home-directory name.
+	Project Attr `json:"project"`
+	// Model is the model the tool was explicitly asked to use, if that is
+	// observable from a command-line flag. Never read from the environment.
+	Model Attr `json:"model"`
+	// Activity is a coarse busy/idle inference from CPU time.
+	Activity Attr `json:"activity"`
+}
+
+// Message is the agent→hub frame. MachineID is advisory only: the hub binds
+// the snapshot to the machine the socket authenticated as and ignores this
+// field for keying.
+type Message struct {
+	Type      string    `json:"type"`
+	MachineID string    `json:"machine_id"`
+	Schema    int       `json:"schema"`
+	Sessions  []Session `json:"sessions"`
+}
+
+// Unknown returns the attribute that states "no evidence".
+func Unknown() Attr {
+	return Attr{Source: SourceNone, Confidence: ConfidenceUnknown}
+}
+
+// ValidTool reports whether tool is in the whitelist.
+func ValidTool(tool string) bool {
+	switch tool {
+	case ToolClaude, ToolCodex, ToolKimi:
+		return true
+	}
+	return false
+}
+
+// SessionID derives the opaque session id from process identity. The PID
+// itself is not sent; a fresh process reusing a PID gets a different id
+// because the start time differs.
+func SessionID(pid int32, startUnixMillis int64) string {
+	sum := sha256.Sum256([]byte("bloxos-ai-session:" + strconv.FormatInt(int64(pid), 10) + ":" + strconv.FormatInt(startUnixMillis, 10)))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// ProjectFromDir derives the project attribute from a working directory.
+// It returns ok=false, and callers must emit Unknown(), when the directory
+// is not safely a project: the filesystem root, a top-level directory, a
+// home directory (/home/<x>, /Users/<x>, <drive>:\Users\<x>), or a basename
+// equal to the OS username. Both '/' and '\' are treated as separators so
+// the rule is identical on Linux and Windows.
+func ProjectFromDir(dir, username string) (Attr, bool) {
+	parts := splitPath(dir)
+	if len(parts) == 0 {
+		return Unknown(), false
+	}
+	// A Windows drive ("C:") is a root, not a directory component.
+	if len(parts[0]) == 2 && parts[0][1] == ':' && isASCIILetter(parts[0][0]) {
+		parts = parts[1:]
+	}
+	switch len(parts) {
+	case 0, 1:
+		return Unknown(), false
+	case 2:
+		if strings.EqualFold(parts[0], "home") || strings.EqualFold(parts[0], "users") {
+			return Unknown(), false
+		}
+	}
+	base := parts[len(parts)-1]
+	if username != "" && strings.EqualFold(base, username) {
+		return Unknown(), false
+	}
+	name, ok := cleanProjectName(base)
+	if !ok {
+		return Unknown(), false
+	}
+	return Attr{Value: name, Source: SourceCwd, Confidence: ConfidenceExact}, true
+}
+
+// ModelFromFlag derives the model attribute from the value of an explicit
+// --model / -m flag. A full model id (one containing a digit, e.g.
+// "claude-opus-5" or "gpt-5-codex") is exact; a bare alias such as "opus"
+// is inferred. Values that do not look like a model id yield Unknown().
+func ModelFromFlag(raw string) Attr {
+	value, ok := cleanModelValue(raw)
+	if !ok {
+		return Unknown()
+	}
+	conf := ConfidenceInferred
+	if strings.ContainsFunc(value, unicode.IsDigit) {
+		conf = ConfidenceExact
+	}
+	return Attr{Value: value, Source: SourceArgvFlag, Confidence: conf}
+}
+
+// Sanitize returns a copy of msg reduced to the contract: whitelisted tools,
+// capped counts and lengths, enumerated source/confidence values, and
+// values that cannot be paths, command lines or free text. It is the last
+// step on the agent before sending and the first step on the hub after
+// decoding. Sessions that fail validation are dropped, not repaired.
+func Sanitize(msg Message) Message {
+	out := Message{
+		Type:      MessageType,
+		MachineID: msg.MachineID,
+		Schema:    msg.Schema,
+		Sessions:  []Session{},
+	}
+	if out.Schema <= 0 {
+		out.Schema = SchemaVersion
+	}
+	for _, in := range msg.Sessions {
+		if len(out.Sessions) >= MaxSessionsPerMachine {
+			break
+		}
+		s, ok := sanitizeSession(in)
+		if !ok {
+			continue
+		}
+		out.Sessions = append(out.Sessions, s)
+	}
+	return out
+}
+
+func sanitizeSession(in Session) (Session, bool) {
+	if !ValidTool(in.Tool) {
+		return Session{}, false
+	}
+	id := strings.ToLower(strings.TrimSpace(in.ID))
+	if id == "" || len(id) > maxIDHexLen || !isHex(id) {
+		return Session{}, false
+	}
+	out := Session{ID: id, Tool: in.Tool}
+	if t, err := time.Parse(time.RFC3339, in.StartedAt); err == nil {
+		out.StartedAt = t.UTC().Format(time.RFC3339)
+	}
+	out.Project = sanitizeAttr(in.Project, SourceCwd, cleanProjectName)
+	out.Model = sanitizeAttr(in.Model, SourceArgvFlag, cleanModelValue)
+	out.Activity = sanitizeActivity(in.Activity)
+	return out, true
+}
+
+// sanitizeAttr keeps an attribute only when its source is the single
+// source allowed for that attribute, its confidence is a known level, and
+// its value passes clean. Anything else collapses to Unknown().
+func sanitizeAttr(a Attr, allowedSource string, clean func(string) (string, bool)) Attr {
+	if a.Source != allowedSource {
+		return Unknown()
+	}
+	if a.Confidence != ConfidenceExact && a.Confidence != ConfidenceInferred {
+		return Unknown()
+	}
+	value, ok := clean(a.Value)
+	if !ok {
+		return Unknown()
+	}
+	return Attr{Value: value, Source: allowedSource, Confidence: a.Confidence}
+}
+
+// sanitizeActivity only ever admits inferred active/idle from CPU time —
+// the sole activity evidence this checkpoint collects. Nothing may claim an
+// exact activity state.
+func sanitizeActivity(a Attr) Attr {
+	if a.Source != SourceCPUTime || a.Confidence != ConfidenceInferred {
+		return Unknown()
+	}
+	switch a.Value {
+	case ActivityActive, ActivityIdle:
+		return Attr{Value: a.Value, Source: SourceCPUTime, Confidence: ConfidenceInferred}
+	}
+	return Unknown()
+}
+
+// cleanProjectName accepts a single path component: printable, no
+// separators, not "." or "..", at most MaxValueRunes runes.
+func cleanProjectName(raw string) (string, bool) {
+	name := strings.TrimSpace(raw)
+	if name == "" || name == "." || name == ".." {
+		return "", false
+	}
+	if strings.ContainsAny(name, "/\\") {
+		return "", false
+	}
+	for _, r := range name {
+		if !unicode.IsPrint(r) {
+			return "", false
+		}
+	}
+	return truncateRunes(name, MaxValueRunes), true
+}
+
+// cleanModelValue accepts identifiers only: ASCII letters, digits and
+// ".", "_", ":", "-". No separators, spaces or quotes, so a flag value that
+// is really a path or free text is rejected rather than forwarded.
+func cleanModelValue(raw string) (string, bool) {
+	v := strings.TrimSpace(raw)
+	if v == "" || len(v) > MaxValueRunes {
+		return "", false
+	}
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		switch {
+		case isASCIILetter(c), c >= '0' && c <= '9', c == '.', c == '_', c == ':', c == '-':
+		default:
+			return "", false
+		}
+	}
+	return v, true
+}
+
+func splitPath(p string) []string {
+	var parts []string
+	for _, seg := range strings.FieldsFunc(p, func(r rune) bool { return r == '/' || r == '\\' }) {
+		if seg != "" && seg != "." {
+			parts = append(parts, seg)
+		}
+	}
+	return parts
+}
+
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n])
+}
+
+func isHex(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIILetter(c byte) bool {
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z'
+}

--- a/proto/aisessions/aisessions_test.go
+++ b/proto/aisessions/aisessions_test.go
@@ -1,0 +1,225 @@
+package aisessions
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestProjectFromDir(t *testing.T) {
+	cases := []struct {
+		dir, user string
+		want      string
+		ok        bool
+	}{
+		{"/home/alice/projects/bloxos", "alice", "bloxos", true},
+		{"/root/bloxos", "root", "bloxos", true},
+		{"/srv/app/api", "", "api", true},
+		{`C:\Users\alice\src\bloxos`, "alice", "bloxos", true},
+		{`C:\code\my app`, "", "my app", true},
+		{"/home/alice/projects/bloxos/", "alice", "bloxos", true},
+		// Home directories: the basename IS the username.
+		{"/home/alice", "alice", "", false},
+		{"/home/alice", "", "", false},
+		{"/Users/alice", "", "", false},
+		{`C:\Users\alice`, "", "", false},
+		{`c:\users\alice`, "", "", false},
+		// Basename equal to the username anywhere is withheld.
+		{"/srv/alice", "alice", "", false},
+		{"/srv/ALICE", "alice", "", false},
+		// Root / top-level / degenerate.
+		{"/", "", "", false},
+		{"/root", "root", "", false},
+		{"/tmp", "", "", false},
+		{"C:\\", "", "", false},
+		{"", "", "", false},
+		{"relative", "", "", false},
+		{"/a/b/..", "", "", false},
+	}
+	for _, c := range cases {
+		got, ok := ProjectFromDir(c.dir, c.user)
+		if ok != c.ok {
+			t.Errorf("ProjectFromDir(%q,%q) ok=%v want %v", c.dir, c.user, ok, c.ok)
+			continue
+		}
+		if !ok {
+			if got != Unknown() {
+				t.Errorf("ProjectFromDir(%q) returned %+v for !ok; want Unknown()", c.dir, got)
+			}
+			continue
+		}
+		if got.Value != c.want || got.Source != SourceCwd || got.Confidence != ConfidenceExact {
+			t.Errorf("ProjectFromDir(%q) = %+v, want value %q/cwd/exact", c.dir, got, c.want)
+		}
+	}
+}
+
+func TestProjectFromDirTruncatesLongNames(t *testing.T) {
+	long := strings.Repeat("é", 100)
+	got, ok := ProjectFromDir("/srv/x/"+long, "")
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if n := len([]rune(got.Value)); n != MaxValueRunes {
+		t.Fatalf("value has %d runes, want %d", n, MaxValueRunes)
+	}
+}
+
+func TestModelFromFlag(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Attr
+	}{
+		{"claude-opus-5", Attr{"claude-opus-5", SourceArgvFlag, ConfidenceExact}},
+		{"gpt-5-codex", Attr{"gpt-5-codex", SourceArgvFlag, ConfidenceExact}},
+		{"kimi-k2:latest", Attr{"kimi-k2:latest", SourceArgvFlag, ConfidenceExact}},
+		{"opus", Attr{"opus", SourceArgvFlag, ConfidenceInferred}},
+		{" sonnet ", Attr{"sonnet", SourceArgvFlag, ConfidenceInferred}},
+		{"", Unknown()},
+		{"/etc/passwd", Unknown()},
+		{"opus; rm -rf /", Unknown()},
+		{"tell me a secret", Unknown()},
+		{"sk-ant-api03-abc/def", Unknown()},
+		{strings.Repeat("a", 65), Unknown()},
+	}
+	for _, c := range cases {
+		if got := ModelFromFlag(c.in); got != c.want {
+			t.Errorf("ModelFromFlag(%q) = %+v, want %+v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSanitizeDropsInvalidSessionsAndCollapsesAttrs(t *testing.T) {
+	msg := Message{
+		Type:      "whatever",
+		MachineID: "m1",
+		Sessions: []Session{
+			{ // valid, everything known
+				ID:        "ABCDEF0123456789",
+				Tool:      ToolClaude,
+				StartedAt: "2026-09-05T10:00:00+02:00",
+				Project:   Attr{"bloxos", SourceCwd, ConfidenceExact},
+				Model:     Attr{"claude-opus-5", SourceArgvFlag, ConfidenceExact},
+				Activity:  Attr{ActivityActive, SourceCPUTime, ConfidenceInferred},
+			},
+			{ // tool outside the whitelist
+				ID: "0123456789abcdef", Tool: "cursor",
+			},
+			{ // non-hex id
+				ID: "not-hex!", Tool: ToolCodex,
+			},
+			{ // empty id
+				ID: "", Tool: ToolCodex,
+			},
+			{ // attrs that overclaim or carry the wrong source/shape
+				ID:        "1111",
+				Tool:      ToolKimi,
+				StartedAt: "yesterday",
+				Project:   Attr{"/home/alice/secret", SourceCwd, ConfidenceExact},
+				Model:     Attr{"claude-opus-5", "env", ConfidenceExact},
+				Activity:  Attr{ActivityActive, SourceCPUTime, ConfidenceExact},
+			},
+			{ // project with a wrong source; activity with a bogus value
+				ID:       "2222",
+				Tool:     ToolCodex,
+				Project:  Attr{"bloxos", "transcript", ConfidenceExact},
+				Model:    Attr{"o3 --danger", SourceArgvFlag, ConfidenceExact},
+				Activity: Attr{"typing prompt", SourceCPUTime, ConfidenceInferred},
+			},
+		},
+	}
+	out := Sanitize(msg)
+	if out.Type != MessageType || out.MachineID != "m1" || out.Schema != SchemaVersion {
+		t.Fatalf("envelope not normalized: %+v", out)
+	}
+	if len(out.Sessions) != 3 {
+		t.Fatalf("got %d sessions, want 3: %+v", len(out.Sessions), out.Sessions)
+	}
+	s0 := out.Sessions[0]
+	if s0.ID != "abcdef0123456789" || s0.StartedAt != "2026-09-05T08:00:00Z" {
+		t.Errorf("valid session not preserved/normalized: %+v", s0)
+	}
+	if s0.Project.Value != "bloxos" || s0.Model.Value != "claude-opus-5" || s0.Activity.Value != ActivityActive {
+		t.Errorf("valid attrs altered: %+v", s0)
+	}
+	s1 := out.Sessions[1]
+	if s1.ID != "1111" || s1.StartedAt != "" {
+		t.Errorf("bad started_at should be dropped: %+v", s1)
+	}
+	if s1.Project != Unknown() || s1.Model != Unknown() || s1.Activity != Unknown() {
+		t.Errorf("overclaiming attrs must collapse to Unknown: %+v", s1)
+	}
+	s2 := out.Sessions[2]
+	if s2.Project != Unknown() || s2.Model != Unknown() || s2.Activity != Unknown() {
+		t.Errorf("wrong-source/bogus attrs must collapse to Unknown: %+v", s2)
+	}
+}
+
+func TestSanitizeCapsSessionCount(t *testing.T) {
+	var msg Message
+	for i := 0; i < MaxSessionsPerMachine+20; i++ {
+		msg.Sessions = append(msg.Sessions, Session{ID: "ab", Tool: ToolClaude})
+	}
+	if got := len(Sanitize(msg).Sessions); got != MaxSessionsPerMachine {
+		t.Fatalf("got %d sessions, want cap %d", got, MaxSessionsPerMachine)
+	}
+}
+
+func TestSanitizeEmptyMessageHasEmptySessionsArray(t *testing.T) {
+	out := Sanitize(Message{})
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"sessions":[]`) {
+		t.Fatalf("empty sessions must serialize as [] not null: %s", data)
+	}
+}
+
+// TestWireShapeCarriesOnlyContractFields pins the JSON field set. Adding a
+// field here is a deliberate privacy decision, not a refactor.
+func TestWireShapeCarriesOnlyContractFields(t *testing.T) {
+	s := Session{ID: "ab", Tool: ToolClaude, Project: Unknown(), Model: Unknown(), Activity: Unknown()}
+	data, _ := json.Marshal(Message{Type: MessageType, MachineID: "m", Schema: 1, Sessions: []Session{s}})
+	var generic map[string]any
+	if err := json.Unmarshal(data, &generic); err != nil {
+		t.Fatal(err)
+	}
+	wantTop := []string{"type", "machine_id", "schema", "sessions"}
+	if len(generic) != len(wantTop) {
+		t.Fatalf("top-level keys = %v, want %v", keys(generic), wantTop)
+	}
+	sess := generic["sessions"].([]any)[0].(map[string]any)
+	wantSess := map[string]bool{"id": true, "tool": true, "project": true, "model": true, "activity": true}
+	for k := range sess {
+		if !wantSess[k] {
+			t.Errorf("unexpected session field %q on the wire", k)
+		}
+	}
+	for _, k := range []string{"project", "model", "activity"} {
+		attr := sess[k].(map[string]any)
+		if len(attr) != 3 {
+			t.Errorf("attr %q keys = %v, want value/source/confidence", k, keys(attr))
+		}
+	}
+}
+
+func TestSessionIDIsOpaqueAndStable(t *testing.T) {
+	a := SessionID(1234, 1700000000000)
+	b := SessionID(1234, 1700000000000)
+	c := SessionID(1234, 1700000000001)
+	if a != b || a == c || len(a) != 16 || !isHex(a) {
+		t.Fatalf("SessionID a=%s b=%s c=%s", a, b, c)
+	}
+	if strings.Contains(a, "1234") {
+		t.Fatalf("session id leaks the pid: %s", a)
+	}
+}
+
+func keys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/proto/aisessions/aisessions_test.go
+++ b/proto/aisessions/aisessions_test.go
@@ -27,6 +27,16 @@ func TestProjectFromDir(t *testing.T) {
 		// Basename equal to the username anywhere is withheld.
 		{"/srv/alice", "alice", "", false},
 		{"/srv/ALICE", "alice", "", false},
+		// Domain-qualified usernames (Windows DOMAIN\user, COMPUTER\user)
+		{`C:\work\alice`, `DOMAIN\alice`, "", false},
+		{`C:\work\alice`, `COMPUTER\alice`, "", false},
+		{`C:\work\Alice`, `domain\ALICE`, "", false},
+		{"/home/bob/projects/bob", "COMPANY/bob", "", false},
+		{`C:\work\alice`, `DOMAIN\bob`, "alice", true},
+		// user@DOMAIN format
+		{"/srv/alice", "alice@COMPANY", "", false},
+		{"/srv/Alice", "alice@domain.com", "", false},
+		{"/srv/alice", "bob@company.com", "alice", true},
 		// Root / top-level / degenerate.
 		{"/", "", "", false},
 		{"/root", "root", "", false},


### PR DESCRIPTION
## Summary

Adds **AI Sessions**: read-only, live-only visibility into which supported AI coding tools (Claude Code, Codex, Kimi) are running on fleet machines. Two commits: the backend vertical slice (agent discovery, protocol, hub store, read API, admin switch) and the user-facing experience (SSE delivery and dashboard surfaces).

## User experience

- **Fleet pulse strip** gains an "AI Sessions" cell: running session count and how many machines they are on. Click-through to `/sessions`.
- **`/sessions`** lists live sessions grouped by machine. Each row shows the tool, the model with an **exact / inferred / unknown** mark, running duration, project folder name, and a coarse activity hint explicitly labelled *inferred*.
- **Machine page** gets an "AI Sessions" tab (with a count) on agent machines.
- **Settings** gets an admin-only "AI Sessions" tab with the switch, stating metadata-only, live-only, and the local opt-out.
- Header link and command-palette entry for navigation.
- **Running is the only definitive state**: a session is shown because its process exists. Idle is an inferred CPU reading and is never presented as "ended".
- States handled: loading, disabled by admin, empty, machine not reporting, error with retry, stale snapshot, and live-updates-paused. Sessions and machines disappear without a refresh when a process ends or an agent disconnects.
- Read-only throughout. No control acts on a session.

## Privacy contract

The wire contract lives in `proto/aisessions` and is shared by agent and hub so rules cannot drift. A session carries only: an opaque id (not the PID), tool, start time, and three `{value, source, confidence}` attributes:

- **project** — the working-directory **basename** only, withheld for the filesystem root, top-level directories, home directories, and any name equal to the OS username.
- **model** — only from an explicit `--model` (or Codex `-m`) flag among the tool's own arguments; a full id is `exact`, an alias like `opus` is `inferred`. Never read from the environment.
- **activity** — `active`/`idle` inferred from CPU time between scans, `unknown` on first observation. Never reported as exact.

**Never collected or transmitted:** prompts, responses, transcript contents, tool commands or output, environment variables, full argv, full paths, or OS usernames. **No history is retained**: the hub keeps one in-memory snapshot per connected machine and drops it when the socket unregisters, the machine is deleted, the switch is turned off, or 90s pass without a report. The hub re-sanitizes every inbound frame (whitelisted tools, capped counts and lengths, enumerated source/confidence, identifier-only model values, path-free project names); unknown fields are dropped. SSE payloads carry the same sanitized view and nothing else.

## Architecture

- **Agent** — `agent/aiscan` is a pure, cross-platform classifier and reducer: exact-token matching on the process name, `argv[0]`, or the script/module an interpreter runs (no substring matches, so `claude-desktop` or `codex-server` never match); wrapper scripts and self-spawned children collapse into one session; `python -m kimi_cli` is not misread as a model. `agent/ai_sessions.go` reads the process table via gopsutil (already a dependency; no new dependencies anywhere) and reports on the existing 30s cadence.
- **Hub** — snapshots are keyed by the socket's authenticated machine identity (the frame's own `machine_id` is ignored) and accepted only from the registered connection. `GET /api/ai-sessions` (fleet.read) and `PATCH /api/ai-sessions/settings` (fleet.admin). Switch persisted in a new `hub_settings` table; missing row = enabled, so no setup is required. SSE events on `/api/events`: `ai_sessions`, `ai_sessions_removed`, `ai_sessions_config`. The GET response includes the hub clock so clients age snapshots without clock agreement.
- **Dashboard** — the SSE provider gains a generic `subscribe(event, handler)` that re-attaches on reconnect; `AISessionsContext` is the single store, bootstrapping from GET on auth and every reconnect and applying SSE deltas. No second stream, no polling (the only timer is a 10s render clock for durations where sessions are displayed).
- **Backward compatibility** — older hubs log the unknown frame and continue; older agents never send it and treat the config frame as an id-less command they ignore. Windows builds vet and compile.

## Admin and local opt-outs

- **Admin switch** (default on): turning it off clears every snapshot and pushes an `ai_sessions_config` frame to all connected agents, which **stop scanning** immediately. The switch is cached with a monotonic revision captured atomically for every send; agents accept only strictly greater revisions on a connection, so a delayed registration "enabled" cannot undo a newer "disabled", and equal-revision duplicates or forgeries cannot flip the gate. Concurrent toggles are serialized under one lock so the persisted order matches revision order.
- **Agent gate**: scanning runs only after the hub has said "enabled" on the current connection, so an agent talking to an older hub never scans.
- **Local hard opt-out**: `BLOXOS_AI_SESSIONS=0` in the agent's environment; no hub setting can override it.

## Validation performed

- hub: `go vet ./...`, `go test -count=1 ./...`, `go test -race -count=1 -timeout=10m ./...` — pass, 0 data races.
- agent: `GOOS=linux` and `GOOS=windows` `go vet ./...`, `go vet -tags insecure`, test binaries compile for both targets; `agent/aiscan` tests pass with `-race`. Package-main agent tests compile for linux/windows and run in CI (they cannot execute on the macOS dev host).
- proto: `go test -race ./...` pass. `go mod tidy -diff` clean in all three modules.
- dashboard: `tsc --noEmit`, `eslint`, `next build` — pass.
- End-to-end on a scratch hub with a fake agent: enrollment, config frame with revisions, session reports, SSE `ai_sessions` and `ai_sessions_config` events observed, agent stopped and resumed on toggle.
- Test coverage: classifier positives/negatives; privacy regressions on agent, hub, and SSE with planted secrets, prompts, full paths, argv, env and unknown fields; stale expiry; spoofed and unregistered identity; displaced sockets; RBAC (viewer/operator/admin/unauthenticated); protocol compatibility (future schema, malformed frames, old-agent traffic); race safety; revision ordering and DB/cache consistency under concurrent toggles; removal and config broadcasts.
- Four existing hub tests were adjusted to tolerate the new post-registration config frame; nothing else in them changed.

## Residual risks

- The model field is shape-checked only (identifier charset, 64 chars); an identifier-shaped string from a compromised agent passes. Documented by a dedicated test.
- Activity is an uncalibrated CPU-rate heuristic (1%), always labelled inferred.
- A tool launched directly by a versioned binary path rather than its `claude` launcher is not classified.
- Hub-side stale eviction is lazy (on GET); the dashboard computes staleness itself, so a live-but-silent agent shows as stale rather than vanishing until the next bootstrap.
- Browser screenshots at desktop and phone widths were not taken during development; responsive and accessibility semantics (semantic lists, `time` elements, `role="switch"` with `aria-checked`, `role="status"` notices, text-plus-colour confidence marks, stacked phone layout) were verified by review and build only.
- The repo has no frontend test runner, so no component tests were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQHxs4yyRwNjaWmsEE76Tz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds process-table scanning and a new agent→hub metadata channel with strict sanitization, but misclassification or a compromised agent could still publish identifier-shaped model strings; admin toggles affect all connected agents.
> 
> **Overview**
> Introduces **AI Sessions**: read-only, live visibility into Claude Code, Codex, and Kimi processes on agent machines, bounded by a shared `proto/aisessions` contract and documented in **AGENTS.md**.
> 
> **Agent:** New `aiscan` classifier/reducer and `ai_sessions.go` scan the process table on the existing 30s metrics tick, gated by hub `ai_sessions_config` (revision-ordered) and local **`BLOXOS_AI_SESSIONS=0`**. Reports are sanitized before send; scan failures never tear down the connection.
> 
> **Hub:** In-memory snapshots per authenticated socket (no history), **`GET /api/ai-sessions`** / **`PATCH .../settings`** (persisted in new **`hub_settings`**, default on), re-sanitize on ingest, 90s stale expiry, SSE events **`ai_sessions`**, **`ai_sessions_removed`**, **`ai_sessions_config`**. Snapshots clear on disconnect, machine delete, or admin off.
> 
> **Dashboard:** **`AISessionsProvider`** bootstraps from GET on SSE reconnect; **`SSEContext.subscribe`** fans out named events without a second stream. Surfaces: fleet pulse cell, **`/sessions`**, machine **AI Sessions** tab, admin settings switch, nav/command palette.
> 
> Existing hub tests tolerate the post-registration config frame alongside **`agent_version`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86720d139481e5a56f26e5fc9db034389d8de847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->