### PR TITLE
fix: prevent signed agent update downgrades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,15 @@ Fleet management dashboard for AI machines. Go hub + agent, Next.js dashboard.
   trusted provisioning path.
 - The signature may come from a detached `<binary>.sig` produced offline, in
   which case the hub holds no private key — do not assume the hub signs.
+- **Protocol-2 update rollback protection** keeps the same v1 signature format.
+  Its SHA authenticates the release marker inside the binary. Agents persist
+  a release number plus SHA floor before replacing the executable, reject
+  unnumbered/older builds, and accept the same number only for the same SHA.
+  Bump the source-controlled number and marker in `agent/release.go` for every
+  new agent release, including rebuilds with changed bytes. Never raise the
+  floor from unsigned announcement metadata, reset it on key rotation or
+  installer re-runs, or delete it in automatic `.prev` recovery. Protocol-1
+  binaries cannot enforce this floor, including a pre-migration `.prev`.
 - **AI Sessions is metadata-only monitoring.** Agents report which supported
   AI coding tools (Claude Code, Codex, Kimi) are running, reduced to the
   contract in `proto/aisessions`: opaque id, tool, start time, project

--- a/agent/main.go
+++ b/agent/main.go
@@ -363,6 +363,11 @@ func main() {
 		log.Printf("using install token for initial enrollment")
 	}
 
+	// Establish the release floor from the binary that is actually running,
+	// before any connection and before Windows applies a pending update.
+	// Never fatal: a broken floor disables self-update, not the agent.
+	seedReleaseFloorAtBoot()
+
 	runPlatformAgent()
 }
 

--- a/agent/marker.go
+++ b/agent/marker.go
@@ -2,16 +2,24 @@ package main
 
 import (
 	"os"
+	"strconv"
 	"strings"
 )
 
 type pendingMarker struct {
 	ExpectedSHA string
 	Signature   string
+	// Release is the embedded release sequence performUpdateWindows read
+	// out of the staged binary. Informational: validatePendingUpdate
+	// re-extracts it from the bytes and only uses this to detect a marker
+	// and staged file that no longer belong together. 0 when absent or
+	// unparseable (a marker written by an older agent).
+	Release uint64
 }
 
-// parsePendingMarker reads the marker file and extracts sha256 and signature.
-// It handles arbitrary ordering, unknown fields, and duplicate fields (takes the last one).
+// parsePendingMarker reads the marker file and extracts sha256, signature
+// and release. It handles arbitrary ordering, unknown fields, and duplicate
+// fields (takes the last one).
 func parsePendingMarker(path string) (pendingMarker, error) {
 	var pm pendingMarker
 	data, err := os.ReadFile(path)
@@ -25,6 +33,12 @@ func parsePendingMarker(path string) (pendingMarker, error) {
 			pm.ExpectedSHA = strings.TrimPrefix(line, "sha256=")
 		} else if strings.HasPrefix(line, "signature=") {
 			pm.Signature = strings.TrimPrefix(line, "signature=")
+		} else if strings.HasPrefix(line, "release=") {
+			seq, err := strconv.ParseUint(strings.TrimPrefix(line, "release="), 10, 64)
+			if err != nil {
+				seq = 0
+			}
+			pm.Release = seq
 		}
 	}
 	return pm, nil

--- a/agent/marker_test.go
+++ b/agent/marker_test.go
@@ -15,12 +15,27 @@ func TestParsePendingMarker(t *testing.T) {
 		content     string
 		expectedSHA string
 		expectedSig string
+		expectedRel uint64
 	}{
 		{
 			name:        "normal",
 			content:     "source=a\ntarget=b\nat=time\nsha256=123456\nsignature=base64pad==\n",
 			expectedSHA: "123456",
 			expectedSig: "base64pad==",
+		},
+		{
+			name:        "with release",
+			content:     "sha256=123456\nsignature=sig=\nrelease=42\n",
+			expectedSHA: "123456",
+			expectedSig: "sig=",
+			expectedRel: 42,
+		},
+		{
+			name:        "unparseable release reads as absent",
+			content:     "sha256=123456\nsignature=sig=\nrelease=forty-two\n",
+			expectedSHA: "123456",
+			expectedSig: "sig=",
+			expectedRel: 0,
 		},
 		{
 			name:        "different order with unknown fields",
@@ -56,6 +71,9 @@ func TestParsePendingMarker(t *testing.T) {
 			}
 			if pm.Signature != tt.expectedSig {
 				t.Errorf("expected signature %q, got %q", tt.expectedSig, pm.Signature)
+			}
+			if pm.Release != tt.expectedRel {
+				t.Errorf("expected release %d, got %d", tt.expectedRel, pm.Release)
 			}
 		})
 	}

--- a/agent/release.go
+++ b/agent/release.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"log"
+	"strings"
+	"sync"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
+)
+
+/* ============================================================================
+ * Release sequence
+ *
+ * agentRelease is this build's place in the release order. It is bumped by
+ * hand, in source, once per release — never derived from the clock, git
+ * metadata (absent from the Docker build context), or a build flag. Two
+ * builds of the same commit therefore carry the same number, and a number
+ * can only be changed by changing the source that is built.
+ *
+ * agentReleaseMarker is the same number rendered as the literal that
+ * updatesigning.ExtractRelease scans for in the finished binary. It MUST
+ * stay a plain string constant that is used on a live code path: that is
+ * what puts one contiguous copy of it into the binary's read-only data,
+ * where the hub (and a receiving agent) read it back out of the bytes the
+ * v1 signature already covers. TestAgentReleaseMarkerMatchesConstant fails
+ * if the two drift apart.
+ *
+ * Bumping a release: increment agentRelease, re-render the marker with the
+ * same value zero-padded to updatesigning.ReleaseMarkerDigits, run the tests.
+ * ============================================================================ */
+
+// agentRelease is the release sequence compiled into this binary.
+const agentRelease uint64 = 1
+
+// agentReleaseMarker is agentRelease as the scannable literal.
+const agentReleaseMarker = "BLOXOS-AGENT-RELEASE:0000000001:"
+
+var (
+	embeddedReleaseOnce sync.Once
+	embeddedReleaseSeq  uint64
+)
+
+// agentEmbeddedRelease returns the release sequence this binary carries,
+// parsed from the marker literal itself rather than from agentRelease. That
+// keeps the literal live (so it is never dropped from the binary) and means
+// the number the agent reports is exactly the one an external scanner reads.
+func agentEmbeddedRelease() uint64 {
+	embeddedReleaseOnce.Do(func() {
+		seq, err := updatesigning.ExtractReleaseReader(strings.NewReader(agentReleaseMarker))
+		if err != nil || seq != agentRelease {
+			// Unreachable if the test suite passed; if it ever trips, the
+			// binary is mis-stamped and must not claim any release.
+			log.Printf("release: embedded marker %q does not match agentRelease %d (%v); treating this build as unnumbered",
+				agentReleaseMarker, agentRelease, err)
+			return
+		}
+		embeddedReleaseSeq = seq
+	})
+	return embeddedReleaseSeq
+}

--- a/agent/release_floor.go
+++ b/agent/release_floor.go
@@ -1,0 +1,496 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
+)
+
+/* ============================================================================
+ * Persistent release floor (downgrade protection, issue #145)
+ *
+ * The v1 signature proves an announced binary is one the release key signed.
+ * It does not prove the binary is not OLDER than what this agent already
+ * runs — any (os, sha) ever signed verifies forever, so a compromised hub or
+ * an operator redeploying an old artifact could walk the fleet back to a
+ * build with a known hole.
+ *
+ * The floor is the agent's own memory of how far forward it has gone:
+ *
+ *     release=<sequence>
+ *     sha256=<hex of the binary that set it>
+ *
+ * A candidate is accepted only if its embedded release (read out of the
+ * downloaded bytes the signature covers, see updatesigning.ExtractRelease)
+ * is HIGHER than the floor, or EQUAL with exactly the floor's SHA. Equal
+ * with a different SHA is refused: two builds that share a counter would
+ * otherwise be replayable against each other. Lower is refused.
+ *
+ * The file only ever moves forward through the update path. It is seeded at
+ * boot from the running binary's own release and SHA, so it never depends on
+ * a later update (the same-SHA early return in handleAgentVersion never
+ * reaches authorisation, and the seed must not either). Installers do not
+ * touch it, the systemd recovery script does not touch it, and it is not
+ * keyed on the pinned update key, so re-running an installer or rotating the
+ * key leaves it alone.
+ *
+ * Crash ordering: the floor is raised BEFORE the binary swap. If the process
+ * dies between the two, the agent restarts on the old binary with the floor
+ * already at the new release; the hub re-announces the same (release, sha),
+ * which the equal-and-same-SHA rule accepts, so the retry succeeds.
+ *
+ * Rolled back by the recovery unit to the .prev binary: the agent boots
+ * with its own release below the stored floor. It keeps running (the floor
+ * gates updates, never the agent itself), keeps the higher floor, reports
+ * both, and accepts the next announcement at or above the floor.
+ *
+ * Deliberate local recovery: root places the wanted binary, deletes the
+ * floor file, restarts. The agent reseeds from what is now running. There
+ * is no remote path that lowers a floor, and no implicit one either: a
+ * same-numbered but DIFFERENT build found running at boot (a reinstall of a
+ * rebuilt artifact, say) is not adopted as the new identity — it is an
+ * error until an operator resets the floor on purpose.
+ *
+ * Fail closed, and stickily. Anything that goes wrong at boot — the floor
+ * cannot be read, written or reconciled; the binary cannot be hashed; the
+ * scanner does not read back the release the constant claims — disables
+ * self-update for the life of the process. Every later read additionally
+ * re-checks that the floor on disk still covers the running binary, so a
+ * floor that is replaced by an older valid file after boot cannot re-open
+ * downgrades below what is running. All of it is reported to the hub as
+ * release_floor_ok=false so it withholds with a reason instead of arming a
+ * reconnect timer for a refusal it provoked.
+ * ============================================================================ */
+
+// releaseFloor is one persisted floor: the highest accepted release, pinned
+// to the exact build that set it.
+type releaseFloor struct {
+	Release uint64
+	SHA     string
+}
+
+// defaultReleaseFloorPathLinux sits beside the pinned update key.
+const defaultReleaseFloorPathLinux = "/etc/bloxos/agent-release-floor"
+
+// releaseFloorFileName is the Windows file name, placed beside the agent
+// executable and agent-update.pub in the admin-only install directory.
+const releaseFloorFileName = "agent-release-floor"
+
+var errReleaseFloorAbsent = errors.New("no release floor is recorded")
+
+// releaseFloorState is the process-wide state established once at boot.
+type releaseFloorState struct {
+	booted bool
+	// path is where the floor lives, resolved at boot.
+	path string
+	// self is the running binary's identity, established at boot.
+	self releaseFloor
+	// bootErr is sticky: once set, self-update stays disabled until restart.
+	bootErr error
+}
+
+var (
+	releaseFloorMu sync.Mutex
+	floorState     releaseFloorState
+)
+
+// releaseFloorPath returns where the floor lives. exePath is the agent's own
+// resolved binary; Windows keeps the floor beside it, Linux under /etc/bloxos.
+// BLOXOS_RELEASE_FLOOR_PATH overrides both (tests, unusual layouts).
+func releaseFloorPath(exePath string) string {
+	if p := strings.TrimSpace(os.Getenv("BLOXOS_RELEASE_FLOOR_PATH")); p != "" {
+		return p
+	}
+	if runtime.GOOS == "windows" {
+		return filepath.Join(filepath.Dir(exePath), releaseFloorFileName)
+	}
+	return defaultReleaseFloorPathLinux
+}
+
+// permits reports whether candidate may be installed over this floor.
+func (f releaseFloor) permits(candidate releaseFloor) error {
+	switch {
+	case candidate.Release == 0:
+		return fmt.Errorf("candidate binary carries no release sequence; this agent enforces a release floor of %d and refuses unnumbered builds", f.Release)
+	case candidate.Release > f.Release:
+		return nil
+	case candidate.Release == f.Release && strings.EqualFold(candidate.SHA, f.SHA):
+		return nil
+	case candidate.Release == f.Release:
+		return fmt.Errorf("candidate release %d equals the floor but is a different build (%s, floor pinned to %s); a release number cannot be reused for different bytes",
+			candidate.Release, shortSHA(candidate.SHA), shortSHA(f.SHA))
+	default:
+		return fmt.Errorf("candidate release %d is below this agent's floor of %d; refusing downgrade", candidate.Release, f.Release)
+	}
+}
+
+// covers reports whether this floor is consistent with `running` being the
+// binary in execution: the floor is higher (we were rolled back), or it is
+// exactly this build. A floor below the running release, or a same-numbered
+// floor pinned to other bytes, is not a floor this process may enforce.
+func (f releaseFloor) covers(running releaseFloor) error {
+	switch {
+	case running.Release == 0:
+		return fmt.Errorf("running binary is unnumbered")
+	case f.Release > running.Release:
+		return nil
+	case f.Release == running.Release && strings.EqualFold(f.SHA, running.SHA):
+		return nil
+	case f.Release == running.Release:
+		return fmt.Errorf("floor is pinned to release %d build %s but the running binary is a different build %s of the same release; "+
+			"a release number cannot be reused for different bytes — an operator must reset the floor deliberately",
+			f.Release, shortSHA(f.SHA), shortSHA(running.SHA))
+	default:
+		return fmt.Errorf("floor release %d is below the running release %d", f.Release, running.Release)
+	}
+}
+
+// readReleaseFloor parses the floor file. errReleaseFloorAbsent when it does
+// not exist; any other error means the file exists but is not trustworthy,
+// and callers must fail closed rather than overwrite it.
+func readReleaseFloor(path string) (releaseFloor, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return releaseFloor{}, errReleaseFloorAbsent
+		}
+		return releaseFloor{}, fmt.Errorf("read release floor %s: %w", path, err)
+	}
+	return parseReleaseFloor(data)
+}
+
+func parseReleaseFloor(data []byte) (releaseFloor, error) {
+	var (
+		f          releaseFloor
+		gotRelease bool
+		gotSHA     bool
+	)
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return releaseFloor{}, fmt.Errorf("release floor is corrupt: unparseable line %q", line)
+		}
+		switch strings.TrimSpace(key) {
+		case "release":
+			if gotRelease {
+				return releaseFloor{}, fmt.Errorf("release floor is corrupt: duplicate release field")
+			}
+			seq, err := strconv.ParseUint(strings.TrimSpace(value), 10, 64)
+			if err != nil || seq == 0 || seq > updatesigning.MaxRelease {
+				return releaseFloor{}, fmt.Errorf("release floor is corrupt: bad release %q", value)
+			}
+			f.Release, gotRelease = seq, true
+		case "sha256":
+			if gotSHA {
+				return releaseFloor{}, fmt.Errorf("release floor is corrupt: duplicate sha256 field")
+			}
+			sha := strings.ToLower(strings.TrimSpace(value))
+			if !isHexSHA256(sha) {
+				return releaseFloor{}, fmt.Errorf("release floor is corrupt: bad sha256 %q", value)
+			}
+			f.SHA, gotSHA = sha, true
+		default:
+			// Unknown keys are tolerated so a future field does not brick
+			// the floor for an older agent.
+		}
+	}
+	if !gotRelease || !gotSHA {
+		return releaseFloor{}, fmt.Errorf("release floor is corrupt: release and sha256 are both required")
+	}
+	return f, nil
+}
+
+func isHexSHA256(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// writeReleaseFloor durably replaces the floor file: temp file in the same
+// directory, fsync, then the shared crash-durable rename (which fsyncs the
+// directory). A crash leaves either the old floor or the new one, never a
+// torn file.
+func writeReleaseFloor(path string, f releaseFloor) error {
+	if f.Release == 0 || f.Release > updatesigning.MaxRelease || !isHexSHA256(strings.ToLower(f.SHA)) {
+		return fmt.Errorf("refusing to write an invalid release floor (release=%d sha=%q)", f.Release, f.SHA)
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create release floor directory %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary release floor in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	keep := false
+	defer func() {
+		if !keep {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	body := fmt.Sprintf("release=%d\nsha256=%s\n", f.Release, strings.ToLower(f.SHA))
+	if _, err := io.WriteString(tmp, body); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write release floor: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync release floor: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close release floor: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0o644); err != nil {
+		return fmt.Errorf("chmod release floor: %w", err)
+	}
+	if err := releaseFloorRename(tmpPath, path); err != nil {
+		return fmt.Errorf("install release floor %s: %w", path, err)
+	}
+	keep = true
+	return nil
+}
+
+// releaseFloorRename is the crash-durable replace used by writeReleaseFloor.
+// A variable so tests can inject a rename that succeeds on disk but fails
+// its durability fsync, the exact case raiseReleaseFloor's unconditional
+// rewrite exists for.
+var releaseFloorRename = durableRename
+
+// seedReleaseFloor reconciles the stored floor with the binary that is
+// actually running and returns the floor in force afterwards.
+//
+//   - absent            → written from self (first boot of a numbered build)
+//   - corrupt           → error; never overwritten
+//   - stored higher     → kept as is (we were rolled back or recovered)
+//   - equal, same SHA   → kept as is
+//   - equal, other SHA  → error: the accepted identity for this release is
+//     the stored one; adopting whatever is running would let any local
+//     reinstall silently re-pin the release, so it takes a deliberate reset
+//   - stored lower      → rewritten to self
+//
+// An unnumbered self is an error: there is nothing to seed and no floor this
+// process may enforce.
+func seedReleaseFloor(path string, self releaseFloor) (releaseFloor, error) {
+	if self.Release == 0 {
+		return releaseFloor{}, fmt.Errorf("this build is unnumbered; it cannot seed or enforce a release floor")
+	}
+	stored, err := readReleaseFloor(path)
+	switch {
+	case err == nil:
+		if coverErr := stored.covers(self); coverErr == nil {
+			return stored, nil
+		} else if stored.Release == self.Release {
+			return releaseFloor{}, coverErr
+		}
+		// stored lower than self: fall through and raise.
+	case errors.Is(err, errReleaseFloorAbsent):
+	default:
+		return releaseFloor{}, err
+	}
+	if err := writeReleaseFloor(path, self); err != nil {
+		return releaseFloor{}, err
+	}
+	return self, nil
+}
+
+// raiseReleaseFloor advances the stored floor to candidate on the update
+// path. It requires a floor to exist (boot seeds one) and requires the floor
+// to permit the candidate. It ALWAYS writes and syncs, even when the visible
+// floor already equals the candidate: that case is the retry after a crash
+// between the floor write and the binary swap, and the previous attempt may
+// have renamed the file into place yet failed the directory fsync — visible,
+// but with no durability proof. Rewriting the same value is cheap,
+// update-only I/O and is the proof. The floor can never go down here:
+// permits() only admits a higher release or the floor's own build.
+func raiseReleaseFloor(path string, candidate releaseFloor) error {
+	stored, err := readReleaseFloor(path)
+	if err != nil {
+		return err
+	}
+	if err := stored.permits(candidate); err != nil {
+		return err
+	}
+	return writeReleaseFloor(path, candidate)
+}
+
+// seedReleaseFloorAtBoot resolves this binary's identity and floor path and
+// establishes the process-wide state. Called once from main before any
+// connection (and, on Windows, before applyPendingUpdate). Never fatal: a
+// broken floor disables self-update, not the agent.
+func seedReleaseFloorAtBoot() {
+	exe, err := selfExePath()
+	if err != nil {
+		initReleaseFloorState("", releaseFloor{}, fmt.Errorf("cannot resolve own path: %w", err))
+		return
+	}
+	path := releaseFloorPath(exe)
+	self := releaseFloor{Release: agentEmbeddedRelease()}
+	sha, err := computeFileSHA256(exe)
+	if err != nil {
+		initReleaseFloorState(path, self, fmt.Errorf("cannot hash own binary: %w", err))
+		return
+	}
+	self.SHA = sha
+
+	// The scanner must read back exactly the number the constant says, or
+	// the hub withholds/announces on a different basis than this agent
+	// enforces and the floor's identity is not the one external tooling
+	// sees. That is a mis-stamped build: disable, do not guess.
+	scanned, err := updatesigning.ExtractRelease(exe)
+	if err != nil {
+		initReleaseFloorState(path, self, fmt.Errorf("own binary release marker unreadable: %w", err))
+		return
+	}
+	if scanned != self.Release {
+		initReleaseFloorState(path, self, fmt.Errorf("own binary scans as release %d but reports %d", scanned, self.Release))
+		return
+	}
+	initReleaseFloorState(path, self, nil)
+}
+
+// initReleaseFloorState is the testable core of seedReleaseFloorAtBoot:
+// records path and self, and seeds the floor unless bootErr already rules
+// this process out. Any failure here is sticky for the life of the process.
+func initReleaseFloorState(path string, self releaseFloor, bootErr error) {
+	releaseFloorMu.Lock()
+	defer releaseFloorMu.Unlock()
+	floorState = releaseFloorState{booted: true, path: path, self: self, bootErr: bootErr}
+	if bootErr != nil {
+		log.Printf("release: %v; self-update disabled until restart", bootErr)
+		return
+	}
+	floor, err := seedReleaseFloor(path, self)
+	if err != nil {
+		floorState.bootErr = err
+		log.Printf("release: floor at %s is unusable (%v); self-update disabled until an operator repairs it and restarts the agent", path, err)
+		return
+	}
+	if floor.Release > self.Release {
+		log.Printf("release: running release %d is BELOW the recorded floor %d (%s) — this binary was restored locally; "+
+			"only announcements at or above the floor will be accepted", self.Release, floor.Release, shortSHA(floor.SHA))
+		return
+	}
+	log.Printf("release: running release %d, floor %d (%s) at %s", self.Release, floor.Release, shortSHA(floor.SHA), path)
+}
+
+// currentReleaseFloor re-reads the floor from disk (so a local operator
+// edit takes effect without a restart) and fails closed when boot did not
+// establish a usable state, when the file is absent or corrupt, or when the
+// file no longer covers the running binary — a valid but OLDER floor put in
+// place after boot must not re-open downgrades below what is running.
+func currentReleaseFloor() (releaseFloor, error) {
+	releaseFloorMu.Lock()
+	st := floorState
+	releaseFloorMu.Unlock()
+	if !st.booted {
+		return releaseFloor{}, fmt.Errorf("release floor was never initialised at boot")
+	}
+	if st.bootErr != nil {
+		return releaseFloor{}, fmt.Errorf("release floor disabled since boot: %w", st.bootErr)
+	}
+	floor, err := readReleaseFloor(st.path)
+	if err != nil {
+		return releaseFloor{}, fmt.Errorf("release floor at %s is unusable (%v); self-update is disabled — "+
+			"restart the agent to reseed it, or repair the file", st.path, err)
+	}
+	if err := floor.covers(st.self); err != nil {
+		return releaseFloor{}, fmt.Errorf("release floor at %s no longer covers the running binary (%v); self-update is disabled", st.path, err)
+	}
+	return floor, nil
+}
+
+// currentReleaseFloorPath returns the path established at boot.
+func currentReleaseFloorPath() string {
+	releaseFloorMu.Lock()
+	defer releaseFloorMu.Unlock()
+	return floorState.path
+}
+
+// loadReleaseFloorForUpdate is the update path's view of the floor.
+func loadReleaseFloorForUpdate() (releaseFloor, error) {
+	return currentReleaseFloor()
+}
+
+// releaseFloorStatus is what reportAgentVersion sends: the floor in force
+// and whether it is usable, under exactly the rules the update path applies.
+func releaseFloorStatus() (floor releaseFloor, ok bool) {
+	floor, err := currentReleaseFloor()
+	if err != nil {
+		return releaseFloor{}, false
+	}
+	return floor, true
+}
+
+// verifyCandidateRelease reads the release sequence out of a downloaded,
+// SHA-verified binary and checks it against the floor. Returns the candidate
+// floor entry to raise to. Nothing here executes the candidate.
+func verifyCandidateRelease(candidatePath, candidateSHA string) (releaseFloor, error) {
+	floor, err := loadReleaseFloorForUpdate()
+	if err != nil {
+		return releaseFloor{}, err
+	}
+	seq, err := updatesigning.ExtractRelease(candidatePath)
+	if err != nil {
+		return releaseFloor{}, fmt.Errorf("cannot read the downloaded binary's release sequence: %w", err)
+	}
+	candidate := releaseFloor{Release: seq, SHA: strings.ToLower(candidateSHA)}
+	if err := floor.permits(candidate); err != nil {
+		return releaseFloor{}, err
+	}
+	return candidate, nil
+}
+
+// checkStagedRelease is the Windows boot-time re-check of a staged
+// <exe>.new against the floor, shared here so it can be tested on every
+// platform. performUpdateWindows raised the floor before writing the marker,
+// so a genuine staged update is the equal-and-same-SHA case and passes; a
+// marker and staged file replayed after the floor moved on, a staged file
+// whose bytes no longer match the release the marker recorded, or an
+// unnumbered staged file are refused. Raising is idempotent and covers a
+// floor repaired between the two boots. markerRelease is 0 for a marker
+// written by an agent that predates the field.
+func checkStagedRelease(stagedPath, stagedSHA string, markerRelease uint64) error {
+	candidate, err := verifyCandidateRelease(stagedPath, stagedSHA)
+	if err != nil {
+		return fmt.Errorf("staged binary rejected by release floor: %w", err)
+	}
+	if markerRelease != 0 && markerRelease != candidate.Release {
+		return fmt.Errorf("staged binary carries release %d but the marker says %d", candidate.Release, markerRelease)
+	}
+	if err := raiseReleaseFloor(currentReleaseFloorPath(), candidate); err != nil {
+		return fmt.Errorf("cannot raise release floor to %d: %w", candidate.Release, err)
+	}
+	return nil
+}
+
+// checkAdvisoryRelease applies the hub's unsigned release hint from the
+// announcement. It is refuse-only: a hint below the floor (or equal with a
+// different SHA than the floor pins) saves a download that would be refused
+// after verification anyway. The hint is never trusted to raise anything;
+// the authoritative check is verifyCandidateRelease on the actual bytes.
+func checkAdvisoryRelease(floor releaseFloor, advisory uint64, announcedSHA string) error {
+	if advisory == 0 {
+		return nil
+	}
+	return floor.permits(releaseFloor{Release: advisory, SHA: strings.ToLower(strings.TrimSpace(announcedSHA))})
+}

--- a/agent/release_floor_test.go
+++ b/agent/release_floor_test.go
@@ -1,0 +1,764 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
+)
+
+const (
+	floorSHAa = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	floorSHAb = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	floorSHAc = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+)
+
+// bootFloorForTest establishes process-wide floor state as a successful boot
+// of `self` would, against a floor file in a fresh temp dir (pre-populated
+// with `stored` when non-nil). Returns the floor path.
+func bootFloorForTest(t *testing.T, self releaseFloor, stored *releaseFloor) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "agent-release-floor")
+	if stored != nil {
+		if err := writeReleaseFloor(path, *stored); err != nil {
+			t.Fatalf("seed stored floor: %v", err)
+		}
+	}
+	resetReleaseFloorStateForTest()
+	t.Cleanup(resetReleaseFloorStateForTest)
+	initReleaseFloorState(path, self, nil)
+	return path
+}
+
+func mustReadFloor(t *testing.T, path string) releaseFloor {
+	t.Helper()
+	f, err := readReleaseFloor(path)
+	if err != nil {
+		t.Fatalf("read floor: %v", err)
+	}
+	return f
+}
+
+// writeCandidateBinary writes a fake binary carrying the given markers.
+func writeCandidateBinary(t *testing.T, dir string, markers ...string) string {
+	t.Helper()
+	path := filepath.Join(dir, "candidate")
+	body := "ELF-ish head " + strings.Join(markers, " middle ") + " tail"
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func markerFor(t *testing.T, seq uint64) string {
+	t.Helper()
+	m, err := updatesigning.ReleaseMarker(seq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func TestParseReleaseFloor(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		want    releaseFloor
+		wantErr string
+	}{
+		{name: "canonical", body: "release=7\nsha256=" + floorSHAa + "\n", want: releaseFloor{7, floorSHAa}},
+		{name: "order comments unknown keys crlf", body: "# note\r\nsha256=" + strings.ToUpper(floorSHAa) + "\r\nfuture=x\r\nrelease=7\r\n", want: releaseFloor{7, floorSHAa}},
+		{name: "duplicate release", body: "release=7\nrelease=8\nsha256=" + floorSHAa + "\n", wantErr: "duplicate release"},
+		{name: "duplicate sha", body: "release=7\nsha256=" + floorSHAa + "\nsha256=" + floorSHAb + "\n", wantErr: "duplicate sha256"},
+		{name: "missing sha", body: "release=7\n", wantErr: "are both required"},
+		{name: "missing release", body: "sha256=" + floorSHAa + "\n", wantErr: "are both required"},
+		{name: "zero release", body: "release=0\nsha256=" + floorSHAa + "\n", wantErr: "bad release"},
+		{name: "over max", body: "release=10000000000\nsha256=" + floorSHAa + "\n", wantErr: "bad release"},
+		{name: "negative", body: "release=-1\nsha256=" + floorSHAa + "\n", wantErr: "bad release"},
+		{name: "short sha", body: "release=1\nsha256=abc\n", wantErr: "bad sha256"},
+		{name: "garbage line", body: "release=1\nwhat\nsha256=" + floorSHAa + "\n", wantErr: "unparseable"},
+		{name: "empty", body: "", wantErr: "are both required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseReleaseFloor([]byte(tc.body))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteReleaseFloorRejectsInvalid(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "floor")
+	for _, bad := range []releaseFloor{
+		{0, floorSHAa},
+		{updatesigning.MaxRelease + 1, floorSHAa},
+		{1, "nothex"},
+		{1, ""},
+	} {
+		if err := writeReleaseFloor(path, bad); err == nil {
+			t.Fatalf("writeReleaseFloor accepted %+v", bad)
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("invalid write left a file behind for %+v", bad)
+		}
+	}
+	if err := writeReleaseFloor(path, releaseFloor{updatesigning.MaxRelease, floorSHAa}); err != nil {
+		t.Fatalf("max release must be writable: %v", err)
+	}
+	if got := mustReadFloor(t, path); got.Release != updatesigning.MaxRelease {
+		t.Fatalf("round trip = %+v", got)
+	}
+	// No temp files left behind.
+	entries, _ := os.ReadDir(filepath.Dir(path))
+	if len(entries) != 1 {
+		t.Fatalf("expected only the floor file, found %d entries", len(entries))
+	}
+}
+
+func TestReleaseFloorPermits(t *testing.T) {
+	floor := releaseFloor{5, floorSHAa}
+	cases := []struct {
+		name string
+		cand releaseFloor
+		ok   bool
+	}{
+		{"higher", releaseFloor{6, floorSHAb}, true},
+		{"equal same sha", releaseFloor{5, floorSHAa}, true},
+		{"equal same sha upper case", releaseFloor{5, strings.ToUpper(floorSHAa)}, true},
+		{"equal different sha", releaseFloor{5, floorSHAb}, false},
+		{"lower", releaseFloor{4, floorSHAa}, false},
+		{"lower same sha", releaseFloor{4, floorSHAa}, false},
+		{"unnumbered", releaseFloor{0, floorSHAb}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := floor.permits(tc.cand)
+			if (err == nil) != tc.ok {
+				t.Fatalf("permits(%+v) = %v, want ok=%v", tc.cand, err, tc.ok)
+			}
+		})
+	}
+}
+
+func TestReleaseFloorCovers(t *testing.T) {
+	running := releaseFloor{5, floorSHAa}
+	cases := []struct {
+		name  string
+		floor releaseFloor
+		ok    bool
+	}{
+		{"higher floor (rolled back)", releaseFloor{6, floorSHAb}, true},
+		{"exact build", releaseFloor{5, floorSHAa}, true},
+		{"same release other build", releaseFloor{5, floorSHAb}, false},
+		{"lower floor", releaseFloor{4, floorSHAa}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.floor.covers(running)
+			if (err == nil) != tc.ok {
+				t.Fatalf("covers = %v, want ok=%v", err, tc.ok)
+			}
+		})
+	}
+	if err := (releaseFloor{5, floorSHAa}).covers(releaseFloor{0, floorSHAa}); err == nil {
+		t.Fatal("an unnumbered running binary must never be covered")
+	}
+}
+
+func TestSeedReleaseFloor(t *testing.T) {
+	self := releaseFloor{5, floorSHAa}
+
+	t.Run("absent is seeded from self", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "floor")
+		got, err := seedReleaseFloor(path, self)
+		if err != nil || got != self {
+			t.Fatalf("got %+v, %v", got, err)
+		}
+		if mustReadFloor(t, path) != self {
+			t.Fatal("file does not hold self")
+		}
+	})
+	t.Run("absent and unnumbered self errors", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "floor")
+		if _, err := seedReleaseFloor(path, releaseFloor{0, floorSHAa}); err == nil {
+			t.Fatal("unnumbered self must not seed")
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatal("unnumbered self must not write a floor")
+		}
+	})
+	t.Run("higher stored is preserved", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "floor")
+		higher := releaseFloor{9, floorSHAb}
+		if err := writeReleaseFloor(path, higher); err != nil {
+			t.Fatal(err)
+		}
+		got, err := seedReleaseFloor(path, self)
+		if err != nil || got != higher {
+			t.Fatalf("got %+v, %v; want stored floor preserved", got, err)
+		}
+		if mustReadFloor(t, path) != higher {
+			t.Fatal("recovery lowered the floor")
+		}
+	})
+	t.Run("equal same sha is kept", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "floor")
+		if err := writeReleaseFloor(path, self); err != nil {
+			t.Fatal(err)
+		}
+		before, _ := os.Stat(path)
+		got, err := seedReleaseFloor(path, self)
+		if err != nil || got != self {
+			t.Fatalf("got %+v, %v", got, err)
+		}
+		after, _ := os.Stat(path)
+		if !before.ModTime().Equal(after.ModTime()) {
+			t.Fatal("identical floor was rewritten")
+		}
+	})
+	t.Run("equal different sha is an error and file untouched", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "floor")
+		pinned := releaseFloor{5, floorSHAb}
+		if err := writeReleaseFloor(path, pinned); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := seedReleaseFloor(path, self); err == nil {
+			t.Fatal("a same-numbered different build must not be adopted implicitly")
+		}
+		if mustReadFloor(t, path) != pinned {
+			t.Fatal("accepted identity was rewritten")
+		}
+	})
+	t.Run("lower stored is raised to self", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "floor")
+		if err := writeReleaseFloor(path, releaseFloor{2, floorSHAc}); err != nil {
+			t.Fatal(err)
+		}
+		got, err := seedReleaseFloor(path, self)
+		if err != nil || got != self {
+			t.Fatalf("got %+v, %v", got, err)
+		}
+		if mustReadFloor(t, path) != self {
+			t.Fatal("file not raised")
+		}
+	})
+	t.Run("corrupt is an error and never overwritten", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "floor")
+		if err := os.WriteFile(path, []byte("release=5\nrelease=5\nsha256="+floorSHAa+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := seedReleaseFloor(path, self); err == nil {
+			t.Fatal("corrupt floor must error")
+		}
+		data, _ := os.ReadFile(path)
+		if !strings.Contains(string(data), "release=5\nrelease=5") {
+			t.Fatal("corrupt floor was overwritten")
+		}
+	})
+}
+
+func TestRaiseReleaseFloor(t *testing.T) {
+	stored := releaseFloor{5, floorSHAa}
+	newFloor := func(t *testing.T) string {
+		path := filepath.Join(t.TempDir(), "floor")
+		if err := writeReleaseFloor(path, stored); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	t.Run("higher writes", func(t *testing.T) {
+		path := newFloor(t)
+		if err := raiseReleaseFloor(path, releaseFloor{6, floorSHAb}); err != nil {
+			t.Fatal(err)
+		}
+		if got := mustReadFloor(t, path); got != (releaseFloor{6, floorSHAb}) {
+			t.Fatalf("got %+v", got)
+		}
+	})
+	t.Run("equal same sha is an idempotent no-op (crash retry)", func(t *testing.T) {
+		path := newFloor(t)
+		if err := raiseReleaseFloor(path, stored); err != nil {
+			t.Fatal(err)
+		}
+		if err := raiseReleaseFloor(path, stored); err != nil {
+			t.Fatal(err)
+		}
+		if mustReadFloor(t, path) != stored {
+			t.Fatal("floor changed")
+		}
+	})
+	t.Run("equal different sha refused", func(t *testing.T) {
+		path := newFloor(t)
+		if err := raiseReleaseFloor(path, releaseFloor{5, floorSHAb}); err == nil {
+			t.Fatal("must refuse")
+		}
+		if mustReadFloor(t, path) != stored {
+			t.Fatal("floor changed")
+		}
+	})
+	t.Run("lower refused", func(t *testing.T) {
+		path := newFloor(t)
+		if err := raiseReleaseFloor(path, releaseFloor{4, floorSHAb}); err == nil {
+			t.Fatal("must refuse")
+		}
+	})
+	t.Run("absent refused", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "floor")
+		if err := raiseReleaseFloor(path, releaseFloor{6, floorSHAb}); !errors.Is(err, errReleaseFloorAbsent) {
+			t.Fatalf("err = %v, want absent", err)
+		}
+	})
+}
+
+func TestReleaseFloorBootStateIsStickyAndFailClosed(t *testing.T) {
+	self := releaseFloor{5, floorSHAa}
+
+	t.Run("never booted refuses", func(t *testing.T) {
+		resetReleaseFloorStateForTest()
+		t.Cleanup(resetReleaseFloorStateForTest)
+		if _, err := currentReleaseFloor(); err == nil {
+			t.Fatal("must refuse before boot")
+		}
+		if _, ok := releaseFloorStatus(); ok {
+			t.Fatal("status must be not-ok before boot")
+		}
+	})
+	t.Run("boot error is sticky even with a valid file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "floor")
+		if err := writeReleaseFloor(path, self); err != nil {
+			t.Fatal(err)
+		}
+		resetReleaseFloorStateForTest()
+		t.Cleanup(resetReleaseFloorStateForTest)
+		initReleaseFloorState(path, self, errors.New("own binary scans as release 9 but reports 5"))
+		if _, err := currentReleaseFloor(); err == nil || !strings.Contains(err.Error(), "disabled since boot") {
+			t.Fatalf("err = %v", err)
+		}
+		if _, ok := releaseFloorStatus(); ok {
+			t.Fatal("status must be not-ok")
+		}
+	})
+	t.Run("seed failure at boot is sticky", func(t *testing.T) {
+		path := bootFloorForTest(t, self, &releaseFloor{5, floorSHAb})
+		if _, err := currentReleaseFloor(); err == nil {
+			t.Fatal("equal-different at boot must disable updates")
+		}
+		// Even repairing the file does not lift a boot error without restart.
+		if err := writeReleaseFloor(path, self); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := currentReleaseFloor(); err == nil {
+			t.Fatal("boot error must be sticky")
+		}
+	})
+	t.Run("healthy boot then floor replaced by valid older file refuses", func(t *testing.T) {
+		path := bootFloorForTest(t, self, nil)
+		if _, err := currentReleaseFloor(); err != nil {
+			t.Fatalf("healthy boot: %v", err)
+		}
+		if err := writeReleaseFloor(path, releaseFloor{3, floorSHAc}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := currentReleaseFloor(); err == nil || !strings.Contains(err.Error(), "no longer covers") {
+			t.Fatalf("older floor after boot must refuse, got %v", err)
+		}
+		if _, ok := releaseFloorStatus(); ok {
+			t.Fatal("status must be not-ok")
+		}
+	})
+	t.Run("healthy boot then floor replaced by same release other build refuses", func(t *testing.T) {
+		path := bootFloorForTest(t, self, nil)
+		if err := writeReleaseFloor(path, releaseFloor{5, floorSHAb}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := currentReleaseFloor(); err == nil {
+			t.Fatal("must refuse")
+		}
+	})
+	t.Run("healthy boot then floor deleted refuses until restart", func(t *testing.T) {
+		path := bootFloorForTest(t, self, nil)
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := currentReleaseFloor(); err == nil {
+			t.Fatal("must refuse")
+		}
+	})
+	t.Run("healthy boot then floor raised externally is honoured", func(t *testing.T) {
+		path := bootFloorForTest(t, self, nil)
+		if err := writeReleaseFloor(path, releaseFloor{8, floorSHAb}); err != nil {
+			t.Fatal(err)
+		}
+		floor, err := currentReleaseFloor()
+		if err != nil || floor.Release != 8 {
+			t.Fatalf("got %+v, %v", floor, err)
+		}
+	})
+	t.Run("rolled back binary keeps higher floor and reports it", func(t *testing.T) {
+		bootFloorForTest(t, releaseFloor{3, floorSHAc}, &releaseFloor{5, floorSHAa})
+		floor, ok := releaseFloorStatus()
+		if !ok || floor != (releaseFloor{5, floorSHAa}) {
+			t.Fatalf("got %+v ok=%v", floor, ok)
+		}
+	})
+}
+
+func TestVerifyCandidateRelease(t *testing.T) {
+	self := releaseFloor{5, floorSHAa}
+	dir := t.TempDir()
+
+	t.Run("higher accepted", func(t *testing.T) {
+		bootFloorForTest(t, self, nil)
+		cand := writeCandidateBinary(t, dir, markerFor(t, 6))
+		got, err := verifyCandidateRelease(cand, strings.ToUpper(floorSHAb))
+		if err != nil || got != (releaseFloor{6, floorSHAb}) {
+			t.Fatalf("got %+v, %v", got, err)
+		}
+	})
+	t.Run("equal same sha accepted (retry)", func(t *testing.T) {
+		bootFloorForTest(t, self, nil)
+		cand := writeCandidateBinary(t, dir, markerFor(t, 5))
+		if _, err := verifyCandidateRelease(cand, floorSHAa); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("equal different sha refused", func(t *testing.T) {
+		bootFloorForTest(t, self, nil)
+		cand := writeCandidateBinary(t, dir, markerFor(t, 5))
+		if _, err := verifyCandidateRelease(cand, floorSHAb); err == nil {
+			t.Fatal("must refuse")
+		}
+	})
+	t.Run("lower refused", func(t *testing.T) {
+		bootFloorForTest(t, self, nil)
+		cand := writeCandidateBinary(t, dir, markerFor(t, 4))
+		if _, err := verifyCandidateRelease(cand, floorSHAb); err == nil || !strings.Contains(err.Error(), "downgrade") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("unnumbered refused", func(t *testing.T) {
+		bootFloorForTest(t, self, nil)
+		cand := writeCandidateBinary(t, dir)
+		if _, err := verifyCandidateRelease(cand, floorSHAb); err == nil || !strings.Contains(err.Error(), "no release sequence") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("ambiguous refused", func(t *testing.T) {
+		bootFloorForTest(t, self, nil)
+		cand := writeCandidateBinary(t, dir, markerFor(t, 6), markerFor(t, 7))
+		if _, err := verifyCandidateRelease(cand, floorSHAb); err == nil {
+			t.Fatal("must refuse")
+		}
+	})
+	t.Run("floor unusable refuses before reading candidate", func(t *testing.T) {
+		resetReleaseFloorStateForTest()
+		t.Cleanup(resetReleaseFloorStateForTest)
+		cand := writeCandidateBinary(t, dir, markerFor(t, 99))
+		if _, err := verifyCandidateRelease(cand, floorSHAb); err == nil {
+			t.Fatal("must refuse")
+		}
+	})
+}
+
+func TestCheckAdvisoryRelease(t *testing.T) {
+	floor := releaseFloor{5, floorSHAa}
+	if err := checkAdvisoryRelease(floor, 0, floorSHAb); err != nil {
+		t.Fatalf("absent advisory must pass: %v", err)
+	}
+	if err := checkAdvisoryRelease(floor, 6, floorSHAb); err != nil {
+		t.Fatalf("higher advisory must pass: %v", err)
+	}
+	if err := checkAdvisoryRelease(floor, 5, " "+strings.ToUpper(floorSHAa)+" "); err != nil {
+		t.Fatalf("equal same sha must pass: %v", err)
+	}
+	if err := checkAdvisoryRelease(floor, 5, floorSHAb); err == nil {
+		t.Fatal("equal different sha must refuse")
+	}
+	if err := checkAdvisoryRelease(floor, 4, floorSHAb); err == nil {
+		t.Fatal("lower advisory must refuse")
+	}
+}
+
+// resetReleaseFloorStateForTest clears the process-wide boot state so each
+// test starts as an un-booted process.
+func resetReleaseFloorStateForTest() {
+	releaseFloorMu.Lock()
+	floorState = releaseFloorState{}
+	releaseFloorMu.Unlock()
+}
+
+// TestReleaseFloorCrashRetrySameReleaseSameSHA walks the crash-ordering
+// scenario end to end: the floor is raised for a candidate, the process dies
+// before the swap, restarts on the OLD binary, and the hub re-announces the
+// same candidate. The retry must pass; a same-numbered different build must
+// not; the floor must never go down.
+func TestReleaseFloorCrashRetrySameReleaseSameSHA(t *testing.T) {
+	dir := t.TempDir()
+	oldSelf := releaseFloor{5, floorSHAa}
+	path := bootFloorForTest(t, oldSelf, nil)
+
+	// First attempt: verify + raise, then "crash" (no swap).
+	cand := writeCandidateBinary(t, dir, markerFor(t, 6))
+	got, err := verifyCandidateRelease(cand, floorSHAb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := raiseReleaseFloor(currentReleaseFloorPath(), got); err != nil {
+		t.Fatal(err)
+	}
+	if mustReadFloor(t, path) != (releaseFloor{6, floorSHAb}) {
+		t.Fatal("floor not raised before swap")
+	}
+
+	// Restart on the old binary with the raised floor already on disk.
+	resetReleaseFloorStateForTest()
+	initReleaseFloorState(path, oldSelf, nil)
+	floor, ok := releaseFloorStatus()
+	if !ok || floor != (releaseFloor{6, floorSHAb}) {
+		t.Fatalf("after restart floor = %+v ok=%v; the raised floor must survive", floor, ok)
+	}
+
+	// Retry of the identical candidate passes and re-proves durability.
+	if _, err := verifyCandidateRelease(cand, floorSHAb); err != nil {
+		t.Fatalf("retry of the same (release, sha) must pass: %v", err)
+	}
+	if err := raiseReleaseFloor(currentReleaseFloorPath(), releaseFloor{6, floorSHAb}); err != nil {
+		t.Fatalf("retry raise must pass: %v", err)
+	}
+	// A rebuilt release 6 with other bytes does not.
+	if _, err := verifyCandidateRelease(cand, floorSHAc); err == nil {
+		t.Fatal("same release, different sha must be refused after a partial update")
+	}
+	// And the old binary itself can never be re-installed by the hub.
+	oldCand := writeCandidateBinary(t, t.TempDir(), markerFor(t, 5))
+	if _, err := verifyCandidateRelease(oldCand, floorSHAa); err == nil {
+		t.Fatal("the running (older) build must not be accepted as an update once the floor moved on")
+	}
+	if mustReadFloor(t, path) != (releaseFloor{6, floorSHAb}) {
+		t.Fatal("floor changed during refusals")
+	}
+}
+
+// TestReleaseFloorCorruptAtBootIsSticky: a corrupt floor found at boot
+// disables updates for the life of the process, is never overwritten, and a
+// later repair of the file does not lift the disable without a restart.
+func TestReleaseFloorCorruptAtBootIsSticky(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "floor")
+	corrupt := "release=5\nsha256=" + floorSHAa + "\nsha256=" + floorSHAb + "\n"
+	if err := os.WriteFile(path, []byte(corrupt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resetReleaseFloorStateForTest()
+	t.Cleanup(resetReleaseFloorStateForTest)
+	initReleaseFloorState(path, releaseFloor{5, floorSHAa}, nil)
+
+	if _, ok := releaseFloorStatus(); ok {
+		t.Fatal("corrupt floor at boot must report not-ok")
+	}
+	if _, err := currentReleaseFloor(); err == nil || !strings.Contains(err.Error(), "disabled since boot") {
+		t.Fatalf("err = %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if string(data) != corrupt {
+		t.Fatal("corrupt floor was rewritten at boot")
+	}
+	if err := writeReleaseFloor(path, releaseFloor{5, floorSHAa}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := currentReleaseFloor(); err == nil {
+		t.Fatal("repairing the file must not lift a boot error without restart")
+	}
+	// A restart with the repaired file works.
+	resetReleaseFloorStateForTest()
+	initReleaseFloorState(path, releaseFloor{5, floorSHAa}, nil)
+	if _, ok := releaseFloorStatus(); !ok {
+		t.Fatal("restart after repair must be ok")
+	}
+}
+
+// TestReleaseFloorBootHashOrScanFailureIsSticky covers the boot errors that
+// arrive from outside the floor file itself (own-binary hash failure,
+// scanner mismatch): they must disable updates even though a perfectly
+// valid floor is on disk.
+func TestReleaseFloorBootHashOrScanFailureIsSticky(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "floor")
+	self := releaseFloor{5, floorSHAa}
+	if err := writeReleaseFloor(path, self); err != nil {
+		t.Fatal(err)
+	}
+	for _, bootErr := range []error{
+		errors.New("cannot hash own binary: permission denied"),
+		errors.New("own binary release marker unreadable: more than one release marker found"),
+		errors.New("own binary scans as release 4 but reports 5"),
+	} {
+		resetReleaseFloorStateForTest()
+		initReleaseFloorState(path, self, bootErr)
+		if _, ok := releaseFloorStatus(); ok {
+			t.Fatalf("boot error %q must disable updates", bootErr)
+		}
+		if _, err := verifyCandidateRelease(filepath.Join(t.TempDir(), "none"), floorSHAb); err == nil {
+			t.Fatalf("boot error %q must refuse candidates", bootErr)
+		}
+	}
+	resetReleaseFloorStateForTest()
+}
+
+// TestCheckStagedRelease is the Windows boot-time replay guard, run here on
+// every platform: the staged .new plus marker are re-checked after the
+// process that wrote them exited.
+func TestCheckStagedRelease(t *testing.T) {
+	dir := t.TempDir()
+	self := releaseFloor{5, floorSHAa}
+
+	t.Run("genuine staged update passes (floor already raised)", func(t *testing.T) {
+		path := bootFloorForTest(t, self, &releaseFloor{6, floorSHAb})
+		staged := writeCandidateBinary(t, dir, markerFor(t, 6))
+		if err := checkStagedRelease(staged, floorSHAb, 6); err != nil {
+			t.Fatal(err)
+		}
+		if mustReadFloor(t, path) != (releaseFloor{6, floorSHAb}) {
+			t.Fatal("floor changed")
+		}
+	})
+	t.Run("marker from an older agent without release passes", func(t *testing.T) {
+		bootFloorForTest(t, self, &releaseFloor{6, floorSHAb})
+		staged := writeCandidateBinary(t, dir, markerFor(t, 6))
+		if err := checkStagedRelease(staged, floorSHAb, 0); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("replayed after the floor moved on is refused", func(t *testing.T) {
+		path := bootFloorForTest(t, self, &releaseFloor{7, floorSHAc})
+		staged := writeCandidateBinary(t, dir, markerFor(t, 6))
+		if err := checkStagedRelease(staged, floorSHAb, 6); err == nil || !strings.Contains(err.Error(), "downgrade") {
+			t.Fatalf("err = %v", err)
+		}
+		if mustReadFloor(t, path) != (releaseFloor{7, floorSHAc}) {
+			t.Fatal("floor lowered by a replay")
+		}
+	})
+	t.Run("same release other build replayed is refused", func(t *testing.T) {
+		bootFloorForTest(t, self, &releaseFloor{6, floorSHAb})
+		staged := writeCandidateBinary(t, dir, markerFor(t, 6))
+		if err := checkStagedRelease(staged, floorSHAc, 6); err == nil || !strings.Contains(err.Error(), "different build") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("staged bytes disagree with marker release", func(t *testing.T) {
+		bootFloorForTest(t, self, nil)
+		staged := writeCandidateBinary(t, dir, markerFor(t, 7))
+		if err := checkStagedRelease(staged, floorSHAb, 6); err == nil || !strings.Contains(err.Error(), "marker says") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("unnumbered staged file refused", func(t *testing.T) {
+		bootFloorForTest(t, self, nil)
+		staged := writeCandidateBinary(t, dir)
+		if err := checkStagedRelease(staged, floorSHAb, 0); err == nil {
+			t.Fatal("must refuse")
+		}
+	})
+	t.Run("no usable floor refuses", func(t *testing.T) {
+		resetReleaseFloorStateForTest()
+		t.Cleanup(resetReleaseFloorStateForTest)
+		staged := writeCandidateBinary(t, dir, markerFor(t, 9))
+		if err := checkStagedRelease(staged, floorSHAb, 9); err == nil {
+			t.Fatal("must refuse")
+		}
+	})
+}
+
+// TestRaiseReleaseFloorDurabilityFailurePropagates injects a rename that
+// puts the file in place but fails its durability proof (the directory
+// fsync). The raise must report the error so the swap does not happen, the
+// visible floor must not be lower than before, and the retry — which sees an
+// equal, same-SHA floor — must write and sync AGAIN rather than short-cut on
+// the visible value.
+func TestRaiseReleaseFloorDurabilityFailurePropagates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "floor")
+	if err := writeReleaseFloor(path, releaseFloor{5, floorSHAa}); err != nil {
+		t.Fatal(err)
+	}
+
+	renameCalls := 0
+	failNext := true
+	orig := releaseFloorRename
+	releaseFloorRename = func(oldpath, newpath string) error {
+		renameCalls++
+		if err := os.Rename(oldpath, newpath); err != nil {
+			return err
+		}
+		if failNext {
+			failNext = false
+			return errors.New("fsync parent directory: injected failure")
+		}
+		return nil
+	}
+	t.Cleanup(func() { releaseFloorRename = orig })
+
+	cand := releaseFloor{6, floorSHAb}
+	if err := raiseReleaseFloor(path, cand); err == nil || !strings.Contains(err.Error(), "injected failure") {
+		t.Fatalf("first raise must propagate the durability failure, got %v", err)
+	}
+	// Visible state is the new floor (rename happened) — never lower.
+	if got := mustReadFloor(t, path); got != cand {
+		t.Fatalf("visible floor after failed fsync = %+v", got)
+	}
+	// Retry: equal + same SHA. Must go through rename+fsync again.
+	before := renameCalls
+	if err := raiseReleaseFloor(path, cand); err != nil {
+		t.Fatalf("retry must succeed: %v", err)
+	}
+	if renameCalls != before+1 {
+		t.Fatalf("retry skipped persistence (rename calls %d -> %d); an equal floor must be re-proven durable", before, renameCalls)
+	}
+	if got := mustReadFloor(t, path); got != cand {
+		t.Fatalf("floor after retry = %+v", got)
+	}
+	// No stray temp files after either attempt.
+	entries, _ := os.ReadDir(filepath.Dir(path))
+	if len(entries) != 1 {
+		t.Fatalf("expected only the floor file, found %d entries", len(entries))
+	}
+}
+
+// TestSeedReleaseFloorWriteFailureIsBootError: an unwritable floor at first
+// boot disables updates rather than pretending a floor exists.
+func TestSeedReleaseFloorWriteFailureIsBootError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "floor")
+	orig := releaseFloorRename
+	releaseFloorRename = func(oldpath, newpath string) error {
+		return errors.New("injected rename failure")
+	}
+	t.Cleanup(func() { releaseFloorRename = orig })
+	resetReleaseFloorStateForTest()
+	t.Cleanup(resetReleaseFloorStateForTest)
+	initReleaseFloorState(path, releaseFloor{5, floorSHAa}, nil)
+	if _, ok := releaseFloorStatus(); ok {
+		t.Fatal("unwritable floor at boot must disable updates")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("no floor file should exist after a failed seed")
+	}
+}
+
+func TestReleaseFloorPathOverride(t *testing.T) {
+	t.Setenv("BLOXOS_RELEASE_FLOOR_PATH", "/custom/floor")
+	if got := releaseFloorPath("/opt/bloxos-agent"); got != "/custom/floor" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/agent/release_test.go
+++ b/agent/release_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
+)
+
+// TestAgentReleaseMarkerMatchesConstant is the guard against a half-bumped
+// release: agentRelease and agentReleaseMarker must describe the same number,
+// and the number the process reports must be the one a scanner reads.
+func TestAgentReleaseMarkerMatchesConstant(t *testing.T) {
+	want, err := updatesigning.ReleaseMarker(agentRelease)
+	if err != nil {
+		t.Fatalf("agentRelease %d is not a valid release: %v", agentRelease, err)
+	}
+	if agentReleaseMarker != want {
+		t.Fatalf("agentReleaseMarker = %q, want %q for agentRelease %d — bump both together",
+			agentReleaseMarker, want, agentRelease)
+	}
+	seq, err := updatesigning.ExtractReleaseReader(strings.NewReader(agentReleaseMarker))
+	if err != nil || seq != agentRelease {
+		t.Fatalf("scanner reads %d (%v) from the marker, want %d", seq, err, agentRelease)
+	}
+	if got := agentEmbeddedRelease(); got != agentRelease {
+		t.Fatalf("agentEmbeddedRelease() = %d, want %d", got, agentRelease)
+	}
+}
+
+// TestBuiltAgentBinaryCarriesExactlyOneMarker builds the agent the way the
+// Dockerfile does (stripped) for the host platform and this package's
+// supported targets, then scans the artifact with the same extractor the hub
+// uses. This is the end-to-end property everything else rests on: the number
+// in source is the number in the bytes, exactly once.
+func TestBuiltAgentBinaryCarriesExactlyOneMarker(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping build in -short mode")
+	}
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go toolchain not on PATH")
+	}
+	targets := []struct{ goos, goarch string }{
+		{"linux", "amd64"},
+		{"linux", "arm64"},
+		{"windows", "amd64"},
+	}
+	for _, tgt := range targets {
+		t.Run(tgt.goos+"/"+tgt.goarch, func(t *testing.T) {
+			out := filepath.Join(t.TempDir(), "bloxos-agent")
+			cmd := exec.Command(goBin, "build", "-ldflags=-s -w", "-o", out, ".")
+			cmd.Env = append(os.Environ(), "GOOS="+tgt.goos, "GOARCH="+tgt.goarch, "CGO_ENABLED=0")
+			if outb, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("build %s/%s: %v\n%s", tgt.goos, tgt.goarch, err, outb)
+			}
+			seq, err := updatesigning.ExtractRelease(out)
+			if err != nil {
+				t.Fatalf("scan built binary: %v", err)
+			}
+			if seq != agentRelease {
+				t.Fatalf("built binary carries release %d, source says %d", seq, agentRelease)
+			}
+		})
+	}
+}

--- a/agent/update_verify.go
+++ b/agent/update_verify.go
@@ -43,7 +43,16 @@ import (
 // into a binary that is already deployed; the hub uses the absence of this
 // field to decide whether announcing to that agent is safe at all. See
 // legacyBootstrapAllowed in hub/update_signing.go.
-const agentUpdateProtocol = 1
+//
+// Version 2 additionally means "this binary enforces a persistent release
+// floor" (release_floor.go): it reads the release sequence embedded in a
+// downloaded binary and refuses anything older than, or a different build
+// of, the highest release it has accepted. The signature format is unchanged
+// — the sequence is inside the bytes the v1 signature already covers. A v2
+// agent reports release, release_floor, release_floor_sha and
+// release_floor_ok so the hub can withhold, with a reason, an announcement
+// the agent is certain to refuse.
+const agentUpdateProtocol = 2
 
 // defaultUpdatePublicKeyPathLinux is where the hub-generated install.sh pins
 // the key. Windows pins it next to the agent executable instead.
@@ -153,10 +162,22 @@ func verifyAnnouncedRelease(exePath, osName, sha256hex, sigB64 string) error {
 
 // authorizeUpdate is the single gate every self-update must clear before any
 // bytes are fetched: the transport must be one an off-host attacker cannot
-// tamper with, and the announced SHA must be signed by the pinned key.
-func authorizeUpdate(rawHubURL, exePath, osName, sha256hex, sigB64 string) error {
+// tamper with, the announced SHA must be signed by the pinned key, and the
+// release floor must be usable. advisoryRelease is the hub's unsigned hint
+// of the served binary's release sequence; it can only refuse early (a
+// download that would fail the floor anyway), never admit anything — the
+// authoritative check reads the sequence out of the downloaded bytes in
+// verifyCandidateRelease.
+func authorizeUpdate(rawHubURL, exePath, osName, sha256hex, sigB64 string, advisoryRelease uint64) error {
 	if _, err := agentDownloadURL(rawHubURL, ""); err != nil {
 		return err
 	}
-	return verifyAnnouncedRelease(exePath, osName, sha256hex, sigB64)
+	if err := verifyAnnouncedRelease(exePath, osName, sha256hex, sigB64); err != nil {
+		return err
+	}
+	floor, err := loadReleaseFloorForUpdate()
+	if err != nil {
+		return err
+	}
+	return checkAdvisoryRelease(floor, advisoryRelease, sha256hex)
 }

--- a/agent/update_verify_test.go
+++ b/agent/update_verify_test.go
@@ -177,7 +177,7 @@ func TestAuthorizeUpdateRejectsPlaintextTransport(t *testing.T) {
 	sig := signFor(t, priv, "linux", testSHA)
 
 	err := authorizeUpdate("ws://hub.example.com:4000/ws/agent", "/usr/local/bin/bloxos-agent",
-		"linux", testSHA, sig)
+		"linux", testSHA, sig, 0)
 	if err == nil {
 		t.Fatal("authorizeUpdate accepted a plaintext hub with a valid signature")
 	}
@@ -193,7 +193,7 @@ func TestAuthorizeUpdateRequiresPinnedKey(t *testing.T) {
 	t.Setenv("BLOXOS_UPDATE_PUBKEY_PATH", missing)
 
 	err := authorizeUpdate("wss://hub.example.com:4000/ws/agent", "/usr/local/bin/bloxos-agent",
-		"linux", testSHA, "")
+		"linux", testSHA, "", 0)
 	if err == nil {
 		t.Fatal("authorizeUpdate proceeded with no pinned key")
 	}
@@ -210,7 +210,7 @@ func TestAuthorizeUpdateRejectsForeignSigner(t *testing.T) {
 	pinKey(t, pub)
 
 	err := authorizeUpdate("wss://hub.example.com:4000/ws/agent", "/usr/local/bin/bloxos-agent",
-		"linux", testSHA, signFor(t, attacker, "linux", testSHA))
+		"linux", testSHA, signFor(t, attacker, "linux", testSHA), 0)
 	if err == nil {
 		t.Fatal("authorizeUpdate accepted a signature from an unpinned key")
 	}
@@ -222,10 +222,74 @@ func TestAuthorizeUpdateRejectsForeignSigner(t *testing.T) {
 func TestAuthorizeUpdateHappyPath(t *testing.T) {
 	pub, priv := newTestKey(t)
 	pinKey(t, pub)
+	bootFloorForTest(t, releaseFloor{5, floorSHAa}, nil)
 
 	if err := authorizeUpdate("wss://hub.example.com:4000/ws/agent", "/usr/local/bin/bloxos-agent",
-		"linux", testSHA, signFor(t, priv, "linux", testSHA)); err != nil {
+		"linux", testSHA, signFor(t, priv, "linux", testSHA), 0); err != nil {
 		t.Fatalf("authorizeUpdate rejected a valid update: %v", err)
+	}
+	// A truthful advisory at or above the floor changes nothing.
+	if err := authorizeUpdate("wss://hub.example.com:4000/ws/agent", "/usr/local/bin/bloxos-agent",
+		"linux", testSHA, signFor(t, priv, "linux", testSHA), 6); err != nil {
+		t.Fatalf("authorizeUpdate rejected a valid update with a higher advisory: %v", err)
+	}
+}
+
+// A signed, TLS-carried announcement is still refused when the release floor
+// was never established (or failed) at boot: the agent cannot prove the
+// candidate is not a downgrade, so it must not fetch it.
+func TestAuthorizeUpdateRequiresUsableReleaseFloor(t *testing.T) {
+	pub, priv := newTestKey(t)
+	pinKey(t, pub)
+	resetReleaseFloorStateForTest()
+	t.Cleanup(resetReleaseFloorStateForTest)
+
+	err := authorizeUpdate("wss://hub.example.com:4000/ws/agent", "/usr/local/bin/bloxos-agent",
+		"linux", testSHA, signFor(t, priv, "linux", testSHA), 0)
+	if err == nil {
+		t.Fatal("authorizeUpdate proceeded without a release floor")
+	}
+	if !strings.Contains(err.Error(), "release floor") {
+		t.Fatalf("error = %v, want the release-floor refusal", err)
+	}
+}
+
+// The hub's advisory release is refuse-only: below the floor (or the floor's
+// release with another SHA) skips the download, but it never admits anything
+// on its own — the higher-advisory case above still goes on to the
+// post-download extraction.
+func TestAuthorizeUpdateRefusesOnAdvisoryBelowFloor(t *testing.T) {
+	pub, priv := newTestKey(t)
+	pinKey(t, pub)
+	bootFloorForTest(t, releaseFloor{5, floorSHAa}, nil)
+
+	err := authorizeUpdate("wss://hub.example.com:4000/ws/agent", "/usr/local/bin/bloxos-agent",
+		"linux", testSHA, signFor(t, priv, "linux", testSHA), 4)
+	if err == nil || !strings.Contains(err.Error(), "downgrade") {
+		t.Fatalf("error = %v, want the downgrade refusal", err)
+	}
+	// Same release, but the announced SHA is not the build the floor pins.
+	err = authorizeUpdate("wss://hub.example.com:4000/ws/agent", "/usr/local/bin/bloxos-agent",
+		"linux", testSHA, signFor(t, priv, "linux", testSHA), 5)
+	if err == nil || !strings.Contains(err.Error(), "different build") {
+		t.Fatalf("error = %v, want the same-release-different-build refusal", err)
+	}
+}
+
+// The transport and signature gates run before the floor is consulted, so a
+// forged or plaintext announcement never reaches floor logic — and a floor
+// problem is never reported in place of the more fundamental refusal.
+func TestAuthorizeUpdateSignatureBeforeFloor(t *testing.T) {
+	pub, _ := newTestKey(t)
+	_, attacker := newTestKey(t)
+	pinKey(t, pub)
+	resetReleaseFloorStateForTest()
+	t.Cleanup(resetReleaseFloorStateForTest)
+
+	err := authorizeUpdate("wss://hub.example.com:4000/ws/agent", "/usr/local/bin/bloxos-agent",
+		"linux", testSHA, signFor(t, attacker, "linux", testSHA), 0)
+	if err == nil || !strings.Contains(err.Error(), "does not verify") {
+		t.Fatalf("error = %v, want the signature refusal first", err)
 	}
 }
 

--- a/agent/updater.go
+++ b/agent/updater.go
@@ -56,6 +56,10 @@ type AgentVersionMessage struct {
 	// so a future rotation can be told apart from a malformed frame.
 	Signature string `json:"signature,omitempty"`
 	SigAlg    string `json:"sig_alg,omitempty"`
+	// Release is the hub's advisory reading of the served binary's embedded
+	// release sequence. Unsigned; used only to refuse early. The value that
+	// counts is extracted from the downloaded bytes.
+	Release uint64 `json:"release,omitempty"`
 }
 
 // handleAgentVersion is called when the agent receives an "agent_version"
@@ -92,7 +96,7 @@ func handleAgentVersion(msg []byte) {
 		log.Printf("update: cannot resolve own path: %v", err)
 		return
 	}
-	if err := authorizeUpdate(hubURL, exe, runtime.GOOS, version.SHA256, version.Signature); err != nil {
+	if err := authorizeUpdate(hubURL, exe, runtime.GOOS, version.SHA256, version.Signature, version.Release); err != nil {
 		log.Printf("update: REFUSED — %v", err)
 		return
 	}
@@ -193,6 +197,23 @@ func performUpdate(expectedSHA string) error {
 		os.Remove(newPath)
 		return fmt.Errorf("downloaded binary rejected: %w", err)
 	}
+
+	// Downgrade protection. The SHA above proves these are the bytes the
+	// signature covers; the release sequence inside them is therefore
+	// authenticated too. Refuse anything at or below the floor that is not
+	// the floor's own build, then raise the floor durably BEFORE the swap
+	// so a crash in between can only leave a higher floor, never a newer
+	// binary with an older floor.
+	candidate, err := verifyCandidateRelease(newPath, downloadedSHA)
+	if err != nil {
+		os.Remove(newPath)
+		return fmt.Errorf("downloaded binary rejected: %w", err)
+	}
+	if err := raiseReleaseFloor(currentReleaseFloorPath(), candidate); err != nil {
+		os.Remove(newPath)
+		return fmt.Errorf("cannot raise release floor to %d: %w", candidate.Release, err)
+	}
+	log.Printf("update: release floor raised to %d (%s)", candidate.Release, shortSHA(candidate.SHA))
 
 	if err := os.Chmod(newPath, 0755); err != nil {
 		os.Remove(newPath)
@@ -346,6 +367,7 @@ func reportAgentVersion(conn *websocket.Conn, mu *sync.Mutex) {
 		log.Printf("update: failed to compute self SHA for reporting: %v", err)
 		return
 	}
+	floor, floorOK := releaseFloorStatus()
 	msg := map[string]interface{}{
 		"type":   "agent_running_version",
 		"sha256": sha,
@@ -355,6 +377,14 @@ func reportAgentVersion(conn *websocket.Conn, mu *sync.Mutex) {
 		// architecture's build, and withholds when it has none. Its absence
 		// is how the hub recognises an agent that downloads without ?arch=.
 		"arch": runtime.GOARCH,
+		// Release floor (protocol 2). release is this binary's embedded
+		// sequence; the floor is the highest accepted release and the build
+		// that set it. release_floor_ok=false means the floor is absent or
+		// corrupt and the agent will refuse every update until repaired.
+		"release":           agentEmbeddedRelease(),
+		"release_floor":     floor.Release,
+		"release_floor_sha": floor.SHA,
+		"release_floor_ok":  floorOK,
 		// Tells the hub this binary verifies signed announcements. Its
 		// absence is how the hub recognises a pre-signature agent.
 		"update_protocol": agentUpdateProtocol,
@@ -372,6 +402,7 @@ func reportAgentVersion(conn *websocket.Conn, mu *sync.Mutex) {
 		log.Printf("update: failed to report version: %v", err)
 		return
 	}
-	log.Printf("update: reported running version %s to hub (os=%s, arch=%s, update_protocol=%d, transport_ok=%v, key_pinned=%v)",
-		shortSHA(sha), runtime.GOOS, runtime.GOARCH, agentUpdateProtocol, selfUpdateTransportOK(), updateKeyPinned())
+	log.Printf("update: reported running version %s to hub (os=%s, arch=%s, update_protocol=%d, transport_ok=%v, key_pinned=%v, release=%d, floor=%d/%s, floor_ok=%v)",
+		shortSHA(sha), runtime.GOOS, runtime.GOARCH, agentUpdateProtocol, selfUpdateTransportOK(), updateKeyPinned(),
+		agentEmbeddedRelease(), floor.Release, shortSHA(floor.SHA), floorOK)
 }

--- a/agent/updater_windows.go
+++ b/agent/updater_windows.go
@@ -62,6 +62,10 @@ type AgentVersionMessage struct {
 	// produced by the hub's update signing key.
 	Signature string `json:"signature,omitempty"`
 	SigAlg    string `json:"sig_alg,omitempty"`
+	// Release is the hub's advisory reading of the served binary's embedded
+	// release sequence. Unsigned; used only to refuse early. The value that
+	// counts is extracted from the downloaded bytes.
+	Release uint64 `json:"release,omitempty"`
 }
 
 // handleAgentVersion — Windows version. Same flow as Linux's
@@ -98,7 +102,7 @@ func handleAgentVersion(msg []byte) {
 		log.Printf("update: cannot resolve own path: %v", err)
 		return
 	}
-	if err := authorizeUpdate(hubURL, exe, runtime.GOOS, version.SHA256, version.Signature); err != nil {
+	if err := authorizeUpdate(hubURL, exe, runtime.GOOS, version.SHA256, version.Signature, version.Release); err != nil {
 		log.Printf("update: REFUSED — %v", err)
 		return
 	}
@@ -159,6 +163,24 @@ func performUpdateWindows(expectedSHA, signature string) error {
 	}
 	log.Printf("update: SHA verified (%s)", shortSHA(downloadedSHA))
 
+	// Downgrade protection. The SHA above proves these are the bytes the
+	// signature covers; the release sequence inside them is therefore
+	// authenticated too. Refuse anything at or below the floor that is not
+	// the floor's own build, then raise the floor durably BEFORE the marker
+	// is written, so a crash in between can only leave a higher floor —
+	// never a staged newer binary with an older floor. applyPendingUpdate
+	// repeats the check against the staged file at next boot.
+	candidate, err := verifyCandidateRelease(newPath, downloadedSHA)
+	if err != nil {
+		os.Remove(newPath)
+		return fmt.Errorf("downloaded binary rejected: %w", err)
+	}
+	if err := raiseReleaseFloor(currentReleaseFloorPath(), candidate); err != nil {
+		os.Remove(newPath)
+		return fmt.Errorf("cannot raise release floor to %d: %w", candidate.Release, err)
+	}
+	log.Printf("update: release floor raised to %d (%s)", candidate.Release, shortSHA(candidate.SHA))
+
 	// Snapshot current running exe to .prev before the swap so the helper
 	// (or a future Windows recovery script) can roll back.
 	if err := copyFile(exe, prevPath); err != nil {
@@ -170,7 +192,8 @@ func performUpdateWindows(expectedSHA, signature string) error {
 	// Write the pending marker so applyPendingUpdate, on next boot,
 	// picks up the swap.
 	now := time.Now().UTC().Format(time.RFC3339)
-	marker := fmt.Sprintf("source=%s\ntarget=%s\nat=%s\nsha256=%s\nsignature=%s\n", newPath, exe, now, expectedSHA, signature)
+	marker := fmt.Sprintf("source=%s\ntarget=%s\nat=%s\nsha256=%s\nsignature=%s\nrelease=%d\n",
+		newPath, exe, now, expectedSHA, signature, candidate.Release)
 	if err := os.WriteFile(markerPath, []byte(marker), 0644); err != nil {
 		os.Remove(newPath)
 		return fmt.Errorf("write pending marker: %w", err)
@@ -282,7 +305,10 @@ func validatePendingUpdate(exe, markerPath, newPath string) error {
 		return fmt.Errorf("staged binary failed signature verification: %w", err)
 	}
 
-	return nil
+	// Release floor, again, against the staged bytes: a replayed marker and
+	// .new after the floor moved on, or swapped staged bytes, are refused
+	// here and cleaned up by the caller. See checkStagedRelease.
+	return checkStagedRelease(newPath, downloadedSHA, pm.Release)
 }
 
 // buildHelperBatch returns the contents of the .bat we leave on disk.
@@ -432,10 +458,19 @@ func reportAgentVersion(conn *websocket.Conn, mu *sync.Mutex) {
 		log.Printf("update: failed to compute self SHA for reporting: %v", err)
 		return
 	}
+	floor, floorOK := releaseFloorStatus()
 	msg := map[string]interface{}{
 		"type":   "agent_running_version",
 		"sha256": sha,
 		"os":     runtime.GOOS,
+		// Release floor (protocol 2). release is this binary's embedded
+		// sequence; the floor is the highest accepted release and the build
+		// that set it. release_floor_ok=false means the floor is absent or
+		// corrupt and the agent will refuse every update until repaired.
+		"release":           agentEmbeddedRelease(),
+		"release_floor":     floor.Release,
+		"release_floor_sha": floor.SHA,
+		"release_floor_ok":  floorOK,
 		// Tells the hub this binary verifies signed announcements. Its
 		// absence is how the hub recognises a pre-signature agent.
 		"update_protocol": agentUpdateProtocol,
@@ -453,6 +488,7 @@ func reportAgentVersion(conn *websocket.Conn, mu *sync.Mutex) {
 		log.Printf("update: failed to report version: %v", err)
 		return
 	}
-	log.Printf("update: reported running version %s to hub (os=%s, update_protocol=%d, transport_ok=%v, key_pinned=%v)",
-		shortSHA(sha), runtime.GOOS, agentUpdateProtocol, selfUpdateTransportOK(), updateKeyPinned())
+	log.Printf("update: reported running version %s to hub (os=%s, update_protocol=%d, transport_ok=%v, key_pinned=%v, release=%d, floor=%d/%s, floor_ok=%v)",
+		shortSHA(sha), runtime.GOOS, agentUpdateProtocol, selfUpdateTransportOK(), updateKeyPinned(),
+		agentEmbeddedRelease(), floor.Release, shortSHA(floor.SHA), floorOK)
 }

--- a/agent/updater_windows_test.go
+++ b/agent/updater_windows_test.go
@@ -39,9 +39,14 @@ func TestCheckAndCleanPendingUpdate(t *testing.T) {
 	newPath := exe + ".new"
 	markerPath := exe + ".pending"
 
-	// Create dummy binary to generate valid references
-	validSHA := writeTestBinary(t, newPath, "dummy exe content")
+	// The staged binary carries release 6; the running build is release 5.
+	// performUpdateWindows raises the floor before writing the marker, so
+	// the floor a genuine pending update boots into already names the
+	// staged build.
+	stagedContent := "dummy exe content " + markerFor(t, 6)
+	validSHA := writeTestBinary(t, newPath, stagedContent)
 	validSig := signFor(t, priv, "windows", validSHA)
+	floorPath := bootFloorForTest(t, releaseFloor{5, floorSHAa}, &releaseFloor{6, validSHA})
 
 	tests := []struct {
 		name    string
@@ -51,10 +56,38 @@ func TestCheckAndCleanPendingUpdate(t *testing.T) {
 		{
 			name: "success - keeps files",
 			setup: func() {
-				writeTestBinary(t, newPath, "dummy exe content")
+				writeTestBinary(t, newPath, stagedContent)
 				writeTestMarker(t, markerPath, validSHA, validSig)
 			},
 			wantErr: false,
+		},
+		{
+			name: "success - marker from older agent without release",
+			setup: func() {
+				writeTestBinary(t, newPath, stagedContent)
+				writeTestMarker(t, markerPath, validSHA, validSig)
+			},
+			wantErr: false,
+		},
+		{
+			name: "replayed after floor moved on - deletes files",
+			setup: func() {
+				if err := writeReleaseFloor(floorPath, releaseFloor{7, floorSHAc}); err != nil {
+					t.Fatal(err)
+				}
+				writeTestBinary(t, newPath, stagedContent)
+				writeTestMarker(t, markerPath, validSHA, validSig)
+			},
+			wantErr: true,
+		},
+		{
+			name: "unnumbered staged binary - deletes files",
+			setup: func() {
+				content := "dummy exe content without a marker"
+				sha := writeTestBinary(t, newPath, content)
+				writeTestMarker(t, markerPath, sha, signFor(t, priv, "windows", sha))
+			},
+			wantErr: true,
 		},
 		{
 			name: "missing SHA - deletes files",
@@ -102,6 +135,11 @@ func TestCheckAndCleanPendingUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			os.Remove(newPath)
 			os.Remove(markerPath)
+			// Each case starts from the floor a genuine pending update
+			// boots into; cases that move it do so inside setup.
+			if err := writeReleaseFloor(floorPath, releaseFloor{6, validSHA}); err != nil {
+				t.Fatal(err)
+			}
 			tt.setup()
 
 			err := checkAndCleanPendingUpdate(exe, markerPath, newPath)

--- a/docs/agent-update-recovery.md
+++ b/docs/agent-update-recovery.md
@@ -1,0 +1,83 @@
+# Agent update rollback protection
+
+Normal installation and signing commands do not change. Protocol-2 agents
+remember the newest accepted **release number and binary SHA** on their own
+machine. They keep running if that state cannot be read or saved, but refuse
+self-updates until it is repaired and the agent is restarted.
+
+## Release preparation
+
+Before publishing changed agent bytes, increase the number and matching marker
+in `agent/release.go`. Use the same number for Linux amd64, Linux arm64 and
+Windows amd64 in that release. Rebuilding with a different compiler, dependencies
+or build flags can change the SHA and therefore also requires a new number.
+Never reuse a number for different bytes of the same platform.
+
+For local development, use a disposable agent with a separate floor path
+(`BLOXOS_RELEASE_FLOOR_PATH`) so test builds never change a real machine's floor.
+When changed source, compiler or build settings produce different bytes at the
+same number, bump the number or explicitly reset only that disposable agent's
+floor using the stopped-service recovery procedure below. Do not disable the
+check or reset a deployed agent merely to simplify a development build.
+
+The existing Ed25519 signature authenticates the full SHA, including the embedded
+number. The hub does not invent numbers at startup, and agents never advance their
+floor from the advisory number in a WebSocket announcement. They inspect the
+verified downloaded bytes without executing them.
+
+## Refused updates
+
+The Versions API exposes the agent's running release, floor and floor SHA, plus
+the same withholding reason used by the announcement path:
+
+- `agent_release_missing`: serve a numbered agent release.
+- `agent_release_below_floor`: serve a release newer than the accepted floor.
+- `agent_release_conflict`: different bytes reused a number; build with a higher number.
+- `agent_release_floor_unreadable`: repair the agent's local state/permissions and restart it.
+
+The hub does not start a reconnect timer for these refused updates. Agents also
+enforce the rules independently, including when connected to an older hub.
+
+## Crash recovery and intentional rollback
+
+The floor is saved durably **before** the executable swap. If staging or swapping
+fails after that save, the identical release/SHA can be retried. Other binaries
+at that number cannot be substituted.
+
+Linux's existing crash-recovery helper may restore `.prev`; Windows recovery
+remains manual. Recovery does not delete or lower the floor. A recovered
+protocol-2 agent can keep monitoring normally and accept a later release, or
+retry the exact accepted binary. Do not lower the floor merely to fix a failed
+download or swap.
+
+For a fleet-wide return to known-good code, rebuild that code with the rollback
+protection intact and a **higher** release number, test, and sign it normally.
+Re-signing unchanged old bytes cannot change their embedded number.
+
+If a local administrator must intentionally reset the floor, first stop the
+agent service, preserve the current executable and floor as backups, and install
+an independently verified recovery binary. Move only the floor file aside and
+restart the service; a protocol-2 binary seeds a new floor from itself. This is a
+deliberate reduction of rollback protection, not a remote hub operation. Preserve
+the pinned key, CA, credentials and all unrelated files. The floor is
+`/etc/bloxos/agent-release-floor` on Linux and `agent-release-floor` beside the
+agent executable on Windows.
+
+## Limits and migration
+
+Existing protocol-1 agents still use their original signature checks for the
+migration update. A protocol-2 binary seeds its floor on startup without another
+enrollment step. An old protocol-1 `.prev` cannot enforce the new rule if restored;
+use a canary and verify recovery during migration. Do not describe legacy agents
+as rollback-protected.
+A `.prev` restored across the migration boundary remains unenforced until it is
+updated or reinstalled to a numbered protocol-2 build.
+
+Rotating the pinned signing key must not reset or namespace the floor. The new
+key's releases continue the same numbering. This does not introduce a remote key
+rotation mechanism.
+
+Offline signing protects against replay by a hub that cannot forge signatures.
+A compromised signer (including a compromised hub holding the private key) can
+still sign malicious higher-numbered code. Local administrator access can also
+replace the executable or floor. These are not threats this mechanism solves.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -245,8 +245,15 @@ snapshot `.prev` but has no automatic rollback, so recovery remains manual.
 The hub tracks reported running versions so the dashboard can show rollout
 state and pending updates.
 
-Signatures still carry no downgrade or monotonicity protection, so a previously
-valid `(os, sha)` pair remains valid indefinitely ([#145]).
+Protocol-2 agents additionally enforce a persistent release-number/SHA floor.
+The sequence is embedded in the binary, so the existing signed SHA authenticates
+it without a new signature format. Before installing, agents reject unnumbered
+or older binaries and equal-number binaries with a different SHA, then durably
+save the accepted floor. Startup seeds the floor from the running binary without
+waiting for a hub announcement. Local `.prev` recovery does not lower the floor.
+Protocol-1 binaries remain replayable until upgraded; returning to a pre-migration
+`.prev` temporarily loses enforcement. A compromised signing key can still
+authorize a malicious higher-numbered binary. See [update recovery](agent-update-recovery.md).
 
 ### Resolving served agent binaries
 

--- a/docs/offline-update-signing.md
+++ b/docs/offline-update-signing.md
@@ -12,11 +12,19 @@ the hub. The private Ed25519 key stays on the offline build host.
 ## Invariants
 
 - Build from a pinned, clean commit and record it with the artifact hashes.
+- For each new agent release, bump both the release number and matching marker
+  in `agent/release.go` before building. A rebuild that changes the binary SHA
+  also needs a new number; equal-number/different-SHA updates are refused by
+  protocol-2 agents. Use the same number across the platform builds of a release.
 - The signing input and private key remain on FAT-LOLO. Never copy the private
   key to the hub or print it in a terminal transcript.
 - `bloxos-sign` and both agents use `updatesigning.Message`; the signed bytes
   are `bloxos-agent-update:v1:<os>:<sha256>` after trimming and lowercasing the
   OS and SHA.
+- Protocol-2 agents extract the release number from the signed binary itself.
+  No extra sidecar, signing command, or onboarding step is required. Their local
+  release/SHA floor survives key rotation and installer re-runs. See
+  [update recovery](agent-update-recovery.md) for migration and recovery limits.
 - A detached signature is standard-base64 Ed25519 in `<binary>.sig`, with one
   trailing newline. The hub verifies it against the configured public key
   before announcing it.

--- a/hub/agent_binary.go
+++ b/hub/agent_binary.go
@@ -57,11 +57,12 @@ type agentBinaryResolution struct {
 }
 
 type agentBinaryState struct {
-	Path   string    `json:"path"`
-	Source string    `json:"source"`
-	SHA    string    `json:"sha"`
-	Mtime  time.Time `json:"mtime"`
-	Error  string    `json:"error"`
+	Release uint64    `json:"release"`
+	Path    string    `json:"path"`
+	Source  string    `json:"source"`
+	SHA     string    `json:"sha"`
+	Mtime   time.Time `json:"mtime"`
+	Error   string    `json:"error"`
 }
 
 type agentBinaryResolver struct {

--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bokiko/bloxos/proto/updatesigning"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 )
@@ -87,6 +88,11 @@ type agentVersionInfo struct {
 	// existed never reports it, and the zero value (false) is what makes
 	// that safe: absent must mean "not pinned", never "assume yes".
 	UpdateKeyPinned bool `json:"update_key_pinned"`
+	// Protocol 2 reports the durable anti-rollback floor, independent of keys.
+	Release         uint64 `json:"release"`
+	ReleaseFloor    uint64 `json:"release_floor"`
+	ReleaseFloorSHA string `json:"release_floor_sha"`
+	ReleaseFloorOK  bool   `json:"release_floor_ok"`
 	// UpdateBlockedReason explains, when UpdatePending is true, why the hub
 	// is not announcing the update. Empty means nothing is blocking it.
 	// Without this an operator cannot tell a rollout in progress from a
@@ -114,7 +120,11 @@ type agentVersionReport struct {
 	// KeyPinned is the agent's own answer to "do I have a usable pinned
 	// update key on disk". Meaningless when UpdateProtocol is 0. Absent
 	// (zero value false) on any agent that predates this field.
-	KeyPinned bool
+	KeyPinned       bool
+	Release         uint64
+	ReleaseFloor    uint64
+	ReleaseFloorSHA string
+	ReleaseFloorOK  bool
 }
 
 type rolloutFailure struct {
@@ -227,9 +237,10 @@ func recomputeBinaryForPlatform(platform agentPlatform) {
 		return
 	}
 	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
+	release, err := updatesigning.ExtractReleaseReader(io.TeeReader(f, h))
+	if err != nil {
 		_ = f.Close()
-		failAgentBinaryState(platform, resolved, fmt.Errorf("hash resolved path %s: %w", resolved.Path, err))
+		failAgentBinaryState(platform, resolved, fmt.Errorf("read release and hash at %s: %w", resolved.Path, err))
 		return
 	}
 	if err := f.Close(); err != nil {
@@ -238,7 +249,7 @@ func recomputeBinaryForPlatform(platform agentPlatform) {
 	}
 	sha := hex.EncodeToString(h.Sum(nil))
 
-	state := agentBinaryState{Path: resolved.Path, Source: resolved.Source, SHA: sha, Mtime: info.ModTime()}
+	state := agentBinaryState{Path: resolved.Path, Source: resolved.Source, SHA: sha, Mtime: info.ModTime(), Release: release}
 	previous := replaceAgentBinaryState(platform, state)
 	if previous.Path != state.Path || previous.Source != state.Source || previous.Error != "" {
 		log.Printf("version: %s agent binary resolved source=%s path=%s", platform, state.Source, state.Path)
@@ -329,11 +340,14 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 		return
 	}
 
-	msg := map[string]string{
+	msg := map[string]interface{}{
 		"type":      "agent_version",
 		"sha256":    sha,
 		"signature": sig,
 		"sig_alg":   "ed25519",
+	}
+	if v.UpdateProtocol >= 2 {
+		msg["release"] = currentAgentBinaryStateFor(osName, v.Arch).Release
 	}
 	data, _ := json.Marshal(msg)
 
@@ -402,6 +416,9 @@ func announceDecision(report *agentVersionInfo, osName, sha string) (sig string,
 	// trip and removes the guess.
 	if report == nil {
 		return "", "the hub has not yet received agent_running_version from this agent"
+	}
+	if reason := releaseAnnounceBlocked(report, currentAgentBinaryStateFor(osName, arch), sha); reason != "" {
+		return "", reason
 	}
 
 	// Architecture. An agent that never reported its arch also never asks
@@ -646,6 +663,10 @@ func (s *Server) recordAgentRunningVersion(machineID string, report agentVersion
 		UpdateProtocol:    report.UpdateProtocol,
 		UpdateTransportOK: report.TransportOK,
 		UpdateKeyPinned:   report.KeyPinned,
+		Release:           report.Release,
+		ReleaseFloor:      report.ReleaseFloor,
+		ReleaseFloorSHA:   strings.ToLower(report.ReleaseFloorSHA),
+		ReleaseFloorOK:    report.ReleaseFloorOK,
 	}
 	agentRunningVersionsMu.Unlock()
 	log.Printf("rollout: agent reported running=%s expected=%s os=%s arch=%s proto=%d pending=%v machine=%s",
@@ -676,7 +697,10 @@ func (s *Server) recordAgentRunningVersion(machineID string, report agentVersion
 	if osName != "" && (!hadPrev || prev.OS != osName || prev.Arch != arch ||
 		prev.UpdateProtocol != report.UpdateProtocol ||
 		prev.UpdateTransportOK != report.TransportOK ||
-		prev.UpdateKeyPinned != report.KeyPinned) &&
+		prev.UpdateKeyPinned != report.KeyPinned ||
+		prev.Release != report.Release || prev.ReleaseFloor != report.ReleaseFloor ||
+		!strings.EqualFold(prev.ReleaseFloorSHA, report.ReleaseFloorSHA) ||
+		prev.ReleaseFloorOK != report.ReleaseFloorOK) &&
 		expectedSHA != "" && runningSHA != expectedSHA {
 		s.agentsMu.RLock()
 		agent, online := s.agents[machineID]
@@ -764,6 +788,8 @@ func (s *Server) handleListVersions(c echo.Context) error {
 		expected := announcedSHAForArch(v.OS, v.Arch)
 		v.UpdatePending = expected != "" && v.RunningSHA != expected
 		switch {
+		case v.UpdateProtocol >= 2 && !v.ReleaseFloorOK:
+			v.UpdateBlockedReason = "agent_release_floor_unreadable: the agent cannot use its update floor; repair its local state and restart the agent before updating"
 		case v.UpdatePending:
 			// Same policy announceVersionToAgent applies, so what the API
 			// reports and what the hub actually does cannot drift.

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -1173,7 +1173,11 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 				// UpdateProtocol is absent (0) on every agent built before
 				// signature verification existed. The hub uses that to decide
 				// whether announcing an update to it is safe at all.
-				UpdateProtocol int `json:"update_protocol"`
+				UpdateProtocol  int    `json:"update_protocol"`
+				Release         uint64 `json:"release"`
+				ReleaseFloor    uint64 `json:"release_floor"`
+				ReleaseFloorSHA string `json:"release_floor_sha"`
+				ReleaseFloorOK  bool   `json:"release_floor_ok"`
 				// UpdateTransportOK is the agent's own answer to whether its
 				// BLOXOS_HUB permits self-update, computed from the URL it is
 				// actually connected to rather than guessed from PUBLIC_URL.
@@ -1191,12 +1195,16 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 			}
 			if versionMsg.SHA256 != "" && machineID != "" {
 				s.recordAgentRunningVersion(machineID, agentVersionReport{
-					RunningSHA:     versionMsg.SHA256,
-					OS:             versionMsg.OS,
-					Arch:           versionMsg.Arch,
-					UpdateProtocol: versionMsg.UpdateProtocol,
-					TransportOK:    versionMsg.UpdateTransportOK,
-					KeyPinned:      versionMsg.UpdateKeyPinned,
+					RunningSHA:      versionMsg.SHA256,
+					OS:              versionMsg.OS,
+					Arch:            versionMsg.Arch,
+					UpdateProtocol:  versionMsg.UpdateProtocol,
+					Release:         versionMsg.Release,
+					ReleaseFloor:    versionMsg.ReleaseFloor,
+					ReleaseFloorSHA: versionMsg.ReleaseFloorSHA,
+					ReleaseFloorOK:  versionMsg.ReleaseFloorOK,
+					TransportOK:     versionMsg.UpdateTransportOK,
+					KeyPinned:       versionMsg.UpdateKeyPinned,
 				})
 			}
 

--- a/hub/release_policy.go
+++ b/hub/release_policy.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// releaseAnnounceBlocked mirrors the protocol-2 agent's anti-rollback gate.
+// This is rollout hygiene, not the trust boundary: the agent independently
+// checks the signed download and its own durable floor before installing it.
+// Legacy agents retain their existing migration/signature policy.
+func releaseAnnounceBlocked(report *agentVersionInfo, state agentBinaryState, sha string) string {
+	if report == nil || report.UpdateProtocol < 2 {
+		return ""
+	}
+	floorSHA, err := hex.DecodeString(report.ReleaseFloorSHA)
+	if !report.ReleaseFloorOK || report.ReleaseFloor == 0 || report.Release == 0 ||
+		report.ReleaseFloor < report.Release || err != nil || len(floorSHA) != 32 {
+		return "agent_release_floor_unreadable: the agent has not reported a valid durable update floor; repair its local state and restart the agent before updating"
+	}
+	if state.SHA != sha {
+		return "agent_release_changed: the served binary changed during the update check; retry after it is refreshed"
+	}
+	if state.Release == 0 {
+		return "agent_release_missing: the served binary has no release number; serve a numbered release for this agent"
+	}
+	if state.Release < report.ReleaseFloor {
+		return fmt.Sprintf("agent_release_below_floor: served release %d is older than this agent's accepted release %d", state.Release, report.ReleaseFloor)
+	}
+	if state.Release == report.ReleaseFloor && !strings.EqualFold(sha, report.ReleaseFloorSHA) {
+		return "agent_release_conflict: different binary bytes reuse an accepted release number; build the release with a higher number"
+	}
+	return ""
+}

--- a/hub/release_policy_test.go
+++ b/hub/release_policy_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
+)
+
+func TestReleaseAnnouncePolicy(t *testing.T) {
+	oldSHA, nextSHA := strings.Repeat("ab", 32), strings.Repeat("cd", 32)
+	base := agentVersionInfo{UpdateProtocol: 2, Release: 4, ReleaseFloor: 4, ReleaseFloorSHA: oldSHA, ReleaseFloorOK: true}
+	tests := []struct {
+		name    string
+		release uint64
+		sha     string
+		change  func(*agentVersionInfo)
+		want    string
+	}{
+		{name: "newer", release: 5, sha: nextSHA},
+		{name: "same bytes retry", release: 4, sha: oldSHA},
+		{name: "same release different bytes", release: 4, sha: nextSHA, want: "agent_release_conflict"},
+		{name: "older signed release", release: 3, sha: nextSHA, want: "agent_release_below_floor"},
+		{name: "legacy binary", release: 0, sha: nextSHA, want: "agent_release_missing"},
+		{name: "corrupt state", release: 5, sha: nextSHA, change: func(v *agentVersionInfo) { v.ReleaseFloorOK = false }, want: "agent_release_floor_unreadable"},
+		{name: "missing floor", release: 5, sha: nextSHA, change: func(v *agentVersionInfo) { v.ReleaseFloor = 0 }, want: "agent_release_floor_unreadable"},
+		{name: "missing hash", release: 5, sha: nextSHA, change: func(v *agentVersionInfo) { v.ReleaseFloorSHA = "" }, want: "agent_release_floor_unreadable"},
+		{name: "malformed hash", release: 5, sha: nextSHA, change: func(v *agentVersionInfo) { v.ReleaseFloorSHA = strings.Repeat("zz", 32) }, want: "agent_release_floor_unreadable"},
+		{name: "floor behind running release", release: 5, sha: nextSHA, change: func(v *agentVersionInfo) { v.Release = 5 }, want: "agent_release_floor_unreadable"},
+		{name: "local recovery preserves higher floor", release: 3, sha: nextSHA, change: func(v *agentVersionInfo) { v.Release = 2 }, want: "agent_release_below_floor"},
+		{name: "local recovery can retry accepted bytes", release: 4, sha: oldSHA, change: func(v *agentVersionInfo) { v.Release = 2 }},
+		{name: "legacy protocol unchanged", release: 0, sha: nextSHA, change: func(v *agentVersionInfo) { v.UpdateProtocol = 1; v.ReleaseFloorOK = false }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := base
+			if tt.change != nil {
+				tt.change(&v)
+			}
+			state := agentBinaryState{SHA: tt.sha, Release: tt.release}
+			got := releaseAnnounceBlocked(&v, state, tt.sha)
+			if tt.want == "" && got != "" || tt.want != "" && !strings.HasPrefix(got, tt.want+":") {
+				t.Fatalf("reason = %q, want %q", got, tt.want)
+			}
+		})
+	}
+	if got := releaseAnnounceBlocked(&base, agentBinaryState{SHA: oldSHA, Release: 5}, nextSHA); !strings.HasPrefix(got, "agent_release_changed:") {
+		t.Fatalf("changed binary not withheld: %q", got)
+	}
+}
+
+func TestRecomputeReleaseAndHashFromBinary(t *testing.T) {
+	withAgentBinaryState(t)
+	marker, err := updatesigning.ReleaseMarker(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("binary prefix\x00" + marker + "\x00binary suffix")
+	path := filepath.Join(t.TempDir(), "agent")
+	if err := os.WriteFile(path, body, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldResolver := resolveAgentBinaryFor
+	resolveAgentBinaryFor = func(_, _ string) (agentBinaryResolution, error) {
+		return agentBinaryResolution{Path: path, Source: "test"}, nil
+	}
+	t.Cleanup(func() { resolveAgentBinaryFor = oldResolver })
+	recomputeBinaryFor("linux")
+	got := currentAgentBinaryState("linux")
+	wantSHA := sha256.Sum256(body)
+	if got.Release != 7 || got.SHA != hex.EncodeToString(wantSHA[:]) || got.Error != "" {
+		t.Fatalf("release/hash not derived from complete binary: %+v", got)
+	}
+	// The marker belongs to the source, not to this hub process's lifetime.
+	setAgentBinaryState("linux", agentBinaryState{})
+	recomputeBinaryFor("linux")
+	if again := currentAgentBinaryState("linux"); again.Release != got.Release || again.SHA != got.SHA {
+		t.Fatalf("recomputing changed release identity: %+v", again)
+	}
+}
+
+func TestReleaseWithholdingDoesNotArmReconnectAndIsVisible(t *testing.T) {
+	e, s := setupTestServer(t)
+	withAgentBinaryState(t)
+	const id = "release-floor-test"
+	servedSHA := strings.Repeat("cd", 32)
+	setAgentBinaryState("linux", agentBinaryState{SHA: servedSHA, Release: 3})
+	v := agentVersionInfo{MachineID: id, OS: "linux", Arch: "amd64", ArchReported: true,
+		RunningSHA: strings.Repeat("ab", 32), UpdateProtocol: 2, UpdateTransportOK: true, UpdateKeyPinned: true,
+		Release: 4, ReleaseFloor: 4, ReleaseFloorSHA: strings.Repeat("ab", 32), ReleaseFloorOK: true}
+	agentRunningVersionsMu.Lock()
+	agentRunningVersions[id] = v
+	agentRunningVersionsMu.Unlock()
+	t.Cleanup(func() {
+		agentRunningVersionsMu.Lock()
+		delete(agentRunningVersions, id)
+		agentRunningVersionsMu.Unlock()
+		clearReconnectExpectation(id)
+	})
+	// A nil connection is deliberate: the policy must return before any write.
+	s.announceVersionToAgent(id, &ConnectedAgent{})
+	assertNoReconnectExpectation(t, id)
+	rec := httptest.NewRecorder()
+	if err := s.handleListVersions(e.NewContext(httptest.NewRequest(http.MethodGet, "/api/versions", nil), rec)); err != nil {
+		t.Fatal(err)
+	}
+	var result struct {
+		Agents []agentVersionInfo `json:"agents"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	for _, got := range result.Agents {
+		if got.MachineID != id {
+			continue
+		}
+		if got.ReleaseFloor != 4 || !strings.HasPrefix(got.UpdateBlockedReason, "agent_release_below_floor:") {
+			t.Fatalf("API did not expose the persisted floor and withhold reason: %+v", got)
+		}
+		return
+	}
+	t.Fatal("machine missing from versions API")
+}
+
+func TestReleaseReportOverWebSocket(t *testing.T) {
+	for _, release := range []uint64{0, 3, 4, 5} {
+		t.Run(fmt.Sprint(release), func(t *testing.T) {
+			e, s := setupTestServer(t)
+			stagePendingUpdate(t)
+			state := currentAgentBinaryState("linux")
+			state.Release = release
+			setAgentBinaryState("linux", state)
+			const id = "numbered-agent"
+			report := &agentVersionReport{Release: 4, ReleaseFloor: 4, ReleaseFloorSHA: strings.Repeat("11", 32), ReleaseFloorOK: true}
+			frames := s.collectAnnounceFrames(t, e, announceProbe{machineID: id, proto: 2, transportOK: true, keyPinned: true, arch: "amd64", releaseReport: report})
+			agentRunningVersionsMu.RLock()
+			got := agentRunningVersions[id]
+			agentRunningVersionsMu.RUnlock()
+			if got.Release != 4 || got.ReleaseFloor != 4 || got.ReleaseFloorSHA != report.ReleaseFloorSHA || !got.ReleaseFloorOK {
+				t.Fatalf("wire report lost floor fields: %+v", got)
+			}
+			if release <= 4 {
+				if len(frames) != 0 {
+					t.Fatalf("refused update announced: %v", frames)
+				}
+				assertNoReconnectExpectation(t, id)
+				return
+			}
+			if len(frames) != 1 {
+				t.Fatalf("want one newer-release announcement, got %v", frames)
+			}
+			var msg struct {
+				Release   uint64 `json:"release"`
+				SHA       string `json:"sha256"`
+				Signature string `json:"signature"`
+			}
+			if err := json.Unmarshal([]byte(frames[0]), &msg); err != nil {
+				t.Fatal(err)
+			}
+			if msg.Release != 5 || msg.SHA != state.SHA || msg.Signature == "" {
+				t.Fatalf("invalid numbered announcement: %+v", msg)
+			}
+		})
+	}
+}

--- a/hub/update_signing.go
+++ b/hub/update_signing.go
@@ -41,10 +41,10 @@ import (
  * unauthenticated route) can no longer be substituted by anything that is
  * not the hub, which together with the agent's transport gate closes the
  * network-path attack. Mode 1 additionally means a compromised hub cannot
- * forge a signature for a new, malicious binary — but it can still replay a
- * previously-signed release, vulnerable ones included, since neither mode
- * has downgrade/monotonicity protection yet. That is a separate gap, not
- * closed by either signing mode.
+ * forge a signature for a new, malicious binary. Protocol-2 agents also
+ * enforce a persistent release/hash floor against the sequence embedded in
+ * the signed binary; protocol-1 agents remain replayable until upgraded.
+ * A compromised signer can still forge a higher-numbered malicious release.
  *
  * The canonical message and key codecs live in the updatesigning package,
  * shared by the hub, agent, and offline signing tool.

--- a/hub/update_signing_test.go
+++ b/hub/update_signing_test.go
@@ -663,7 +663,8 @@ type announceProbe struct {
 	// metricsOS overrides the OS string sent in the metrics frame (default
 	// "linux/amd64"), which is what the hub infers a legacy agent's
 	// architecture from.
-	metricsOS string
+	metricsOS     string
+	releaseReport *agentVersionReport
 }
 
 // collectAnnounceFrames enrols an agent, sends metrics so the hub learns the
@@ -735,6 +736,13 @@ func (s *Server) collectAnnounceFrames(t *testing.T, e *echo.Echo, p announcePro
 		}
 	}
 	data, _ := json.Marshal(running)
+	if p.releaseReport != nil {
+		running["release"] = p.releaseReport.Release
+		running["release_floor"] = p.releaseReport.ReleaseFloor
+		running["release_floor_sha"] = p.releaseReport.ReleaseFloorSHA
+		running["release_floor_ok"] = p.releaseReport.ReleaseFloorOK
+		data, _ = json.Marshal(running)
+	}
 	if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
 		t.Fatalf("write agent_running_version: %v", err)
 	}

--- a/proto/updatesigning/release.go
+++ b/proto/updatesigning/release.go
@@ -1,0 +1,184 @@
+package updatesigning
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+/* ============================================================================
+ * Embedded release sequence
+ *
+ * Every numbered agent binary carries exactly one marker literal in its
+ * read-only data:
+ *
+ *     BLOXOS-AGENT-RELEASE:<10 decimal digits>:
+ *
+ * The digits are the agent's release sequence — a hand-bumped constant in
+ * agent/release.go, so the number is a property of the source the binary was
+ * built from: not of the clock, not of git metadata (the Docker build context
+ * has none), and not of anything the hub decides at runtime. Because the
+ * existing v1 signature covers the binary's SHA-256, and the SHA-256 covers
+ * these bytes, the sequence is authenticated by the signature the fleet
+ * already verifies. No second signature format is needed.
+ *
+ * The hub, the agent and any tooling read the sequence back out of the bytes
+ * with the scanner below, which never executes the candidate. The scanner
+ * assembles the prefix at runtime from split fragments so a binary that
+ * merely links this package (the hub, bloxos-sign) does not itself contain a
+ * contiguous marker and cannot be mistaken for a numbered agent.
+ *
+ * Contract:
+ *   - no marker            → (0, nil): the binary is unnumbered
+ *   - exactly one marker   → (sequence, nil)
+ *   - malformed / zero /
+ *     more than one marker → (0, error): fail closed
+ * ============================================================================ */
+
+// ReleaseMarkerDigits is the fixed width of the sequence inside a marker.
+const ReleaseMarkerDigits = 10
+
+// MaxRelease is the largest sequence a fixed-width marker can carry.
+const MaxRelease uint64 = 9_999_999_999
+
+// releaseMarkerParts is joined at runtime to form the marker prefix. It is a
+// var, not a const expression, so the compiler cannot fold it back into the
+// contiguous literal that the scanner is looking for.
+var releaseMarkerParts = []string{"BLOXOS-", "AGENT-", "RELEASE:"}
+
+func releaseMarkerPrefix() []byte {
+	return []byte(strings.Join(releaseMarkerParts, ""))
+}
+
+// releaseMarkerLen is len(prefix) + digits + terminating ':'.
+func releaseMarkerLen() int {
+	return len(releaseMarkerPrefix()) + ReleaseMarkerDigits + 1
+}
+
+// ReleaseMarker renders the marker literal for a sequence. The agent embeds
+// the result as a source constant; tests use this to assert that constant
+// and the numeric sequence agree. It is built at runtime, so calling it does
+// not itself plant a marker in the caller's binary.
+func ReleaseMarker(seq uint64) (string, error) {
+	if seq == 0 || seq > MaxRelease {
+		return "", fmt.Errorf("release sequence %d is outside 1..%d", seq, MaxRelease)
+	}
+	return string(releaseMarkerPrefix()) +
+		fmt.Sprintf("%0*d", ReleaseMarkerDigits, seq) + ":", nil
+}
+
+// ErrAmbiguousRelease is returned when a stream carries more than one marker.
+var ErrAmbiguousRelease = errors.New("more than one release marker found")
+
+// ExtractRelease reads the file at path and returns its embedded release
+// sequence. See ExtractReleaseReader for the contract.
+func ExtractRelease(path string) (uint64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	seq, err := ExtractReleaseReader(f)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", path, err)
+	}
+	return seq, nil
+}
+
+// ExtractReleaseReader streams r to EOF and returns the single embedded
+// release sequence. It returns (0, nil) when no marker is present, and an
+// error when a marker is malformed, carries sequence zero, or appears more
+// than once. The whole stream is always consumed, so a caller that tees the
+// same reader into a hash sees identical bytes for both results.
+func ExtractReleaseReader(r io.Reader) (uint64, error) {
+	prefix := releaseMarkerPrefix()
+	markerLen := releaseMarkerLen()
+	const chunkSize = 256 * 1024
+
+	buf := make([]byte, 0, chunkSize+markerLen)
+	var (
+		found uint64
+		count int
+		eof   bool
+	)
+	for !eof {
+		// Grow the buffer by one chunk after whatever carry is left.
+		start := len(buf)
+		buf = buf[:start+chunkSize]
+		n, err := io.ReadFull(r, buf[start:])
+		buf = buf[:start+n]
+		switch {
+		case err == nil:
+		case errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF):
+			eof = true
+		default:
+			return 0, err
+		}
+
+		// Scan every prefix occurrence that has enough trailing bytes to be
+		// evaluated now. One that runs off the end waits for the next chunk
+		// via the carry below; at EOF it is a truncated marker.
+		from := 0
+		for {
+			i := bytes.Index(buf[from:], prefix)
+			if i < 0 {
+				break
+			}
+			i += from
+			if i+markerLen > len(buf) {
+				if eof {
+					return 0, fmt.Errorf("truncated release marker at end of stream")
+				}
+				break
+			}
+			seq, err := parseMarkerBody(buf[i+len(prefix) : i+markerLen])
+			if err != nil {
+				return 0, err
+			}
+			count++
+			if count > 1 {
+				return 0, ErrAmbiguousRelease
+			}
+			found = seq
+			from = i + 1
+		}
+
+		if !eof {
+			// Keep the last markerLen-1 bytes: a marker cannot fit entirely
+			// inside that tail, so nothing evaluated above is seen twice,
+			// and any prefix that began there is re-scanned with its
+			// trailing bytes attached.
+			keep := markerLen - 1
+			if len(buf) > keep {
+				copy(buf, buf[len(buf)-keep:])
+				buf = buf[:keep]
+			}
+		}
+	}
+	return found, nil
+}
+
+// parseMarkerBody validates "<digits>:" and returns the sequence.
+func parseMarkerBody(body []byte) (uint64, error) {
+	digits := body[:ReleaseMarkerDigits]
+	for _, c := range digits {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("malformed release marker %q", string(body))
+		}
+	}
+	if body[ReleaseMarkerDigits] != ':' {
+		return 0, fmt.Errorf("malformed release marker %q", string(body))
+	}
+	seq, err := strconv.ParseUint(string(digits), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("malformed release marker %q: %w", string(body), err)
+	}
+	if seq == 0 {
+		return 0, fmt.Errorf("release marker carries sequence 0, which is reserved for unnumbered builds")
+	}
+	return seq, nil
+}

--- a/proto/updatesigning/release_test.go
+++ b/proto/updatesigning/release_test.go
@@ -1,0 +1,203 @@
+package updatesigning
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func mustMarker(t *testing.T, seq uint64) string {
+	t.Helper()
+	m, err := ReleaseMarker(seq)
+	if err != nil {
+		t.Fatalf("ReleaseMarker(%d): %v", seq, err)
+	}
+	return m
+}
+
+func TestReleaseMarkerFormat(t *testing.T) {
+	// The expected value is assembled from the split parts on purpose: a
+	// literal here would plant the contiguous marker in the test binary and
+	// trip TestScannerBinaryHasNoContiguousPrefix.
+	if got, want := mustMarker(t, 42), string(releaseMarkerPrefix())+"0000000042:"; got != want {
+		t.Fatalf("marker = %q, want %q", got, want)
+	}
+	// Compared part by part: a constant concatenation would be folded by
+	// the compiler into the very literal the guard test forbids.
+	if len(releaseMarkerParts) != 3 || releaseMarkerParts[0] != "BLOXOS-" ||
+		releaseMarkerParts[1] != "AGENT-" || releaseMarkerParts[2] != "RELEASE:" {
+		t.Fatalf("marker prefix changed; the agent's embedded literal and the hub's scanner must agree")
+	}
+	if _, err := ReleaseMarker(0); err == nil {
+		t.Fatalf("ReleaseMarker(0) must fail")
+	}
+	if _, err := ReleaseMarker(MaxRelease + 1); err == nil {
+		t.Fatalf("ReleaseMarker(MaxRelease+1) must fail")
+	}
+	if m := mustMarker(t, MaxRelease); len(m) != releaseMarkerLen() {
+		t.Fatalf("marker length %d, want %d", len(m), releaseMarkerLen())
+	}
+}
+
+func TestExtractReleaseReaderContract(t *testing.T) {
+	marker := mustMarker(t, 7)
+	prefix := string(releaseMarkerPrefix())
+
+	cases := []struct {
+		name    string
+		input   string
+		want    uint64
+		wantErr bool
+		errIs   error
+	}{
+		{name: "empty stream", input: "", want: 0},
+		{name: "no marker", input: "just some bytes without a marker", want: 0},
+		{name: "single marker", input: "head" + marker + "tail", want: 7},
+		{name: "marker at start", input: marker + "tail", want: 7},
+		{name: "marker at end", input: "head" + marker, want: 7},
+		{name: "prefix only is truncated", input: "head" + prefix, wantErr: true},
+		{name: "truncated digits", input: "head" + prefix + "00000", wantErr: true},
+		{name: "non digit", input: "head" + prefix + "00000000x7:", wantErr: true},
+		{name: "missing terminator", input: "head" + prefix + "0000000007;", wantErr: true},
+		{name: "zero sequence", input: "head" + prefix + "0000000000:", wantErr: true},
+		{name: "two markers same value", input: marker + "mid" + marker, wantErr: true, errIs: ErrAmbiguousRelease},
+		{name: "two markers different values", input: marker + "mid" + mustMarker(t, 8), wantErr: true, errIs: ErrAmbiguousRelease},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ExtractReleaseReader(strings.NewReader(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %d", got)
+				}
+				if tc.errIs != nil && !errors.Is(err, tc.errIs) {
+					t.Fatalf("error %v, want %v", err, tc.errIs)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractReleaseReaderChunkBoundaries plants a marker at every offset
+// around the scanner's chunk boundary, in a stream several chunks long, and
+// checks it is found exactly once regardless of how it straddles reads.
+func TestExtractReleaseReaderChunkBoundaries(t *testing.T) {
+	const chunk = 256 * 1024
+	marker := mustMarker(t, 123456)
+	markerLen := len(marker)
+	filler := make([]byte, 3*chunk)
+	if _, err := rand.Read(filler); err != nil {
+		t.Fatal(err)
+	}
+	// Random filler cannot accidentally contain the marker prefix in any
+	// realistic run, but a stray byte pattern would only make the test
+	// stricter (an unexpected count), never let a bug pass.
+	for off := chunk - markerLen - 2; off <= chunk+2; off++ {
+		data := append([]byte{}, filler...)
+		copy(data[off:], marker)
+		got, err := ExtractReleaseReader(bytes.NewReader(data))
+		if err != nil {
+			t.Fatalf("offset %d: %v", off, err)
+		}
+		if got != 123456 {
+			t.Fatalf("offset %d: got %d", off, got)
+		}
+	}
+	// Same, with a second marker far away: must be ambiguous no matter
+	// where the first one straddles.
+	for off := chunk - markerLen - 2; off <= chunk+2; off++ {
+		data := append([]byte{}, filler...)
+		copy(data[off:], marker)
+		copy(data[2*chunk+100:], marker)
+		if _, err := ExtractReleaseReader(bytes.NewReader(data)); !errors.Is(err, ErrAmbiguousRelease) {
+			t.Fatalf("offset %d: err = %v, want ambiguous", off, err)
+		}
+	}
+}
+
+// TestExtractReleaseReaderSmallReads feeds the scanner one byte at a time to
+// prove the carry logic does not depend on read sizes.
+func TestExtractReleaseReaderSmallReads(t *testing.T) {
+	marker := mustMarker(t, 99)
+	data := "aaaa" + marker + "bbbb"
+	got, err := ExtractReleaseReader(iotest1(strings.NewReader(data)))
+	if err != nil || got != 99 {
+		t.Fatalf("got %d, %v", got, err)
+	}
+}
+
+type oneByteReader struct{ r io.Reader }
+
+func iotest1(r io.Reader) io.Reader { return oneByteReader{r} }
+
+func (o oneByteReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return o.r.Read(p[:1])
+}
+
+// TestExtractReleaseReaderConsumesToEOF is the property the hub relies on:
+// teeing the reader into a hash must hash the entire file, not just up to
+// the marker.
+func TestExtractReleaseReaderConsumesToEOF(t *testing.T) {
+	marker := mustMarker(t, 5)
+	data := []byte("prefix-bytes " + marker + " and a long tail after the marker")
+	h := sha256.New()
+	got, err := ExtractReleaseReader(io.TeeReader(bytes.NewReader(data), h))
+	if err != nil || got != 5 {
+		t.Fatalf("got %d, %v", got, err)
+	}
+	want := sha256.Sum256(data)
+	if hex.EncodeToString(h.Sum(nil)) != hex.EncodeToString(want[:]) {
+		t.Fatalf("tee hash does not cover the whole stream")
+	}
+}
+
+func TestExtractReleaseFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent")
+	if err := os.WriteFile(path, []byte("x"+mustMarker(t, 3)+"y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ExtractRelease(path)
+	if err != nil || got != 3 {
+		t.Fatalf("got %d, %v", got, err)
+	}
+	if _, err := ExtractRelease(filepath.Join(dir, "missing")); err == nil {
+		t.Fatalf("missing file must error")
+	}
+}
+
+// TestScannerBinaryHasNoContiguousPrefix guards the runtime-assembled prefix:
+// if a refactor turned releaseMarkerParts back into a constant expression,
+// every binary linking this package would carry the prefix and a hub or
+// signer could read as a numbered agent. The check inspects this test
+// binary, which links the scanner but embeds no marker of its own.
+func TestScannerBinaryHasNoContiguousPrefix(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skip("cannot locate test binary")
+	}
+	data, err := os.ReadFile(exe)
+	if err != nil {
+		t.Skip("cannot read test binary")
+	}
+	if bytes.Contains(data, releaseMarkerPrefix()) {
+		t.Fatalf("test binary contains a contiguous release marker prefix; the prefix must stay split at compile time")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #145 for protocol-2 agents, without changing installation commands, the existing v1 signature format, detached `.sig` files, or signing-key provisioning.

- Embed a source-controlled release number in each agent binary. The existing signed SHA authenticates that number; the hub cannot relabel old bytes with a new number.
- Seed and persist a local release/SHA floor before network connection. Refuse older/unnumbered binaries and equal-number/different-SHA binaries. Identical accepted bytes can be retried after interrupted updates.
- Persist the floor durably before Linux replacement or Windows staging, and revalidate staged Windows updates before the helper runs. Retry re-proves durability even if a previous rename succeeded but directory sync failed.
- Keep monitoring available on state errors but disable self-update, with sticky boot errors and checks against the running binary. Key changes, installer re-runs and automatic recovery do not reset the floor.
- Mirror withholding reasons in the hub and Versions API without false reconnect timers. Legacy agents retain their migration behavior.
- Document release numbering, development builds, deliberate local recovery and migration limitations.

## Validation performed locally

- Full hub `go vet`, tests and race suite passed (race suite ~393s).
- Full proto race suite passed.
- Full agent race suite and insecure-tag tests passed natively on Linux arm64 in a disposable Lima Docker container, source mounted read-only.
- Linux and Windows agent vet passed; Windows tests cross-compiled.
- Stripped Linux amd64, Linux arm64 and Windows amd64 binaries built; exactly one release-1 marker verified in all three.
- Fresh Linux agent startup in a network-disabled disposable container created the expected floor and SHA automatically. No live hub or machines contacted.
- Regression tests cover malformed/ambiguous markers, counter/hash binding, stale/replayed updates, boot errors, floor corruption, interrupted persistence and exact-byte retries, Windows staging, real WebSocket reports and hub withholding/API behavior.
- Claude implemented agent/proto; Codex implemented hub integration and independently tested/reviewed; Kimi independently reviewed with no blocking findings. Documentation nits addressed.

## Deliberate limits / remaining gates

- Draft pending CI, including native Windows tests. Windows SCM/helper behavior has not been exercised on a live Windows machine in this change.
- No end-to-end live fleet update, deployment, merge or release tag performed. Evaluation app and PR179 preview remain unchanged.
- Protocol-1 agents remain replayable until migrated. Restoring a pre-migration protocol-1 `.prev` loses enforcement until upgraded again; this is documented, not presented as protected.
- A compromised signer can still sign malicious higher-numbered code. Offline-key mode provides replay protection against a hub that cannot forge signatures; local administrator tampering is outside scope.
- Every published change in agent bytes requires a higher source release number, including compiler/build-setting changes. No additional steps are imposed on normal onboarding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the fleet agent self-update trust boundary and persistent on-disk state, but changes are additive (protocol-2), fail-closed on errors, and protocol-1 behavior is preserved until migration.
> 
> **Overview**
> Adds **protocol-2** agent self-update rollback protection without changing the v1 Ed25519 signature format or install/signing workflows.
> 
> Each agent binary now embeds a source-controlled **release sequence** (`agent/release.go` + `proto/updatesigning` scanner). Protocol-2 agents seed a durable **release/SHA floor** at boot, report it on `agent_running_version`, and refuse unnumbered, older, or same-number/different-SHA candidates. The floor is raised **before** Linux swap or Windows staging; staged Windows updates are re-checked at boot, and pending markers gain an optional `release=` field.
> 
> `authorizeUpdate` still gates transport and signature first, then applies a **refuse-only** advisory `release` from hub announcements. Floor/boot corruption disables self-update for the process (monitoring continues) and surfaces `release_floor_ok=false`.
> 
> The hub hashes served binaries together with embedded release, withholds announcements for protocol-2 agents that would certainly refuse (mirrored in Versions API, no false reconnect timers), and includes advisory `release` on `agent_version` frames. Docs cover numbering, recovery, and protocol-1 limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93bd9f3aaf8bacf3e0cd8996accef5fa57585501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->