### PR TITLE
feat: durable 24-hour component power history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  proto:
+    name: Shared Protocol Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: proto
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.25.9"
+          # This standard-library-only module has no go.sum.
+          cache: false
+
+      - name: Vet shared protocols
+        run: go vet ./...
+
+      - name: Test shared protocols with the race detector
+        run: go test -race -count=1 ./...
+
   hub:
     name: Hub Tests
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,13 @@ Fleet management dashboard for AI machines. Go hub + agent, Next.js dashboard.
   trustworthy pin. Never emit an unpinned `-k`, a `| bash`, or a
   Host-derived authority, and keep join codes out of logs.
 - Credentials NEVER committed — use env vars or local config
+- **Power history is component telemetry, not wall power.** Keep legacy
+  instantaneous `power_watts` separate from the 30-second mean and sampled peak
+  in `proto/powerhistory`. Missing sensors are unavailable, not zero. GPU-total
+  peaks require complete simultaneous readings; never sum per-device maxima.
+  The local journal is isolated from credentials and CA/update-key files. Only
+  durable windows are replayed, the authenticated socket supplies machine
+  identity, and the hub ACKs after commit. See `docs/power-history.md`.
 - Dark mode is the default UI theme
 - Caddy TLS uses RSA-2048 keys, not ECDSA. Do not change without testing on stock Windows PowerShell 5.1.
 

--- a/agent/main.go
+++ b/agent/main.go
@@ -493,6 +493,9 @@ func nextRejectedPendingSecret(current string, sel credentialSelection, outcome 
 }
 
 func connectLoop(machineID string) {
+	// Power history collects offline as well; boot it once, off this goroutine.
+	startPowerHistory()
+
 	backoff := time.Second
 	maxBackoff := 60 * time.Second
 
@@ -701,6 +704,12 @@ func runAgent(machineID string) (authOutcome, error) {
 				// Admin switch for AI Sessions reporting (see ai_sessions.go).
 				handleAISessionsConfig(conn, &writeMu, machineID, msg)
 
+			case powerAckType:
+				// Hub committed a contiguous prefix of power-history buckets
+				// (see power_history.go). Non-blocking hand-off to the journal
+				// worker; never touches disk on this goroutine.
+				handlePowerHistoryAck(msg)
+
 			default:
 				// Anything else is a command (restart_service, refresh_metrics, etc.)
 				go handleCommand(conn, &writeMu, msg)
@@ -770,6 +779,7 @@ func sendAll(conn *websocket.Conn, mu *sync.Mutex, machineID string) error {
 	sendServices(conn, mu, machineID)
 	sendContainers(conn, mu, machineID)
 	sendAISessions(conn, mu, machineID)
+	sendPowerHistory(conn, mu)
 	return nil
 }
 

--- a/agent/power_accumulator_test.go
+++ b/agent/power_accumulator_test.go
@@ -207,3 +207,251 @@ func TestAccumulatorClockStepBackwardAndForward(t *testing.T) {
 		}
 	}
 }
+
+// --- GPU membership within a window (PR181 blocker) ---
+//
+// A combined GPU total is only truthful when every counted tick observed the
+// same set of devices. If the set changes inside a window (a device drops,
+// appears, or is replaced under the same count), the total is omitted for
+// that window while per-GPU and CPU readings are kept; the next window with
+// a stable set reports a total again.
+
+type rd struct {
+	id string
+	w  *float64
+}
+
+func mkTick(at time.Time, complete bool, rds ...rd) powerGPUTick {
+	t := powerGPUTick{at: at, complete: complete}
+	for _, r := range rds {
+		t.readings = append(t.readings, powerReading{id: r.id, watts: r.w})
+	}
+	return t
+}
+
+// feedTicks feeds one tick per second from sec `from` (inclusive) to `to`
+// (exclusive), each built by mk(sec).
+func feedTicks(a *powerAccumulator, c *accClock, from, to int, mk func(sec int) powerGPUTick) {
+	for s := from; s < to; s++ {
+		tk := mk(s)
+		tk.at = c.at(float64(s))
+		a.addGPUAt(tk, c.wall(float64(s)))
+	}
+}
+
+func sensorSamples(b powerhistory.Bucket) map[string]int {
+	out := map[string]int{}
+	for _, g := range b.GPUs {
+		out[g.ID] = g.Samples
+	}
+	return out
+}
+
+func closeWindow(t *testing.T, a *powerAccumulator, c *accClock, endSec float64) powerhistory.Bucket {
+	t.Helper()
+	out := a.tickAt(c.at(endSec), c.wall(endSec))
+	if len(out) != 1 {
+		t.Fatalf("want exactly one bucket at %vs, got %d", endSec, len(out))
+	}
+	return out[0]
+}
+
+func TestAccumulatorMembershipAdditionOmitsTotalKeepsSensorsAndCPU(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	ab := func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}, rd{"B", f(50)}) }
+	abc := func(int) powerGPUTick {
+		return mkTick(time.Time{}, true, rd{"A", f(100)}, rd{"B", f(50)}, rd{"C", f(25)})
+	}
+	feedTicks(a, c, 0, 15, ab)
+	feedTicks(a, c, 15, 30, abc)
+	for s := 0; s < 30; s++ {
+		a.addCPUAt(c.at(float64(s)), c.wall(float64(s)), 12)
+	}
+	b := closeWindow(t, a, c, 30)
+	if b.GPUTotal != nil {
+		t.Fatalf("device added mid-window: total must be omitted, got %+v", *b.GPUTotal)
+	}
+	ss := sensorSamples(b)
+	if ss["A"] != 30 || ss["B"] != 30 || ss["C"] != 15 {
+		t.Fatalf("per-GPU readings must be retained: %v", ss)
+	}
+	if b.CPU == nil || b.CPU.Samples != 30 || *b.CPU.MeanWatts != 12 {
+		t.Fatalf("CPU must be retained: %+v", b.CPU)
+	}
+}
+
+func TestAccumulatorMembershipRemovalOmitsTotal(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	feedTicks(a, c, 0, 15, func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}, rd{"B", f(50)}) })
+	feedTicks(a, c, 15, 30, func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}) })
+	b := closeWindow(t, a, c, 30)
+	if b.GPUTotal != nil {
+		t.Fatalf("device removed mid-window: total must be omitted, got %+v", *b.GPUTotal)
+	}
+	if ss := sensorSamples(b); ss["A"] != 30 || ss["B"] != 15 {
+		t.Fatalf("per-GPU readings must be retained: %v", ss)
+	}
+}
+
+func TestAccumulatorMembershipSameCountReplacementOmitsTotal(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	feedTicks(a, c, 0, 15, func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}, rd{"B", f(50)}) })
+	// Same device count, different identity (uuid fallback flip, re-enumeration).
+	feedTicks(a, c, 15, 30, func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}, rd{"gpu-1", f(50)}) })
+	b := closeWindow(t, a, c, 30)
+	if b.GPUTotal != nil {
+		t.Fatalf("same-count replacement: total must be omitted, got %+v", *b.GPUTotal)
+	}
+	if ss := sensorSamples(b); ss["A"] != 30 || ss["B"] != 15 || ss["gpu-1"] != 15 {
+		t.Fatalf("per-GPU readings must be retained: %v", ss)
+	}
+}
+
+func TestAccumulatorMembershipLeaveAndReturnOmitsTotal(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	ab := func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}, rd{"B", f(50)}) }
+	feedTicks(a, c, 0, 10, ab)
+	feedTicks(a, c, 10, 15, func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}) })
+	feedTicks(a, c, 15, 30, ab)
+	b := closeWindow(t, a, c, 30)
+	if b.GPUTotal != nil {
+		t.Fatalf("device left and returned: total must be omitted for the whole window, got %+v", *b.GPUTotal)
+	}
+	if ss := sensorSamples(b); ss["A"] != 30 || ss["B"] != 25 {
+		t.Fatalf("per-GPU readings must be retained: %v", ss)
+	}
+}
+
+func TestAccumulatorMixedTotalThatPassesCountCheckIsStillOmitted(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	// 10 ticks over {A,B} with watts: total would be 10 over {A,B}.
+	feedTicks(a, c, 0, 10, func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}, rd{"B", f(50)}) })
+	// 20 ticks over {A,C} where A is N/A: these never enter the total, so a
+	// naive "total.n <= min sensor samples" gate passes (10 <= min(10,10,20)),
+	// yet the total no longer describes the reported sensor set.
+	feedTicks(a, c, 10, 30, func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", nil}, rd{"C", f(25)}) })
+	b := closeWindow(t, a, c, 30)
+	ss := sensorSamples(b)
+	if ss["A"] != 10 || ss["B"] != 10 || ss["C"] != 20 {
+		t.Fatalf("per-GPU readings: %v", ss)
+	}
+	if b.GPUTotal != nil {
+		t.Fatalf("mixed membership must omit the total even when counts look consistent, got %+v", *b.GPUTotal)
+	}
+}
+
+func TestAccumulatorTotalRecoversInNextStableWindow(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	feedTicks(a, c, 0, 15, func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}, rd{"B", f(50)}) })
+	ac := func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}, rd{"C", f(25)}) }
+	feedTicks(a, c, 15, 30, ac)
+	if b := closeWindow(t, a, c, 30); b.GPUTotal != nil {
+		t.Fatalf("mixed window must omit total, got %+v", *b.GPUTotal)
+	}
+	feedTicks(a, c, 30, 60, ac)
+	b := closeWindow(t, a, c, 60)
+	if b.GPUTotal == nil || b.GPUTotal.Samples != 30 || *b.GPUTotal.MeanWatts != 125 {
+		t.Fatalf("stable next window must report a total again: %+v", b.GPUTotal)
+	}
+	if len(b.GPUs) != 2 {
+		t.Fatalf("stable window sensors: %+v", b.GPUs)
+	}
+}
+
+func TestAccumulatorStableReorderNAAndIncompleteTicksKeepTotal(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	feedTicks(a, c, 0, 30, func(s int) powerGPUTick {
+		switch {
+		case s%3 == 0:
+			// Same set, reported in the other order.
+			return mkTick(time.Time{}, true, rd{"B", f(50)}, rd{"A", f(100)})
+		case s%5 == 0:
+			// Same set, one reading unavailable: not a membership change,
+			// just a tick that cannot enter the total.
+			return mkTick(time.Time{}, true, rd{"A", f(100)}, rd{"B", nil})
+		case s%7 == 0:
+			// Incomplete iteration (device missing from the read): never
+			// counted, and must not be mistaken for a smaller device set.
+			return mkTick(time.Time{}, false, rd{"A", f(100)})
+		default:
+			return mkTick(time.Time{}, true, rd{"A", f(100)}, rd{"B", f(50)})
+		}
+	})
+	b := closeWindow(t, a, c, 30)
+	if b.GPUTotal == nil {
+		t.Fatal("stable membership with reorder, N/A and incomplete ticks must keep the total")
+	}
+	// N/A ticks: 5, 10, 20, 25 (s%5 but not s%3). Incomplete ticks: 7, 14, 28
+	// (s%7 but not s%3 or s%5). Total counts the remaining 30 - 4 - 3 = 23.
+	if b.GPUTotal.Samples != 23 || *b.GPUTotal.PeakWatts != 150 {
+		t.Fatalf("total over stable ticks: %+v", *b.GPUTotal)
+	}
+	// B is absent from the 3 incomplete ticks and N/A on 4: 30 - 7 = 23.
+	if ss := sensorSamples(b); ss["A"] != 30 || ss["B"] != 23 {
+		t.Fatalf("per-GPU readings: %v", ss)
+	}
+}
+
+func TestAccumulatorIncompleteTickIntroducingSensorOmitsTotal(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	// Reference set {A} from complete ticks; an incomplete tick then reports
+	// a device B the reference never saw. The emitted union {A,B} no longer
+	// matches the set the total was computed over, and B has fewer samples
+	// than the total.
+	feedTicks(a, c, 0, 20, func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}) })
+	feedTicks(a, c, 20, 30, func(int) powerGPUTick { return mkTick(time.Time{}, false, rd{"A", f(100)}, rd{"B", f(50)}) })
+	b := closeWindow(t, a, c, 30)
+	if ss := sensorSamples(b); ss["A"] != 30 || ss["B"] != 10 {
+		t.Fatalf("per-GPU readings: %v", ss)
+	}
+	if b.GPUTotal != nil {
+		t.Fatalf("sensor introduced by an incomplete tick must omit the total, got %+v", *b.GPUTotal)
+	}
+}
+
+func TestAccumulatorPartialTicksBeforeAndAfterCompleteReferenceOmitTotal(t *testing.T) {
+	for _, before := range []bool{true, false} {
+		a := newPowerAccumulator(30*time.Second, time.Second)
+		c := newAccClock()
+		partial := func(int) powerGPUTick { return mkTick(time.Time{}, false, rd{"A", f(100)}, rd{"B", f(50)}) }
+		complete := func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}) }
+		if before {
+			feedTicks(a, c, 0, 5, partial)
+			feedTicks(a, c, 5, 30, complete)
+		} else {
+			feedTicks(a, c, 0, 25, complete)
+			feedTicks(a, c, 25, 30, partial)
+		}
+		b := closeWindow(t, a, c, 30)
+		if ss := sensorSamples(b); ss["A"] != 30 || ss["B"] != 5 {
+			t.Fatalf("before=%v per-GPU readings: %v", before, ss)
+		}
+		if b.GPUTotal != nil {
+			t.Fatalf("before=%v: partial ticks outside the reference set must omit the total, got %+v", before, *b.GPUTotal)
+		}
+	}
+}
+
+func TestAccumulatorPartialTicksWithKnownSensorsKeepTotal(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	feedTicks(a, c, 0, 25, func(int) powerGPUTick { return mkTick(time.Time{}, true, rd{"A", f(100)}, rd{"B", f(50)}) })
+	// Incomplete ticks naming only devices already in the reference set:
+	// not counted, but not a membership change either.
+	feedTicks(a, c, 25, 30, func(int) powerGPUTick { return mkTick(time.Time{}, false, rd{"A", f(100)}) })
+	b := closeWindow(t, a, c, 30)
+	if b.GPUTotal == nil || b.GPUTotal.Samples != 25 || *b.GPUTotal.MeanWatts != 150 {
+		t.Fatalf("partial ticks over known sensors must keep the total: %+v", b.GPUTotal)
+	}
+	if ss := sensorSamples(b); ss["A"] != 30 || ss["B"] != 25 {
+		t.Fatalf("per-GPU readings: %v", ss)
+	}
+}

--- a/agent/power_accumulator_test.go
+++ b/agent/power_accumulator_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/powerhistory"
+)
+
+// accClock drives the accumulator with an explicit monotonic time (base has
+// a monotonic reading; Add keeps it) and an independently controlled wall
+// clock so clock steps can be simulated.
+type accClock struct {
+	base   time.Time
+	wallMS int64 // wall clock at base
+	skewMS int64 // extra wall offset (simulated step)
+}
+
+func newAccClock() *accClock {
+	b := time.Now()
+	return &accClock{base: b, wallMS: b.UnixMilli()}
+}
+
+func (c *accClock) at(sec float64) time.Time {
+	return c.base.Add(time.Duration(sec * float64(time.Second)))
+}
+func (c *accClock) wall(sec float64) int64 { return c.wallMS + int64(sec*1000) + c.skewMS }
+
+func f(v float64) *float64 { return &v }
+
+func gpuTick(at time.Time, complete bool, watts ...*float64) powerGPUTick {
+	t := powerGPUTick{at: at, complete: complete}
+	for i, w := range watts {
+		t.readings = append(t.readings, powerReading{id: "GPU-" + string(rune('A'+i)), watts: w})
+	}
+	return t
+}
+
+func feedGPU(a *powerAccumulator, c *accClock, from, to int, watts func(sec int) []*float64) {
+	for s := from; s < to; s++ {
+		a.addGPUAt(gpuTick(c.at(float64(s)), true, watts(s)...), c.wall(float64(s)))
+	}
+}
+
+func TestAccumulatorMeanPeakCoverageAndGapFlag(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	feedGPU(a, c, 0, 30, func(int) []*float64 { return []*float64{f(100), f(200)} })
+	if got := a.tickAt(c.at(29.5), c.wall(29.5)); len(got) != 0 {
+		t.Fatalf("window closed early: %+v", got)
+	}
+	out := a.tickAt(c.at(30), c.wall(30))
+	if len(out) != 1 {
+		t.Fatalf("want 1 bucket, got %d", len(out))
+	}
+	b := out[0]
+	if !b.GapBefore {
+		t.Error("first bucket after boot must carry GapBefore")
+	}
+	if b.EndUnixMS-b.StartUnixMS != 30000 || b.StartUnixMS != c.wall(0) {
+		t.Errorf("bad window bounds: start=%d end=%d", b.StartUnixMS, b.EndUnixMS)
+	}
+	if b.ExpectedSamples != 30 || len(b.GPUs) != 2 {
+		t.Fatalf("expected=%d gpus=%d", b.ExpectedSamples, len(b.GPUs))
+	}
+	if *b.GPUs[0].MeanWatts != 100 || *b.GPUs[1].PeakWatts != 200 || b.GPUs[0].Samples != 30 {
+		t.Errorf("per-sensor stats wrong: %+v %+v", b.GPUs[0].Stats, b.GPUs[1].Stats)
+	}
+	if b.GPUTotal == nil || *b.GPUTotal.MeanWatts != 300 || *b.GPUTotal.PeakWatts != 300 || b.GPUTotal.Samples != 30 {
+		t.Errorf("total wrong: %+v", b.GPUTotal)
+	}
+	if b.CPU != nil {
+		t.Error("CPU must be nil when no CPU samples were added")
+	}
+	feedGPU(a, c, 30, 60, func(int) []*float64 { return []*float64{f(1), f(1)} })
+	out = a.tickAt(c.at(60), c.wall(60))
+	if len(out) != 1 || out[0].GapBefore {
+		t.Fatalf("second bucket must be contiguous (no gap): %+v", out)
+	}
+	if out[0].StartUnixMS != b.EndUnixMS {
+		t.Errorf("windows must tile: prev end %d, next start %d", b.EndUnixMS, out[0].StartUnixMS)
+	}
+}
+
+func TestAccumulatorTotalPeakIsSimultaneousNotSumOfMaxima(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	feedGPU(a, c, 0, 30, func(s int) []*float64 {
+		if s < 15 {
+			return []*float64{f(100), f(0)}
+		}
+		return []*float64{f(0), f(100)}
+	})
+	b := a.tickAt(c.at(30), c.wall(30))[0]
+	if *b.GPUs[0].PeakWatts != 100 || *b.GPUs[1].PeakWatts != 100 {
+		t.Fatalf("per-device peaks: %+v %+v", b.GPUs[0].Stats, b.GPUs[1].Stats)
+	}
+	if *b.GPUTotal.PeakWatts != 100 {
+		t.Errorf("total peak must be 100 (simultaneous), got %v", *b.GPUTotal.PeakWatts)
+	}
+}
+
+func TestAccumulatorNAIncompleteAndOversizedTicksNeverProducePartialTotal(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	// N/A on one device: that device contributes nothing, total skips the tick.
+	a.addGPUAt(gpuTick(c.at(0), true, f(50), nil), c.wall(0))
+	// Incomplete tick (device missing from the iteration): total skips.
+	a.addGPUAt(gpuTick(c.at(1), false, f(50)), c.wall(1))
+	b := a.tickAt(c.at(30), c.wall(30))[0]
+	if b.GPUTotal != nil {
+		t.Errorf("total must be nil without any complete tick, got %+v", b.GPUTotal)
+	}
+	if len(b.GPUs) != 2 || b.GPUs[0].Samples != 2 || b.GPUs[1].Samples != 0 || b.GPUs[1].MeanWatts != nil {
+		t.Errorf("sensor stats: %+v", b.GPUs)
+	}
+
+	// 17 sensors: keep 16, never a total.
+	a2 := newPowerAccumulator(30*time.Second, time.Second)
+	many := make([]*float64, 17)
+	for i := range many {
+		many[i] = f(10)
+	}
+	a2.addGPUAt(gpuTick(c.at(0), true, many...), c.wall(0))
+	b2 := a2.tickAt(c.at(30), c.wall(30))[0]
+	if len(b2.GPUs) != powerhistory.MaxSensors || b2.GPUTotal != nil {
+		t.Errorf("17 sensors: gpus=%d total=%v", len(b2.GPUs), b2.GPUTotal)
+	}
+}
+
+func TestAccumulatorCapsSamplesAtExpected(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	// Producer jitter: 36 GPU ticks and 36 CPU samples inside one window.
+	for i := 0; i < 36; i++ {
+		s := float64(i) * 0.8
+		a.addGPUAt(gpuTick(c.at(s), true, f(10)), c.wall(s))
+		a.addCPUAt(c.at(s), c.wall(s), 20)
+	}
+	b := a.tickAt(c.at(30), c.wall(30))[0]
+	if b.GPUs[0].Samples != 30 || b.GPUTotal.Samples != 30 || b.CPU.Samples != 30 {
+		t.Errorf("samples must be capped at 30: gpu=%d total=%d cpu=%d", b.GPUs[0].Samples, b.GPUTotal.Samples, b.CPU.Samples)
+	}
+	if *b.CPU.MeanWatts != 20 {
+		t.Errorf("cpu mean %v", *b.CPU.MeanWatts)
+	}
+}
+
+func TestAccumulatorEmptyWindowEmitsNothingAndFlagsGap(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	feedGPU(a, c, 0, 30, func(int) []*float64 { return []*float64{f(1)} })
+	a.tickAt(c.at(30), c.wall(30))
+	// 30..60: nothing sampled.
+	if out := a.tickAt(c.at(60), c.wall(60)); len(out) != 0 {
+		t.Fatalf("empty window must not emit: %+v", out)
+	}
+	feedGPU(a, c, 60, 90, func(int) []*float64 { return []*float64{f(1)} })
+	out := a.tickAt(c.at(90), c.wall(90))
+	if len(out) != 1 || !out[0].GapBefore {
+		t.Fatalf("bucket after empty window must carry GapBefore: %+v", out)
+	}
+}
+
+func TestAccumulatorSuspendResumeDoesNotEmitEmptyRun(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	feedGPU(a, c, 0, 30, func(int) []*float64 { return []*float64{f(1)} })
+	a.tickAt(c.at(30), c.wall(30))
+	feedGPU(a, c, 30, 40, func(int) []*float64 { return []*float64{f(1)} })
+	// Machine sleeps for 10 minutes.
+	out := a.tickAt(c.at(640), c.wall(640))
+	if len(out) != 1 {
+		t.Fatalf("want exactly the one partial bucket, got %d", len(out))
+	}
+	if out[0].GPUs[0].Samples != 10 || out[0].EndUnixMS-out[0].StartUnixMS != 30000 {
+		t.Errorf("partial bucket: %+v", out[0])
+	}
+	feedGPU(a, c, 640, 670, func(int) []*float64 { return []*float64{f(1)} })
+	out = a.tickAt(c.at(670), c.wall(670))
+	if len(out) != 1 || !out[0].GapBefore || out[0].StartUnixMS != c.wall(640) {
+		t.Fatalf("post-resume bucket must be re-anchored and gap-flagged: %+v", out)
+	}
+}
+
+func TestAccumulatorClockStepBackwardAndForward(t *testing.T) {
+	for _, step := range []int64{-3600_000, +3600_000} {
+		a := newPowerAccumulator(30*time.Second, time.Second)
+		c := newAccClock()
+		feedGPU(a, c, 0, 10, func(int) []*float64 { return []*float64{f(5)} })
+		c.skewMS = step // wall clock jumps; monotonic keeps going
+		feedGPU(a, c, 10, 40, func(int) []*float64 { return []*float64{f(7)} })
+		out := a.tickAt(c.at(40), c.wall(40))
+		if len(out) != 2 {
+			t.Fatalf("step %d: want partial + full bucket, got %d: %+v", step, len(out), out)
+		}
+		p, n := out[0], out[1]
+		if p.EndUnixMS <= p.StartUnixMS || p.EndUnixMS-p.StartUnixMS != 10000 || p.GPUs[0].Samples != 10 {
+			t.Errorf("step %d: partial bucket must be start+monotonic elapsed: %+v", step, p)
+		}
+		if !n.GapBefore {
+			t.Errorf("step %d: bucket after clock step must carry GapBefore", step)
+		}
+		if n.StartUnixMS != c.wall(10) || n.EndUnixMS-n.StartUnixMS != 30000 || n.GPUs[0].Samples != 30 {
+			t.Errorf("step %d: re-anchored bucket wrong: start=%d (want %d) dur=%d samples=%d",
+				step, n.StartUnixMS, c.wall(10), n.EndUnixMS-n.StartUnixMS, n.GPUs[0].Samples)
+		}
+	}
+}

--- a/agent/power_cpu_linux.go
+++ b/agent/power_cpu_linux.go
@@ -1,0 +1,146 @@
+//go:build linux
+
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Linux CPU package power comes from the powercap RAPL energy counters.
+// Only top-level, non-overlapping package zones are summed:
+//
+//	/sys/class/powercap/intel-rapl:<n>   name "package-<n>"
+//
+// Sub-zones (intel-rapl:<n>:<m> — core/uncore/dram), the platform zone
+// (psys, which contains the packages) and the MMIO mirror
+// (intel-rapl-mmio:<n>, the same package via a second interface) are
+// excluded so nothing is counted twice. The counters are readable by root
+// only on current kernels; the agent runs as root. Anything else (no
+// powercap, VM without RAPL, unreadable) reports the backend as unavailable.
+
+const raplRoot = "/sys/class/powercap"
+
+var raplTopLevel = regexp.MustCompile(`^intel-rapl:\d+$`)
+
+type raplZone struct {
+	energyPath string
+	maxRange   uint64
+	last       uint64
+}
+
+type raplSampler struct {
+	zones  []*raplZone
+	lastAt time.Time
+	primed bool
+	read   func(string) ([]byte, error)
+}
+
+func newPowerCPUSampler() powerCPUSampler {
+	s := discoverRAPL(raplRoot, os.ReadFile)
+	if s == nil {
+		return nil // interface nil, not a typed nil
+	}
+	return s
+}
+
+func discoverRAPL(root string, read func(string) ([]byte, error)) *raplSampler {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	s := &raplSampler{read: read}
+	for _, e := range entries {
+		if !raplTopLevel.MatchString(e.Name()) {
+			continue
+		}
+		dir := filepath.Join(root, e.Name())
+		name, err := read(filepath.Join(dir, "name"))
+		if err != nil || !strings.HasPrefix(strings.TrimSpace(string(name)), "package") {
+			continue
+		}
+		z := &raplZone{energyPath: filepath.Join(dir, "energy_uj")}
+		if _, err := readRAPLUint(read, z.energyPath); err != nil {
+			// A package we can see but not read would make the sum a
+			// silent partial. All or nothing.
+			log.Printf("power-history: CPU energy backend unavailable: %s unreadable: %v", z.energyPath, err)
+			return nil
+		}
+		if v, err := readRAPLUint(read, filepath.Join(dir, "max_energy_range_uj")); err == nil {
+			z.maxRange = v
+		}
+		s.zones = append(s.zones, z)
+	}
+	if len(s.zones) == 0 {
+		return nil
+	}
+	log.Printf("power-history: CPU energy backend: %d RAPL package zone(s)", len(s.zones))
+	return s
+}
+
+func readRAPLUint(read func(string) ([]byte, error), path string) (uint64, error) {
+	b, err := read(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64)
+}
+
+// sample returns mean package watts over the interval since the previous
+// successful sample. Counter wrap is corrected with max_energy_range_uj; a
+// read error, an implausible interval or an implausible result re-primes
+// and reports no value rather than a wrong one.
+func (s *raplSampler) sample(now time.Time) (float64, bool) {
+	vals := make([]uint64, len(s.zones))
+	for i, z := range s.zones {
+		v, err := readRAPLUint(s.read, z.energyPath)
+		if err != nil {
+			s.primed = false
+			return 0, false
+		}
+		vals[i] = v
+	}
+	if !s.primed {
+		s.prime(vals, now)
+		return 0, false
+	}
+	dt := now.Sub(s.lastAt).Seconds()
+	if dt <= 0 || dt > 5*powerSampleInterval.Seconds() {
+		s.prime(vals, now)
+		return 0, false
+	}
+	var deltaUJ float64
+	for i, z := range s.zones {
+		v := vals[i]
+		var d uint64
+		switch {
+		case v >= z.last:
+			d = v - z.last
+		case z.maxRange > 0:
+			d = z.maxRange - z.last + v
+		default:
+			s.prime(vals, now)
+			return 0, false
+		}
+		deltaUJ += float64(d)
+	}
+	s.prime(vals, now)
+	w := deltaUJ / 1e6 / dt
+	if w < 0 || w > 10000 {
+		return 0, false
+	}
+	return w, true
+}
+
+func (s *raplSampler) prime(vals []uint64, now time.Time) {
+	for i, z := range s.zones {
+		z.last = vals[i]
+	}
+	s.lastAt = now
+	s.primed = true
+}

--- a/agent/power_cpu_linux_test.go
+++ b/agent/power_cpu_linux_test.go
@@ -1,0 +1,133 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// fakeRAPL lays out a powercap tree on disk (for discovery, which uses
+// os.ReadDir) and answers reads from an in-memory map so counters can be
+// advanced or made unreadable per test.
+type fakeRAPL struct {
+	root  string
+	files map[string]string
+	fail  map[string]bool
+}
+
+func newFakeRAPL(t *testing.T) *fakeRAPL {
+	t.Helper()
+	return &fakeRAPL{root: t.TempDir(), files: map[string]string{}, fail: map[string]bool{}}
+}
+
+func (r *fakeRAPL) zone(name, zoneName string, energy, maxRange uint64) {
+	dir := filepath.Join(r.root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		panic(err)
+	}
+	r.files[filepath.Join(dir, "name")] = zoneName + "\n"
+	r.files[filepath.Join(dir, "energy_uj")] = strconv.FormatUint(energy, 10) + "\n"
+	if maxRange > 0 {
+		r.files[filepath.Join(dir, "max_energy_range_uj")] = strconv.FormatUint(maxRange, 10) + "\n"
+	}
+}
+
+func (r *fakeRAPL) set(name string, energy uint64) {
+	r.files[filepath.Join(r.root, name, "energy_uj")] = strconv.FormatUint(energy, 10) + "\n"
+}
+
+func (r *fakeRAPL) read(p string) ([]byte, error) {
+	if r.fail[p] {
+		return nil, errors.New("permission denied")
+	}
+	v, ok := r.files[p]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return []byte(v), nil
+}
+
+func TestRAPLDiscoverySelectsOnlyTopLevelPackages(t *testing.T) {
+	r := newFakeRAPL(t)
+	r.zone("intel-rapl:0", "package-0", 1000, 1<<40)
+	r.zone("intel-rapl:1", "package-1", 2000, 1<<40)
+	r.zone("intel-rapl:0:0", "core", 500, 1<<40)      // sub-zone: overlaps package
+	r.zone("intel-rapl:0:1", "dram", 500, 1<<40)      // sub-zone
+	r.zone("intel-rapl-mmio:0", "package-0", 1000, 0) // MMIO mirror of package-0
+	r.zone("intel-rapl:2", "psys", 9000, 1<<40)       // platform: contains packages
+	s := discoverRAPL(r.root, r.read)
+	if s == nil || len(s.zones) != 2 {
+		t.Fatalf("want exactly the two package zones, got %+v", s)
+	}
+}
+
+func TestRAPLUnreadablePackageDisablesBackend(t *testing.T) {
+	r := newFakeRAPL(t)
+	r.zone("intel-rapl:0", "package-0", 1000, 1<<40)
+	r.zone("intel-rapl:1", "package-1", 2000, 1<<40)
+	r.fail[filepath.Join(r.root, "intel-rapl:1", "energy_uj")] = true
+	if s := discoverRAPL(r.root, r.read); s != nil {
+		t.Fatalf("a partially readable package set must not be reported as CPU total: %+v", s)
+	}
+	if s := discoverRAPL(filepath.Join(r.root, "missing"), r.read); s != nil {
+		t.Fatal("no powercap tree must mean unavailable")
+	}
+	// The interface value must be a true nil when unavailable.
+	var iface powerCPUSampler
+	if s := discoverRAPL(filepath.Join(r.root, "missing"), r.read); s != nil {
+		iface = s
+	}
+	if iface != nil {
+		t.Fatal("typed nil leaked into the interface")
+	}
+}
+
+func TestRAPLSampleRatesAndWraps(t *testing.T) {
+	r := newFakeRAPL(t)
+	const maxRange = 1_000_000 // 1 J range to make wrap easy
+	r.zone("intel-rapl:0", "package-0", 900_000, maxRange)
+	r.zone("intel-rapl:1", "package-1", 100_000, maxRange)
+	s := discoverRAPL(r.root, r.read)
+	if s == nil {
+		t.Fatal("discovery failed")
+	}
+	base := time.Now()
+	if _, ok := s.sample(base); ok {
+		t.Fatal("first sample has no rate")
+	}
+	// +50 mJ on each package over 1 s → 0.1 W total; package-0 wraps.
+	r.set("intel-rapl:0", 950_000)
+	r.set("intel-rapl:1", 150_000)
+	w, ok := s.sample(base.Add(time.Second))
+	if !ok || w < 0.0999 || w > 0.1001 {
+		t.Fatalf("rate: ok=%v w=%v", ok, w)
+	}
+	r.set("intel-rapl:0", 25_000) // wrapped: 950000 → 1000000 → 25000 = +75 mJ
+	r.set("intel-rapl:1", 175_000)
+	w, ok = s.sample(base.Add(2 * time.Second))
+	if !ok || w < 0.0999 || w > 0.1001 {
+		t.Fatalf("wrap: ok=%v w=%v", ok, w)
+	}
+	// Implausible interval (long stall) re-primes instead of reporting.
+	r.set("intel-rapl:0", 30_000)
+	if _, ok := s.sample(base.Add(60 * time.Second)); ok {
+		t.Fatal("stale interval must not produce a value")
+	}
+	// A read error re-primes; the following sample is again rate-less.
+	r.fail[filepath.Join(r.root, "intel-rapl:1", "energy_uj")] = true
+	if _, ok := s.sample(base.Add(61 * time.Second)); ok {
+		t.Fatal("read error must not produce a value")
+	}
+	delete(r.fail, filepath.Join(r.root, "intel-rapl:1", "energy_uj"))
+	if _, ok := s.sample(base.Add(62 * time.Second)); ok {
+		t.Fatal("sample right after a read error must only prime")
+	}
+	if _, ok := s.sample(base.Add(63 * time.Second)); !ok {
+		t.Fatal("rate must resume after re-priming")
+	}
+}

--- a/agent/power_cpu_other.go
+++ b/agent/power_cpu_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package main
+
+// newPowerCPUSampler reports the CPU energy backend as unavailable on this
+// platform. Windows has no vendor-neutral package energy counter the agent
+// can read without extra drivers, so CPU stays nil in the buckets rather
+// than being estimated.
+func newPowerCPUSampler() powerCPUSampler { return nil }

--- a/agent/power_history.go
+++ b/agent/power_history.go
@@ -1,0 +1,577 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/powerhistory"
+	"github.com/gorilla/websocket"
+)
+
+// Power history: a 1 Hz component-power sampler (GPU via a streaming
+// nvidia-smi process, CPU via the Linux RAPL energy counter where readable)
+// feeding a 30 s accumulator whose completed buckets are appended to a
+// bounded local journal and fsync'd BEFORE they become eligible for upload.
+// Upload is one bounded batch per 30 s metrics tick; the hub ACKs a
+// contiguous durable prefix and the agent persists that cursor.
+//
+// Concurrency contract: the journal (and every fsync) is owned by ONE worker
+// goroutine. The metrics tick reads an immutable atomic snapshot to build a
+// batch, and the websocket read loop only drops an ACK into a coalescing
+// mailbox. Neither can ever wait on disk.
+//
+// Nothing here touches the existing instant `power_watts` field in the
+// metrics frame — that stays an instantaneous nvidia-smi reading and is
+// semantically distinct from the 30 s mean carried in these buckets.
+
+const (
+	powerSampleInterval = time.Second
+	powerWindow         = powerhistory.WindowSeconds * time.Second
+	// powerQueueDepth bounds completed buckets waiting on the journal
+	// goroutine. A blocked fsync therefore never stalls the sampler or the
+	// metrics tick; overflow drops the bucket and flags a gap instead.
+	powerQueueDepth = 64
+	// powerMaxSeq keeps sequence numbers exactly representable in JS
+	// (shared contract). Reaching it rotates the stream identity.
+	powerMaxSeq = powerhistory.MaxSeq
+	// powerClockStepTolerance is how far the wall clock may drift from the
+	// monotonic clock across one window before the next bucket is flagged
+	// as following a clock discontinuity.
+	powerClockStepTolerance = 2 * time.Second
+	// powerJournalRetry paces reopening an unavailable journal directory.
+	powerJournalRetry = time.Minute
+	// powerSendMinInterval enforces the approved upload cadence (one batch
+	// per 30 s tick) even though sendAll also runs on reconnect and on a
+	// manual refresh_metrics. Slightly under the tick so ticker jitter never
+	// skips a regular send.
+	powerSendMinInterval = 25 * time.Second
+)
+
+// powerRetentionTick is how often the journal worker enforces retention
+// even when no bucket arrives (sensors gone, everything acknowledged).
+var powerRetentionTick = time.Minute
+
+// powerReading is one sensor's sample within a tick. Nil watts = N/A.
+type powerReading struct {
+	id    string
+	watts *float64
+}
+
+// powerGPUTick is one simultaneous read of every GPU sensor. complete is
+// true only when the tick includes every sensor the sampler knows about,
+// which is the precondition for a truthful GPU total.
+type powerGPUTick struct {
+	at       time.Time
+	readings []powerReading
+	complete bool
+}
+
+type statsAcc struct {
+	sum  float64
+	n    int
+	peak float64
+}
+
+func (a *statsAcc) add(w float64) {
+	if a.n == 0 || w > a.peak {
+		a.peak = w
+	}
+	a.sum += w
+	a.n++
+}
+
+func (a *statsAcc) stats() powerhistory.Stats {
+	if a.n == 0 {
+		return powerhistory.Stats{}
+	}
+	mean := a.sum / float64(a.n)
+	peak := a.peak
+	// Summation rounding can push the mean of a constant series a hair
+	// above its peak (0.1 × 30); the hub requires mean ≤ peak.
+	if mean > peak {
+		mean = peak
+	}
+	return powerhistory.Stats{MeanWatts: &mean, PeakWatts: &peak, Samples: a.n}
+}
+
+type powerWindowState struct {
+	gpus  map[string]*statsAcc
+	order []string
+	total statsAcc
+	cpu   statsAcc
+	any   bool
+}
+
+// powerAccumulator folds 1 Hz samples into fixed 30 s windows tiled on the
+// monotonic clock. Bucket start is a wall anchor; bucket end is always
+// start + monotonic elapsed, so end > start. A wall-clock step can close the
+// open window early, preserving its partial sample count; the next window
+// is re-anchored to the new wall time and flagged GapBefore. Per-sensor counts are
+// capped at ExpectedSamples so producer jitter can never over-report.
+type powerAccumulator struct {
+	mu          sync.Mutex
+	window      time.Duration
+	expected    int
+	startMono   time.Time // zero until the first event
+	startWallMS int64
+	cur         *powerWindowState
+	gapPending  bool
+	ready       []powerhistory.Bucket
+}
+
+func newPowerAccumulator(window, interval time.Duration) *powerAccumulator {
+	return &powerAccumulator{window: window, expected: int(window / interval), gapPending: true}
+}
+
+func newPowerWindowState() *powerWindowState {
+	return &powerWindowState{gpus: map[string]*statsAcc{}}
+}
+
+// roll closes every window that has elapsed as of now (monotonic) and wallMS
+// (observed wall clock). Caller holds mu.
+func (a *powerAccumulator) roll(now time.Time, wallMS int64) {
+	if a.startMono.IsZero() {
+		a.startMono, a.startWallMS, a.cur = now, wallMS, newPowerWindowState()
+		return
+	}
+	for now.Sub(a.startMono) >= a.window {
+		endMS := a.startWallMS + a.window.Milliseconds()
+		a.emit(endMS)
+		a.startMono = a.startMono.Add(a.window)
+		a.startWallMS = endMS
+		a.cur = newPowerWindowState()
+		// Far behind (suspend/resume): don't emit a run of empty windows.
+		if now.Sub(a.startMono) >= 2*a.window {
+			a.startMono, a.startWallMS, a.gapPending = now, wallMS, true
+			break
+		}
+	}
+	// Clock discontinuity: wall time no longer agrees with the monotonic
+	// anchor. Re-anchor the open window's start so its end stays truthful
+	// and flag the discontinuity on whatever is emitted next.
+	expectedMS := a.startWallMS + now.Sub(a.startMono).Milliseconds()
+	if d := wallMS - expectedMS; d > powerClockStepTolerance.Milliseconds() || d < -powerClockStepTolerance.Milliseconds() {
+		if a.cur != nil && a.cur.any {
+			a.emit(expectedMS)
+			a.cur = newPowerWindowState()
+		}
+		a.startMono, a.startWallMS, a.gapPending = now, wallMS, true
+	}
+}
+
+// emit converts the open window into a bucket (if it saw any sample).
+// Caller holds mu.
+func (a *powerAccumulator) emit(endMS int64) {
+	w := a.cur
+	if w == nil || !w.any {
+		a.gapPending = true
+		return
+	}
+	b := powerhistory.Bucket{
+		StartUnixMS:     a.startWallMS,
+		EndUnixMS:       endMS,
+		ExpectedSamples: a.expected,
+		GPUs:            make([]powerhistory.Sensor, 0, len(w.order)),
+		GapBefore:       a.gapPending,
+	}
+	a.gapPending = false
+	for _, id := range w.order {
+		b.GPUs = append(b.GPUs, powerhistory.Sensor{ID: id, Stats: w.gpus[id].stats()})
+	}
+	if w.total.n > 0 {
+		s := w.total.stats()
+		b.GPUTotal = &s
+	}
+	if w.cpu.n > 0 {
+		s := w.cpu.stats()
+		b.CPU = &s
+	}
+	a.ready = append(a.ready, b)
+}
+
+func (a *powerAccumulator) addGPU(t powerGPUTick) { a.addGPUAt(t, t.at.UnixMilli()) }
+
+func (a *powerAccumulator) addGPUAt(t powerGPUTick, wallMS int64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.roll(t.at, wallMS)
+	w := a.cur
+	sum := 0.0
+	allPresent := t.complete && len(t.readings) > 0
+	for _, r := range t.readings {
+		acc, ok := w.gpus[r.id]
+		if !ok {
+			if len(w.order) >= powerhistory.MaxSensors {
+				allPresent = false
+				continue
+			}
+			acc = &statsAcc{}
+			w.gpus[r.id] = acc
+			w.order = append(w.order, r.id)
+		}
+		if r.watts == nil {
+			allPresent = false
+			continue
+		}
+		if acc.n < a.expected {
+			acc.add(*r.watts)
+			w.any = true
+		}
+		sum += *r.watts
+	}
+	if allPresent && w.total.n < a.expected {
+		w.total.add(sum)
+	}
+}
+
+func (a *powerAccumulator) addCPU(at time.Time, watts float64) { a.addCPUAt(at, at.UnixMilli(), watts) }
+
+func (a *powerAccumulator) addCPUAt(at time.Time, wallMS int64, watts float64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.roll(at, wallMS)
+	if a.cur.cpu.n < a.expected {
+		a.cur.cpu.add(watts)
+		a.cur.any = true
+	}
+}
+
+// tick advances the window clock and drains completed buckets (Seq unset;
+// the journal assigns it).
+func (a *powerAccumulator) tick(now time.Time) []powerhistory.Bucket {
+	return a.tickAt(now, now.UnixMilli())
+}
+
+func (a *powerAccumulator) tickAt(now time.Time, wallMS int64) []powerhistory.Bucket {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.roll(now, wallMS)
+	out := a.ready
+	a.ready = nil
+	return out
+}
+
+// markGap flags the next emitted bucket as preceded by collection loss.
+func (a *powerAccumulator) markGap() {
+	a.mu.Lock()
+	a.gapPending = true
+	a.mu.Unlock()
+}
+
+// powerCPUSampler is implemented per platform (RAPL on Linux). Nil means the
+// backend is unavailable on this host.
+type powerCPUSampler interface {
+	// sample returns package watts since the previous call, or false when no
+	// rate is available yet (first call, counter reset, read error).
+	sample(now time.Time) (float64, bool)
+}
+
+// powerHistory is the process-wide singleton wiring sampler → accumulator →
+// journal worker → uplink.
+type powerHistory struct {
+	acc     *powerAccumulator
+	journal *powerJournal // worker goroutine only
+	queue   chan powerhistory.Bucket
+	ackMu   sync.Mutex
+	ackNext *powerhistory.Ack // coalescing mailbox: newest ACK wins
+	ackSig  chan struct{}
+	snap    atomic.Pointer[powerSnapshot]
+	// dropped: a bucket was lost at the queue; the NEXT enqueued bucket
+	// declares the gap. writeFailed: a bucket was lost at the journal; the
+	// next successfully appended bucket declares it.
+	dropped     atomic.Bool
+	writeFailed atomic.Bool
+	// workerDone is closed when journalWorker returns (the journal is then
+	// closed and may be touched by nobody else).
+	workerDone chan struct{}
+	// sendMu/lastSend implement the upload throttle (monotonic clock).
+	sendMu   sync.Mutex
+	lastSend time.Time
+	// degraded is true while buckets are being lost locally (queue overflow
+	// or journal write failure). Cleared by the next successful append.
+	degraded atomic.Bool
+	cancel   context.CancelFunc
+}
+
+var (
+	powerOnce sync.Once
+	powerInst atomic.Pointer[powerHistory]
+)
+
+// powerHistoryDir is /etc/bloxos/power-history when running as root on a
+// POSIX host, and otherwise sits beside the agent's other durable state
+// (Windows: the systemprofile credential directory).
+func powerHistoryDir() string {
+	if runtime.GOOS != "windows" {
+		if u, err := user.Current(); err == nil && u.Uid == "0" {
+			return "/etc/bloxos/power-history"
+		}
+	}
+	return filepath.Join(filepath.Dir(credentialFilePath()), "power-history")
+}
+
+// startPowerHistory boots the singleton once, off the caller's goroutine so
+// slow or unavailable storage never delays agent startup. An unavailable
+// journal directory is retried on a fixed cadence rather than disabling the
+// feature for the life of the process. BLOXOS_POWER_HISTORY=0 is a hard
+// local opt-out.
+func startPowerHistory() {
+	powerOnce.Do(func() {
+		if os.Getenv("BLOXOS_POWER_HISTORY") == "0" {
+			log.Println("power-history: disabled by BLOXOS_POWER_HISTORY=0")
+			return
+		}
+		go bootPowerHistory(context.Background(), powerHistoryDir(), powerJournalRetry)
+	})
+}
+
+func bootPowerHistory(ctx context.Context, dir string, retry time.Duration) {
+	gpu := resolveNvidiaSmiPath() != ""
+	cpu := newPowerCPUSampler()
+	if !gpu && cpu == nil {
+		log.Println("power-history: no supported power sensor on this host (no nvidia-smi, no readable CPU energy counter); not started")
+		return
+	}
+	var j *powerJournal
+	for attempt := 1; ; attempt++ {
+		var err error
+		j, err = openPowerJournal(dir)
+		if err == nil {
+			break
+		}
+		if attempt == 1 || attempt%10 == 0 {
+			log.Printf("power-history: journal unavailable at %s (attempt %d), history degraded, retrying every %s: %v", dir, attempt, retry, err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(retry):
+		}
+	}
+	// Log journal state before the worker owns it; afterwards only the
+	// worker may read these fields.
+	log.Printf("power-history: starting stream=%s dir=%s gpu=%v cpu=%v next_seq=%d acked=%d retained=%d",
+		j.streamID, j.dir, gpu, cpu != nil, j.nextSeq, j.acked, len(j.records))
+	ph := newPowerHistory(j)
+	ctx, ph.cancel = context.WithCancel(ctx)
+	go ph.journalWorker(ctx)
+	go ph.windowLoop(ctx)
+	if gpu {
+		s := newNvidiaPowerStream(resolveNvidiaSmiPath, ph.acc.addGPU)
+		go s.run(ctx)
+	}
+	if cpu != nil {
+		go ph.cpuLoop(ctx, cpu)
+	}
+	powerInst.Store(ph)
+}
+
+func newPowerHistory(j *powerJournal) *powerHistory {
+	ph := &powerHistory{
+		acc:        newPowerAccumulator(powerWindow, powerSampleInterval),
+		journal:    j,
+		queue:      make(chan powerhistory.Bucket, powerQueueDepth),
+		ackSig:     make(chan struct{}, 1),
+		workerDone: make(chan struct{}),
+	}
+	ph.snap.Store(j.snapshot())
+	return ph
+}
+
+func (ph *powerHistory) windowLoop(ctx context.Context) {
+	t := time.NewTicker(powerSampleInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			for _, b := range ph.acc.tick(now) {
+				ph.enqueue(b)
+			}
+		}
+	}
+}
+
+// enqueue hands a completed bucket to the journal worker without blocking.
+func (ph *powerHistory) enqueue(b powerhistory.Bucket) {
+	if ph.dropped.Load() {
+		b.GapBefore = true
+	}
+	select {
+	case ph.queue <- b:
+		ph.dropped.Store(false)
+	default:
+		ph.dropped.Store(true)
+		ph.degraded.Store(true)
+		log.Printf("power-history: journal queue full, bucket dropped (gap declared)")
+	}
+}
+
+// journalWorker is the only goroutine that touches the journal or fsyncs.
+func (ph *powerHistory) journalWorker(ctx context.Context) {
+	defer close(ph.workerDone)
+	defer ph.journal.close()
+	retention := time.NewTicker(powerRetentionTick)
+	defer retention.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case b := <-ph.queue:
+			ph.appendBucket(b)
+		case <-retention.C:
+			if err := ph.journal.enforce(); err != nil {
+				if ph.degraded.CompareAndSwap(false, true) {
+					log.Printf("power-history: retention enforcement failed, history degraded: %v", err)
+				}
+			}
+			ph.snap.Store(ph.journal.snapshot())
+		case <-ph.ackSig:
+			ph.ackMu.Lock()
+			ack := ph.ackNext
+			ph.ackNext = nil
+			ph.ackMu.Unlock()
+			if ack != nil {
+				ph.applyAck(*ack)
+			}
+		}
+	}
+}
+
+func (ph *powerHistory) appendBucket(b powerhistory.Bucket) {
+	if ph.writeFailed.Load() {
+		b.GapBefore = true
+	}
+	if err := ph.journal.append(b); err != nil {
+		// Not durable → never uploaded. The next durable bucket declares
+		// the gap.
+		ph.writeFailed.Store(true)
+		if ph.degraded.CompareAndSwap(false, true) {
+			log.Printf("power-history: journal write failed, history degraded until writes recover: %v", err)
+		}
+		return
+	}
+	ph.writeFailed.Store(false)
+	if ph.degraded.Swap(false) {
+		log.Println("power-history: journal writes recovered")
+	}
+	ph.snap.Store(ph.journal.snapshot())
+}
+
+func (ph *powerHistory) applyAck(ack powerhistory.Ack) {
+	advanced, err := ph.journal.ack(ack.StreamID, ack.Through)
+	if err != nil {
+		log.Printf("power-history: ack %d rejected: %v", ack.Through, err)
+		return
+	}
+	if advanced {
+		ph.snap.Store(ph.journal.snapshot())
+	}
+}
+
+// offerAck is the non-blocking hand-off from the websocket read loop. ACKs
+// are monotone, so only the newest unprocessed one needs to survive.
+func (ph *powerHistory) offerAck(ack powerhistory.Ack) {
+	ph.ackMu.Lock()
+	if ph.ackNext == nil || ack.Through > ph.ackNext.Through || ack.StreamID != ph.ackNext.StreamID {
+		ph.ackNext = &ack
+	}
+	ph.ackMu.Unlock()
+	select {
+	case ph.ackSig <- struct{}{}:
+	default:
+	}
+}
+
+func (ph *powerHistory) cpuLoop(ctx context.Context, s powerCPUSampler) {
+	t := time.NewTicker(powerSampleInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			if w, ok := s.sample(now); ok {
+				ph.acc.addCPU(now, w)
+			}
+		}
+	}
+}
+
+// nextBatch builds the next upload from the immutable snapshot. Never
+// touches the journal or disk.
+func (ph *powerHistory) nextBatch() (*powerhistory.Batch, bool) {
+	snap := ph.snap.Load()
+	if snap == nil {
+		return nil, false
+	}
+	batch, ok := snap.pendingBatch(powerhistory.MaxBatchRecords, powerhistory.MaxFrameBytes)
+	if !ok {
+		return nil, false
+	}
+	batch.Degraded = ph.degraded.Load()
+	return batch, true
+}
+
+// allowSend claims a send slot if at least powerSendMinInterval has passed
+// on the monotonic clock since the last claim. The lock is held only for
+// the check, never across the network write.
+func (ph *powerHistory) allowSend(now time.Time) bool {
+	ph.sendMu.Lock()
+	defer ph.sendMu.Unlock()
+	if !ph.lastSend.IsZero() && now.Sub(ph.lastSend) < powerSendMinInterval {
+		return false
+	}
+	ph.lastSend = now
+	return true
+}
+
+// sendPowerHistory ships at most one bounded batch per powerSendMinInterval,
+// whatever triggers sendAll (30 s tick, reconnect, manual refresh). The
+// normal cadence is one batch per 30 s tick: a full 24 h backlog (2880
+// buckets) drains in roughly 47 minutes with new windows arriving. Lost ACKs cause
+// the same prefix to be resent; the hub dedupes on (stream, seq).
+func sendPowerHistory(conn *websocket.Conn, mu *sync.Mutex) {
+	ph := powerInst.Load()
+	if ph == nil {
+		return
+	}
+	batch, ok := ph.nextBatch()
+	if !ok {
+		return
+	}
+	if !ph.allowSend(time.Now()) {
+		return
+	}
+	if err := writeJSON(conn, mu, batch); err != nil {
+		log.Printf("power-history: send batch: %v", err)
+	}
+}
+
+// handlePowerHistoryAck parses an ACK and hands it to the journal worker.
+// Validation (stream match, not beyond last durable seq, not behind the
+// cursor) happens on the worker, which owns the authoritative state.
+func handlePowerHistoryAck(msg []byte) {
+	ph := powerInst.Load()
+	if ph == nil {
+		return
+	}
+	var ack powerhistory.Ack
+	if err := json.Unmarshal(msg, &ack); err != nil {
+		log.Printf("power-history: bad ack: %v", err)
+		return
+	}
+	ph.offerAck(ack)
+}
+
+// powerAckType is the inbound frame type dispatched by runAgent's read loop.
+const powerAckType = powerhistory.AckType

--- a/agent/power_history.go
+++ b/agent/power_history.go
@@ -8,6 +8,8 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -108,6 +110,30 @@ type powerWindowState struct {
 	total statsAcc
 	cpu   statsAcc
 	any   bool
+	// totalSig is the device set (order-independent) the running total is
+	// being computed over, fixed by the first complete tick of the window;
+	// totalMembers is its size. totalMixed is set once a later complete
+	// tick reports a different set (device added, removed, or replaced
+	// under the same count): the total is then omitted for the rest of this
+	// window, because a sum over a changing set is not a simultaneous
+	// reading of the sensors reported. Incomplete ticks and unavailable
+	// readings never change membership, but an incomplete tick can still
+	// add a sensor to the emitted union; emit therefore also requires the
+	// union to be exactly the reference set (union ⊇ reference always, so
+	// equal size means equal set).
+	totalSig     string
+	totalMembers int
+	totalMixed   bool
+}
+
+// membershipSig is an order-independent identity of a tick's device set.
+func membershipSig(readings []powerReading) string {
+	ids := make([]string, len(readings))
+	for i, r := range readings {
+		ids[i] = r.id
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, "\x00")
 }
 
 // powerAccumulator folds 1 Hz samples into fixed 30 s windows tiled on the
@@ -186,7 +212,7 @@ func (a *powerAccumulator) emit(endMS int64) {
 	for _, id := range w.order {
 		b.GPUs = append(b.GPUs, powerhistory.Sensor{ID: id, Stats: w.gpus[id].stats()})
 	}
-	if w.total.n > 0 {
+	if w.total.n > 0 && !w.totalMixed && len(w.order) == w.totalMembers {
 		s := w.total.stats()
 		b.GPUTotal = &s
 	}
@@ -204,6 +230,13 @@ func (a *powerAccumulator) addGPUAt(t powerGPUTick, wallMS int64) {
 	defer a.mu.Unlock()
 	a.roll(t.at, wallMS)
 	w := a.cur
+	if t.complete && len(t.readings) > 0 {
+		if sig := membershipSig(t.readings); w.totalSig == "" {
+			w.totalSig, w.totalMembers = sig, len(t.readings)
+		} else if sig != w.totalSig {
+			w.totalMixed = true
+		}
+	}
 	sum := 0.0
 	allPresent := t.complete && len(t.readings) > 0
 	for _, r := range t.readings {

--- a/agent/power_journal.go
+++ b/agent/power_journal.go
@@ -1,0 +1,732 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/powerhistory"
+)
+
+// powerJournal is a bounded, append-only log of completed buckets. It is
+// owned by exactly one goroutine (the journal worker); everything else reads
+// the immutable powerSnapshot it publishes.
+//
+// Files, all inside dir and scoped by stream id:
+//
+//	stream.json                       current identity — the ONE commit point
+//	state-<id>.json                   {acked, reserved}: durable ACK cursor and
+//	                                  sequence high-water reservation
+//	seg-<id>-<firstseq>.ndjson        record segments, one Bucket per line
+//
+// Durability rules:
+//   - a record is visible to upload only after its line is fsync'd;
+//   - a sequence number is only assigned below a reservation that was
+//     fsync'd first, so a torn or lost tail after a crash can never hand a
+//     hub-committed sequence to different data (the next restart skips
+//     ahead to the reservation and flags GapBefore);
+//   - identity rotation writes the new state file, then commits stream.json
+//     with a single durable rename; a crash on either side leaves a
+//     consistent (old or new) world. Any inconsistency found on open
+//     (identity without its state file) rotates: fail closed, never reuse.
+//
+// Bounds (hard, enforced on every append):
+//   - retained records ≤ powerJournalMaxRec (24 h of 30 s buckets) and none
+//     older than the retention window, checked across ALL records (a clock
+//     regression can leave expired records in the interior);
+//   - on disk, every segment (powerJournalSegRec = 10 records = 5 min, the
+//     live one included) is reconciled against the retained set on every
+//     append and on a periodic worker tick, so expiry happens even when no
+//     samples arrive. A segment whose records are all gone is deleted; one
+//     that is partly gone (horizon crossing, or an expired interior record
+//     after a clock regression) is compacted in place via temp file +
+//     durable rename. Disk therefore never holds an expired record past the
+//     next enforcement and no valid data is ever trimmed early;
+//   - on-disk bytes ≤ powerJournalMaxBytes by deleting whole oldest
+//     segments (their still-valid records are dropped and the loss is
+//     declared through RetainedFrom); a record line above
+//     powerJournalMaxLine is refused;
+//   - recovery decodes at most the same bounds (records, bytes, segments);
+//   - when ANY delete or compaction fails, appends fail (degraded) until
+//     enforcement succeeds, rather than letting the directory grow.
+type powerJournal struct {
+	dir      string
+	streamID string
+
+	segs     []*powerSegment
+	cur      *os.File // append handle for the last segment; nil = reopen needed
+	records  []powerhistory.Bucket
+	acked    uint64
+	reserved uint64
+	nextSeq  uint64
+	overCap  bool // last enforcement failed while over a hard cap
+
+	maxRecords int
+	maxBytes   int64
+	segRecords int
+	retention  time.Duration
+	now        func() time.Time
+}
+
+type powerSegment struct {
+	path     string
+	firstSeq uint64
+	lastSeq  uint64
+	count    int
+	bytes    int64
+}
+
+const (
+	powerStreamFile      = "stream.json"
+	powerJournalMaxBytes = 32 << 20
+	powerJournalMaxLine  = 64 << 10
+	powerJournalMaxRec   = powerhistory.RetentionSeconds / powerhistory.WindowSeconds
+	powerJournalSegRec   = 10 // five minutes per segment; small so compaction rewrites stay cheap
+	powerJournalReserve  = 64 // sequence numbers reserved per state write
+)
+
+type powerStreamMeta struct {
+	StreamID  string `json:"stream_id"`
+	CreatedMS int64  `json:"created_unix_ms"`
+}
+
+type powerState struct {
+	Acked    uint64 `json:"acked"`
+	Reserved uint64 `json:"reserved"`
+}
+
+var errPowerLineTooLong = errors.New("record exceeds line limit")
+
+func openPowerJournal(dir string) (*powerJournal, error) {
+	return openPowerJournalWith(dir, time.Now)
+}
+
+func openPowerJournalWith(dir string, now func() time.Time) (*powerJournal, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create %s: %w", dir, err)
+	}
+	j := &powerJournal{
+		dir:        dir,
+		maxRecords: powerJournalMaxRec,
+		maxBytes:   powerJournalMaxBytes,
+		segRecords: powerJournalSegRec,
+		retention:  powerhistory.RetentionSeconds * time.Second,
+		now:        now,
+	}
+	if err := j.loadIdentity(); err != nil {
+		return nil, err
+	}
+	if err := j.recover(); err != nil {
+		return nil, err
+	}
+	j.removeOrphans()
+	last := max(j.acked, j.reserved)
+	if n := len(j.records); n > 0 && j.records[n-1].Seq > last {
+		last = j.records[n-1].Seq
+	}
+	j.nextSeq = last + 1
+	if j.nextSeq >= powerMaxSeq {
+		if err := j.rotateStream("sequence space exhausted"); err != nil {
+			return nil, err
+		}
+	}
+	if err := j.enforce(); err != nil {
+		return nil, err
+	}
+	return j, nil
+}
+
+func (j *powerJournal) statePath() string {
+	return filepath.Join(j.dir, "state-"+j.streamID+".json")
+}
+
+func (j *powerJournal) segPath(firstSeq uint64) string {
+	return filepath.Join(j.dir, fmt.Sprintf("seg-%s-%020d.ndjson", j.streamID, firstSeq))
+}
+
+// loadIdentity reads stream.json and its state file, rotating on anything
+// inconsistent. Identity without state means either a crash mid-rotation
+// (impossible by construction) or external tampering; either way the safe
+// answer is a new stream.
+func (j *powerJournal) loadIdentity() error {
+	data, err := os.ReadFile(filepath.Join(j.dir, powerStreamFile))
+	if err == nil {
+		var m powerStreamMeta
+		if json.Unmarshal(data, &m) == nil && isPowerStreamID(m.StreamID) {
+			j.streamID = m.StreamID
+			st, err := os.ReadFile(j.statePath())
+			var s powerState
+			if err == nil && json.Unmarshal(st, &s) == nil {
+				j.acked, j.reserved = s.Acked, s.Reserved
+				return nil
+			}
+			return j.rotateStream("state file missing or unreadable for stream " + j.streamID)
+		}
+		log.Printf("power-history: %s unreadable, starting a new stream", powerStreamFile)
+	}
+	return j.rotateStream("no stream identity")
+}
+
+func isPowerStreamID(s string) bool {
+	if len(s) != 32 {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
+}
+
+// rotateStream creates a fresh identity. Order: new state file first (an
+// orphan if we crash), then stream.json via one durable rename, which is
+// the commit. Old files are orphans afterwards and removed best-effort.
+func (j *powerJournal) rotateStream(why string) error {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Errorf("stream id: %w", err)
+	}
+	id := hex.EncodeToString(b[:])
+	if j.cur != nil {
+		j.cur.Close()
+		j.cur = nil
+	}
+	old := j.streamID
+	j.streamID = id
+	// Reserved 0: no sequence has been handed out under this identity, so
+	// the first append reserves and starts at 1. A restart later resumes
+	// at reserved+1 (never below), whatever the journal tail looks like.
+	st, _ := json.Marshal(powerState{Acked: 0, Reserved: 0})
+	if err := writePowerFileAtomic(j.statePath(), st); err != nil {
+		j.streamID = old
+		return fmt.Errorf("write state: %w", err)
+	}
+	meta, _ := json.Marshal(powerStreamMeta{StreamID: id, CreatedMS: j.now().UnixMilli()})
+	if err := writePowerFileAtomic(filepath.Join(j.dir, powerStreamFile), meta); err != nil {
+		j.streamID = old
+		return fmt.Errorf("write stream identity: %w", err)
+	}
+	log.Printf("power-history: new stream %s (%s)", id, why)
+	j.segs = nil
+	j.records = nil
+	j.acked = 0
+	j.reserved = 0
+	j.nextSeq = 1
+	j.overCap = false
+	j.removeOrphans()
+	return nil
+}
+
+// removeOrphans deletes segment/state files that belong to other streams.
+func (j *powerJournal) removeOrphans() {
+	entries, err := os.ReadDir(j.dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		n := e.Name()
+		if e.IsDir() {
+			continue
+		}
+		ours := n == powerStreamFile ||
+			n == "state-"+j.streamID+".json" ||
+			strings.HasPrefix(n, "seg-"+j.streamID+"-")
+		known := strings.HasPrefix(n, "state-") || strings.HasPrefix(n, "seg-") ||
+			(strings.HasPrefix(n, ".") && strings.HasSuffix(n, ".tmp"))
+		if !ours && known {
+			_ = os.Remove(filepath.Join(j.dir, n))
+		}
+	}
+}
+
+// recover loads this stream's segments in sequence order, keeping the
+// longest valid strictly-ascending prefix. A torn/corrupt line truncates
+// its segment there and drops every later segment.
+func (j *powerJournal) recover() error {
+	entries, err := os.ReadDir(j.dir)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", j.dir, err)
+	}
+	prefix := "seg-" + j.streamID + "-"
+	for _, e := range entries {
+		n := e.Name()
+		if e.IsDir() || !strings.HasPrefix(n, prefix) || !strings.HasSuffix(n, ".ndjson") {
+			continue
+		}
+		fs, err := strconv.ParseUint(strings.TrimSuffix(strings.TrimPrefix(n, prefix), ".ndjson"), 10, 64)
+		if err != nil {
+			continue
+		}
+		j.segs = append(j.segs, &powerSegment{path: filepath.Join(j.dir, n), firstSeq: fs})
+	}
+	sort.Slice(j.segs, func(a, b int) bool { return j.segs[a].firstSeq < j.segs[b].firstSeq })
+	// Never load more files than retention could have produced; surplus
+	// oldest segments are already outside every bound.
+	if maxSegs := j.maxRecords/j.segRecords + 2; len(j.segs) > maxSegs {
+		for _, s := range j.segs[:len(j.segs)-maxSegs] {
+			_ = os.Remove(s.path)
+		}
+		j.segs = j.segs[len(j.segs)-maxSegs:]
+	}
+
+	var lastSeq uint64
+	var totalBytes int64
+	for i, seg := range j.segs {
+		good, count, recs, clean := j.readSegment(seg.path, lastSeq, j.maxBytes-totalBytes)
+		totalBytes += good
+		if len(recs) > 0 {
+			lastSeq = recs[len(recs)-1].Seq
+			seg.lastSeq = lastSeq
+		}
+		j.records = append(j.records, recs...)
+		seg.count, seg.bytes = count, good
+		if clean {
+			continue
+		}
+		log.Printf("power-history: %s truncated at byte %d (torn or corrupt record)", filepath.Base(seg.path), good)
+		if err := os.Truncate(seg.path, good); err != nil {
+			return fmt.Errorf("truncate %s: %w", seg.path, err)
+		}
+		for _, later := range j.segs[i+1:] {
+			_ = os.Remove(later.path)
+		}
+		j.segs = j.segs[:i+1]
+		break
+	}
+	// Drop empty segments (a truncated-to-zero tail) so firstSeq stays honest.
+	kept := j.segs[:0]
+	for _, seg := range j.segs {
+		if seg.count == 0 {
+			_ = os.Remove(seg.path)
+			continue
+		}
+		kept = append(kept, seg)
+	}
+	j.segs = kept
+	return nil
+}
+
+// readSegment parses one segment, returning the valid byte prefix, record
+// count, records, and whether the whole file was clean. Decoding stops (and
+// the rest is treated as corrupt) at the segment record cap, at the line
+// cap, or once byteBudget is exhausted, so an oversized file is never
+// loaded whole.
+func (j *powerJournal) readSegment(path string, lastSeq uint64, byteBudget int64) (int64, int, []powerhistory.Bucket, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, 0, nil, false
+	}
+	defer f.Close()
+	r := bufio.NewReaderSize(f, powerJournalMaxLine+1)
+	var good int64
+	var recs []powerhistory.Bucket
+	for {
+		if len(recs) >= j.segRecords || good >= byteBudget {
+			// Anything beyond the cap: is there more? then it's not clean.
+			_, peekErr := r.Peek(1)
+			return good, len(recs), recs, peekErr != nil
+		}
+		line, err := r.ReadSlice('\n')
+		if errors.Is(err, bufio.ErrBufferFull) || int64(len(line)) > byteBudget-good {
+			return good, len(recs), recs, false
+		}
+		if err != nil { // io.EOF: any partial trailing bytes are torn
+			return good, len(recs), recs, len(line) == 0
+		}
+		var b powerhistory.Bucket
+		if json.Unmarshal(bytes.TrimSpace(line), &b) != nil || b.Seq <= lastSeq {
+			return good, len(recs), recs, false
+		}
+		lastSeq = b.Seq
+		recs = append(recs, b)
+		good += int64(len(line))
+	}
+}
+
+// ensureOpen (re)opens the append handle for the current segment, starting a
+// new segment when there is none or the last one is full. Safe to call after
+// any failure: it never leaves the journal permanently closed, and a segment
+// is only registered once its file is actually open.
+func (j *powerJournal) ensureOpen() error {
+	if j.cur != nil {
+		return nil
+	}
+	var seg *powerSegment
+	if n := len(j.segs); n > 0 && j.segs[n-1].count < j.segRecords {
+		seg = j.segs[n-1]
+	}
+	fresh := seg == nil
+	if fresh {
+		seg = &powerSegment{path: j.segPath(j.nextSeq), firstSeq: j.nextSeq}
+		// Create the empty segment through the atomic writer so the new
+		// directory entry itself is durable (fsync of the parent on POSIX,
+		// write-through move on Windows) before any record lands in it. A
+		// path with firstSeq == nextSeq can never be a confirmed segment
+		// (recovery loaded everything below nextSeq), so replacing whatever
+		// sits there is safe; confirmed segments are never truncated here.
+		if err := writePowerFileAtomic(seg.path, nil); err != nil {
+			return err
+		}
+	}
+	f, err := os.OpenFile(seg.path, os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	// A failed earlier write may have left a partial line on an existing
+	// segment; cut back to the known-good byte count so it stays parseable.
+	if st, err := f.Stat(); err == nil && st.Size() != seg.bytes {
+		if err := f.Truncate(seg.bytes); err != nil {
+			f.Close()
+			return err
+		}
+	}
+	if fresh {
+		j.segs = append(j.segs, seg)
+	}
+	j.cur = f
+	return nil
+}
+
+func (j *powerJournal) writeState(acked, reserved uint64) error {
+	data, _ := json.Marshal(powerState{Acked: acked, Reserved: reserved})
+	if err := writePowerFileAtomic(j.statePath(), data); err != nil {
+		return fmt.Errorf("persist state: %w", err)
+	}
+	j.acked, j.reserved = acked, reserved
+	return nil
+}
+
+// append assigns the next sequence, writes and fsyncs the record, then makes
+// it retained. Every failure path leaves the journal ready to retry.
+func (j *powerJournal) append(b powerhistory.Bucket) error {
+	if j.overCap {
+		if err := j.enforce(); err != nil {
+			return fmt.Errorf("retention not enforceable, refusing new history: %w", err)
+		}
+	}
+	if j.nextSeq >= powerMaxSeq {
+		if err := j.rotateStream("sequence space exhausted"); err != nil {
+			return err
+		}
+	}
+	if j.nextSeq > j.reserved {
+		if err := j.writeState(j.acked, j.nextSeq+powerJournalReserve); err != nil {
+			return err
+		}
+	}
+	b.Seq = j.nextSeq
+	line, err := json.Marshal(b)
+	if err != nil {
+		return err
+	}
+	if len(line) > powerJournalMaxLine {
+		return errPowerLineTooLong
+	}
+	line = append(line, '\n')
+	if len(j.segs) > 0 && j.segs[len(j.segs)-1].count >= j.segRecords && j.cur != nil {
+		j.cur.Close()
+		j.cur = nil
+	}
+	if err := j.ensureOpen(); err != nil {
+		return err
+	}
+	if _, err := j.cur.Write(line); err != nil {
+		j.cur.Close()
+		j.cur = nil
+		return err
+	}
+	if err := j.cur.Sync(); err != nil {
+		j.cur.Close()
+		j.cur = nil
+		return err
+	}
+	seg := j.segs[len(j.segs)-1]
+	seg.count++
+	seg.bytes += int64(len(line))
+	seg.lastSeq = b.Seq
+	j.nextSeq++
+	j.records = append(j.records, b)
+	return j.enforce()
+}
+
+// enforce applies the hard bounds. In RAM: age filter across all records,
+// then the newest maxRecords. On disk: every segment is reconciled with RAM
+// membership — deleted when nothing in it is retained, compacted when only
+// part of it is — and then whole oldest segments go while total bytes
+// exceed the cap. Any failure sets overCap, which makes appends refuse
+// until a later enforcement succeeds.
+func (j *powerJournal) enforce() error {
+	now := j.now()
+	cut := now.Add(-j.retention).UnixMilli()
+	horizon := now.Add(powerhistory.MaxFutureSkewSeconds * time.Second).UnixMilli()
+	expired := 0
+	for _, r := range j.records {
+		if !powerRecordLive(r, cut, horizon) {
+			expired++
+		}
+	}
+	if expired > 0 {
+		// Fresh slice: the published snapshot aliases the old backing
+		// array and must never observe in-place compaction.
+		kept := make([]powerhistory.Bucket, 0, len(j.records)-expired)
+		for _, r := range j.records {
+			if powerRecordLive(r, cut, horizon) {
+				kept = append(kept, r)
+			}
+		}
+		j.records = kept
+	}
+	if n := len(j.records); n > j.maxRecords {
+		j.records = j.records[n-j.maxRecords:]
+	}
+
+	var firstErr error
+	var total int64
+	live := (*powerSegment)(nil)
+	if n := len(j.segs); n > 0 {
+		live = j.segs[n-1]
+	}
+	kept := make([]*powerSegment, 0, len(j.segs))
+	ri := 0
+	for _, s := range j.segs {
+		for ri < len(j.records) && j.records[ri].Seq < s.firstSeq {
+			ri++
+		}
+		start := ri
+		for ri < len(j.records) && j.records[ri].Seq <= s.lastSeq {
+			ri++
+		}
+		inSeg := j.records[start:ri]
+		if len(inSeg) == s.count || firstErr != nil {
+			kept = append(kept, s)
+			total += s.bytes
+			continue
+		}
+		if s == live && j.cur != nil {
+			j.cur.Close()
+			j.cur = nil
+		}
+		if len(inSeg) == 0 {
+			if err := os.Remove(s.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				firstErr = err
+				kept = append(kept, s)
+				total += s.bytes
+			}
+			continue
+		}
+		if err := j.compactSegment(s, inSeg); err != nil {
+			firstErr = err
+		}
+		kept = append(kept, s)
+		total += s.bytes
+	}
+	j.segs = kept
+
+	for firstErr == nil && total > j.maxBytes && len(j.segs) > 0 {
+		s := j.segs[0]
+		if s == live && j.cur != nil {
+			j.cur.Close()
+			j.cur = nil
+		}
+		if err := os.Remove(s.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			firstErr = err
+			break
+		}
+		total -= s.bytes
+		i := 0
+		for i < len(j.records) && j.records[i].Seq <= s.lastSeq {
+			i++
+		}
+		j.records = j.records[i:]
+		j.segs = j.segs[1:]
+	}
+
+	if cap(j.records) > 2*j.maxRecords+2*j.segRecords {
+		fresh := make([]powerhistory.Bucket, len(j.records))
+		copy(fresh, j.records)
+		j.records = fresh
+	}
+	if firstErr != nil {
+		j.overCap = true
+		return firstErr
+	}
+	j.overCap = false
+	return nil
+}
+
+// powerRecordLive reports whether a record is inside the retention window
+// and not implausibly far in the future. A bucket stamped while the wall
+// clock was wrong (jumped ahead, later corrected) would otherwise sit at the
+// head of the replay queue and be rejected by the hub's skew check for as
+// long as it stayed "in the future", blocking every valid bucket behind it.
+// Such records are treated as lost: dropped, compacted away, and declared
+// through RetainedFrom like any other retention loss.
+func powerRecordLive(r powerhistory.Bucket, cut, horizon int64) bool {
+	return r.EndUnixMS >= cut && r.EndUnixMS <= horizon
+}
+
+// compactSegment rewrites s so it holds exactly recs (temp file + durable
+// rename; the caller has closed the live handle if s is live).
+func (j *powerJournal) compactSegment(s *powerSegment, recs []powerhistory.Bucket) error {
+	var buf bytes.Buffer
+	for _, b := range recs {
+		line, err := json.Marshal(b)
+		if err != nil {
+			return err
+		}
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+	if err := writePowerFileAtomic(s.path, buf.Bytes()); err != nil {
+		return err
+	}
+	s.count = len(recs)
+	s.bytes = int64(buf.Len())
+	s.lastSeq = recs[len(recs)-1].Seq
+	return nil
+}
+
+// ack advances the cursor for a matching stream. through must not exceed
+// the last durable seq; anything at or below the current cursor is a
+// harmless replay. The cursor is persisted before the call returns.
+func (j *powerJournal) ack(streamID string, through uint64) (bool, error) {
+	if streamID != j.streamID {
+		return false, fmt.Errorf("stream mismatch (%s != %s)", streamID, j.streamID)
+	}
+	if through >= j.nextSeq {
+		return false, fmt.Errorf("through %d beyond last durable seq %d", through, j.nextSeq-1)
+	}
+	if through <= j.acked {
+		return false, nil
+	}
+	if err := j.writeState(through, j.reserved); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (j *powerJournal) close() {
+	if j.cur != nil {
+		j.cur.Close()
+		j.cur = nil
+	}
+}
+
+// powerSnapshot is the immutable view published to the send path. records
+// aliases the journal's slice: the worker only ever appends past this
+// length or replaces the slice, never mutates elements within it.
+type powerSnapshot struct {
+	streamID  string
+	acked     uint64
+	nextSeq   uint64
+	records   []powerhistory.Bucket
+	retention time.Duration
+	now       func() time.Time
+}
+
+func (j *powerJournal) snapshot() *powerSnapshot {
+	return &powerSnapshot{
+		streamID:  j.streamID,
+		acked:     j.acked,
+		nextSeq:   j.nextSeq,
+		records:   j.records[:len(j.records):len(j.records)],
+		retention: j.retention,
+		now:       j.now,
+	}
+}
+
+// pendingBatch returns the next replayable buckets: the oldest contiguous
+// run of unacknowledged records, bounded by count and encoded size, with the
+// age and future-skew bounds applied at read time so a stale snapshot never
+// exposes expired or clock-poisoned records. RetainedFrom is the oldest replayable pending seq (nextSeq when
+// nothing is pending) — NOT the oldest record on disk, since acknowledged
+// history is kept locally for the full retention window. A RetainedFrom
+// above acked+1 explicitly declares every sequence in between as lost
+// (retention trim, torn journal, or a post-restart reservation skip); the
+// hub commits that gap and ACKs across it. ok is false when there is
+// nothing to send and no gap to declare.
+func (s *powerSnapshot) pendingBatch(maxRecords, maxBytes int) (*powerhistory.Batch, bool) {
+	now := s.now()
+	cut := now.Add(-s.retention).UnixMilli()
+	horizon := now.Add(powerhistory.MaxFutureSkewSeconds * time.Second).UnixMilli()
+	var pending []powerhistory.Bucket
+	for _, r := range s.records {
+		if r.Seq > s.acked && powerRecordLive(r, cut, horizon) {
+			pending = append(pending, r)
+		}
+	}
+	// Only a contiguous run is replayable in one batch; anything after a
+	// sequence hole waits for the ACK that lets the next batch declare it.
+	end := 0
+	for end < len(pending) && end < maxRecords {
+		if end > 0 && pending[end].Seq != pending[end-1].Seq+1 {
+			break
+		}
+		end++
+	}
+	pending = pending[:end]
+	retainedFrom := s.nextSeq
+	if len(pending) > 0 {
+		retainedFrom = pending[0].Seq
+	}
+	gap := retainedFrom > s.acked+1
+	if len(pending) == 0 && !gap {
+		return nil, false
+	}
+	for {
+		batch := &powerhistory.Batch{
+			Type:         powerhistory.BatchType,
+			StreamID:     s.streamID,
+			RetainedFrom: retainedFrom,
+			Buckets:      pending,
+		}
+		if batch.Buckets == nil {
+			batch.Buckets = []powerhistory.Bucket{}
+		}
+		enc, err := json.Marshal(batch)
+		if err != nil {
+			return nil, false
+		}
+		if len(enc) <= maxBytes || len(pending) <= 1 {
+			return batch, true
+		}
+		pending = pending[:len(pending)/2]
+	}
+}
+
+// writePowerFileAtomic writes data to a same-directory temp file, fsyncs it
+// and durably renames it over path.
+func writePowerFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { tmp.Close(); os.Remove(tmpName) }
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := durableRename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return nil
+}

--- a/agent/power_journal_test.go
+++ b/agent/power_journal_test.go
@@ -1,0 +1,611 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/powerhistory"
+)
+
+// jclock is a settable wall clock for the journal's age bound.
+type jclock struct{ t time.Time }
+
+func (c *jclock) now() time.Time { return c.t }
+
+func openTestJournal(t *testing.T, dir string, c *jclock) *powerJournal {
+	t.Helper()
+	j, err := openPowerJournalWith(dir, c.now)
+	if err != nil {
+		t.Fatalf("open journal: %v", err)
+	}
+	t.Cleanup(j.close)
+	return j
+}
+
+func bucketEnding(endMS int64) powerhistory.Bucket {
+	m, p := 100.0, 120.0
+	return powerhistory.Bucket{
+		StartUnixMS: endMS - 30000, EndUnixMS: endMS, ExpectedSamples: 30,
+		GPUs: []powerhistory.Sensor{{ID: "GPU-a", Stats: powerhistory.Stats{MeanWatts: &m, PeakWatts: &p, Samples: 30}}},
+	}
+}
+
+func appendN(t *testing.T, j *powerJournal, c *jclock, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		c.t = c.t.Add(30 * time.Second)
+		if err := j.append(bucketEnding(c.t.UnixMilli())); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+}
+
+func seqs(bs []powerhistory.Bucket) []uint64 {
+	out := make([]uint64, len(bs))
+	for i, b := range bs {
+		out[i] = b.Seq
+	}
+	return out
+}
+
+func eqSeqs(a, b []uint64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func segFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, _ := os.ReadDir(dir)
+	var out []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "seg-") {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+func TestJournalIdentityPersistsAndSequenceNeverReused(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	id := j.streamID
+	if !isPowerStreamID(id) || j.nextSeq != 1 || j.reserved != 0 {
+		t.Fatalf("fresh journal: id=%q next=%d reserved=%d", id, j.nextSeq, j.reserved)
+	}
+	appendN(t, j, c, 20)
+	if j.records[0].Seq != 1 || j.reserved < 20 {
+		t.Fatalf("new stream must start at seq 1 and reserve ahead: first=%d reserved=%d", j.records[0].Seq, j.reserved)
+	}
+	reserved := j.reserved
+	j.close()
+
+	// Restart: identity kept, records replayable, next seq skips past the
+	// durable reservation so a torn tail can never reuse a committed seq.
+	j2 := openTestJournal(t, dir, c)
+	if j2.streamID != id {
+		t.Fatalf("stream id changed across restart: %s -> %s", id, j2.streamID)
+	}
+	if got := seqs(j2.records); len(got) != 20 || got[0] != 1 || got[19] != 20 {
+		t.Fatalf("records after restart: %v", got)
+	}
+	if j2.reserved != reserved || j2.nextSeq != reserved+1 {
+		t.Fatalf("nextSeq must resume at reservation+1 (%d), got %d (reserved %d)", reserved+1, j2.nextSeq, j2.reserved)
+	}
+	skip := reserved + 1 // first seq after the restart hole
+
+	// Simulate the hub's contiguous ACK progression across the hole.
+	snap := j2.snapshot()
+	b, ok := snap.pendingBatch(32, 1<<20)
+	if !ok || b.RetainedFrom != 1 || !eqSeqs(seqs(b.Buckets), seqs(j2.records)) {
+		t.Fatalf("first replay batch: ok=%v %+v", ok, b)
+	}
+	if adv, err := j2.ack(id, 20); err != nil || !adv {
+		t.Fatalf("ack 20: adv=%v err=%v", adv, err)
+	}
+	// Nothing pending yet: header-only batch declares 21..reserved lost.
+	b, ok = j2.snapshot().pendingBatch(32, 1<<20)
+	if !ok || len(b.Buckets) != 0 || b.RetainedFrom != skip {
+		t.Fatalf("gap declaration batch: ok=%v %+v", ok, b)
+	}
+	if adv, err := j2.ack(id, skip-1); err != nil || !adv {
+		t.Fatalf("ack across declared gap: adv=%v err=%v", adv, err)
+	}
+	if _, ok := j2.snapshot().pendingBatch(32, 1<<20); ok {
+		t.Fatal("nothing should be pending after the gap is acknowledged")
+	}
+	appendN(t, j2, c, 1)
+	b, ok = j2.snapshot().pendingBatch(32, 1<<20)
+	if !ok || b.RetainedFrom != skip || len(b.Buckets) != 1 || b.Buckets[0].Seq != skip {
+		t.Fatalf("post-gap batch: %+v", b)
+	}
+	// Acknowledged records stay on disk (24 h retention) — the hole is not
+	// a reason to drop them.
+	if len(j2.records) != 21 {
+		t.Fatalf("acked records must remain retained locally, have %d", len(j2.records))
+	}
+}
+
+func TestJournalBatchIsContiguousRunAndRetainedFromIsOldestPending(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	appendN(t, j, c, 5)
+	j.close()
+	j = openTestJournal(t, dir, c) // hole 6..reserved
+	skip := j.nextSeq
+	appendN(t, j, c, 3) // skip, skip+1, skip+2
+	if _, err := j.ack(j.streamID, 2); err != nil {
+		t.Fatal(err)
+	}
+	b, ok := j.snapshot().pendingBatch(32, 1<<20)
+	if !ok || b.RetainedFrom != 3 || !eqSeqs(seqs(b.Buckets), []uint64{3, 4, 5}) {
+		t.Fatalf("batch must stop at the hole: %+v", b)
+	}
+	if _, err := j.ack(j.streamID, 5); err != nil {
+		t.Fatal(err)
+	}
+	b, _ = j.snapshot().pendingBatch(32, 1<<20)
+	if b.RetainedFrom != skip || !eqSeqs(seqs(b.Buckets), []uint64{skip, skip + 1, skip + 2}) {
+		t.Fatalf("after ack the next run is offered with the gap declared: %+v", b)
+	}
+	// Size bound halves the run rather than exceeding the frame cap.
+	small, _ := j.snapshot().pendingBatch(32, 400)
+	if len(small.Buckets) >= 3 {
+		t.Fatalf("byte cap not applied: %d buckets", len(small.Buckets))
+	}
+}
+
+func TestJournalAckValidation(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	appendN(t, j, c, 3)
+	if _, err := j.ack("00000000000000000000000000000000", 1); err == nil {
+		t.Error("foreign stream ACK must be rejected")
+	}
+	if _, err := j.ack(j.streamID, 3); err != nil {
+		t.Errorf("ack of last durable seq must succeed: %v", err)
+	}
+	if _, err := j.ack(j.streamID, 4); err == nil {
+		t.Error("ACK beyond last durable seq must be rejected")
+	}
+	if adv, err := j.ack(j.streamID, 2); err != nil || adv {
+		t.Errorf("replayed/older ACK must be a no-op: adv=%v err=%v", adv, err)
+	}
+	j.close()
+	j2 := openTestJournal(t, dir, c)
+	if j2.acked != 3 {
+		t.Errorf("ACK cursor must persist across restart, got %d", j2.acked)
+	}
+	// After a restart the reservation hole (4..reserved) is declared by a
+	// header-only batch so the hub can ACK across it; no buckets travel.
+	b, ok := j2.snapshot().pendingBatch(32, 1<<20)
+	if !ok || len(b.Buckets) != 0 || b.RetainedFrom != j2.nextSeq {
+		t.Errorf("restart must declare the reservation hole: ok=%v %+v", ok, b)
+	}
+}
+
+func TestJournalTornTailIsTruncatedAndAppendContinues(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	appendN(t, j, c, 5)
+	j.close()
+	files := segFiles(t, dir)
+	if len(files) != 1 {
+		t.Fatalf("want one segment, got %v", files)
+	}
+	p := filepath.Join(dir, files[0])
+	data, _ := os.ReadFile(p)
+	if err := os.WriteFile(p, data[:len(data)-7], 0o644); err != nil {
+		t.Fatal(err)
+	}
+	j2 := openTestJournal(t, dir, c)
+	if got := seqs(j2.records); !eqSeqs(got, []uint64{1, 2, 3, 4}) {
+		t.Fatalf("torn record must be dropped: %v", got)
+	}
+	if st, _ := os.Stat(p); st.Size() != int64(len(data)-len(data[strings.LastIndex(string(data[:len(data)-1]), "\n")+1:])) {
+		t.Errorf("file must be truncated to the last good line, size=%d", st.Size())
+	}
+	skip := j2.reserved + 1
+	appendN(t, j2, c, 1)
+	if got := j2.records[len(j2.records)-1].Seq; got != skip || got <= 5 {
+		t.Errorf("post-recovery seq must come from the reservation (%d), got %d", skip, got)
+	}
+	j2.close()
+	j3 := openTestJournal(t, dir, c)
+	if got := seqs(j3.records); !eqSeqs(got, []uint64{1, 2, 3, 4, skip}) {
+		t.Fatalf("third open: %v", got)
+	}
+}
+
+func TestJournalCorruptMiddleSegmentDropsLaterSegments(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	j.segRecords = 2
+	appendN(t, j, c, 6) // segs: [1,2] [3,4] [5,6]
+	j.close()
+	files := segFiles(t, dir)
+	if len(files) != 3 {
+		t.Fatalf("want 3 segments, got %v", files)
+	}
+	if err := os.WriteFile(filepath.Join(dir, files[1]), []byte("{garbage\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	j2 := openTestJournal(t, dir, c)
+	j2.segRecords = 2
+	if got := seqs(j2.records); !eqSeqs(got, []uint64{1, 2}) {
+		t.Fatalf("records after corrupt middle segment: %v", got)
+	}
+	if left := segFiles(t, dir); len(left) != 1 {
+		t.Fatalf("later segments must be removed, left %v", left)
+	}
+}
+
+func TestJournalMissingStateRotatesIdentity(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	id := j.streamID
+	appendN(t, j, c, 3)
+	j.close()
+	if err := os.Remove(filepath.Join(dir, "state-"+id+".json")); err != nil {
+		t.Fatal(err)
+	}
+	j2 := openTestJournal(t, dir, c)
+	if j2.streamID == id {
+		t.Fatal("identity without its state file must rotate (fail closed)")
+	}
+	if len(j2.records) != 0 || j2.nextSeq != 1 {
+		t.Fatalf("rotated stream must start empty: %d records next=%d", len(j2.records), j2.nextSeq)
+	}
+	for _, f := range segFiles(t, dir) {
+		if strings.Contains(f, id) {
+			t.Errorf("orphan segment of old stream left behind: %s", f)
+		}
+	}
+}
+
+func TestJournalCountBoundCompactsSegments(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	j.maxRecords, j.segRecords = 10, 4
+	appendN(t, j, c, 20)
+	// Strict RAM bound; on disk, fully-dropped segments are deleted and the
+	// boundary segment is compacted to exactly the retained records.
+	if got := seqs(j.records); len(got) != 10 || got[0] != 11 {
+		t.Fatalf("retained after count bound: %v", got)
+	}
+	files := segFiles(t, dir)
+	if len(files) != 3 { // [9-12]→[11,12], [13-16], [17-20]
+		t.Fatalf("segments on disk: %v", files)
+	}
+	if n := segLines(t, filepath.Join(dir, files[0])); n != 2 {
+		t.Fatalf("boundary segment must be compacted to 2 lines, has %d", n)
+	}
+	b, _ := j.snapshot().pendingBatch(32, 1<<20)
+	if b.RetainedFrom != 11 {
+		t.Errorf("retention gap must be declared: RetainedFrom=%d", b.RetainedFrom)
+	}
+	j.close()
+	j2 := openTestJournal(t, dir, c)
+	if got := seqs(j2.records); len(got) != 10 || got[0] != 11 {
+		t.Fatalf("after reopen: %v", got)
+	}
+}
+
+func TestJournalByteBoundIsStrict(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	line, _ := json.Marshal(bucketEnding(0))
+	j.segRecords = 2
+	j.maxBytes = int64(len(line)+20) * 5
+	for i := 0; i < 40; i++ {
+		appendN(t, j, c, 1)
+		var total int64
+		for _, f := range segFiles(t, dir) {
+			st, _ := os.Stat(filepath.Join(dir, f))
+			total += st.Size()
+		}
+		if total > j.maxBytes {
+			t.Fatalf("after %d appends disk holds %d > cap %d", i+1, total, j.maxBytes)
+		}
+	}
+}
+
+func TestJournalAgeBoundAcrossAllRecordsAndOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	j.segRecords = 3
+	appendN(t, j, c, 6) // 6 records over 3 min
+	// Clock regression: a record whose end time is far in the past lands in
+	// the interior of the sequence.
+	old := bucketEnding(c.t.Add(-48 * time.Hour).UnixMilli())
+	if err := j.append(old); err != nil {
+		t.Fatal(err)
+	}
+	appendN(t, j, c, 2)
+	for _, r := range j.records {
+		if r.Seq == 7 {
+			t.Fatal("expired interior record must not be retained in RAM")
+		}
+	}
+	b, _ := j.snapshot().pendingBatch(32, 1<<20)
+	for _, r := range b.Buckets {
+		if r.Seq == 7 {
+			t.Fatal("expired interior record must not be uploaded")
+		}
+	}
+	// Advance past retention for the first two segments: they must be gone
+	// from disk even though the last one is still live.
+	c.t = c.t.Add(24*time.Hour + time.Minute)
+	appendN(t, j, c, 1)
+	if got := seqs(j.records); len(got) != 1 {
+		t.Fatalf("only the fresh record may remain: %v", got)
+	}
+	if files := segFiles(t, dir); len(files) != 1 {
+		t.Fatalf("expired segments must be deleted: %v", files)
+	}
+	// Retention gap is explicit.
+	b, _ = j.snapshot().pendingBatch(32, 1<<20)
+	if b.RetainedFrom != 10 {
+		t.Errorf("RetainedFrom=%d", b.RetainedFrom)
+	}
+}
+
+func TestJournalDiskFailureIsRetriedNotPermanent(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	appendN(t, j, c, 2)
+	// Storage vanishes: close the handle, make the live segment "full" so
+	// the next append must create a new segment, and point the directory at
+	// a path that does not exist.
+	real := j.dir
+	j.close()
+	j.segRecords = 2
+	j.dir = filepath.Join(dir, "gone")
+	for i := 0; i < 3; i++ {
+		if err := j.append(bucketEnding(1)); err == nil {
+			t.Fatal("append must fail while the journal directory is unavailable")
+		}
+	}
+	if j.nextSeq != 3 {
+		t.Fatalf("a failed append must not consume a sequence, nextSeq=%d", j.nextSeq)
+	}
+	if len(j.segs) != 1 {
+		t.Fatalf("failed opens must not register phantom segments: %d", len(j.segs))
+	}
+	// Storage returns: the next append creates the new segment and continues.
+	j.dir = real
+	appendN(t, j, c, 1)
+	if got := seqs(j.records); !eqSeqs(got, []uint64{1, 2, 3}) {
+		t.Fatalf("after recovery: %v", got)
+	}
+	j.close()
+	j2 := openTestJournal(t, dir, c)
+	if got := seqs(j2.records); !eqSeqs(got, []uint64{1, 2, 3}) {
+		t.Fatalf("durable after recovery: %v", got)
+	}
+}
+
+func TestJournalRefusesOversizedRecordAndUnenforceableRetention(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	big := bucketEnding(1)
+	big.GPUs[0].ID = strings.Repeat("x", powerJournalMaxLine)
+	if err := j.append(big); !errors.Is(err, errPowerLineTooLong) {
+		t.Fatalf("oversized line must be refused, got %v", err)
+	}
+	if j.nextSeq != 1 {
+		t.Fatal("refused record must not consume a sequence")
+	}
+
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions; cannot force an unlink failure")
+	}
+	j.segRecords, j.maxRecords = 2, 2
+	appendN(t, j, c, 2)
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0o755) })
+	// Next append must roll to a new segment (needs create → fails) or, if
+	// it can proceed, retention must be enforced; either way no growth
+	// beyond the caps and no permanent wedge.
+	err := j.append(bucketEnding(c.t.UnixMilli()))
+	if err == nil && len(segFiles(t, dir)) > 2 {
+		t.Fatal("journal grew past its bound while retention could not be enforced")
+	}
+	os.Chmod(dir, 0o755)
+	appendN(t, j, c, 2)
+	if len(j.records) > 2 {
+		t.Fatalf("RAM bound violated: %d", len(j.records))
+	}
+}
+
+func TestJournalRecoveryIsBounded(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	j.segRecords = 2
+	appendN(t, j, c, 4)
+	j.close()
+	files := segFiles(t, dir)
+	// Inflate the first segment far past its record cap.
+	p := filepath.Join(dir, files[0])
+	data, _ := os.ReadFile(p)
+	var blob []byte
+	for i := 0; i < 50; i++ {
+		blob = append(blob, data...)
+	}
+	if err := os.WriteFile(p, blob, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	j2, err := openPowerJournalWith(dir, c.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer j2.close()
+	// Duplicate seqs are not ascending → treated as corrupt after the valid
+	// prefix; later segments dropped; nothing unbounded loaded.
+	if len(j2.records) > powerJournalSegRec {
+		t.Fatalf("recovery loaded %d records from an oversized segment", len(j2.records))
+	}
+	if st, _ := os.Stat(p); st.Size() >= int64(len(blob)) {
+		t.Error("oversized segment must be truncated back to its valid prefix")
+	}
+}
+
+func segLines(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return strings.Count(string(data), "\n")
+}
+
+func TestJournalExpiredInteriorRecordIsCompactedOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	j.segRecords = 3
+	appendN(t, j, c, 3) // seg A: 1,2,3
+	appendN(t, j, c, 1) // seg B: 4
+	old := bucketEnding(c.t.Add(-48 * time.Hour).UnixMilli())
+	if err := j.append(old); err != nil { // seg B: 5 (expired interior) → compacted out at once
+		t.Fatal(err)
+	}
+	appendN(t, j, c, 2) // seg B: 6, 7 (compaction freed the slot)
+	files := segFiles(t, dir)
+	if len(files) != 2 {
+		t.Fatalf("segments: %v", files)
+	}
+	if n := segLines(t, filepath.Join(dir, files[1])); n != 3 {
+		t.Fatalf("interior expired record must be compacted away on disk; seg B has %d lines", n)
+	}
+	if got := seqs(j.records); !eqSeqs(got, []uint64{1, 2, 3, 4, 6, 7}) {
+		t.Fatalf("RAM: %v", got)
+	}
+	j.close()
+	j2 := openTestJournal(t, dir, c)
+	if got := seqs(j2.records); !eqSeqs(got, []uint64{1, 2, 3, 4, 6, 7}) {
+		t.Fatalf("after reopen: %v", got)
+	}
+	// Horizon crossing compacts the LIVE segment too: 1..6 expire, 7 stays,
+	// and the next append lands in the compacted live segment.
+	c.t = c.t.Add(24*time.Hour - 30*time.Second)
+	appendN(t, j2, c, 1) // seq resumes past the reservation after the reopen
+	got := seqs(j2.records)
+	if len(got) == 0 || got[0] != 7 || got[len(got)-1] != j2.nextSeq-1 {
+		t.Fatalf("horizon crossing: %v (next %d)", got, j2.nextSeq)
+	}
+	for _, r := range j2.records {
+		if r.EndUnixMS < c.t.Add(-24*time.Hour).UnixMilli() {
+			t.Fatalf("expired record retained: seq %d", r.Seq)
+		}
+	}
+	left := segFiles(t, dir)
+	if len(left) != 1 {
+		t.Fatalf("seg A must be deleted and seg B compacted+live: %v", left)
+	}
+	if n := segLines(t, filepath.Join(dir, left[0])); n != len(j2.records) {
+		t.Fatalf("live segment lines %d != retained records %d", n, len(j2.records))
+	}
+}
+
+func TestJournalIdleAllExpiredIsPurgedByRetentionTick(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	j.segRecords = 2
+	appendN(t, j, c, 5) // 3 segments incl. live
+	if _, err := j.ack(j.streamID, 5); err != nil {
+		t.Fatal(err)
+	}
+	// Sensors stop, everything is acknowledged, a day passes.
+	c.t = c.t.Add(25 * time.Hour)
+	if err := j.enforce(); err != nil {
+		t.Fatal(err)
+	}
+	if len(j.records) != 0 || len(segFiles(t, dir)) != 0 || len(j.segs) != 0 {
+		t.Fatalf("idle expiry must purge every segment including the live one: records=%d files=%v segs=%d",
+			len(j.records), segFiles(t, dir), len(j.segs))
+	}
+	// And the journal keeps working afterwards.
+	appendN(t, j, c, 1)
+	if got := seqs(j.records); len(got) != 1 || got[0] != 6 {
+		t.Fatalf("append after purge: %v", got)
+	}
+}
+
+func TestPowerHistoryWorkerTickEnforcesRetentionWithoutSamples(t *testing.T) {
+	prev := powerRetentionTick
+	powerRetentionTick = 10 * time.Millisecond
+	t.Cleanup(func() { powerRetentionTick = prev })
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openWorkerJournal(t, dir, c)
+	appendN(t, j, c, 3)
+	var mu sync.Mutex
+	now := c.t
+	j.now = func() time.Time { mu.Lock(); defer mu.Unlock(); return now }
+	ph := newPowerHistory(j)
+	startWorker(t, ph)
+	mu.Lock()
+	now = now.Add(25 * time.Hour)
+	mu.Unlock()
+	waitFor(t, "retention tick purge", func() bool { return len(ph.snap.Load().records) == 0 })
+	// Join the worker before inspecting the directory.
+	ph.cancelForTest()
+	if files := segFiles(t, dir); len(files) != 0 {
+		t.Fatalf("segments left on disk after idle expiry: %v", files)
+	}
+}
+
+func TestJournalFutureStampedBucketIsDroppedNotReplayed(t *testing.T) {
+	dir := t.TempDir()
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, dir, c)
+	// Clock jumps 48 h ahead; a bucket is stamped there.
+	c.t = c.t.Add(48 * time.Hour)
+	appendN(t, j, c, 1) // seq 1, end ≈ now+48h (by the wrong clock it is "now")
+	// Clock corrects; a normal bucket follows.
+	c.t = c.t.Add(-48 * time.Hour)
+	appendN(t, j, c, 1) // seq 2
+	b, ok := j.snapshot().pendingBatch(32, 1<<20)
+	if !ok || b.RetainedFrom != 2 || !eqSeqs(seqs(b.Buckets), []uint64{2}) {
+		t.Fatalf("future bucket must be declared lost and seq 2 offered: ok=%v %+v", ok, b)
+	}
+	if got := seqs(j.records); !eqSeqs(got, []uint64{2}) {
+		t.Fatalf("future bucket must be purged from RAM: %v", got)
+	}
+	if n := segLines(t, filepath.Join(dir, segFiles(t, dir)[0])); n != 1 {
+		t.Fatalf("future bucket must be compacted off disk, %d lines", n)
+	}
+	// Small allowed skew is not touched.
+	c.t = c.t.Add(-10 * time.Minute)
+	if got, _ := j.snapshot().pendingBatch(32, 1<<20); len(got.Buckets) != 1 {
+		t.Fatalf("a bucket within the allowed skew must remain replayable: %+v", got)
+	}
+}

--- a/agent/power_nvidia.go
+++ b/agent/power_nvidia.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"log"
+	"math"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/powerhistory"
+)
+
+// nvidiaPowerStream keeps ONE long-lived nvidia-smi process streaming
+// per-GPU power at 1 Hz instead of forking a full `-x -q` dump every second.
+// The process is restarted with bounded exponential backoff when it exits,
+// and killed when it stalls (no line within stallTimeout). Nothing here
+// touches the network or the journal.
+type nvidiaPowerStream struct {
+	resolve    func() string
+	start      func(ctx context.Context, path string) (io.ReadCloser, func() error, error)
+	emit       func(powerGPUTick)
+	now        func() time.Time
+	stall      time.Duration
+	minBackoff time.Duration
+	maxBackoff time.Duration
+}
+
+func newNvidiaPowerStream(resolve func() string, emit func(powerGPUTick)) *nvidiaPowerStream {
+	return &nvidiaPowerStream{
+		resolve:    resolve,
+		start:      startNvidiaSmiStream,
+		emit:       emit,
+		now:        time.Now,
+		stall:      10 * time.Second,
+		minBackoff: 2 * time.Second,
+		maxBackoff: 5 * time.Minute,
+	}
+}
+
+// nvidiaPowerArgs is the streaming query. count (repeated on every line)
+// tells the grouper how many lines make one complete iteration; uuid gives a
+// sensor id that is stable across reboots and re-enumeration; index only
+// detects the start of a new iteration when the previous one was partial.
+var nvidiaPowerArgs = []string{
+	"--query-gpu=count,index,uuid,power.draw",
+	"--format=csv,noheader,nounits",
+	"-lms", strconv.Itoa(int(powerSampleInterval / time.Millisecond)),
+}
+
+func startNvidiaSmiStream(ctx context.Context, path string) (io.ReadCloser, func() error, error) {
+	cmd := exec.CommandContext(ctx, path, nvidiaPowerArgs...)
+	cmd.WaitDelay = 2 * time.Second
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+	return out, cmd.Wait, nil
+}
+
+func (s *nvidiaPowerStream) run(ctx context.Context) {
+	backoff := s.minBackoff
+	for ctx.Err() == nil {
+		path := s.resolve()
+		progressed := false
+		if path != "" {
+			progressed = s.runOnce(ctx, path)
+		}
+		if progressed {
+			backoff = s.minBackoff
+		} else {
+			backoff = min(backoff*2, s.maxBackoff)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+	}
+}
+
+// runOnce drives one process to completion and reports whether it produced
+// at least one usable tick (which resets the restart backoff).
+func (s *nvidiaPowerStream) runOnce(ctx context.Context, path string) bool {
+	pctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	out, wait, err := s.start(pctx, path)
+	if err != nil {
+		log.Printf("power-history: start nvidia-smi stream: %v", err)
+		return false
+	}
+	lines := make(chan string, 64)
+	go func() {
+		defer close(lines)
+		sc := bufio.NewScanner(out)
+		sc.Buffer(make([]byte, 4096), 64<<10)
+		for sc.Scan() {
+			select {
+			case lines <- sc.Text():
+			case <-pctx.Done():
+				return
+			}
+		}
+	}()
+	g := &nvidiaTickGrouper{}
+	progressed := false
+	stall := time.NewTimer(s.stall)
+	defer stall.Stop()
+	for {
+		select {
+		case <-pctx.Done():
+			cancel()
+			_ = wait()
+			return progressed
+		case <-stall.C:
+			log.Printf("power-history: nvidia-smi stream stalled for %s, restarting", s.stall)
+			cancel()
+			_ = wait()
+			return progressed
+		case line, ok := <-lines:
+			if !ok {
+				if t := g.flush(); t != nil {
+					s.emit(*t)
+					progressed = true
+				}
+				err := wait()
+				if ctx.Err() == nil {
+					log.Printf("power-history: nvidia-smi stream exited: %v", err)
+				}
+				return progressed
+			}
+			stall.Reset(s.stall) // Go ≥1.23 timers: safe without draining
+			l, ok := parseNvidiaPowerLine(line)
+			if !ok {
+				continue
+			}
+			for _, t := range g.push(l, s.now()) {
+				s.emit(t)
+				progressed = true
+			}
+		}
+	}
+}
+
+// nvidiaPowerLine is one parsed "count, index, uuid, power" line.
+type nvidiaPowerLine struct {
+	count int
+	index int
+	r     powerReading
+}
+
+// nvidiaMaxWatts bounds a plausible single-device reading.
+const nvidiaMaxWatts = 10000
+
+// parseNvidiaPowerLine parses a line emitted with --format=csv,noheader,
+// nounits. Unreadable power ("[N/A]", "[Not Supported]", "[Unknown Error]",
+// non-finite or out of range) yields a nil reading for that sensor. A
+// missing or malformed uuid falls back to "gpu-<index>".
+func parseNvidiaPowerLine(line string) (nvidiaPowerLine, bool) {
+	parts := strings.Split(line, ",")
+	if len(parts) != 4 {
+		return nvidiaPowerLine{}, false
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil || count < 1 || count > powerhistory.MaxSensors {
+		return nvidiaPowerLine{}, false
+	}
+	idx, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil || idx < 0 || idx >= count {
+		return nvidiaPowerLine{}, false
+	}
+	id := strings.TrimSpace(parts[2])
+	if !isPowerSensorID(id) {
+		id = "gpu-" + strconv.Itoa(idx)
+	}
+	l := nvidiaPowerLine{count: count, index: idx, r: powerReading{id: id}}
+	if w, err := strconv.ParseFloat(strings.TrimSpace(parts[3]), 64); err == nil &&
+		!math.IsNaN(w) && !math.IsInf(w, 0) && w >= 0 && w <= nvidiaMaxWatts {
+		l.r.watts = &w
+	}
+	return l, true
+}
+
+// isPowerSensorID accepts the hub's sensor-id alphabet: 1–64 chars of
+// [A-Za-z0-9_-] (an NVIDIA uuid such as "GPU-9d8c…" fits).
+func isPowerSensorID(s string) bool {
+	if len(s) == 0 || len(s) > 64 {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '-', c == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// nvidiaTickGrouper reassembles the per-GPU lines of one -lms iteration
+// into a tick. An iteration is complete when it holds `count` distinct
+// sensors; it is flushed incomplete when a new iteration starts early
+// (index no longer increasing), when the count changes mid-iteration, or
+// when a sensor id repeats (that line is discarded). The group can never
+// exceed MaxSensors.
+type nvidiaTickGrouper struct {
+	count     int
+	cur       []powerReading
+	seen      map[string]bool
+	lastIndex int
+	at        time.Time
+	valid     bool
+}
+
+// push adds one line and returns zero, one or two ticks: a partial
+// predecessor that had to be flushed early, and/or the group just completed.
+func (g *nvidiaTickGrouper) push(l nvidiaPowerLine, now time.Time) []powerGPUTick {
+	var out []powerGPUTick
+	if len(g.cur) > 0 && (l.index <= g.lastIndex || l.count != g.count) {
+		if t := g.flush(); t != nil {
+			out = append(out, *t)
+		}
+	}
+	if len(g.cur) > 0 && (g.seen[l.r.id] || len(g.cur) >= powerhistory.MaxSensors) {
+		// A repeated sensor or an overlong iteration: the group is broken.
+		// Flush it incomplete and drop the offending line.
+		g.valid = false
+		if t := g.flush(); t != nil {
+			out = append(out, *t)
+		}
+		g.lastIndex = l.index
+		return out
+	}
+	if len(g.cur) == 0 {
+		g.at, g.count, g.seen, g.valid = now, l.count, map[string]bool{}, true
+	}
+	g.seen[l.r.id] = true
+	g.cur = append(g.cur, l.r)
+	g.lastIndex = l.index
+	if len(g.cur) >= g.count {
+		if t := g.flush(); t != nil {
+			out = append(out, *t)
+		}
+	}
+	return out
+}
+
+// flush emits the current group; complete only when it holds exactly the
+// advertised count of distinct, valid sensors.
+func (g *nvidiaTickGrouper) flush() *powerGPUTick {
+	if len(g.cur) == 0 {
+		return nil
+	}
+	t := &powerGPUTick{at: g.at, readings: g.cur, complete: g.valid && len(g.cur) == g.count}
+	g.cur, g.seen = nil, nil
+	return t
+}

--- a/agent/power_nvidia_test.go
+++ b/agent/power_nvidia_test.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestParseNvidiaPowerLine(t *testing.T) {
+	cases := []struct {
+		in    string
+		ok    bool
+		count int
+		idx   int
+		id    string
+		watts *float64
+	}{
+		{"2, 0, GPU-9d8c1a2b-1234-5678-9abc-def012345678, 34.12", true, 2, 0, "GPU-9d8c1a2b-1234-5678-9abc-def012345678", f(34.12)},
+		{"2, 1, GPU-abc, [N/A]", true, 2, 1, "GPU-abc", nil},
+		{"2, 1, GPU-abc, [Not Supported]", true, 2, 1, "GPU-abc", nil},
+		{"1, 0, [N/A], 12", true, 1, 0, "gpu-0", f(12)},
+		{"1, 0, bad id!, 12", true, 1, 0, "gpu-0", f(12)},
+		{"1, 0, GPU-x, +Inf", true, 1, 0, "GPU-x", nil},
+		{"1, 0, GPU-x, NaN", true, 1, 0, "GPU-x", nil},
+		{"1, 0, GPU-x, -5", true, 1, 0, "GPU-x", nil},
+		{"1, 0, GPU-x, 99999", true, 1, 0, "GPU-x", nil},
+		{"0, 0, GPU-x, 10", false, 0, 0, "", nil},
+		{"2, 2, GPU-x, 10", false, 0, 0, "", nil},
+		{"17, 0, GPU-x, 10", false, 0, 0, "", nil},
+		{"0, GPU-x, 10", false, 0, 0, "", nil},
+		{"", false, 0, 0, "", nil},
+	}
+	for _, c := range cases {
+		l, ok := parseNvidiaPowerLine(c.in)
+		if ok != c.ok {
+			t.Errorf("%q: ok=%v want %v", c.in, ok, c.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if l.count != c.count || l.index != c.idx || l.r.id != c.id {
+			t.Errorf("%q: got count=%d idx=%d id=%q", c.in, l.count, l.index, l.r.id)
+		}
+		switch {
+		case c.watts == nil && l.r.watts != nil:
+			t.Errorf("%q: want nil watts, got %v", c.in, *l.r.watts)
+		case c.watts != nil && (l.r.watts == nil || *l.r.watts != *c.watts):
+			t.Errorf("%q: want %v watts, got %v", c.in, *c.watts, l.r.watts)
+		}
+	}
+}
+
+func pushLines(g *nvidiaTickGrouper, lines ...string) []powerGPUTick {
+	var out []powerGPUTick
+	for _, ln := range lines {
+		l, ok := parseNvidiaPowerLine(ln)
+		if !ok {
+			continue
+		}
+		out = append(out, g.push(l, time.Now())...)
+	}
+	return out
+}
+
+func TestNvidiaGrouperCompletenessComesFromCount(t *testing.T) {
+	g := &nvidiaTickGrouper{}
+	// A complete iteration flushes as soon as count lines are in — no 1 s lag.
+	ticks := pushLines(g, "2, 0, GPU-a, 100", "2, 1, GPU-b, 200")
+	if len(ticks) != 1 || !ticks[0].complete || len(ticks[0].readings) != 2 {
+		t.Fatalf("complete iteration: %+v", ticks)
+	}
+	// First partial iteration (stream started mid-iteration) is NOT total.
+	g = &nvidiaTickGrouper{}
+	ticks = pushLines(g, "2, 1, GPU-b, 200", "2, 0, GPU-a, 100", "2, 1, GPU-b, 200")
+	if len(ticks) != 2 || ticks[0].complete || !ticks[1].complete {
+		t.Fatalf("partial-then-complete: %+v", ticks)
+	}
+	// EOF with a partial group is incomplete.
+	g = &nvidiaTickGrouper{}
+	pushLines(g, "2, 0, GPU-a, 100")
+	if tk := g.flush(); tk == nil || tk.complete {
+		t.Fatalf("EOF partial must be incomplete: %+v", tk)
+	}
+	// N/A device: still a complete iteration structurally; the accumulator
+	// decides the total from nil watts.
+	g = &nvidiaTickGrouper{}
+	ticks = pushLines(g, "2, 0, GPU-a, 100", "2, 1, GPU-b, [N/A]")
+	if len(ticks) != 1 || !ticks[0].complete || ticks[0].readings[1].watts != nil {
+		t.Fatalf("N/A iteration: %+v", ticks)
+	}
+	// Repeated id inside one iteration invalidates it.
+	g = &nvidiaTickGrouper{}
+	ticks = pushLines(g, "2, 0, GPU-a, 100", "2, 1, GPU-a, 200")
+	if len(ticks) != 1 || ticks[0].complete {
+		t.Fatalf("repeated id must not be complete: %+v", ticks)
+	}
+	// Count change mid-iteration flushes the old group incomplete, and a
+	// count-1 successor completes immediately — both are returned.
+	g = &nvidiaTickGrouper{}
+	ticks = pushLines(g, "2, 0, GPU-a, 100", "1, 0, GPU-a, 100")
+	if len(ticks) != 2 || ticks[0].complete || !ticks[1].complete {
+		t.Fatalf("count change: %+v", ticks)
+	}
+}
+
+func TestNvidiaGrouperIsBounded(t *testing.T) {
+	g := &nvidiaTickGrouper{}
+	// Hostile stream: strictly ascending index forever with count pinned at
+	// 16 never completes; the group must not grow past MaxSensors.
+	for i := 0; i < 1000; i++ {
+		l := nvidiaPowerLine{count: 16, index: 15, r: powerReading{id: "GPU-" + strings.Repeat("x", i%8) + string(rune('a'+i%26))}}
+		if i == 0 {
+			l.index = 0
+		}
+		g.push(l, time.Now())
+		if len(g.cur) > 16 {
+			t.Fatalf("group grew to %d", len(g.cur))
+		}
+	}
+}
+
+// fakeProc simulates the nvidia-smi child: a pipe the test writes to, and a
+// wait that returns once the pipe is closed or the context is cancelled.
+type fakeProc struct {
+	r    *io.PipeReader
+	w    *io.PipeWriter
+	done chan struct{}
+	once sync.Once
+}
+
+func newFakeProc() *fakeProc {
+	r, w := io.Pipe()
+	return &fakeProc{r: r, w: w, done: make(chan struct{})}
+}
+
+func (p *fakeProc) start(ctx context.Context, _ string) (io.ReadCloser, func() error, error) {
+	go func() {
+		<-ctx.Done()
+		p.once.Do(func() { p.w.Close(); close(p.done) })
+	}()
+	return p.r, func() error { <-p.done; return errors.New("exited") }, nil
+}
+
+func (p *fakeProc) writeln(s string) { _, _ = io.WriteString(p.w, s+"\n") }
+func (p *fakeProc) exit()            { p.once.Do(func() { p.w.Close(); close(p.done) }) }
+
+func TestNvidiaStreamEmitsTicksAndReportsProgress(t *testing.T) {
+	proc := newFakeProc()
+	var mu sync.Mutex
+	var got []powerGPUTick
+	s := &nvidiaPowerStream{
+		resolve: func() string { return "nvidia-smi" },
+		start:   proc.start,
+		emit: func(tk powerGPUTick) {
+			mu.Lock()
+			got = append(got, tk)
+			mu.Unlock()
+		},
+		now:   time.Now,
+		stall: 2 * time.Second,
+	}
+	res := make(chan bool, 1)
+	go func() { res <- s.runOnce(context.Background(), "nvidia-smi") }()
+	proc.writeln("2, 0, GPU-a, 100")
+	proc.writeln("2, 1, GPU-b, 200")
+	proc.writeln("2, 0, GPU-a, 110")
+	proc.writeln("2, 1, GPU-b, 210")
+	proc.writeln("2, 0, GPU-a, 120") // partial at exit
+	proc.exit()
+	select {
+	case progressed := <-res:
+		if !progressed {
+			t.Fatal("stream produced ticks but reported no progress")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runOnce did not return after process exit")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 3 || !got[0].complete || !got[1].complete || got[2].complete {
+		t.Fatalf("ticks: %+v", got)
+	}
+	if *got[1].readings[1].watts != 210 {
+		t.Errorf("second tick GPU-b = %v", *got[1].readings[1].watts)
+	}
+}
+
+func TestNvidiaStreamKillsStalledProcess(t *testing.T) {
+	proc := newFakeProc()
+	s := &nvidiaPowerStream{
+		resolve: func() string { return "nvidia-smi" },
+		start:   proc.start,
+		emit:    func(powerGPUTick) {},
+		now:     time.Now,
+		stall:   100 * time.Millisecond,
+	}
+	startAt := time.Now()
+	progressed := s.runOnce(context.Background(), "nvidia-smi")
+	if progressed {
+		t.Error("stalled process must not count as progress")
+	}
+	if d := time.Since(startAt); d > 3*time.Second {
+		t.Fatalf("stall detection took %s", d)
+	}
+	select {
+	case <-proc.done:
+	default:
+		t.Error("stalled process was not torn down")
+	}
+}
+
+func TestNvidiaStreamBackoffIsBoundedAndResets(t *testing.T) {
+	var starts int
+	var mu sync.Mutex
+	s := &nvidiaPowerStream{
+		resolve: func() string { return "" }, // nvidia-smi absent
+		start: func(ctx context.Context, _ string) (io.ReadCloser, func() error, error) {
+			mu.Lock()
+			starts++
+			mu.Unlock()
+			return nil, nil, errors.New("no device")
+		},
+		emit:       func(powerGPUTick) {},
+		now:        time.Now,
+		stall:      time.Second,
+		minBackoff: time.Millisecond,
+		maxBackoff: 5 * time.Millisecond,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+	defer cancel()
+	s.run(ctx) // must return when ctx ends, without spinning
+	mu.Lock()
+	defer mu.Unlock()
+	if starts != 0 {
+		t.Errorf("must not start a process while nvidia-smi is unresolvable, started %d", starts)
+	}
+}

--- a/agent/power_review_test.go
+++ b/agent/power_review_test.go
@@ -39,6 +39,50 @@ func TestReviewPowerConstantFractionMeetsWireContract(t *testing.T) {
 	}
 }
 
+func TestReviewPowerMembershipChangeSurvivesJournalReplay(t *testing.T) {
+	a := newPowerAccumulator(30*time.Second, time.Second)
+	c := newAccClock()
+	feedGPU(a, c, 0, 15, func(int) []*float64 { return []*float64{f(100), f(200)} })
+	feedGPU(a, c, 15, 30, func(int) []*float64 { return []*float64{f(100)} })
+	changed := a.tickAt(c.at(30), c.wall(30))
+	feedGPU(a, c, 30, 60, func(int) []*float64 { return []*float64{f(100)} })
+	stable := a.tickAt(c.at(60), c.wall(60))
+	if len(changed) != 1 || len(stable) != 1 {
+		t.Fatal("expected one changed and one stable window")
+	}
+	dir := t.TempDir()
+	j, err := openPowerJournal(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range []powerhistory.Bucket{changed[0], stable[0]} {
+		if err := j.append(b); err != nil {
+			j.close()
+			t.Fatal(err)
+		}
+	}
+	j.close()
+	j, err = openPowerJournal(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer j.close()
+	batch, ok := j.snapshot().pendingBatch(powerhistory.MaxBatchRecords, powerhistory.MaxFrameBytes)
+	if !ok || len(batch.Buckets) != 2 || batch.Buckets[0].Seq != 1 || batch.Buckets[1].Seq != 2 {
+		t.Fatalf("restart did not preserve replay prefix: %+v", batch)
+	}
+	first, second := batch.Buckets[0], batch.Buckets[1]
+	if first.GPUTotal != nil || len(first.GPUs) != 2 || first.GPUs[0].Samples != 30 || first.GPUs[1].Samples != 15 {
+		t.Fatalf("changed window is not replay-safe: %+v", first)
+	}
+	if second.GPUTotal == nil || second.GPUTotal.Samples != 30 || *second.GPUTotal.MeanWatts != 100 {
+		t.Fatalf("next stable window did not recover: %+v", second)
+	}
+	if advanced, err := j.ack(batch.StreamID, 2); err != nil || !advanced {
+		t.Fatalf("replayed windows could not advance ACK: advanced=%v err=%v", advanced, err)
+	}
+}
+
 // Run under -race: filesystem ownership, snapshot reads and ACK coalescing must
 // remain independent even while retention prunes previously published records.
 func TestReviewPowerConcurrentSnapshotAndRetention(t *testing.T) {

--- a/agent/power_review_test.go
+++ b/agent/power_review_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/powerhistory"
+)
+
+func TestReviewEmptyPowerHistoryDoesNotConsumeSendSlot(t *testing.T) {
+	j, err := openPowerJournal(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer j.close()
+	ph := newPowerHistory(j)
+	previous := powerInst.Swap(ph)
+	defer powerInst.Store(previous)
+	// An empty history never reaches the socket; a refresh here must not
+	// postpone the first real completed window.
+	sendPowerHistory(nil, &sync.Mutex{})
+	if !ph.allowSend(time.Now()) {
+		t.Fatal("empty refresh consumed the upload slot")
+	}
+}
+
+func TestReviewPowerConstantFractionMeetsWireContract(t *testing.T) {
+	for _, watts := range []float64{0.1, 33.83, 37.74, 237.13} {
+		var acc statsAcc
+		for i := 0; i < 30; i++ {
+			acc.add(watts)
+		}
+		st := acc.stats()
+		if *st.MeanWatts > *st.PeakWatts {
+			t.Fatalf("constant %g produced mean %.17g > peak %.17g", watts, *st.MeanWatts, *st.PeakWatts)
+		}
+	}
+}
+
+// Run under -race: filesystem ownership, snapshot reads and ACK coalescing must
+// remain independent even while retention prunes previously published records.
+func TestReviewPowerConcurrentSnapshotAndRetention(t *testing.T) {
+	j, err := openPowerJournal(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	j.maxRecords, j.segRecords = 4, 2
+	targetSeq := j.nextSeq + 20
+	ph := newPowerHistory(j)
+	ctx, cancel := context.WithCancel(context.Background())
+	var workers sync.WaitGroup
+	workers.Add(1)
+	go func() { defer workers.Done(); ph.journalWorker(ctx) }()
+	defer func() { cancel(); workers.Wait() }()
+	readerCtx, stopReader := context.WithCancel(ctx)
+	var readers sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for readerCtx.Err() == nil {
+				if batch, ok := ph.nextBatch(); ok && len(batch.Buckets) > 0 {
+					ph.offerAck(powerhistory.Ack{Type: powerhistory.AckType, StreamID: batch.StreamID,
+						Through: batch.Buckets[len(batch.Buckets)-1].Seq})
+				}
+				time.Sleep(time.Millisecond)
+			}
+		}()
+	}
+	defer func() { stopReader(); readers.Wait() }()
+	for i := 0; i < 20; i++ {
+		end := time.Now()
+		watts := 100.0 + float64(i)
+		st := powerhistory.Stats{MeanWatts: &watts, PeakWatts: &watts, Samples: 30}
+		ph.enqueue(powerhistory.Bucket{StartUnixMS: end.Add(-30 * time.Second).UnixMilli(), EndUnixMS: end.UnixMilli(),
+			ExpectedSamples: 30, GPUs: []powerhistory.Sensor{{ID: "GPU-review", Stats: st}}, GPUTotal: &st})
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if snap := ph.snap.Load(); snap != nil && snap.nextSeq >= targetSeq {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("journal worker did not persist the queued windows")
+}

--- a/agent/power_uplink_test.go
+++ b/agent/power_uplink_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/powerhistory"
+)
+
+// waitFor polls cond until it holds or the deadline passes.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// startWorker runs the journal worker for ph and makes the test join it on
+// cleanup, so nothing else ever touches the journal concurrently.
+func startWorker(t *testing.T, ph *powerHistory) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	ph.cancel = cancel
+	go ph.journalWorker(ctx)
+	t.Cleanup(ph.cancelForTest)
+}
+
+// cancelForTest stops the worker started by startWorker and joins it.
+func (ph *powerHistory) cancelForTest() {
+	if ph.cancel != nil {
+		ph.cancel()
+		<-ph.workerDone
+	}
+}
+
+// openWorkerJournal opens a journal whose lifetime is owned by a worker.
+func openWorkerJournal(t *testing.T, dir string, c *jclock) *powerJournal {
+	t.Helper()
+	j, err := openPowerJournalWith(dir, c.now)
+	if err != nil {
+		t.Fatalf("open journal: %v", err)
+	}
+	return j
+}
+
+func TestPowerHistoryWorkerJournalsAndPublishesSnapshot(t *testing.T) {
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openWorkerJournal(t, t.TempDir(), c)
+	ph := newPowerHistory(j)
+	startWorker(t, ph)
+
+	if _, ok := ph.nextBatch(); ok {
+		t.Fatal("empty journal must offer nothing")
+	}
+	for i := 1; i <= 3; i++ {
+		ph.enqueue(bucketEnding(c.t.UnixMilli() + int64(i)*30000))
+	}
+	waitFor(t, "3 durable records", func() bool {
+		b, ok := ph.nextBatch()
+		return ok && len(b.Buckets) == 3
+	})
+	b, _ := ph.nextBatch()
+	if b.Type != powerhistory.BatchType || b.StreamID != j.streamID || b.RetainedFrom != 1 || b.Degraded {
+		t.Fatalf("batch header: %+v", b)
+	}
+	if !eqSeqs(seqs(b.Buckets), []uint64{1, 2, 3}) {
+		t.Fatalf("batch seqs: %v", seqs(b.Buckets))
+	}
+
+	// ACK via the read-loop entry point; worker applies it and republishes.
+	raw, _ := json.Marshal(powerhistory.Ack{Type: powerhistory.AckType, StreamID: j.streamID, Through: 2})
+	powerInst.Store(ph)
+	t.Cleanup(func() { powerInst.Store(nil) })
+	handlePowerHistoryAck(raw)
+	waitFor(t, "ack applied", func() bool {
+		b, ok := ph.nextBatch()
+		return ok && len(b.Buckets) == 1 && b.Buckets[0].Seq == 3
+	})
+
+	// Future and foreign ACKs are ignored without disturbing the cursor.
+	for _, a := range []powerhistory.Ack{
+		{Type: powerhistory.AckType, StreamID: j.streamID, Through: 99},
+		{Type: powerhistory.AckType, StreamID: "ffffffffffffffffffffffffffffffff", Through: 3},
+	} {
+		raw, _ := json.Marshal(a)
+		handlePowerHistoryAck(raw)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if b, ok := ph.nextBatch(); !ok || len(b.Buckets) != 1 || b.Buckets[0].Seq != 3 {
+		t.Fatalf("invalid ACKs must not move the cursor: %+v", b)
+	}
+}
+
+func TestPowerHistoryAckMailboxCoalescesToNewest(t *testing.T) {
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, t.TempDir(), c) // no worker: test owns it
+	ph := newPowerHistory(j)
+	// No worker running: offers must never block and only the newest wins.
+	for i := uint64(1); i <= 1000; i++ {
+		ph.offerAck(powerhistory.Ack{StreamID: j.streamID, Through: i})
+	}
+	ph.offerAck(powerhistory.Ack{StreamID: j.streamID, Through: 5}) // older: ignored
+	ph.ackMu.Lock()
+	got := ph.ackNext.Through
+	ph.ackMu.Unlock()
+	if got != 1000 {
+		t.Fatalf("mailbox holds %d, want newest 1000", got)
+	}
+	select {
+	case <-ph.ackSig:
+	default:
+		t.Fatal("signal must be pending for the worker")
+	}
+}
+
+func TestPowerHistoryQueueOverflowDropsWithGapNotBlock(t *testing.T) {
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openWorkerJournal(t, t.TempDir(), c)
+	ph := newPowerHistory(j)
+	// Worker not running: fill the queue and overflow it. enqueue must
+	// return immediately every time.
+	done := make(chan struct{})
+	go func() {
+		// Ascending ends, all in the recent past (inside retention and not
+		// in the future-skew window).
+		for i := 0; i < powerQueueDepth+5; i++ {
+			ph.enqueue(bucketEnding(c.t.UnixMilli() - int64(powerQueueDepth+20-i)*30000))
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("enqueue blocked on a stalled journal worker")
+	}
+	if !ph.degraded.Load() || !ph.dropped.Load() {
+		t.Fatal("overflow must mark degraded and a pending gap")
+	}
+	startWorker(t, ph)
+	waitFor(t, "queue drained", func() bool {
+		b, ok := ph.nextBatch()
+		return ok && len(b.Buckets) == 32
+	})
+	b, _ := ph.nextBatch()
+	if b.Buckets[0].GapBefore {
+		t.Error("buckets queued before the drop must not be flagged")
+	}
+	if b.Degraded {
+		t.Error("degraded must clear once appends succeed again")
+	}
+	// The bucket enqueued after the loss is the one that declares it.
+	ph.enqueue(bucketEnding(c.t.UnixMilli() - 5*30000))
+	waitFor(t, "post-drop bucket", func() bool {
+		return len(ph.snap.Load().records) == powerQueueDepth+1
+	})
+	recs := ph.snap.Load().records
+	if !recs[len(recs)-1].GapBefore {
+		t.Error("first bucket after a queue drop must declare GapBefore")
+	}
+	for _, r := range recs[:len(recs)-1] {
+		if r.GapBefore {
+			t.Errorf("seq %d wrongly flagged", r.Seq)
+		}
+	}
+}
+
+func TestPowerHistoryNextBatchNeverTouchesDisk(t *testing.T) {
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	dir := t.TempDir()
+	j := openWorkerJournal(t, dir, c)
+	ph := newPowerHistory(j)
+	ctx, cancel := context.WithCancel(context.Background())
+	go ph.journalWorker(ctx)
+	ph.enqueue(bucketEnding(c.t.UnixMilli() + 30000))
+	waitFor(t, "record", func() bool { _, ok := ph.nextBatch(); return ok })
+	// Stop the worker (it closes the journal) and make the directory
+	// disappear; batches still come from the published snapshot.
+	cancel()
+	<-ph.workerDone
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	for i := 0; i < 1000; i++ {
+		if _, ok := ph.nextBatch(); !ok {
+			t.Fatal("snapshot lost")
+		}
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("nextBatch is not cheap")
+	}
+}
+
+func TestPowerHistorySendThrottleIsMonotonicAndIndependentOfSnapshot(t *testing.T) {
+	c := &jclock{t: time.Unix(1_700_000_000, 0)}
+	j := openTestJournal(t, t.TempDir(), c)
+	ph := newPowerHistory(j)
+	base := time.Now()
+	if !ph.allowSend(base) {
+		t.Fatal("first send must be allowed")
+	}
+	// Reconnect + manual refresh inside the window: refused.
+	for _, d := range []time.Duration{0, time.Second, 10 * time.Second, powerSendMinInterval - time.Millisecond} {
+		if ph.allowSend(base.Add(d)) {
+			t.Fatalf("send allowed %s after the previous one", d)
+		}
+	}
+	if !ph.allowSend(base.Add(powerSendMinInterval)) {
+		t.Fatal("send must be allowed once the interval has elapsed")
+	}
+	if ph.allowSend(base.Add(powerSendMinInterval + time.Second)) {
+		t.Fatal("the slot just claimed must throttle again")
+	}
+	// Throttle does not depend on journal state: nothing pending here, and
+	// nextBatch is untouched by the throttle.
+	if _, ok := ph.nextBatch(); ok {
+		t.Fatal("nextBatch must stay pure")
+	}
+}

--- a/agent/release.go
+++ b/agent/release.go
@@ -30,10 +30,10 @@ import (
  * ============================================================================ */
 
 // agentRelease is the release sequence compiled into this binary.
-const agentRelease uint64 = 1
+const agentRelease uint64 = 2
 
 // agentReleaseMarker is agentRelease as the scannable literal.
-const agentReleaseMarker = "BLOXOS-AGENT-RELEASE:0000000001:"
+const agentReleaseMarker = "BLOXOS-AGENT-RELEASE:0000000002:"
 
 var (
 	embeddedReleaseOnce sync.Once

--- a/agent/release.go
+++ b/agent/release.go
@@ -30,10 +30,10 @@ import (
  * ============================================================================ */
 
 // agentRelease is the release sequence compiled into this binary.
-const agentRelease uint64 = 2
+const agentRelease uint64 = 3
 
 // agentReleaseMarker is agentRelease as the scannable literal.
-const agentReleaseMarker = "BLOXOS-AGENT-RELEASE:0000000002:"
+const agentReleaseMarker = "BLOXOS-AGENT-RELEASE:0000000003:"
 
 var (
 	embeddedReleaseOnce sync.Once

--- a/dashboard/src/app/machine/[id]/page.tsx
+++ b/dashboard/src/app/machine/[id]/page.tsx
@@ -11,6 +11,7 @@ import { ServicePanel, Service } from "@/components/ServicePanel";
 import { ContainerPanel, Container } from "@/components/ContainerPanel";
 import { RebootModal } from "@/components/RebootModal";
 import { MetricCharts } from "@/components/MetricCharts";
+import { PowerHistory } from "@/components/PowerHistory";
 import { HardwareCard, type HardwareInfo } from "@/components/HardwareCard";
 import { MachineNotes } from "@/components/MachineNotes";
 import { AISessionsPanel } from "@/components/AISessionsPanel";
@@ -948,7 +949,7 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
                             <div className="flex items-center justify-between py-2 border-t border-blox-border/50">
                               <div className="flex items-center gap-2">
                                 <Zap className="w-3.5 h-3.5 text-blox-muted" />
-                                <span className="text-xs text-blox-muted">Power</span>
+                                <span className="text-xs text-blox-muted">GPU power</span>
                               </div>
                               <span className="text-xs text-blox-text tabular-nums font-mono">
                                 {(gpu.power_watts ?? 0).toFixed(0)} W
@@ -997,6 +998,7 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
               className="bg-blox-card border border-blox-border rounded-xl p-5"
             >
               <MetricCharts machineId={id} hasGpu={hasGpu} />
+              {!isAPIMachine && <PowerHistory key={id} machineId={id} />}
             </motion.div>
           </TabsContent>
 

--- a/dashboard/src/components/FleetOverview.tsx
+++ b/dashboard/src/components/FleetOverview.tsx
@@ -147,7 +147,7 @@ export function FleetOverview({ machines }: FleetOverviewProps) {
           {metrics.hasGpu && metrics.totalPower > 0 && (
             <div className="flex items-baseline gap-2 px-3 py-1.5 rounded-lg bg-surface-sunken border border-border-subtle">
               <span className="text-xs text-text-tertiary uppercase tracking-wider font-medium">
-                Fleet Power
+                Fleet GPU Power
               </span>
               <span className="text-lg font-mono tabular-nums text-text-primary font-semibold">
                 {metrics.totalPower.toFixed(0)}

--- a/dashboard/src/components/MachineGauges.tsx
+++ b/dashboard/src/components/MachineGauges.tsx
@@ -174,7 +174,7 @@ export function MachineGauges({ metrics, gpus }: MachineGaugesProps) {
                     </div>
                     {gpu.power_watts > 0 && (
                       <div className="flex justify-between items-baseline">
-                        <span className="text-[9px] text-text-tertiary uppercase">Power</span>
+                        <span className="text-[9px] text-text-tertiary uppercase">GPU power</span>
                         <span className="text-sm font-mono tabular-nums text-text-primary">
                           {gpu.power_watts.toFixed(0)}W
                         </span>

--- a/dashboard/src/components/PowerHistory.tsx
+++ b/dashboard/src/components/PowerHistory.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { HUB_URL, getStoredToken } from "@/lib/session";
+import { mergePowerHistory, powerChartPoints, powerProblemLabel, powerSensorIDs, sampleAgeLabel } from "@/lib/power-history.mjs";
+
+interface Stats { mean_watts: number | null; peak_watts: number | null; samples: number }
+interface Point {
+  stream_id: string; seq: number; start_unix_ms: number; end_unix_ms: number;
+  expected_samples: number; gap_before?: boolean;
+  gpus: (Stats & { id: string })[]; gpu_total?: Stats; cpu?: Stats;
+}
+interface History { points: Point[]; gaps: { stream_id: string; from: number; through: number }[]; degraded: boolean; cursor: number; problem?: string }
+
+export function PowerHistory({ machineId }: { machineId: string }) {
+  const [sensor, setSensor] = useState("gpu_total");
+  const [state, setState] = useState<{ machineId: string; data?: History; error?: string }>({ machineId });
+  const [now, setNow] = useState(0);
+  useEffect(() => {
+    let stopped = false;
+    let active: AbortController | undefined;
+    let cached: History | undefined;
+    const load = async () => {
+      if (active) return;
+      const controller = new AbortController();
+      active = controller;
+      const timeout = setTimeout(() => controller.abort(), 10000);
+      try {
+        const token = getStoredToken();
+        const after = cached ? `?after=${cached.cursor}` : "";
+        const res = await fetch(`${HUB_URL}/api/machines/${encodeURIComponent(machineId)}/power/history${after}`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {}, signal: controller.signal,
+        });
+        if (cached && (res.status === 400 || res.status === 409)) {
+          throw new RangeError("Power history changed on the hub; reloading.");
+        }
+        if (!res.ok) throw new Error(res.status === 404
+          ? "Power history is not available on this hub yet." : "Could not refresh power history.");
+        const data = await res.json() as History;
+        cached = mergePowerHistory(cached, data, Date.now()) as History;
+        if (!stopped) setState({ machineId, data: cached });
+      } catch (error) {
+        if (error instanceof RangeError) cached = undefined;
+        if (!stopped) setState((previous) => ({ machineId,
+          data: previous.machineId === machineId ? previous.data : undefined,
+          error: error instanceof Error ? error.message : "Could not refresh power history." }));
+      } finally { clearTimeout(timeout); active = undefined; }
+    };
+    void load();
+    const refresh = setInterval(() => void load(), 30000);
+    const clock = setInterval(() => setNow(Date.now()), 1000);
+    return () => { stopped = true; active?.abort(); clearInterval(refresh); clearInterval(clock); };
+  }, [machineId]);
+  const data = state.machineId === machineId ? state.data : undefined;
+  const points = data?.points ?? [];
+  const sensors = powerSensorIDs(points) as string[];
+  const chart = powerChartPoints(points, sensor);
+  const latest = chart.at(-1);
+  const error = state.machineId === machineId ? state.error : undefined;
+  const problem = powerProblemLabel(data?.problem);
+  const hasCPU = points.some((point) => point.cpu && point.cpu.samples > 0);
+  const stale = latest && now > 0 && now - latest.timestamp > 90000;
+  const formatTime = (timestamp: number) => new Date(timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return (
+    <section className="mt-6 space-y-3 border-t border-blox-border pt-5" aria-label="Component power history">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-blox-text">Power history · last 24 hours</h3>
+          <p className="text-xs text-blox-muted">30-second averages and sampled peaks. Component power, not wall power.</p>
+        </div>
+        <select aria-label="Power sensor" value={sensor} onChange={(event) => setSensor(event.target.value)}
+          className="max-w-full rounded border border-blox-border bg-blox-card p-2 text-xs text-blox-text">
+          <option value="gpu_total">All GPUs together</option>
+          {sensors.map((id) => <option key={id} value={id}>{id}</option>)}
+          <option value="cpu">CPU packages{hasCPU ? "" : " (unavailable)"}</option>
+        </select>
+      </div>
+      {error && <p role="status" className="text-xs text-amber-400">{error} Existing readings may be stale.</p>}
+      {problem && <p role="status" className="text-xs text-amber-400">{problem}</p>}
+      {(data?.degraded || (data?.gaps.length ?? 0) > 0 || points.some((point) => point.gap_before)) &&
+        <p role="status" className="text-xs text-amber-400">History has gaps or reduced recording coverage. Missing data is not zero power.</p>}
+      {points.length === 0 ? <p className="py-6 text-sm text-blox-muted">{problem ? "Power history is paused." : data
+        ? "No power history yet. A supported agent normally sends its first completed window within about a minute."
+        : error ? "Power history unavailable." : "Loading power history…"}</p> : <>
+        <p className={`text-xs ${stale ? "text-amber-400" : "text-blox-muted"}`}>
+          Last window: {now ? sampleAgeLabel(latest?.timestamp, now) : "—"}{stale ? " · stale" : ""}
+          {latest?.coverage != null ? ` · ${Math.round(latest.coverage)}% sample coverage` : " · sensor unavailable"}
+        </p>
+        <div className="h-52" role="img" aria-label="Average and sampled peak power in watts over the last 24 hours">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chart}>
+              <XAxis dataKey="timestamp" type="number" domain={["dataMin", "dataMax"]} tickFormatter={formatTime} tick={{ fontSize: 10 }} />
+              <YAxis unit=" W" tick={{ fontSize: 10 }} width={64} />
+              <Tooltip labelFormatter={(label) => formatTime(Number(label))}
+                contentStyle={{ background: "#12121a", border: "1px solid #1e1e2e", fontSize: 12 }} />
+              <Line dataKey="mean" name="Average (W)" stroke="#22c55e" dot={false} connectNulls={false} isAnimationActive={false} />
+              <Line dataKey="peak" name="Sampled peak (W)" stroke="#f59e0b" strokeDasharray="4 3" dot={false} connectNulls={false} isAnimationActive={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+        <p className="text-xs text-blox-muted">Green: average · Amber: highest observed sample. Gaps and unavailable sensors are left blank.</p>
+      </>}
+    </section>
+  );
+}

--- a/dashboard/src/lib/power-history.mjs
+++ b/dashboard/src/lib/power-history.mjs
@@ -1,0 +1,74 @@
+// Keep unavailable readings null. Never reinterpret legacy instantaneous watts
+// as a 30-second mean, or sum independent GPU peaks into a machine peak.
+export function powerStats(point, sensor) {
+  if (sensor === "gpu_total") return point.gpu_total;
+  if (sensor === "cpu") return point.cpu;
+  return point.gpus?.find((gpu) => gpu.id === sensor);
+}
+
+export function powerChartPoints(points, sensor) {
+  const ordered = points.filter((point) =>
+    Number.isFinite(point.start_unix_ms) && Number.isFinite(point.end_unix_ms) &&
+    point.end_unix_ms > point.start_unix_ms
+  ).sort((a, b) => a.start_unix_ms - b.start_unix_ms || a.seq - b.seq);
+  const result = [];
+  let previous;
+  for (const point of ordered) {
+    if (previous && (point.gap_before || point.stream_id !== previous.stream_id ||
+      point.seq !== previous.seq + 1 || point.start_unix_ms - previous.end_unix_ms > 1500)) {
+      result.push({ timestamp: point.start_unix_ms, mean: null, peak: null, coverage: null });
+    }
+    const stats = powerStats(point, sensor);
+    const valid = stats && Number.isInteger(stats.samples) && stats.samples > 0 &&
+      Number.isFinite(stats.mean_watts) && stats.mean_watts >= 0 &&
+      Number.isFinite(stats.peak_watts) && stats.peak_watts >= stats.mean_watts;
+    result.push({
+      timestamp: point.end_unix_ms,
+      mean: valid ? stats.mean_watts : null,
+      peak: valid ? stats.peak_watts : null,
+      coverage: valid && point.expected_samples > 0
+        ? Math.min(100, 100 * stats.samples / point.expected_samples) : null,
+    });
+    previous = point;
+  }
+  return result;
+}
+
+export function powerSensorIDs(points) {
+  return [...new Set(points.flatMap((point) => (point.gpus ?? []).map((gpu) => gpu.id)))].sort();
+}
+
+export function powerProblemLabel(problem) {
+  const labels = {
+    clock_skew: "The machine clock is more than 15 minutes ahead of the hub. Correct its clock to resume power history.",
+    storage_error: "The hub could not save power history. The agent will retry; live metrics are unaffected.",
+    conflicting_replay: "A saved power-history record conflicts with the hub's copy. Existing readings are preserved; agent diagnostics need review.",
+    rejected_data: "The hub rejected a power-history record. Live metrics are unaffected; agent diagnostics need review.",
+  };
+  return Object.hasOwn(labels, problem) ? labels[problem] : null;
+}
+
+// Ingestion cursors (not measurement timestamps) preserve offline backfill.
+// The server returns current gap/degraded metadata even on an empty delta.
+export function mergePowerHistory(previous, incoming, now) {
+  if (!Number.isSafeInteger(incoming.cursor) || incoming.cursor < 0 ||
+    !Array.isArray(incoming.points) || !Array.isArray(incoming.gaps)) {
+    throw new Error("Invalid power history response.");
+  }
+  if (previous && incoming.cursor < previous.cursor) {
+    throw new RangeError("Power history changed on the hub; reloading.");
+  }
+  const cutoff = now - 24 * 60 * 60 * 1000;
+  const points = new Map();
+  for (const point of [...(previous?.points ?? []), ...incoming.points]) {
+    if (point.end_unix_ms >= cutoff) points.set(JSON.stringify([point.stream_id, point.seq]), point);
+  }
+  return { ...incoming, points: [...points.values()] };
+}
+
+export function sampleAgeLabel(endUnixMS, now) {
+  if (!Number.isFinite(endUnixMS)) return "No samples";
+  if (endUnixMS > now + 5000) return "Machine clock ahead";
+  const seconds = Math.max(0, Math.floor((now - endUnixMS) / 1000));
+  return seconds < 60 ? `${seconds}s ago` : `${Math.floor(seconds / 60)}m ago`;
+}

--- a/dashboard/src/lib/power-history.test.mjs
+++ b/dashboard/src/lib/power-history.test.mjs
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mergePowerHistory, powerChartPoints, powerProblemLabel, powerSensorIDs, sampleAgeLabel } from "./power-history.mjs";
+
+const stats = (mean = 100, peak = 200, samples = 30) => ({ mean_watts: mean, peak_watts: peak, samples });
+
+test("rejected telemetry has a useful bounded diagnostic, not raw server errors", () => {
+  assert.match(powerProblemLabel("clock_skew"), /Correct its clock/);
+  assert.match(powerProblemLabel("storage_error"), /will retry/);
+  assert.equal(powerProblemLabel("raw sensitive error"), null);
+  assert.equal(powerProblemLabel("__proto__"), null);
+});
+const bucket = (seq, extra = {}) => ({ stream_id: "a", seq, start_unix_ms: seq * 30000,
+  end_unix_ms: (seq + 1) * 30000, expected_samples: 30,
+  gpus: [{ id: "GPU-a", ...stats() }, { id: "GPU-b", ...stats() }], ...extra });
+
+test("never fabricate GPU totals by summing independent peaks", () => {
+  assert.equal(powerChartPoints([bucket(1)], "gpu_total")[0].peak, null);
+  assert.equal(powerChartPoints([bucket(1, { gpu_total: stats(180, 250) })], "gpu_total")[0].peak, 250);
+});
+test("unknown is not zero and valid zero remains visible", () => {
+  const points = [bucket(1, { cpu: stats(null, null, 0) }), bucket(2, { cpu: stats(0, 0) })];
+  assert.deepEqual(powerChartPoints(points, "cpu").map((p) => p.mean), [null, 0]);
+});
+test("gaps break lines for missing sequences, restarts and declared loss", () => {
+  for (const next of [bucket(3), bucket(2, { stream_id: "b" }), bucket(2, { gap_before: true })]) {
+    const chart = powerChartPoints([next, bucket(1)], "GPU-a");
+    assert.equal(chart.length, 3);
+    assert.equal(chart[1].mean, null);
+  }
+});
+test("partial sampling reports coverage, not invented full-window data", () => {
+  assert.equal(powerChartPoints([bucket(1, { cpu: stats(100, 150, 15) })], "cpu")[0].coverage, 50);
+});
+test("invalid values are unavailable; sensor IDs are stable and unique", () => {
+  assert.equal(powerChartPoints([bucket(1, { cpu: stats(Infinity, 2) })], "cpu")[0].mean, null);
+  assert.deepEqual(powerSensorIDs([bucket(1), bucket(2)]), ["GPU-a", "GPU-b"]);
+});
+test("sample age exposes stale and clock-skewed data", () => {
+  assert.equal(sampleAgeLabel(10000, 45000), "35s ago");
+  assert.equal(sampleAgeLabel(10000, 135000), "2m ago");
+  assert.equal(sampleAgeLabel(50000, 10000), "Machine clock ahead");
+  assert.equal(sampleAgeLabel(undefined, 10000), "No samples");
+});
+
+test("delta history merges late backfill, deduplicates and refreshes gap metadata", () => {
+  const initial = { points: [bucket(5)], gaps: [], degraded: true, cursor: 1 };
+  const delta = { points: [bucket(2), bucket(5)], gaps: [{ stream_id: "a", from: 3, through: 4 }], degraded: false, cursor: 3 };
+  const result = mergePowerHistory(initial, delta, 200000);
+  assert.deepEqual(result.points.map((point) => point.seq).sort(), [2, 5]);
+  assert.deepEqual(result.gaps, delta.gaps);
+  assert.equal(result.degraded, false);
+  assert.equal(result.cursor, 3);
+});
+
+test("empty deltas still expire local history; cursor reset requires full reload", () => {
+  const initial = { points: [bucket(1)], gaps: [], degraded: false, cursor: 3 };
+  const delta = { points: [], gaps: [], degraded: false, cursor: 3 };
+  assert.equal(mergePowerHistory(initial, delta, 86400000 + 60001).points.length, 0);
+  assert.throws(() => mergePowerHistory(initial, { ...delta, cursor: 1 }, 0), RangeError);
+  assert.throws(() => mergePowerHistory(undefined, { ...delta, cursor: NaN }, 0));
+});

--- a/docs/power-history.md
+++ b/docs/power-history.md
@@ -13,6 +13,11 @@ GPU peak is computed from complete simultaneous observations, never by summing
 each device's independently observed maximum. Missing sensors are unavailable,
 not zero. The existing `power_watts` instantaneous field keeps its meaning.
 
+If GPU membership changes inside a window, its combined GPU total is omitted
+rather than mixing different device sets. Per-GPU readings and CPU statistics
+are retained, and combined totals resume in the next stable window. This keeps
+the recorded window valid for replay without relaxing hub validation.
+
 Completed windows are saved locally before becoming eligible for upload. The
 local journal is bounded by 24 hours and a byte limit. The network sends bounded
 batches of new or unacknowledged windows, not the whole journal on every tick.
@@ -155,3 +160,8 @@ wall-power calibration or 24-hour soak. CPU sensors were unavailable in the
 restricted container and correctly absent. Real CPU package readings and
 Windows driver streaming remain unverified; cross-compilation is not a
 substitute for those hardware checks. Fleet rollout remains a separate step.
+
+The subsequent GPU-membership correction advances the agent release marker to 3.
+The hardware canary above tested release 2; it is not a hardware test of this
+later correction. Membership transitions have separate accumulator and hub
+regression coverage.

--- a/docs/power-history.md
+++ b/docs/power-history.md
@@ -127,6 +127,31 @@ The smoke does not simulate an ACK lost after hub commit; duplicate/retry and
 commit-failure behavior also has separate unit/WebSocket integration coverage.
 It does not establish a 24-hour resource soak or physical sensor accuracy.
 
-Still needed before fleet rollout: a real-hardware canary. Real CPU package
-readings and Windows driver streaming have not been runtime-verified.
-Cross-compilation is not a substitute for those hardware checks.
+### Real GPU canary
+
+An isolated Linux canary passed on two RTX 3090 GPUs using release-2 agent and
+hub binaries after integrating PR #180. It used real NVIDIA readings, no host
+credentials or published ports, and disconnected container networking during
+the test. The installed fleet agent remained running with the same PID and
+start timestamp.
+
+Two initial windows each contained all 30 samples. One idle window measured
+33.883 W and 37.153 W, correctly combining to 71.036 W. During the hub outage,
+two additional windows remained unacknowledged on disk. After restarting the
+canary agent and recovering the hub, both replayed unchanged. The test finished
+with five distinct records, ACK 66, one declared reservation gap, and three
+non-overlapping delta records. The disposable canary container was removed;
+logs and API responses were retained outside the repository.
+
+To opt into the two-GPU mode on a disposable Linux Docker host with NVIDIA
+container-runtime support:
+
+```sh
+PHSMOKE_REAL_GPU=1 bash scripts/smoke/power-history.sh
+```
+
+This was an idle GPU pipeline/recovery check, not a loaded-machine experiment,
+wall-power calibration or 24-hour soak. CPU sensors were unavailable in the
+restricted container and correctly absent. Real CPU package readings and
+Windows driver streaming remain unverified; cross-compilation is not a
+substitute for those hardware checks. Fleet rollout remains a separate step.

--- a/docs/power-history.md
+++ b/docs/power-history.md
@@ -1,0 +1,132 @@
+# Component power history
+
+Power history supplements the existing instantaneous GPU readings. It does not
+measure wall power and must not be described as total machine electricity use.
+CPU readings, when available, describe supported CPU package sensors only.
+
+## Data flow
+
+The agent samples power separately from the expensive hardware, services and
+container scans. Every 30 seconds it forms a window of per-GPU average watts,
+highest observed sample, valid sample count and expected sample count. A combined
+GPU peak is computed from complete simultaneous observations, never by summing
+each device's independently observed maximum. Missing sensors are unavailable,
+not zero. The existing `power_watts` instantaneous field keeps its meaning.
+
+Completed windows are saved locally before becoming eligible for upload. The
+local journal is bounded by 24 hours and a byte limit. The network sends bounded
+batches of new or unacknowledged windows, not the whole journal on every tick.
+The hub identifies the machine from its authenticated connection, deduplicates
+by machine/stream/sequence, and acknowledges only after committing the contiguous
+prefix. A lost acknowledgement causes a harmless retry. Sequence identity does
+not depend on the wall clock.
+
+The dashboard's Metrics tab displays the last 24 hours, per GPU, all GPUs
+together, or available CPU packages. It labels averages and sampled peaks,
+displays sample age and coverage, and leaves missing observations blank. A
+one-second sampled peak is not a guaranteed electrical transient maximum.
+
+## Storage and traffic budget
+
+There are 2,880 completed 30-second windows per day. A representative JSON
+record with two GPU sensors, GPU-total statistics and CPU statistics measures
+524 bytes including its newline: about 1.5 MB for a full day. The same fixture
+with 16 GPUs is about 6.5 MB per day. Actual sizes vary with sensor identifiers
+and numeric precision; these are encoded-data measurements, not filesystem or
+network-overhead estimates. The reproducible size check is
+`cd proto && go test -v ./powerhistory -run TestRepresentativeStorageAndBatchSize`.
+
+Steady-state upload sends only the newest completed window each 30-second
+cycle. Reconnect replay is capped at 32 records per cycle, so a full-day backlog
+takes roughly 47 minutes to clear while new windows continue arriving. The
+send throttle also covers manual refresh and reconnect: its minimum interval
+is 25 seconds, allowing scheduling jitter around the normal 30-second tick. The
+dashboard fetches a bounded history view when its Metrics tab is mounted, then
+asks for newly ingested records using a cursor. Because the cursor follows hub
+ingestion order, older samples uploaded after a disconnection still arrive in
+the response; the graph keeps only samples within the last 24 hours. It does
+not request one-second raw samples from each machine.
+
+The Linux journal lives in `/etc/bloxos/power-history` for the root service;
+otherwise it is alongside the agent's existing credential state. It uses small
+10-record segments (five minutes each), plus stream/acknowledgement state. The
+retained journal data is capped at 32 MiB and 2,880 records. Metadata, filesystem
+allocation and temporary compaction files add overhead. Partially expired
+segments are safely compacted, and a one-minute maintenance tick ages out data
+even when sensors stop reporting. An unfinished 30-second window stays in
+memory; completed windows are flushed to disk before upload.
+
+GPU history currently uses NVIDIA's streaming query. CPU history uses readable
+Linux RAPL package counters and excludes overlapping subdomains. Windows CPU
+package power is unavailable; no CPU estimate is invented. Set
+`BLOXOS_POWER_HISTORY=0` on an agent before startup to disable the feature.
+
+## Failure boundaries
+
+- The unfinished window can be lost on an abrupt restart or power loss. There
+  is no zero-loss guarantee.
+- Disk failures must not stop the normal metrics/agent connection. Bounded
+  queues may drop history under sustained storage failure; that is reported
+  as degraded coverage or a gap, not invented zero-watt readings.
+- Retaining only a day means a long disconnection can permanently lose the
+  oldest unacknowledged windows. The protocol declares this retention gap.
+- The hub retains sequence high-water state independently from chart rows, so
+  deleting old chart history does not make an old retransmission new again.
+- Older agents continue sending instantaneous metrics. They do not gain sampled
+  history retroactively. Older hubs may ignore the additive history frames.
+- Rejected batches are not silently acknowledged. The dashboard exposes a
+  bounded diagnostic for clock skew, conflicting replay, invalid data or storage
+  failure on the current agent connection. It clears after a successful batch.
+  Stored JSON is normalized through the current schema before comparing retries;
+  genuinely different data for an existing sequence remains a conflict.
+
+Do not remove the CA, enrollment secret, or pinned update public key while
+maintaining or repairing power history. New telemetry does not require rerunning
+installation, changing credentials, or adding a dashboard onboarding step.
+
+## Review and rollout status
+
+This feature is undergoing PR review. It has not been deployed to the fleet.
+The checks below distinguish synthetic pipeline validation from hardware testing.
+
+Validated locally:
+
+- Full hub tests, full hub race tests and `go vet`.
+- Full Linux agent race tests, including an unprivileged journal failure test.
+- Linux amd64/arm64 and Windows amd64 agent builds; Windows test compilation.
+- Shared protocol race tests.
+- Dashboard tests (17), lint and production build.
+- Read-only NVIDIA streaming-query check on the dual-GPU ASUS machine.
+- Linux agent vet and tests with the optional `insecure` build tag.
+- Isolated real-binary pipeline smoke using synthetic NVIDIA readings:
+  enrollment, two full 30-second windows, valid clock-step partial windows,
+  durable ACK, offline recording, agent restart during the outage, hub recovery,
+  unchanged replayed data, declared restart gap and non-overlapping API deltas.
+- Smoke-script syntax, ShellCheck, host-execution refusal and invalid-prefix
+  refusal. The shared protocol vet/race job is now included in CI; its commands
+  passed locally; consult the PR checks for GitHub Actions results.
+
+The user reviewed and approved the local sample-data preview. This is visual
+acceptance, not a live hardware accuracy check.
+
+The isolated smoke committed four initial readings, recorded two more while the
+hub was down without advancing the ACK, then recovered both unchanged after an
+agent restart. It finished with seven distinct records, one declared reservation
+gap, agent ACK 66 and a delta of three new records. These are test-fixture
+results, not live-machine measurements. Its disposable containers and build
+volume were removed; existing fleet containers were unchanged.
+
+Run the repeatable smoke on a disposable Docker container from a Linux Docker
+host (it does not install an agent on that host):
+
+```sh
+bash scripts/smoke/power-history.sh
+```
+
+The smoke does not simulate an ACK lost after hub commit; duplicate/retry and
+commit-failure behavior also has separate unit/WebSocket integration coverage.
+It does not establish a 24-hour resource soak or physical sensor accuracy.
+
+Still needed before fleet rollout: a real-hardware canary. Real CPU package
+readings and Windows driver streaming have not been runtime-verified.
+Cross-compilation is not a substitute for those hardware checks.

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -15,9 +15,11 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bokiko/bloxos/proto/aisessions"
+	"github.com/bokiko/bloxos/proto/powerhistory"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
@@ -25,9 +27,10 @@ import (
 
 // ConnectedAgent tracks a live WebSocket connection from an agent.
 type ConnectedAgent struct {
-	MachineID string
-	Conn      *websocket.Conn
-	WriteMu   sync.Mutex
+	MachineID  string
+	Conn       *websocket.Conn
+	WriteMu    sync.Mutex
+	powerIssue atomic.Uint32 // current connection's bounded history diagnostic
 }
 
 // wsMessageWriter is exactly gorilla/websocket's (*Conn).WriteMessage
@@ -1204,6 +1207,15 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 			// Read-only AI tool session metadata. Bound to the authenticated
 			// machine and to the registered socket; see ingestAISessions.
 			s.ingestAISessions(machineID, agent, msg)
+
+		case powerhistory.BatchType:
+			// Durable 30s power buckets. Bound to the authenticated machine
+			// and registered socket; ACK only after the contiguous prefix
+			// commits. Never mutates live gpu_metrics — old agents that never
+			// send this frame are unaffected.
+			if err := s.ingestPowerHistory(machineID, agent, msg); err != nil {
+				log.Printf("power history from %s: %v", machineID, err)
+			}
 
 		case "command_response":
 			var resp CommandResponse

--- a/hub/join_test.go
+++ b/hub/join_test.go
@@ -1183,8 +1183,19 @@ func TestJoinScriptScrubMigrationClearsPersistedToken(t *testing.T) {
 		t.Fatalf("seed legacy row: %v", err)
 	}
 
-	// Re-apply only the final (scrub) migration by rewinding the version.
-	if _, err := db.Exec(`UPDATE schema_version SET version = ?`, len(migrations)-1); err != nil {
+	// Locate the scrub explicitly so appending future migrations cannot
+	// silently stop this test from exercising token cleanup.
+	scrubMigrationIndex := -1
+	for i, migration := range migrations {
+		if migration.description == "scrub raw install tokens persisted in tokens.mint_time_script" {
+			scrubMigrationIndex = i
+			break
+		}
+	}
+	if scrubMigrationIndex < 0 {
+		t.Fatal("token scrub migration not found")
+	}
+	if _, err := db.Exec(`UPDATE schema_version SET version = ?`, scrubMigrationIndex); err != nil {
 		t.Fatalf("rewind schema_version: %v", err)
 	}
 	if err := runMigrations(db); err != nil {

--- a/hub/main.go
+++ b/hub/main.go
@@ -287,6 +287,7 @@ func (s *Server) registerRoutes(e *echo.Echo) {
 	api.GET("/api/machines/:id/notes", s.handleGetMachineNotes)
 	api.PUT("/api/machines/:id/notes", s.handleSetMachineNotes)
 	api.GET("/api/machines/:id/metrics/history", s.handleMetricsHistory)
+	api.GET("/api/machines/:id/power/history", s.handlePowerHistory)
 	api.DELETE("/api/machines/:id/credential", s.handleRevokeAgentCredential)
 	api.POST("/api/machines/:id/windows-re-enrollment", s.handleWindowsReenrollment)
 	api.DELETE("/api/machines/:id", s.handleDeleteMachine)
@@ -426,6 +427,14 @@ func (s *Server) runCleanup() {
 		if n > 0 {
 			log.Printf("cleanup: deleted %d old terminal sessions", n)
 		}
+	}
+
+	// Prune 24h power-history chart rows (stream high-water state is kept).
+	if n, err := s.prunePowerHistory(time.Now()); err != nil {
+		log.Printf("cleanup: power history prune: %v", err)
+	} else if n > 0 {
+		total += n
+		log.Printf("cleanup: pruned %d power history rows", n)
 	}
 
 	log.Printf("cleanup complete: %d total rows removed", total)
@@ -722,7 +731,7 @@ func (s *Server) handleDeleteMachine(c echo.Context) error {
 	}
 	defer tx.Rollback()
 
-	tables := []string{"metrics", "gpu_metrics", "services", "containers", "alerts", "terminal_sessions", "agent_credentials"}
+	tables := []string{"metrics", "gpu_metrics", "services", "containers", "alerts", "terminal_sessions", "agent_credentials", "power_history_records", "power_history_stream_state", "power_history_gaps"}
 	for _, table := range tables {
 		if _, err := tx.Exec("DELETE FROM "+table+" WHERE machine_id = ?", id); err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to delete " + table})
@@ -2434,7 +2443,7 @@ func (s *Server) handleDeleteAPIMachine(c echo.Context) error {
 	tx, err := s.db.Begin()
 	if err == nil {
 		// Note: table names are hardcoded constants, not user input — safe from SQL injection
-		for _, table := range []string{"metrics", "gpu_metrics", "services", "containers", "alerts"} {
+		for _, table := range []string{"metrics", "gpu_metrics", "services", "containers", "alerts", "power_history_records", "power_history_stream_state", "power_history_gaps"} {
 			tx.Exec("DELETE FROM "+table+" WHERE machine_id = ?", machineID)
 		}
 		tx.Exec("DELETE FROM machines WHERE id = ?", machineID)

--- a/hub/migrations.go
+++ b/hub/migrations.go
@@ -438,6 +438,61 @@ var migrations = []migration{
 			return err
 		},
 	},
+	{
+		// Power history — 30s component power buckets reported by agents.
+		// Deliberately separate from legacy gpu_metrics: different shape,
+		// different retention, stream/seq identity. Stream state (high-water,
+		// retained_from, degraded) lives apart from chart rows so 24h row
+		// pruning never resets dedupe or ack state. The AUTOINCREMENT id is
+		// the durable delta-read cursor: assigned at ingestion, strictly
+		// monotonic, never reused after pruning (SQLite guarantees this via
+		// sqlite_sequence), so a late backfill is delivered by arrival order,
+		// not measurement time.
+		description: "create power_history_records, power_history_stream_state, power_history_gaps",
+		apply: func(tx *sql.Tx) error {
+			_, err := tx.Exec(`
+			CREATE TABLE IF NOT EXISTS power_history_records (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				machine_id TEXT NOT NULL,
+				stream_id TEXT NOT NULL,
+				seq INTEGER NOT NULL,
+				start_unix_ms INTEGER NOT NULL,
+				end_unix_ms INTEGER NOT NULL,
+				expected_samples INTEGER NOT NULL,
+				payload TEXT NOT NULL,
+				received_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+				UNIQUE (machine_id, stream_id, seq),
+				FOREIGN KEY (machine_id) REFERENCES machines(id)
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_power_history_records_window
+				ON power_history_records(machine_id, end_unix_ms);
+
+			CREATE TABLE IF NOT EXISTS power_history_stream_state (
+				machine_id TEXT NOT NULL,
+				stream_id TEXT NOT NULL,
+				acked_through INTEGER NOT NULL DEFAULT 0,
+				max_seen_seq INTEGER NOT NULL DEFAULT 0,
+				retained_from INTEGER NOT NULL DEFAULT 0,
+				degraded BOOLEAN NOT NULL DEFAULT FALSE,
+				updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY (machine_id, stream_id),
+				FOREIGN KEY (machine_id) REFERENCES machines(id)
+			);
+
+			CREATE TABLE IF NOT EXISTS power_history_gaps (
+				machine_id TEXT NOT NULL,
+				stream_id TEXT NOT NULL,
+				from_seq INTEGER NOT NULL,
+				through_seq INTEGER NOT NULL,
+				recorded_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY (machine_id, stream_id, from_seq),
+				FOREIGN KEY (machine_id) REFERENCES machines(id)
+			);
+			`)
+			return err
+		},
+	},
 }
 
 // isDuplicateColumnErr returns true when SQLite rejects an ALTER TABLE ADD

--- a/hub/power_history.go
+++ b/hub/power_history.go
@@ -1,0 +1,825 @@
+package main
+
+// Power history (hub side) — durable 30s power buckets reported by agents
+// over the authenticated WebSocket. The hub keys everything by the MACHINE
+// THE SOCKET AUTHENTICATED AS, never by anything in the frame: a compromised
+// agent cannot plant history on another machine. Batches are validated whole
+// before any mutation, deduplicated by (machine, stream, seq), and
+// acknowledged only after the transaction committing the contiguous prefix
+// (including explicitly declared retention gaps) has committed. A lost ACK
+// therefore causes a harmless replay, never a duplicate row or a false
+// "new data" signal: sequence high-water lives in stream state, not in the
+// chart rows, so pruning old rows never resurrects an old transmission.
+//
+// Legacy gpu_metrics is untouched: power history is a separate table with
+// its own retention, and old agents simply never send these frames.
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/powerhistory"
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+)
+
+// Validation bounds. The contract caps batch shape (records/sensors/bytes);
+// these are the hub-side sanity bounds for the values inside a bucket.
+const (
+	powerMaxIDLen           = 128
+	powerMaxWattsPerSensor  = 100000.0  // a single sensor reporting >100kW is bogus
+	powerMaxWattsGPUTotal   = 1000000.0 // 16 bogus sensors summed still cap here
+	powerMaxSamples         = 1000000
+	powerMaxExpectedSamples = 86400 // a day of 1Hz samples
+	powerMaxWindowDuration  = time.Hour
+	powerMinStartUnixMS     = 1000000000000 // 2001-09-09; rejects garbage epoch values
+	powerMaxFutureSkew      = powerhistory.MaxFutureSkewSeconds * time.Second
+	powerMaxPastAge         = 48 * time.Hour // retention (24h) plus replay slack
+)
+
+var powerIDRe = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+var (
+	errPowerClockSkew = errors.New("machine clock is too far ahead of hub")
+	errPowerConflict  = errors.New("conflicting power-history replay")
+)
+
+const (
+	powerIssueNone uint32 = iota
+	powerIssueInvalid
+	powerIssueClock
+	powerIssueStorage
+	powerIssueConflict
+)
+
+func (s *Server) powerHistoryProblem(machineID string) string {
+	s.agentsMu.RLock()
+	agent := s.agents[machineID]
+	s.agentsMu.RUnlock()
+	if agent == nil {
+		return ""
+	}
+	switch agent.powerIssue.Load() {
+	case powerIssueInvalid:
+		return "rejected_data"
+	case powerIssueClock:
+		return "clock_skew"
+	case powerIssueStorage:
+		return "storage_error"
+	case powerIssueConflict:
+		return "conflicting_replay"
+	default:
+		return ""
+	}
+}
+
+// --- validation (pure, no I/O — runs before any mutation) ---
+
+func validPowerID(id string) bool {
+	return len(id) > 0 && len(id) <= powerMaxIDLen && powerIDRe.MatchString(id)
+}
+
+func validPowerStats(st *powerhistory.Stats, expected int, maxWatts float64) error {
+	if st.Samples < 0 || st.Samples > powerMaxSamples {
+		return fmt.Errorf("samples %d out of range", st.Samples)
+	}
+	// Stats are meaningful only over observed samples: mean AND peak are
+	// present exactly when samples > 0, never alongside zero samples.
+	if st.Samples == 0 && (st.MeanWatts != nil || st.PeakWatts != nil) {
+		return fmt.Errorf("stats present with zero samples")
+	}
+	if st.Samples > 0 && (st.MeanWatts == nil || st.PeakWatts == nil) {
+		return fmt.Errorf("samples %d without both mean and peak", st.Samples)
+	}
+	if st.Samples > expected {
+		return fmt.Errorf("samples %d exceed expected %d", st.Samples, expected)
+	}
+	for name, w := range map[string]*float64{"mean_watts": st.MeanWatts, "peak_watts": st.PeakWatts} {
+		if w == nil {
+			continue
+		}
+		if math.IsNaN(*w) || math.IsInf(*w, 0) {
+			return fmt.Errorf("%s not finite", name)
+		}
+		if *w < 0 || *w > maxWatts {
+			return fmt.Errorf("%s %f out of range", name, *w)
+		}
+	}
+	if st.MeanWatts != nil && st.PeakWatts != nil && *st.PeakWatts < *st.MeanWatts {
+		return fmt.Errorf("peak %f below mean %f", *st.PeakWatts, *st.MeanWatts)
+	}
+	return nil
+}
+
+// validatePowerBatch rejects the whole batch unless every field is within
+// contract and sanity bounds. Nothing may be written for a half-valid batch.
+//
+// The measurement-AGE check is deliberately NOT here: it runs in
+// commitPowerBatch only for genuinely new seqs, after dedupe. A duplicate
+// replay of already-committed data must never be rejected for age — the
+// agent would retry the same unacked journal entry forever. Agents prune
+// aged entries from the journal before upload instead.
+func validatePowerBatch(b *powerhistory.Batch, now time.Time) error {
+	if b.Type != powerhistory.BatchType {
+		return fmt.Errorf("type %q", b.Type)
+	}
+	if !validPowerID(b.StreamID) {
+		return fmt.Errorf("invalid stream_id %q", b.StreamID)
+	}
+	// 0 means "no retention declared", which is only valid once buckets
+	// exist; a declaration (including the zero-bucket gap-only batch an
+	// agent sends after retention eats its last unsent record) names the
+	// oldest retained seq, which starts at 1.
+	if b.RetainedFrom < 1 || b.RetainedFrom > powerhistory.MaxSeq {
+		return fmt.Errorf("retained_from %d out of range", b.RetainedFrom)
+	}
+	if len(b.Buckets) > powerhistory.MaxBatchRecords {
+		return fmt.Errorf("bucket count %d out of range", len(b.Buckets))
+	}
+	futureLimit := now.Add(powerMaxFutureSkew).UnixMilli()
+	var prevSeq uint64
+	for i := range b.Buckets {
+		bk := &b.Buckets[i]
+		if bk.Seq == 0 || bk.Seq > powerhistory.MaxSeq {
+			return fmt.Errorf("bucket %d: seq %d out of range", i, bk.Seq)
+		}
+		if i > 0 && bk.Seq <= prevSeq {
+			return fmt.Errorf("bucket %d: seq %d not strictly increasing", i, bk.Seq)
+		}
+		prevSeq = bk.Seq
+		if bk.Seq < b.RetainedFrom {
+			return fmt.Errorf("bucket %d: seq %d below retained_from %d", i, bk.Seq, b.RetainedFrom)
+		}
+		if bk.StartUnixMS > futureLimit || bk.EndUnixMS > futureLimit {
+			return fmt.Errorf("%w: bucket %d", errPowerClockSkew, i)
+		}
+		if bk.StartUnixMS < powerMinStartUnixMS {
+			return fmt.Errorf("bucket %d: start_unix_ms %d out of range", i, bk.StartUnixMS)
+		}
+		if bk.EndUnixMS <= bk.StartUnixMS || bk.EndUnixMS > futureLimit {
+			return fmt.Errorf("bucket %d: end_unix_ms %d out of range", i, bk.EndUnixMS)
+		}
+		if time.Duration(bk.EndUnixMS-bk.StartUnixMS)*time.Millisecond > powerMaxWindowDuration {
+			return fmt.Errorf("bucket %d: window duration out of range", i)
+		}
+		if bk.ExpectedSamples < 1 || bk.ExpectedSamples > powerMaxExpectedSamples {
+			return fmt.Errorf("bucket %d: expected_samples %d out of range", i, bk.ExpectedSamples)
+		}
+		if len(bk.GPUs) > powerhistory.MaxSensors {
+			return fmt.Errorf("bucket %d: %d GPUs exceeds max %d", i, len(bk.GPUs), powerhistory.MaxSensors)
+		}
+		seen := make(map[string]struct{}, len(bk.GPUs))
+		minGPUSamples := 0
+		for j := range bk.GPUs {
+			g := &bk.GPUs[j]
+			if !validPowerID(g.ID) {
+				return fmt.Errorf("bucket %d gpu %d: invalid id %q", i, j, g.ID)
+			}
+			if _, dup := seen[g.ID]; dup {
+				return fmt.Errorf("bucket %d: duplicate gpu id %q", i, g.ID)
+			}
+			seen[g.ID] = struct{}{}
+			if err := validPowerStats(&g.Stats, bk.ExpectedSamples, powerMaxWattsPerSensor); err != nil {
+				return fmt.Errorf("bucket %d gpu %q: %w", i, g.ID, err)
+			}
+			if j == 0 || g.Samples < minGPUSamples {
+				minGPUSamples = g.Samples
+			}
+		}
+		if bk.GPUTotal != nil {
+			if err := validPowerStats(bk.GPUTotal, bk.ExpectedSamples, powerMaxWattsGPUTotal); err != nil {
+				return fmt.Errorf("bucket %d gpu_total: %w", i, err)
+			}
+			// GPUTotal is computed from complete simultaneous observations:
+			// it cannot exist without GPUs, and cannot cover more
+			// observations than the least-observed GPU in the set.
+			if bk.GPUTotal.Samples > 0 {
+				if len(bk.GPUs) == 0 {
+					return fmt.Errorf("bucket %d: gpu_total without gpus", i)
+				}
+				if bk.GPUTotal.Samples > minGPUSamples {
+					return fmt.Errorf("bucket %d: gpu_total samples %d exceed least-observed gpu %d", i, bk.GPUTotal.Samples, minGPUSamples)
+				}
+			}
+		}
+		if bk.CPU != nil {
+			if err := validPowerStats(bk.CPU, bk.ExpectedSamples, powerMaxWattsPerSensor); err != nil {
+				return fmt.Errorf("bucket %d cpu: %w", i, err)
+			}
+		}
+	}
+	return nil
+}
+
+// --- ingest (agent WebSocket) ---
+
+// ingestPowerHistory handles one power_history frame from an authenticated
+// agent socket. It returns a non-nil error for every rejected or failed
+// batch and only sends the ACK frame after the committing transaction has
+// durably committed — an ACK implies durable contiguous prefix, so a lost
+// ACK after commit is a harmless replay, while a commit failure must never
+// be acknowledged.
+func (s *Server) ingestPowerHistory(machineID string, agent *ConnectedAgent, raw []byte) error {
+	if machineID == "" || !s.isRegisteredConnection(machineID, agent) {
+		return fmt.Errorf("unregistered connection")
+	}
+	// Diagnostic state belongs only to this registered connection. No invalid
+	// frame mutates durable telemetry or advances an ACK. Never expose raw errors.
+	issue := powerIssueInvalid
+	defer func() { agent.powerIssue.Store(issue) }()
+	if len(raw) > powerhistory.MaxFrameBytes {
+		return fmt.Errorf("frame %d bytes exceeds %d", len(raw), powerhistory.MaxFrameBytes)
+	}
+	var batch powerhistory.Batch
+	if err := json.Unmarshal(raw, &batch); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	if err := validatePowerBatch(&batch, time.Now()); err != nil {
+		if errors.Is(err, errPowerClockSkew) {
+			issue = powerIssueClock
+		}
+		return err
+	}
+	issue = powerIssueStorage
+	through, err := s.commitPowerBatch(machineID, &batch, time.Now())
+	if err != nil {
+		if errors.Is(err, errPowerConflict) {
+			issue = powerIssueConflict
+		}
+		log.Printf("power history commit for %s stream %s: %v", machineID, batch.StreamID, err)
+		return err
+	}
+	issue = powerIssueNone
+	agent.powerIssue.Store(issue) // clear before the successful ACK is observable
+	if agent != nil {
+		ack, _ := json.Marshal(powerhistory.Ack{Type: powerhistory.AckType, StreamID: batch.StreamID, Through: through})
+		if err := agent.writeLocked(websocket.TextMessage, ack); err != nil {
+			return fmt.Errorf("ack write: %w", err)
+		}
+	}
+	return nil
+}
+
+type powerStreamState struct {
+	ackedThrough uint64
+	maxSeenSeq   uint64
+	retainedFrom uint64
+}
+
+// commitPowerBatch applies one validated batch in a single transaction:
+// existence-based idempotent dedupe, conflict rejection, age enforcement
+// for genuinely new data only, explicit gap declaration, and
+// contiguous-prefix advancement. Returns the new acked-through sequence.
+//
+// An empty bucket list is valid: it is the gap-only batch an agent sends
+// after retention eats its last unsent record — retention loss declared,
+// nothing to insert. Dedupe is by RECORD EXISTENCE, not by max_seen_seq:
+// an out-of-order arrival (3, then 1,2 to fill the hole) must insert 1 and
+// 2 even though maxSeen already says 3.
+func (s *Server) commitPowerBatch(machineID string, b *powerhistory.Batch, now time.Time) (uint64, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	st := powerStreamState{}
+	err = tx.QueryRow(`SELECT acked_through, max_seen_seq, retained_from
+		FROM power_history_stream_state WHERE machine_id = ? AND stream_id = ?`,
+		machineID, b.StreamID).Scan(&st.ackedThrough, &st.maxSeenSeq, &st.retainedFrom)
+	if err == sql.ErrNoRows {
+		err = nil
+	} else if err != nil {
+		return 0, err
+	}
+
+	// Load existing rows in the batch's seq range for dedupe/conflict checks.
+	existing := map[uint64]string{}
+	if len(b.Buckets) > 0 {
+		minSeq, maxSeq := b.Buckets[0].Seq, b.Buckets[0].Seq
+		for _, bk := range b.Buckets {
+			if bk.Seq < minSeq {
+				minSeq = bk.Seq
+			}
+			if bk.Seq > maxSeq {
+				maxSeq = bk.Seq
+			}
+		}
+		rows, err := tx.Query(`SELECT seq, payload FROM power_history_records
+			WHERE machine_id = ? AND stream_id = ? AND seq BETWEEN ? AND ?`,
+			machineID, b.StreamID, minSeq, maxSeq)
+		if err != nil {
+			return 0, err
+		}
+		for rows.Next() {
+			var seq uint64
+			var payload string
+			if err := rows.Scan(&seq, &payload); err != nil {
+				rows.Close()
+				return 0, err
+			}
+			existing[seq] = payload
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return 0, err
+		}
+	}
+
+	pastLimit := now.Add(-powerMaxPastAge).UnixMilli()
+	for i := range b.Buckets {
+		bk := &b.Buckets[i]
+		payload, err := json.Marshal(bk)
+		if err != nil {
+			return 0, err
+		}
+		if stored, ok := existing[bk.Seq]; ok {
+			// Compare both sides using the current schema: field order, omitted
+			// optional fields and additive schema changes are not data conflicts.
+			var previous powerhistory.Bucket
+			if err := json.Unmarshal([]byte(stored), &previous); err != nil {
+				return 0, fmt.Errorf("seq %d: corrupt stored payload", bk.Seq)
+			}
+			canonical, err := json.Marshal(previous)
+			if err != nil {
+				return 0, err
+			}
+			if string(canonical) != string(payload) {
+				return 0, fmt.Errorf("%w: seq %d", errPowerConflict, bk.Seq)
+			}
+			continue
+		}
+		if bk.Seq <= st.ackedThrough {
+			// Acked but the row was pruned by retention: absorb silently —
+			// the high-water in stream state still answers for this seq, so
+			// an old retransmission never becomes a new row.
+			continue
+		}
+		// Genuinely new (out-of-order arrivals included). Age is enforced
+		// HERE, after dedupe, so an aged duplicate replay is absorbed above
+		// instead of poisoning the agent's retry loop — the agent prunes aged
+		// entries from its journal before upload; data this old is outside
+		// retention and cannot be accepted as new.
+		if bk.StartUnixMS < pastLimit {
+			return 0, fmt.Errorf("seq %d: start older than retention window; prune before upload", bk.Seq)
+		}
+		if _, err := tx.Exec(`INSERT INTO power_history_records
+			(machine_id, stream_id, seq, start_unix_ms, end_unix_ms, expected_samples, payload)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			machineID, b.StreamID, bk.Seq, bk.StartUnixMS, bk.EndUnixMS, bk.ExpectedSamples, string(payload)); err != nil {
+			return 0, err
+		}
+		if bk.Seq > st.maxSeenSeq {
+			st.maxSeenSeq = bk.Seq
+		}
+	}
+
+	// Explicit retention-gap declaration. retained_from is the oldest seq
+	// the agent still holds; advancing it past unacknowledged seqs declares
+	// them permanently lost. Only that declared pruned prefix becomes gaps —
+	// missing seqs the agent has NOT declared lost stay holes, never silent
+	// gaps, and keep the un-acked prefix discontiguous.
+	if b.RetainedFrom > st.retainedFrom {
+		// Candidate lost seqs are (ackedThrough, retainedFrom). When the
+		// prefix already covers them there is nothing to declare; the guard
+		// also keeps ackedThrough+1 from wrapping at MaxSeq.
+		if b.RetainedFrom > st.ackedThrough+1 {
+			if err := declarePowerGapsForMissing(tx, machineID, b.StreamID, st.ackedThrough+1, b.RetainedFrom-1, b.Buckets); err != nil {
+				return 0, err
+			}
+		}
+		st.retainedFrom = b.RetainedFrom
+	}
+
+	// Advance the contiguous durable prefix: present records and declared
+	// gaps both count; an undeclared hole stops the advance.
+	through, err := powerAckedThrough(tx, machineID, b.StreamID, st.ackedThrough)
+	if err != nil {
+		return 0, err
+	}
+	st.ackedThrough = through
+
+	degraded := 0
+	if b.Degraded {
+		degraded = 1
+	}
+	if _, err := tx.Exec(`INSERT INTO power_history_stream_state
+		(machine_id, stream_id, acked_through, max_seen_seq, retained_from, degraded, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(machine_id, stream_id) DO UPDATE SET
+			acked_through = excluded.acked_through,
+			max_seen_seq = excluded.max_seen_seq,
+			retained_from = excluded.retained_from,
+			degraded = excluded.degraded,
+			updated_at = CURRENT_TIMESTAMP`,
+		machineID, b.StreamID, st.ackedThrough, st.maxSeenSeq, st.retainedFrom, degraded); err != nil {
+		return 0, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return st.ackedThrough, nil
+}
+
+// declarePowerGapsForMissing declares one merged gap per contiguous run of
+// seqs missing from [lo, hi]. Work is O(existing rows + batch buckets):
+// present seqs are collected and sorted, then interval-subtracted from the
+// range — the seq space itself (up to 2^53) is never walked, so a huge
+// declared gap cannot stall the hub.
+func declarePowerGapsForMissing(tx *sql.Tx, machineID, streamID string, lo, hi uint64, buckets []powerhistory.Bucket) error {
+	presentSet := map[uint64]bool{}
+	for _, bk := range buckets {
+		if bk.Seq >= lo && bk.Seq <= hi {
+			presentSet[bk.Seq] = true
+		}
+	}
+	rows, err := tx.Query(`SELECT seq FROM power_history_records
+		WHERE machine_id = ? AND stream_id = ? AND seq BETWEEN ? AND ?`,
+		machineID, streamID, lo, hi)
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var seq uint64
+		if err := rows.Scan(&seq); err != nil {
+			rows.Close()
+			return err
+		}
+		presentSet[seq] = true
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	present := make([]uint64, 0, len(presentSet))
+	for seq := range presentSet {
+		present = append(present, seq)
+	}
+	sort.Slice(present, func(i, j int) bool { return present[i] < present[j] })
+
+	cursor := lo
+	for _, seq := range present {
+		if cursor > hi {
+			break
+		}
+		if seq > cursor {
+			if err := declarePowerGap(tx, machineID, streamID, cursor, seq-1); err != nil {
+				return err
+			}
+		}
+		if seq >= cursor {
+			cursor = seq + 1 // present is sorted+unique; seq+1 cannot exceed hi+1 <= MaxSeq
+		}
+	}
+	if cursor <= hi {
+		return declarePowerGap(tx, machineID, streamID, cursor, hi)
+	}
+	return nil
+}
+
+// declarePowerGap records [fromSeq, throughSeq] as permanently lost for the
+// stream, merging with overlapping or directly adjacent gap rows so the gap
+// table stays one row per contiguous run.
+func declarePowerGap(tx *sql.Tx, machineID, streamID string, fromSeq, throughSeq uint64) error {
+	// Extend across neighbors that overlap or touch the new range. MIN/MAX
+	// over an empty match still returns one row with NULL columns (not
+	// ErrNoRows), so scan into nullable values.
+	lo, hi := fromSeq, throughSeq
+	if lo > 1 {
+		lo--
+	}
+	if hi < powerhistory.MaxSeq {
+		hi++
+	}
+	var mergedLo, mergedHi sql.NullInt64
+	err := tx.QueryRow(`SELECT MIN(from_seq), MAX(through_seq) FROM power_history_gaps
+		WHERE machine_id = ? AND stream_id = ? AND from_seq <= ? AND through_seq >= ?`,
+		machineID, streamID, hi, lo).Scan(&mergedLo, &mergedHi)
+	if err != nil {
+		return err
+	}
+	mergedFrom, mergedThrough := fromSeq, throughSeq
+	if mergedLo.Valid {
+		mergedFrom, mergedThrough = uint64(mergedLo.Int64), uint64(mergedHi.Int64)
+		if fromSeq < mergedFrom {
+			mergedFrom = fromSeq
+		}
+		if throughSeq > mergedThrough {
+			mergedThrough = throughSeq
+		}
+		if _, err := tx.Exec(`DELETE FROM power_history_gaps
+			WHERE machine_id = ? AND stream_id = ? AND from_seq <= ? AND through_seq >= ?`,
+			machineID, streamID, hi, lo); err != nil {
+			return err
+		}
+	}
+	_, err = tx.Exec(`INSERT INTO power_history_gaps (machine_id, stream_id, from_seq, through_seq)
+		VALUES (?, ?, ?, ?)`, machineID, streamID, mergedFrom, mergedThrough)
+	return err
+}
+
+// powerAckedThrough walks present records and declared gaps starting just
+// after fromThrough and returns the last seq of the contiguous committed
+// prefix.
+func powerAckedThrough(tx *sql.Tx, machineID, streamID string, fromThrough uint64) (uint64, error) {
+	if fromThrough >= powerhistory.MaxSeq {
+		return fromThrough, nil
+	}
+	var present []uint64
+	prows, err := tx.Query(`SELECT seq FROM power_history_records
+		WHERE machine_id = ? AND stream_id = ? AND seq > ? ORDER BY seq`,
+		machineID, streamID, fromThrough)
+	if err != nil {
+		return 0, err
+	}
+	for prows.Next() {
+		var seq uint64
+		if err := prows.Scan(&seq); err != nil {
+			prows.Close()
+			return 0, err
+		}
+		present = append(present, seq)
+	}
+	prows.Close()
+	if err := prows.Err(); err != nil {
+		return 0, err
+	}
+
+	type gapRange struct{ from, through uint64 }
+	var gaps []gapRange
+	grows, err := tx.Query(`SELECT from_seq, through_seq FROM power_history_gaps
+		WHERE machine_id = ? AND stream_id = ? AND through_seq > ? ORDER BY from_seq`,
+		machineID, streamID, fromThrough)
+	if err != nil {
+		return 0, err
+	}
+	for grows.Next() {
+		var g gapRange
+		if err := grows.Scan(&g.from, &g.through); err != nil {
+			grows.Close()
+			return 0, err
+		}
+		gaps = append(gaps, g)
+	}
+	grows.Close()
+	if err := grows.Err(); err != nil {
+		return 0, err
+	}
+
+	next := fromThrough + 1
+	pi := 0
+	for {
+		advanced := false
+		for _, g := range gaps {
+			if g.from <= next && next <= g.through {
+				next = g.through + 1
+				advanced = true
+			}
+		}
+		for pi < len(present) && present[pi] < next {
+			pi++
+		}
+		for pi < len(present) && present[pi] == next {
+			next++
+			pi++
+			advanced = true
+		}
+		if !advanced {
+			break
+		}
+	}
+	return next - 1, nil
+}
+
+// --- retention ---
+
+// prunePowerHistory deletes chart rows outside the 24h retention window and
+// stale gap rows. Stream STATE (high-water, retained_from) is deliberately
+// untouched: retention pruning must never make an old retransmission look
+// new again.
+func (s *Server) prunePowerHistory(now time.Time) (int64, error) {
+	cutoff := now.Add(-powerhistory.RetentionSeconds * time.Second).UnixMilli()
+	res, err := s.db.Exec(`DELETE FROM power_history_records WHERE end_unix_ms < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	// Gaps explain holes in the visible window; a gap recorded before the
+	// window started is noise. 48h keeps one full window of overlap.
+	if _, err := s.db.Exec(`DELETE FROM power_history_gaps WHERE recorded_at < datetime('now', '-48 hours')`); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// --- read API ---
+
+const (
+	// Default must hold one normal day of 30-second windows (2880) so an
+	// untruncated initial read covers the full retention window.
+	powerHistoryDefaultMaxRecords = 4096
+	powerHistoryMaxRecordsCap     = 16384
+)
+
+func clampQueryInt(c echo.Context, name string, def, min, max int) int {
+	v, err := strconv.Atoi(c.QueryParam(name))
+	if err != nil {
+		return def
+	}
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
+}
+
+// powerHistoryHighWater returns the durable ingestion high-water for a
+// machine: the larger of the machine's newest record id and the table's
+// AUTOINCREMENT sequence value. The sequence survives row pruning (it lives
+// in sqlite_sequence, never reused), so retention can never regress the
+// cursor.
+func (s *Server) powerHistoryHighWater(machineID string) (uint64, error) {
+	var machineMax, globalSeq uint64
+	if err := s.db.QueryRow(`SELECT COALESCE(MAX(id), 0) FROM power_history_records WHERE machine_id = ?`, machineID).Scan(&machineMax); err != nil {
+		return 0, err
+	}
+	switch err := s.db.QueryRow(`SELECT seq FROM sqlite_sequence WHERE name = 'power_history_records'`).Scan(&globalSeq); err {
+	case nil:
+	case sql.ErrNoRows:
+		globalSeq = 0
+	default:
+		return 0, err
+	}
+	if globalSeq > machineMax {
+		return globalSeq, nil
+	}
+	return machineMax, nil
+}
+
+// handlePowerHistory serves GET /api/machines/:id/power/history — the
+// authenticated dashboard view of component power history.
+//
+// Two modes, one contract:
+//   - Initial: no ?after → the NEWEST buckets of the last 24h (bounded by
+//     max_records), re-sorted chronologically per stream. All streams participate.
+//   - Delta: ?after=N → buckets with an ingestion id > N, ordered by
+//     arrival. The cursor is ingestion order, NOT measurement time, so a
+//     late backfill (e.g. an agent reconnecting with unacked journal
+//     buckets) still reaches a client that already fetched the window.
+//
+// Delta pages ordered by id with cursor = last returned id when truncated
+// never skip records. Gaps and degraded are always the CURRENT machine
+// state — an empty delta still reports them. Every response, including an
+// empty one, carries cursor: the durable ingestion high-water (or the last
+// returned id on a truncated page).
+func (s *Server) handlePowerHistory(c echo.Context) error {
+	machineID := c.Param("id")
+	var exists int
+	if err := s.db.QueryRow(`SELECT 1 FROM machines WHERE id = ?`, machineID).Scan(&exists); err != nil {
+		if err == sql.ErrNoRows {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "machine not found"})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to query machine"})
+	}
+
+	maxRecords := clampQueryInt(c, "max_records", powerHistoryDefaultMaxRecords, 1, powerHistoryMaxRecordsCap)
+	windowStart := time.Now().Add(-powerhistory.RetentionSeconds * time.Second).UnixMilli()
+
+	after, delta, err := parseAfterCursor(c)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	// High-water is read before the rows query: rows landing in between get
+	// an id greater than the cursor and are delivered on the next poll.
+	highWater, err := s.powerHistoryHighWater(machineID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	if highWater > powerhistory.MaxSeq {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "power history cursor exceeds supported range"})
+	}
+	hist := powerhistory.History{Points: []powerhistory.Point{}, Gaps: []powerhistory.Gap{}, Cursor: highWater}
+
+	var rows *sql.Rows
+	if delta {
+		rows, err = s.db.Query(`SELECT id, stream_id, payload FROM power_history_records
+			WHERE machine_id = ? AND id > ? AND id <= ?
+			ORDER BY id ASC LIMIT ?`, machineID, after, highWater, maxRecords)
+	} else {
+		// Newest-first selection: if the cap truncates the window, the
+		// dropped buckets are the oldest, never the current ones.
+		rows, err = s.db.Query(`SELECT id, stream_id, payload FROM power_history_records
+			WHERE machine_id = ? AND end_unix_ms >= ? AND id <= ?
+			ORDER BY end_unix_ms DESC, id DESC LIMIT ?`, machineID, windowStart, highWater, maxRecords)
+	}
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	var lastID uint64
+	for rows.Next() {
+		var ingestID uint64
+		var streamID, payload string
+		if err := rows.Scan(&ingestID, &streamID, &payload); err != nil {
+			rows.Close()
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		var bk powerhistory.Bucket
+		if err := json.Unmarshal([]byte(payload), &bk); err != nil {
+			rows.Close()
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "corrupt stored bucket"})
+		}
+		hist.Points = append(hist.Points, powerhistory.Point{StreamID: streamID, Bucket: bk})
+		lastID = ingestID
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	// Truncated delta page: resume after the LAST RETURNED id so the
+	// unreturned tail is not skipped. Complete or empty page: the durable
+	// high-water.
+	if delta && len(hist.Points) == maxRecords && lastID > 0 {
+		hist.Cursor = lastID
+	}
+
+	if !delta {
+		// Arrival order for deltas; chronological per stream for the
+		// initial view (charts), which selected newest-first above.
+		sort.SliceStable(hist.Points, func(i, j int) bool {
+			if hist.Points[i].StreamID != hist.Points[j].StreamID {
+				return hist.Points[i].StreamID < hist.Points[j].StreamID
+			}
+			return hist.Points[i].Seq < hist.Points[j].Seq
+		})
+	}
+
+	return s.finishPowerHistory(c, machineID, hist)
+}
+
+// finishPowerHistory attaches current gap and degraded state. Both are
+// machine state, not a diff of the returned points: a delta that returns
+// zero new buckets must still report the machine's existing gaps and its
+// degraded flag. Recently declared gaps remain visible even when all their
+// records were lost, or the gap is before/after the surviving sequence range.
+func (s *Server) finishPowerHistory(c echo.Context, machineID string, hist powerhistory.History) error {
+	rows, err := s.db.Query(`SELECT stream_id, from_seq, through_seq FROM power_history_gaps
+		WHERE machine_id = ? AND recorded_at >= datetime('now', '-24 hours')
+		ORDER BY recorded_at DESC, stream_id, from_seq LIMIT ?`, machineID, powerHistoryDefaultMaxRecords)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	for rows.Next() {
+		var gap powerhistory.Gap
+		if err := rows.Scan(&gap.StreamID, &gap.From, &gap.Through); err != nil {
+			rows.Close()
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		hist.Gaps = append(hist.Gaps, gap)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	// Degraded reflects the most recent batch state of any stream that
+	// reported within the retention window; a stale flag ages out.
+	var degradedCount int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM power_history_stream_state
+		WHERE machine_id = ? AND degraded = TRUE AND updated_at >= datetime('now', '-24 hours')`,
+		machineID).Scan(&degradedCount); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	hist.Problem = s.powerHistoryProblem(machineID)
+	hist.Degraded = degradedCount > 0 || hist.Problem != ""
+
+	return c.JSON(http.StatusOK, hist)
+}
+
+// parseAfterCursor extracts the optional ?after delta cursor. Absent means
+// an initial full-window read; present must be a non-negative integer.
+func parseAfterCursor(c echo.Context) (after uint64, delta bool, err error) {
+	raw := c.QueryParam("after")
+	if raw == "" {
+		return 0, false, nil
+	}
+	v, perr := strconv.ParseUint(raw, 10, 64)
+	if perr != nil || v > powerhistory.MaxSeq {
+		return 0, false, fmt.Errorf("invalid after cursor %q", raw)
+	}
+	return v, true, nil
+}

--- a/hub/power_history_test.go
+++ b/hub/power_history_test.go
@@ -1,0 +1,806 @@
+package main
+
+// End-to-end tests for hub-side power history: authenticated WS ingest,
+// whole-batch validation, idempotent replay vs conflict rejection, explicit
+// gap declaration, ACK-only-after-commit, retention pruning that preserves
+// the sequence high-water and the AUTOINCREMENT delta cursor, and late
+// backfill delivery by ingestion order.
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/powerhistory"
+	"github.com/gorilla/websocket"
+)
+
+// --- helpers ---
+
+func powerBucket(seq uint64, startMS, endMS int64, mean, peak float64, samples, expected int) map[string]any {
+	return map[string]any{
+		"seq":              seq,
+		"start_unix_ms":    startMS,
+		"end_unix_ms":      endMS,
+		"expected_samples": expected,
+		"gpus": []any{
+			map[string]any{"id": "gpu-0", "mean_watts": mean, "peak_watts": peak, "samples": samples},
+			map[string]any{"id": "gpu-1", "mean_watts": mean / 2, "peak_watts": peak / 2, "samples": samples},
+		},
+		"gpu_total": map[string]any{"mean_watts": mean * 1.5, "peak_watts": peak * 1.5, "samples": samples},
+		"cpu":       map[string]any{"mean_watts": 65.0, "peak_watts": 80.0, "samples": samples},
+	}
+}
+
+func powerBatch(streamID string, retainedFrom uint64, buckets ...map[string]any) map[string]any {
+	return map[string]any{
+		"type":          "power_history",
+		"stream_id":     streamID,
+		"retained_from": retainedFrom,
+		"buckets":       buckets,
+	}
+}
+
+func nowWindowMS() (int64, int64) {
+	end := time.Now().UnixMilli()
+	return end - 30_000, end
+}
+
+// readPowerAck reads the next frame with a deadline, returning an error on
+// timeout (used both to receive ACKs and to prove none arrived).
+func readPowerAck(t *testing.T, conn *websocket.Conn) (powerhistory.Ack, error) {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		return powerhistory.Ack{}, err
+	}
+	var ack powerhistory.Ack
+	if err := json.Unmarshal(msg, &ack); err != nil {
+		t.Fatalf("unmarshal frame %q: %v", msg, err)
+	}
+	return ack, nil
+}
+
+func expectPowerAck(t *testing.T, conn *websocket.Conn, streamID string, through uint64) {
+	t.Helper()
+	ack, err := readPowerAck(t, conn)
+	if err != nil {
+		t.Fatalf("expected ack for %s, got read error: %v", streamID, err)
+	}
+	if ack.Type != powerhistory.AckType || ack.StreamID != streamID || ack.Through != through {
+		t.Fatalf("unexpected ack: %+v (want stream=%s through=%d)", ack, streamID, through)
+	}
+}
+
+func expectNoPowerAck(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	_, _, err := conn.ReadMessage()
+	if err == nil {
+		t.Fatal("expected no frame, got one")
+	}
+}
+
+func powerHistoryGet(t *testing.T, h http.Handler, token, machineID, query string) (int, powerhistory.History, string) {
+	t.Helper()
+	url := "/api/machines/" + machineID + "/power/history" + query
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	var hist powerhistory.History
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &hist); err != nil {
+			t.Fatalf("unmarshal history: %v (%s)", err, rec.Body.String())
+		}
+	}
+	return rec.Code, hist, rec.Body.String()
+}
+
+func powerRowCount(t *testing.T, s *Server, machineID string) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM power_history_records WHERE machine_id = ?`, machineID).Scan(&n); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	return n
+}
+
+func powerStreamStateOf(t *testing.T, s *Server, machineID, streamID string) (acked, maxSeen uint64) {
+	t.Helper()
+	err := s.db.QueryRow(`SELECT acked_through, max_seen_seq FROM power_history_stream_state
+		WHERE machine_id = ? AND stream_id = ?`, machineID, streamID).Scan(&acked, &maxSeen)
+	if err == sql.ErrNoRows {
+		return 0, 0
+	}
+	if err != nil {
+		t.Fatalf("stream state: %v", err)
+	}
+	return acked, maxSeen
+}
+
+// --- tests ---
+
+func TestPowerHistoryIngestAckAndRead(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn) // drain the registration-time config frame
+	s.sendSentinelMetrics(t, conn, "machine-A", "host-a")
+
+	start, end := nowWindowMS()
+	writeFrame(t, conn, powerBatch("stream-1", 1, powerBucket(1, start, end, 100, 200, 30, 30)))
+	expectPowerAck(t, conn, "stream-1", 1)
+
+	if n := powerRowCount(t, s, "machine-A"); n != 1 {
+		t.Fatalf("rows = %d, want 1", n)
+	}
+
+	code, hist, body := powerHistoryGet(t, e, adminToken, "machine-A", "")
+	if code != http.StatusOK {
+		t.Fatalf("GET: %d %s", code, body)
+	}
+	if len(hist.Points) != 1 || len(hist.Gaps) != 0 || hist.Degraded {
+		t.Fatalf("unexpected history: %+v", hist)
+	}
+	p := hist.Points[0]
+	if p.StreamID != "stream-1" || p.Seq != 1 || p.ExpectedSamples != 30 {
+		t.Fatalf("unexpected point: %+v", p)
+	}
+	if p.GPUTotal == nil || *p.GPUTotal.PeakWatts != 300 || p.CPU == nil || *p.CPU.MeanWatts != 65 {
+		t.Fatalf("gpu_total/cpu not preserved: %+v", p)
+	}
+	if len(p.GPUs) != 2 || p.GPUs[0].ID != "gpu-0" || *p.GPUs[1].MeanWatts != 50 {
+		t.Fatalf("per-GPU breakdown not preserved: %+v", p.GPUs)
+	}
+	if hist.Cursor == 0 {
+		t.Fatal("cursor must be non-zero after ingest")
+	}
+	if !strings.Contains(body, `"points":[`) || !strings.Contains(body, `"gaps":[`) {
+		t.Fatalf("empty-contract fields must serialize as []: %s", body)
+	}
+}
+
+func TestPowerHistoryBoundToAuthenticatedConnection(t *testing.T) {
+	e, s := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+
+	// Spoof attempt: the envelope claims another machine. The identity
+	// guard drops the frame before the switch — nothing is stored for
+	// either machine. A sentinel-metrics barrier confirms the hub processed
+	// everything before this point; a negative websocket read is NOT used
+	// here because a gorilla read timeout permanently poisons the reader.
+	start, end := nowWindowMS()
+	spoofed := powerBatch("stream-1", 1, powerBucket(1, start, end, 100, 200, 30, 30))
+	spoofed["machine_id"] = "machine-B"
+	writeFrame(t, conn, spoofed)
+	s.sendSentinelMetrics(t, conn, "machine-A", "host-a")
+	if n := powerRowCount(t, s, "machine-A"); n != 0 {
+		t.Fatalf("spoofed frame stored %d rows for machine-A", n)
+	}
+	if n := powerRowCount(t, s, "machine-B"); n != 0 {
+		t.Fatalf("spoofed frame stored %d rows for machine-B", n)
+	}
+
+	// The same batch without the spoofed field is accepted and keyed to the
+	// authenticated machine, not any field in the frame.
+	writeFrame(t, conn, powerBatch("stream-1", 1, powerBucket(1, start, end, 100, 200, 30, 30)))
+	expectPowerAck(t, conn, "stream-1", 1)
+	if n := powerRowCount(t, s, "machine-A"); n != 1 {
+		t.Fatalf("rows = %d, want 1", n)
+	}
+}
+
+func TestPowerHistoryInvalidBatchesRejectedWhole(t *testing.T) {
+	e, s := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+
+	start, end := nowWindowMS()
+	fresh := func() map[string]any { return powerBucket(1, start, end, 100, 200, 30, 30) }
+
+	bad := map[string]func() map[string]any{
+		"negative watts": func() map[string]any {
+			b := fresh()
+			b["gpus"] = []any{map[string]any{"id": "gpu-0", "mean_watts": -1, "peak_watts": 10, "samples": 30}}
+			return b
+		},
+		"stats with zero samples": func() map[string]any {
+			b := fresh()
+			b["gpus"] = []any{map[string]any{"id": "gpu-0", "mean_watts": 10, "samples": 0}}
+			return b
+		},
+		"negative samples": func() map[string]any {
+			b := fresh()
+			b["gpus"] = []any{map[string]any{"id": "gpu-0", "samples": -3}}
+			return b
+		},
+		"duplicate gpu ids": func() map[string]any {
+			b := fresh()
+			b["gpus"] = []any{
+				map[string]any{"id": "gpu-0", "samples": 1},
+				map[string]any{"id": "gpu-0", "samples": 1},
+			}
+			return b
+		},
+		"end before start": func() map[string]any {
+			b := fresh()
+			b["start_unix_ms"], b["end_unix_ms"] = end, start
+			return b
+		},
+		"window too long": func() map[string]any {
+			b := fresh()
+			b["end_unix_ms"] = start + int64(2*time.Hour/time.Millisecond)
+			return b
+		},
+		"too old": func() map[string]any {
+			b := fresh()
+			old := time.Now().Add(-72 * time.Hour).UnixMilli()
+			b["start_unix_ms"], b["end_unix_ms"] = old, old+30_000
+			return b
+		},
+		"too far future (clock skew)": func() map[string]any {
+			b := fresh()
+			fut := time.Now().Add(2 * 24 * time.Hour).UnixMilli()
+			b["start_unix_ms"], b["end_unix_ms"] = fut, fut+30_000
+			return b
+		},
+		"seq zero": func() map[string]any {
+			b := fresh()
+			b["seq"] = uint64(0)
+			return b
+		},
+		"seq above max": func() map[string]any {
+			b := fresh()
+			b["seq"] = uint64(1) << 53
+			return b
+		},
+		"wrong type": func() map[string]any {
+			b := fresh()
+			b["expected_samples"] = "thirty"
+			return b
+		},
+		"string watts": func() map[string]any {
+			b := fresh()
+			b["gpus"] = []any{map[string]any{"id": "gpu-0", "mean_watts": "NaN", "samples": 30}}
+			return b
+		},
+		"oversized frame": func() map[string]any {
+			b := fresh()
+			b["gpus"] = []any{map[string]any{"id": "gpu-0", "mean_watts": 10, "samples": 30, "pad": strings.Repeat("x", powerhistory.MaxFrameBytes)}}
+			return b
+		},
+	}
+
+	for name, mk := range bad {
+		t.Run(name, func(t *testing.T) {
+			writeFrame(t, conn, powerBatch("stream-1", 1, mk()))
+			expectNoPowerAck(t, conn)
+			if n := powerRowCount(t, s, "machine-A"); n != 0 {
+				t.Fatalf("invalid batch mutated storage: %d rows", n)
+			}
+		})
+	}
+
+	// Batch-level violations on a valid bucket.
+	writeFrame(t, conn, map[string]any{
+		"type": "power_history", "stream_id": "../evil", "retained_from": 1,
+		"buckets": []any{fresh()},
+	})
+	expectNoPowerAck(t, conn)
+
+	b1, b2 := fresh(), fresh()
+	b2["seq"] = uint64(1) // duplicate/unsorted seq within batch
+	writeFrame(t, conn, powerBatch("stream-1", 1, b1, b2))
+	expectNoPowerAck(t, conn)
+
+	// More buckets than the contract maximum.
+	many := make([]map[string]any, 0, powerhistory.MaxBatchRecords+1)
+	for seq := uint64(1); seq <= powerhistory.MaxBatchRecords+1; seq++ {
+		b := fresh()
+		b["seq"] = seq
+		many = append(many, b)
+	}
+	writeFrame(t, conn, powerBatch("stream-1", 1, many...))
+	expectNoPowerAck(t, conn)
+
+	if n := powerRowCount(t, s, "machine-A"); n != 0 {
+		t.Fatalf("storage mutated by invalid batches: %d rows", n)
+	}
+	if acked, _ := powerStreamStateOf(t, s, "machine-A", "stream-1"); acked != 0 {
+		t.Fatalf("stream state mutated: acked=%d", acked)
+	}
+}
+
+func TestPowerHistoryReplayIdempotentAndConflictRejected(t *testing.T) {
+	e, s := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+
+	start, end := nowWindowMS()
+	b1 := powerBucket(1, start, end, 100, 200, 30, 30)
+	b2 := powerBucket(2, start, end, 110, 210, 30, 30)
+	writeFrame(t, conn, powerBatch("stream-1", 1, b1, b2))
+	expectPowerAck(t, conn, "stream-1", 2)
+
+	// Lost-ACK replay: identical payloads are absorbed, ack re-sent, no
+	// duplicate rows.
+	writeFrame(t, conn, powerBatch("stream-1", 1, b1, b2))
+	expectPowerAck(t, conn, "stream-1", 2)
+	if n := powerRowCount(t, s, "machine-A"); n != 2 {
+		t.Fatalf("replay duplicated rows: %d", n)
+	}
+
+	// Conflicting payload for an already-acked seq: batch rejected whole.
+	bad := powerBucket(1, start, end, 999, 999, 30, 30)
+	writeFrame(t, conn, powerBatch("stream-1", 1, bad))
+	expectNoPowerAck(t, conn)
+	if n := powerRowCount(t, s, "machine-A"); n != 2 {
+		t.Fatalf("conflicting batch mutated rows: %d", n)
+	}
+	if acked, maxSeen := powerStreamStateOf(t, s, "machine-A", "stream-1"); acked != 2 || maxSeen != 2 {
+		t.Fatalf("conflicting batch mutated state: acked=%d max=%d", acked, maxSeen)
+	}
+}
+
+func TestPowerHistoryGapDeclarationAdvancesAckThrough(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+
+	start, end := nowWindowMS()
+	writeFrame(t, conn, powerBatch("stream-1", 1,
+		powerBucket(1, start, end, 100, 200, 30, 30),
+		powerBucket(2, start, end, 100, 200, 30, 30),
+		powerBucket(3, start, end, 100, 200, 30, 30),
+	))
+	expectPowerAck(t, conn, "stream-1", 3)
+
+	// Agent lost seq 4 (journal pruned) and declares retention from 5.
+	// The gap becomes part of the contiguous prefix, so the hub acks
+	// through 6 — but never creates silent holes on its own.
+	writeFrame(t, conn, powerBatch("stream-1", 5,
+		powerBucket(5, start, end, 100, 200, 30, 30),
+		powerBucket(6, start, end, 100, 200, 30, 30),
+	))
+	expectPowerAck(t, conn, "stream-1", 6)
+
+	_, hist, body := powerHistoryGet(t, e, adminToken, "machine-A", "")
+	if len(hist.Gaps) != 1 || hist.Gaps[0].From != 4 || hist.Gaps[0].Through != 4 {
+		t.Fatalf("expected gap [4,4], got %+v (%s)", hist.Gaps, body)
+	}
+}
+
+func TestPowerHistoryNoSilentHoles(t *testing.T) {
+	e, s := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+
+	start, end := nowWindowMS()
+	// Sparse new seqs with NO retention-loss declaration (retained_from 0):
+	// accepted, but the un-acked prefix must stay discontiguous and no gap
+	// may be invented.
+	writeFrame(t, conn, powerBatch("stream-1", 1,
+		powerBucket(10, start, end, 100, 200, 30, 30),
+		powerBucket(11, start, end, 100, 200, 30, 30),
+	))
+	expectPowerAck(t, conn, "stream-1", 0)
+
+	var gapCount int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM power_history_gaps WHERE machine_id = ?`, "machine-A").Scan(&gapCount); err != nil {
+		t.Fatal(err)
+	}
+	if gapCount != 0 {
+		t.Fatalf("silent gap created: %d", gapCount)
+	}
+
+	// Filling the hole makes the prefix contiguous through 11.
+	filled := make([]map[string]any, 0, 9)
+	for seq := uint64(1); seq <= 9; seq++ {
+		filled = append(filled, powerBucket(seq, start, end, 100, 200, 30, 30))
+	}
+	writeFrame(t, conn, powerBatch("stream-1", 1, filled...))
+	expectPowerAck(t, conn, "stream-1", 11)
+}
+
+func TestPowerHistoryNoAckWhenCommitFails(t *testing.T) {
+	e, s := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+
+	if err := s.db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	start, end := nowWindowMS()
+	raw, _ := json.Marshal(powerBatch("stream-1", 1, powerBucket(1, start, end, 100, 200, 30, 30)))
+	if err := s.ingestPowerHistory("machine-A", s.registeredAgent("machine-A"), raw); err == nil {
+		t.Fatal("expected commit failure on closed db")
+	}
+	expectNoPowerAck(t, conn)
+}
+
+func TestPowerHistoryRetentionPrunePreservesHighWaterAndCursor(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+	s.sendSentinelMetrics(t, conn, "machine-A", "host-a")
+
+	start, end := nowWindowMS()
+	writeFrame(t, conn, powerBatch("stream-1", 1, powerBucket(1, start, end, 100, 200, 30, 30)))
+	expectPowerAck(t, conn, "stream-1", 1)
+	writeFrame(t, conn, powerBatch("stream-1", 1, powerBucket(2, start, end, 100, 200, 30, 30)))
+	expectPowerAck(t, conn, "stream-1", 2)
+
+	_, hist, _ := powerHistoryGet(t, e, adminToken, "machine-A", "")
+	if len(hist.Points) != 2 || hist.Cursor == 0 {
+		t.Fatalf("initial read: %+v", hist)
+	}
+	cursor := hist.Cursor
+
+	// Age seq 1 past retention and prune. Stream high-water must survive.
+	old := time.Now().Add(-25 * time.Hour).UnixMilli()
+	if _, err := s.db.Exec(`UPDATE power_history_records SET start_unix_ms = ?, end_unix_ms = ? WHERE seq = 1`, old, old+30_000); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.prunePowerHistory(time.Now()); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if n := powerRowCount(t, s, "machine-A"); n != 1 {
+		t.Fatalf("prune kept %d rows, want 1", n)
+	}
+	if acked, maxSeen := powerStreamStateOf(t, s, "machine-A", "stream-1"); acked != 2 || maxSeen != 2 {
+		t.Fatalf("prune reset high-water: acked=%d max=%d", acked, maxSeen)
+	}
+
+	// Replay of the pruned, acked seq: absorbed, not re-inserted.
+	writeFrame(t, conn, powerBatch("stream-1", 1, powerBucket(1, start, end, 100, 200, 30, 30)))
+	expectPowerAck(t, conn, "stream-1", 2)
+	if n := powerRowCount(t, s, "machine-A"); n != 1 {
+		t.Fatalf("pruned replay resurrected rows: %d", n)
+	}
+
+	// Delta from the pre-prune cursor: empty, cursor never regresses.
+	code, delta, _ := powerHistoryGet(t, e, adminToken, "machine-A", fmt.Sprintf("?after=%d", cursor))
+	if code != http.StatusOK || len(delta.Points) != 0 || delta.Cursor != cursor {
+		t.Fatalf("delta after prune: code=%d %+v", code, delta)
+	}
+
+	// New ingest after prune gets a FRESH id (AUTOINCREMENT does not reuse)
+	// and is delivered exactly once by the delta cursor.
+	writeFrame(t, conn, powerBatch("stream-1", 1, powerBucket(3, start, end, 100, 200, 30, 30)))
+	expectPowerAck(t, conn, "stream-1", 3)
+	code, delta, _ = powerHistoryGet(t, e, adminToken, "machine-A", fmt.Sprintf("?after=%d", cursor))
+	if code != http.StatusOK || len(delta.Points) != 1 || delta.Points[0].Seq != 3 || delta.Cursor <= cursor {
+		t.Fatalf("delta after new ingest: code=%d %+v", code, delta)
+	}
+}
+
+func TestPowerHistoryLateBackfillDeliveredByIngestionOrder(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+	s.sendSentinelMetrics(t, conn, "machine-A", "host-a")
+
+	start, end := nowWindowMS()
+	writeFrame(t, conn, powerBatch("stream-1", 1, powerBucket(1, start, end, 100, 200, 30, 30)))
+	expectPowerAck(t, conn, "stream-1", 1)
+
+	_, hist, _ := powerHistoryGet(t, e, adminToken, "machine-A", "")
+	cursor := hist.Cursor
+
+	// A 30-hour-old unacked journal bucket arrives late. It is outside the
+	// 24h initial window, but the delta cursor is ingestion order, so it
+	// still reaches the client.
+	backStart := time.Now().Add(-30 * time.Hour).UnixMilli()
+	writeFrame(t, conn, powerBatch("stream-1", 1, powerBucket(2, backStart, backStart+30_000, 100, 200, 30, 30)))
+	expectPowerAck(t, conn, "stream-1", 2)
+
+	_, initial, _ := powerHistoryGet(t, e, adminToken, "machine-A", "")
+	if len(initial.Points) != 1 {
+		t.Fatalf("initial window should exclude 20h-old bucket: %+v", initial.Points)
+	}
+	code, delta, _ := powerHistoryGet(t, e, adminToken, "machine-A", fmt.Sprintf("?after=%d", cursor))
+	if code != http.StatusOK || len(delta.Points) != 1 || delta.Points[0].Seq != 2 {
+		t.Fatalf("late backfill missing from delta: code=%d %+v", code, delta)
+	}
+	if delta.Points[0].StartUnixMS != backStart {
+		t.Fatalf("backfill measurement time not preserved: %+v", delta.Points[0])
+	}
+}
+
+func TestPowerHistoryDeltaPaginationCursor(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+	s.sendSentinelMetrics(t, conn, "machine-A", "host-a")
+
+	start, end := nowWindowMS()
+	buckets := make([]map[string]any, 0, 3)
+	for seq := uint64(1); seq <= 3; seq++ {
+		buckets = append(buckets, powerBucket(seq, start, end, 100, 200, 30, 30))
+	}
+	writeFrame(t, conn, powerBatch("stream-1", 1, buckets...))
+	expectPowerAck(t, conn, "stream-1", 3)
+
+	// Truncated delta page: cursor is the last RETURNED id, so the tail is
+	// not skipped.
+	_, page1, _ := powerHistoryGet(t, e, adminToken, "machine-A", "?after=0&max_records=1")
+	if len(page1.Points) != 1 || page1.Cursor == 0 {
+		t.Fatalf("page1: %+v", page1)
+	}
+	_, page2, _ := powerHistoryGet(t, e, adminToken, "machine-A", fmt.Sprintf("?after=%d&max_records=1", page1.Cursor))
+	if len(page2.Points) != 1 || page2.Points[0].Seq != 2 {
+		t.Fatalf("page2 skipped data: %+v", page2)
+	}
+	_, page3, _ := powerHistoryGet(t, e, adminToken, "machine-A", fmt.Sprintf("?after=%d&max_records=100", page2.Cursor))
+	if len(page3.Points) != 1 || page3.Points[0].Seq != 3 {
+		t.Fatalf("page3: %+v", page3)
+	}
+}
+
+func TestPowerHistoryDegradedFlagTracksLatestBatch(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+	s.sendSentinelMetrics(t, conn, "machine-A", "host-a")
+
+	start, end := nowWindowMS()
+	degraded := powerBatch("stream-1", 1, powerBucket(1, start, end, 100, 200, 30, 30))
+	degraded["degraded"] = true
+	writeFrame(t, conn, degraded)
+	expectPowerAck(t, conn, "stream-1", 1)
+
+	_, hist, _ := powerHistoryGet(t, e, adminToken, "machine-A", "")
+	if !hist.Degraded {
+		t.Fatal("degraded batch must surface degraded=true")
+	}
+
+	writeFrame(t, conn, powerBatch("stream-1", 1, powerBucket(2, start, end, 100, 200, 30, 30)))
+	expectPowerAck(t, conn, "stream-1", 2)
+	_, hist, _ = powerHistoryGet(t, e, adminToken, "machine-A", "")
+	if hist.Degraded {
+		t.Fatal("degraded must clear on the next clean batch")
+	}
+}
+
+func TestPowerHistoryReadAPIAuthAndBounds(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+	s.seedTestUser(t, "viewer1", "viewerpass123", "1234", RoleViewer, true, true)
+	viewerToken := loginAndGetTokenForCredentials(t, e, "viewer1", "viewerpass123")
+	s.seedTestMachine(t, "machine-A")
+
+	if code, _, _ := powerHistoryGet(t, e, "", "machine-A", ""); code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated: %d", code)
+	}
+	if code, hist, _ := powerHistoryGet(t, e, viewerToken, "machine-A", ""); code != http.StatusOK {
+		t.Fatalf("viewer read: %d", code)
+	} else if len(hist.Points) != 0 || len(hist.Gaps) != 0 || hist.Degraded || hist.Cursor != 0 {
+		t.Fatalf("empty machine must return empty contract with cursor: %+v", hist)
+	}
+	if code, _, _ := powerHistoryGet(t, e, adminToken, "machine-404", ""); code != http.StatusNotFound {
+		t.Fatalf("unknown machine: %d", code)
+	}
+	if code, _, body := powerHistoryGet(t, e, adminToken, "machine-A", "?after=abc"); code != http.StatusBadRequest {
+		t.Fatalf("bad cursor: %d %s", code, body)
+	}
+}
+
+func TestDeleteMachineRemovesPowerHistory(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	readAISessionsConfig(t, conn)
+
+	start, end := nowWindowMS()
+	writeFrame(t, conn, powerBatch("stream-1", 2, powerBucket(2, start, end, 100, 200, 30, 30)))
+	expectPowerAck(t, conn, "stream-1", 2) // declares gap [1,1]
+	conn.Close()
+	s.waitAgentDrain(t, "machine-A", 2*time.Second)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/machines/machine-A", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete: %d %s", rec.Code, rec.Body.String())
+	}
+
+	for _, table := range []string{"power_history_records", "power_history_stream_state", "power_history_gaps"} {
+		var n int
+		if err := s.db.QueryRow(`SELECT COUNT(*) FROM ` + table + ` WHERE machine_id = ?`, "machine-A").Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if n != 0 {
+			t.Fatalf("%s still has %d rows after machine deletion", table, n)
+		}
+	}
+}
+
+func TestPowerHistoryGapOnlyBatch(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+	s.sendSentinelMetrics(t, conn, "machine-A", "host-a")
+
+	start, end := nowWindowMS()
+	writeFrame(t, conn, powerBatch("stream-1", 1,
+		powerBucket(1, start, end, 100, 200, 30, 30),
+		powerBucket(2, start, end, 100, 200, 30, 30),
+	))
+	expectPowerAck(t, conn, "stream-1", 2)
+
+	// Retention ate the last unsent records: the agent sends a zero-bucket
+	// batch declaring retention from 5. No panic on the empty bucket list,
+	// and the ACK advances across the explicitly declared lost prefix.
+	writeFrame(t, conn, map[string]any{
+		"type": "power_history", "stream_id": "stream-1", "retained_from": 5,
+		"buckets": []any{},
+	})
+	expectPowerAck(t, conn, "stream-1", 4)
+
+	_, hist, body := powerHistoryGet(t, e, adminToken, "machine-A", "")
+	if len(hist.Gaps) != 1 || hist.Gaps[0].From != 3 || hist.Gaps[0].Through != 4 {
+		t.Fatalf("expected declared gap [3,4], got %+v (%s)", hist.Gaps, body)
+	}
+
+	// An empty batch with no retention declaration is meaningless and must
+	// be rejected (retained_from >= 1 is required).
+	writeFrame(t, conn, map[string]any{
+		"type": "power_history", "stream_id": "stream-1", "retained_from": 0,
+		"buckets": []any{},
+	})
+	expectNoPowerAck(t, conn)
+}
+
+func TestPowerHistoryAgedDuplicateReplayNotPoisoned(t *testing.T) {
+	e, s := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+
+	// Simulate data committed long ago (e.g. accepted near the age limit,
+	// replayed after it): an ancient-but-committed seq in stream state with
+	// its canonical row. A byte-identical replay must be absorbed by dedupe
+	// BEFORE any age enforcement — otherwise the agent would retry the same
+	// unacked journal entry forever.
+	start, end := nowWindowMS()
+	bucket := powerBucket(1, start, end, 100, 200, 30, 30)
+	// Canonical payload must be the hub's own encoding (struct field order),
+	// not a map-order marshal.
+	raw, _ := json.Marshal(bucket)
+	var pb powerhistory.Bucket
+	if err := json.Unmarshal(raw, &pb); err != nil {
+		t.Fatal(err)
+	}
+	payload, _ := json.Marshal(pb)
+	if _, err := s.db.Exec(`INSERT INTO power_history_records
+		(machine_id, stream_id, seq, start_unix_ms, end_unix_ms, expected_samples, payload)
+		VALUES (?, ?, 1, ?, ?, 30, ?)`, "machine-A", "stream-1", start, end, string(payload)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`INSERT INTO power_history_stream_state
+		(machine_id, stream_id, acked_through, max_seen_seq, retained_from) VALUES (?, ?, 0, 1, 1)`,
+		"machine-A", "stream-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFrame(t, conn, powerBatch("stream-1", 1, bucket))
+	expectPowerAck(t, conn, "stream-1", 1)
+	if n := powerRowCount(t, s, "machine-A"); n != 1 {
+		t.Fatalf("aged replay duplicated rows: %d", n)
+	}
+
+	// Mixed batch: the aged duplicate is absorbed and the fresh new bucket
+	// still commits in the same transaction.
+	writeFrame(t, conn, powerBatch("stream-1", 1, bucket, powerBucket(2, start, end, 110, 210, 30, 30)))
+	expectPowerAck(t, conn, "stream-1", 2)
+	if n := powerRowCount(t, s, "machine-A"); n != 2 {
+		t.Fatalf("mixed batch rows: %d", n)
+	}
+}
+
+func TestPowerHistoryOldAgentWithoutFramesUnaffected(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	// An old agent speaks only metrics — no power frames, no ACKs, and the
+	// history endpoint serves an empty contract for it.
+	conn := s.connectEnrolledAgent(t, server, "machine-old")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+	s.sendSentinelMetrics(t, conn, "machine-old", "host-old")
+
+	code, hist, _ := powerHistoryGet(t, e, adminToken, "machine-old", "")
+	if code != http.StatusOK || len(hist.Points) != 0 || hist.Cursor != 0 {
+		t.Fatalf("old agent history: %d %+v", code, hist)
+	}
+	var hostname string
+	if err := s.db.QueryRow(`SELECT hostname FROM machines WHERE id = 'machine-old'`).Scan(&hostname); err != nil || hostname != "host-old" {
+		t.Fatalf("metrics flow broken: hostname=%q err=%v", hostname, err)
+	}
+}

--- a/hub/power_review_test.go
+++ b/hub/power_review_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/powerhistory"
+	"github.com/labstack/echo/v4"
+)
+
+func reviewPowerHistory(t *testing.T, s *Server, query string) powerhistory.History {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	c := echo.New().NewContext(httptest.NewRequest(http.MethodGet, "/api/machines/power-review/power/history"+query, nil), recorder)
+	c.SetParamNames("id")
+	c.SetParamValues("power-review")
+	if err := s.handlePowerHistory(c); err != nil {
+		t.Fatal(err)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("history status %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var history powerhistory.History
+	if err := json.Unmarshal(recorder.Body.Bytes(), &history); err != nil {
+		t.Fatal(err)
+	}
+	return history
+}
+
+func TestReviewPowerEmptyDeltaPreservesGapMetadataAndCursor(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedTestMachine(t, "power-review")
+	for _, seq := range []uint64{1, 3} {
+		batch := powerhistory.Batch{Type: powerhistory.BatchType, StreamID: "review", RetainedFrom: seq,
+			Buckets: []powerhistory.Bucket{reviewPowerBucket(seq)}}
+		if _, err := s.commitPowerBatch("power-review", &batch, time.Now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	initial := reviewPowerHistory(t, s, "")
+	if len(initial.Gaps) != 1 {
+		t.Fatalf("initial gap missing: %+v", initial)
+	}
+	delta := reviewPowerHistory(t, s, fmt.Sprintf("?after=%d", initial.Cursor))
+	if len(delta.Points) != 0 || len(delta.Gaps) != 1 {
+		t.Fatalf("empty delta discarded current gap metadata: %+v", delta)
+	}
+	if _, err := s.prunePowerHistory(time.Now().Add(25 * time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	afterPrune := reviewPowerHistory(t, s, fmt.Sprintf("?after=%d", initial.Cursor))
+	if afterPrune.Cursor < initial.Cursor {
+		t.Fatalf("retention reset cursor: %d -> %d", initial.Cursor, afterPrune.Cursor)
+	}
+}
+
+func TestReviewPowerDefaultCoversFullDay(t *testing.T) {
+	if powerHistoryDefaultMaxRecords < powerhistory.RetentionSeconds/powerhistory.WindowSeconds {
+		t.Fatal("default history cap cannot hold one normal day of 30-second windows")
+	}
+}
+
+func TestReviewPowerInitialHistoryIncludesAllRestartStreams(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedTestMachine(t, "power-review")
+	for i := 0; i < 12; i++ {
+		batch := powerhistory.Batch{Type: powerhistory.BatchType, StreamID: fmt.Sprintf("restart-%02d", i),
+			RetainedFrom: 1, Buckets: []powerhistory.Bucket{reviewPowerBucket(1)}}
+		if _, err := s.commitPowerBatch("power-review", &batch, time.Now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if history := reviewPowerHistory(t, s, ""); len(history.Points) != 12 {
+		t.Fatalf("restart streams hidden: %d points", len(history.Points))
+	}
+}
+
+func TestReviewPowerGapWithoutSurvivingRecordsIsVisible(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedTestMachine(t, "power-review")
+	batch := powerhistory.Batch{Type: powerhistory.BatchType, StreamID: "review", RetainedFrom: 5, Buckets: []powerhistory.Bucket{}}
+	if through, err := s.commitPowerBatch("power-review", &batch, time.Now()); err != nil || through != 4 {
+		t.Fatalf("gap: %d %v", through, err)
+	}
+	history := reviewPowerHistory(t, s, "")
+	if len(history.Points) != 0 || len(history.Gaps) != 1 || history.Gaps[0].Through != 4 {
+		t.Fatalf("loss hidden without surviving points: %+v", history)
+	}
+}
+
+func TestReviewPowerReplayNormalizesStoredJSONButRejectsChangedData(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedTestMachine(t, "power-review")
+	batch := powerhistory.Batch{Type: powerhistory.BatchType, StreamID: "review", RetainedFrom: 1,
+		Buckets: []powerhistory.Bucket{reviewPowerBucket(1)}}
+	if _, err := s.commitPowerBatch("power-review", &batch, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(batch.Buckets[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reordered map[string]any
+	if err := json.Unmarshal(raw, &reordered); err != nil {
+		t.Fatal(err)
+	}
+	reordered["gap_before"] = false // explicit default versus an omitted optional field
+	reordered["future_optional"] = nil
+	raw, err = json.Marshal(reordered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`UPDATE power_history_records SET payload = ? WHERE machine_id = ?`, string(raw), "power-review"); err != nil {
+		t.Fatal(err)
+	}
+	if through, err := s.commitPowerBatch("power-review", &batch, time.Now()); err != nil || through != 1 {
+		t.Fatalf("equivalent replay rejected: %d %v", through, err)
+	}
+	changed := 101.0
+	batch.Buckets[0].GPUs[0].MeanWatts = &changed
+	if _, err := s.commitPowerBatch("power-review", &batch, time.Now()); !errors.Is(err, errPowerConflict) {
+		t.Fatalf("changed data must still conflict: %v", err)
+	}
+}
+
+func TestReviewPowerClockRejectionIsVisibleAndClearsOnRecovery(t *testing.T) {
+	e, s := setupTestServer(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	conn := s.connectEnrolledAgent(t, server, "power-review")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+	bucket := reviewPowerBucket(1)
+	bucket.StartUnixMS += (48 * time.Hour).Milliseconds()
+	bucket.EndUnixMS += (48 * time.Hour).Milliseconds()
+	batch := powerhistory.Batch{Type: powerhistory.BatchType, StreamID: "review", RetainedFrom: 1,
+		Buckets: []powerhistory.Bucket{bucket}}
+	writeFrame(t, conn, batch)
+	s.sendSentinelMetrics(t, conn, "power-review", "after-clock-rejection")
+	history := reviewPowerHistory(t, s, "")
+	if history.Problem != "clock_skew" || !history.Degraded || len(history.Points) != 0 {
+		t.Fatalf("missing rejection diagnostic: %+v", history)
+	}
+	if s.powerHistoryProblem("another-machine") != "" {
+		t.Fatal("diagnostic escaped machine binding")
+	}
+	batch.Buckets[0] = reviewPowerBucket(1)
+	writeFrame(t, conn, batch)
+	expectPowerAck(t, conn, "review", 1)
+	history = reviewPowerHistory(t, s, "")
+	if history.Problem != "" || history.Degraded || len(history.Points) != 1 {
+		t.Fatalf("diagnostic did not recover: %+v", history)
+	}
+}
+
+// Independent integration-review regressions, separate from implementation tests.
+func reviewPowerBucket(seq uint64) powerhistory.Bucket {
+	mean, peak := 100.0, 150.0
+	now := time.Now().Add(-time.Minute)
+	st := powerhistory.Stats{MeanWatts: &mean, PeakWatts: &peak, Samples: 30}
+	return powerhistory.Bucket{Seq: seq, StartUnixMS: now.Add(-30 * time.Second).UnixMilli(),
+		EndUnixMS: now.UnixMilli(), ExpectedSamples: 30,
+		GPUs: []powerhistory.Sensor{{ID: "GPU-review", Stats: st}}, GPUTotal: &st}
+}
+
+func TestReviewPowerOutOfOrderRecovery(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedTestMachine(t, "power-review")
+	b := powerhistory.Batch{Type: powerhistory.BatchType, StreamID: "review", RetainedFrom: 1,
+		Buckets: []powerhistory.Bucket{reviewPowerBucket(3)}}
+	through, err := s.commitPowerBatch("power-review", &b, time.Now())
+	if err != nil || through != 0 {
+		t.Fatalf("future record: through=%d err=%v", through, err)
+	}
+	b.Buckets = []powerhistory.Bucket{reviewPowerBucket(1), reviewPowerBucket(2)}
+	through, err = s.commitPowerBatch("power-review", &b, time.Now())
+	if err != nil || through != 3 {
+		t.Fatalf("fill hole: through=%d err=%v", through, err)
+	}
+}
+
+func TestReviewPowerHugeRetentionGapIsBounded(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedTestMachine(t, "power-review")
+	batch := powerhistory.Batch{Type: powerhistory.BatchType, StreamID: "review", RetainedFrom: powerhistory.MaxSeq,
+		Buckets: []powerhistory.Bucket{reviewPowerBucket(powerhistory.MaxSeq)}}
+	start := time.Now()
+	through, err := s.commitPowerBatch("power-review", &batch, start)
+	if err != nil || through != powerhistory.MaxSeq {
+		t.Fatalf("huge gap: through=%d err=%v", through, err)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("gap processing must scale with stored rows, not the numeric sequence range")
+	}
+}
+
+func TestReviewPowerGapUnionKeepsBothEnds(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedTestMachine(t, "power-review")
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	for _, interval := range [][2]uint64{{10, 20}, {15, 25}, {8, 9}, {26, 30}} {
+		if err := declarePowerGap(tx, "power-review", "review", interval[0], interval[1]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var from, through, count int
+	if err := tx.QueryRow(`SELECT MIN(from_seq), MAX(through_seq), COUNT(*) FROM power_history_gaps WHERE machine_id = ?`,
+		"power-review").Scan(&from, &through, &count); err != nil {
+		t.Fatal(err)
+	}
+	if from != 8 || through != 30 || count != 1 {
+		t.Fatalf("gap union=%d..%d (%d rows)", from, through, count)
+	}
+}
+
+func TestReviewPowerRejectsInconsistentStatistics(t *testing.T) {
+	for name, change := range map[string]func(*powerhistory.Bucket){
+		"missing mean":          func(b *powerhistory.Bucket) { b.GPUs[0].MeanWatts = nil },
+		"missing peak":          func(b *powerhistory.Bucket) { b.GPUs[0].PeakWatts = nil },
+		"too many samples":      func(b *powerhistory.Bucket) { b.GPUs[0].Samples = 31 },
+		"mean above peak":       func(b *powerhistory.Bucket) { v := 200.0; b.GPUs[0].MeanWatts = &v },
+		"total without devices": func(b *powerhistory.Bucket) { b.GPUs = nil },
+		"empty duration":        func(b *powerhistory.Bucket) { b.EndUnixMS = b.StartUnixMS },
+		"zero expected samples": func(b *powerhistory.Bucket) { b.ExpectedSamples = 0 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			bucket := reviewPowerBucket(1)
+			change(&bucket)
+			batch := powerhistory.Batch{Type: powerhistory.BatchType, StreamID: "review", RetainedFrom: 1,
+				Buckets: []powerhistory.Bucket{bucket}}
+			if err := validatePowerBatch(&batch, time.Now()); err == nil {
+				t.Fatal("inconsistent statistics accepted")
+			}
+		})
+	}
+}

--- a/hub/power_review_test.go
+++ b/hub/power_review_test.go
@@ -243,3 +243,63 @@ func TestReviewPowerRejectsInconsistentStatistics(t *testing.T) {
 		})
 	}
 }
+
+// A changing GPU set must omit its aggregate before journaling. Keep hub
+// validation strict, and prove an omitted aggregate preserves the rest of the
+// batch, advances the ACK and does not block the next stable window.
+func TestReviewPowerMembershipChangeBatchRecovery(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	conn := s.connectEnrolledAgent(t, server, "power-review")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+
+	changed := reviewPowerBucket(2)
+	partial := changed.GPUs[0]
+	partial.ID = "GPU-added"
+	partial.Samples = 15
+	changed.GPUs = append(changed.GPUs, partial)
+	cpu := changed.GPUs[0].Stats
+	changed.CPU = &cpu
+	batch := powerhistory.Batch{Type: powerhistory.BatchType, StreamID: "membership", RetainedFrom: 1,
+		Buckets: []powerhistory.Bucket{reviewPowerBucket(1), changed, reviewPowerBucket(3)}}
+	writeFrame(t, conn, batch)
+	// Sentinel processing establishes that the preceding frame was handled,
+	// without poisoning this websocket's read state with a timeout.
+	s.sendSentinelMetrics(t, conn, "power-review", "after-membership-rejection")
+	if n := powerRowCount(t, s, "power-review"); n != 0 {
+		t.Fatalf("invalid middle bucket partially committed: %d rows", n)
+	}
+	if acked, maxSeen := powerStreamStateOf(t, s, "power-review", "membership"); acked != 0 || maxSeen != 0 {
+		t.Fatalf("invalid batch advanced stream: ack=%d max=%d", acked, maxSeen)
+	}
+	if problem := s.powerHistoryProblem("power-review"); problem != "rejected_data" {
+		t.Fatalf("missing rejection diagnostic: %q", problem)
+	}
+
+	// Model the corrected agent's wire output, not a hub-side sanitization.
+	batch.Buckets[1].GPUTotal = nil
+	writeFrame(t, conn, batch)
+	expectPowerAck(t, conn, "membership", 3)
+	// An invalid batch must not have left an earlier ACK queued above.
+	writeFrame(t, conn, powerhistory.Batch{Type: powerhistory.BatchType, StreamID: "membership", RetainedFrom: 4,
+		Buckets: []powerhistory.Bucket{reviewPowerBucket(4)}})
+	expectPowerAck(t, conn, "membership", 4)
+	history := reviewPowerHistory(t, s, "")
+	if history.Problem != "" || history.Degraded || len(history.Points) != 4 {
+		t.Fatalf("history did not recover: %+v", history)
+	}
+	for _, point := range history.Points {
+		if point.Seq != 2 {
+			if point.GPUTotal == nil {
+				t.Fatalf("stable window lost total: %+v", point)
+			}
+			continue
+		}
+		if point.GPUTotal != nil || len(point.GPUs) != 2 || point.GPUs[1].Samples != 15 || point.CPU == nil || point.CPU.Samples != 30 {
+			t.Fatalf("changed window lost component data or retained invalid total: %+v", point)
+		}
+	}
+}

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -88,6 +88,7 @@ var routeScopeRequirements = map[string]string{
 	routeScopeKey(http.MethodGet, "/api/machines/:id/services"):                scopeFleetRead,
 	routeScopeKey(http.MethodGet, "/api/machines/:id/containers"):              scopeFleetRead,
 	routeScopeKey(http.MethodGet, "/api/machines/:id/metrics/history"):         scopeFleetRead,
+	routeScopeKey(http.MethodGet, "/api/machines/:id/power/history"):           scopeFleetRead,
 	routeScopeKey(http.MethodPost, "/api/machines/:id/command"):                scopeFleetControl,
 	routeScopeKey(http.MethodPost, "/api/machines/:id/refresh"):                scopeFleetControl,
 	routeScopeKey(http.MethodPost, "/api/refresh"):                             scopeFleetControl,

--- a/proto/powerhistory/types.go
+++ b/proto/powerhistory/types.go
@@ -1,0 +1,88 @@
+// Package powerhistory defines additive, replayable power telemetry. Values are
+// component sensor readings, never whole-machine or wall power estimates.
+package powerhistory
+
+const (
+	BatchType            = "power_history"
+	AckType              = "power_history_ack"
+	MaxBatchRecords      = 32
+	MaxSensors           = 16
+	MaxFrameBytes        = 256 * 1024
+	RetentionSeconds     = 24 * 60 * 60
+	WindowSeconds        = 30
+	MaxFutureSkewSeconds = 15 * 60
+	// All protocol counters are exactly representable by dashboard JavaScript.
+	MaxSeq = uint64(1<<53 - 1)
+)
+
+// Stats describes observed samples in one window. Nil watts means unavailable;
+// zero watts is a valid reading. Peak is a sampled maximum, not electrical peak.
+type Stats struct {
+	MeanWatts *float64 `json:"mean_watts"`
+	PeakWatts *float64 `json:"peak_watts"`
+	Samples   int      `json:"samples"`
+}
+
+type Sensor struct {
+	ID string `json:"id"`
+	Stats
+}
+
+type Bucket struct {
+	Seq             uint64   `json:"seq"`
+	StartUnixMS     int64    `json:"start_unix_ms"`
+	EndUnixMS       int64    `json:"end_unix_ms"`
+	ExpectedSamples int      `json:"expected_samples"`
+	GPUs            []Sensor `json:"gpus"`
+	// GPUTotal is computed from complete simultaneous GPU samples, not from
+	// summing independent per-device peaks. Nil means no complete observation.
+	GPUTotal *Stats `json:"gpu_total,omitempty"`
+	CPU      *Stats `json:"cpu,omitempty"`
+	// GapBefore marks local collection/journal loss before this window.
+	GapBefore bool `json:"gap_before,omitempty"`
+}
+
+// RetainedFrom is the oldest sequence still available for unacknowledged replay.
+// Acknowledged records may remain in the local journal without holding it back.
+// Advancing it past unacknowledged data explicitly declares loss to the hub
+// (retention, corrupt-tail recovery, or unused durable sequence reservations).
+// Machine identity is taken from the authenticated connection, not this frame.
+type Batch struct {
+	Type         string   `json:"type"`
+	StreamID     string   `json:"stream_id"`
+	RetainedFrom uint64   `json:"retained_from"`
+	Buckets      []Bucket `json:"buckets"`
+	Degraded     bool     `json:"degraded,omitempty"`
+}
+
+// Through advances only after the hub transaction commits a contiguous prefix,
+// including any explicitly declared retention gap. Lost ACKs are safe to replay.
+type Ack struct {
+	Type     string `json:"type"`
+	StreamID string `json:"stream_id"`
+	Through  uint64 `json:"through"`
+}
+
+// Point and History are the authenticated dashboard history response.
+type Point struct {
+	StreamID string `json:"stream_id"`
+	Bucket
+}
+
+type Gap struct {
+	StreamID string `json:"stream_id"`
+	From     uint64 `json:"from"`
+	Through  uint64 `json:"through"`
+}
+
+type History struct {
+	Points   []Point `json:"points"`
+	Gaps     []Gap   `json:"gaps"`
+	Degraded bool    `json:"degraded"`
+	// Cursor is the hub's durable ingestion high-water, not a sample timestamp.
+	// GET ?after=cursor includes late backfill without replaying the entire day.
+	Cursor uint64 `json:"cursor"`
+	// Problem is a bounded diagnostic code from the currently connected agent.
+	// It does not acknowledge or accept a rejected telemetry frame.
+	Problem string `json:"problem,omitempty"`
+}

--- a/proto/powerhistory/types_test.go
+++ b/proto/powerhistory/types_test.go
@@ -1,0 +1,92 @@
+package powerhistory
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRepresentativeStorageAndBatchSize(t *testing.T) {
+	// Measure encoded data rather than assuming that a day of history is KBs.
+	mean, peak := 237.1234567890123, 308.9876543210987
+	stats := Stats{MeanWatts: &mean, PeakWatts: &peak, Samples: 30}
+	for _, sensors := range []int{2, MaxSensors} {
+		t.Run(fmt.Sprintf("%d_GPUs", sensors), func(t *testing.T) {
+			bucket := Bucket{Seq: 2880, StartUnixMS: 1788739200000, EndUnixMS: 1788739230000,
+				ExpectedSamples: 30, GPUTotal: &stats, CPU: &stats}
+			for i := 0; i < sensors; i++ {
+				bucket.GPUs = append(bucket.GPUs, Sensor{ID: fmt.Sprintf("GPU-%036d", i), Stats: stats})
+			}
+			record, err := json.Marshal(bucket)
+			if err != nil {
+				t.Fatal(err)
+			}
+			batch := Batch{Type: BatchType, StreamID: strings.Repeat("a", 32), RetainedFrom: 1}
+			for i := 0; i < MaxBatchRecords; i++ {
+				batch.Buckets = append(batch.Buckets, bucket)
+			}
+			encoded, err := json.Marshal(batch)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(encoded) > MaxFrameBytes {
+				t.Fatalf("representative full batch exceeds frame cap: %d", len(encoded))
+			}
+			t.Logf("JSON record+newline=%d B; 24h journal=%d B; 32-record batch=%d B (excludes transport/filesystem overhead)",
+				len(record)+1, (len(record)+1)*(RetentionSeconds/WindowSeconds), len(encoded))
+		})
+	}
+}
+
+func TestUnavailableAndZeroRemainDistinct(t *testing.T) {
+	zero := 0.0
+	for _, tc := range []struct {
+		stats Stats
+		want  string
+	}{
+		{Stats{}, `"mean_watts":null`},
+		{Stats{MeanWatts: &zero, PeakWatts: &zero, Samples: 30}, `"mean_watts":0`},
+	} {
+		b, err := json.Marshal(tc.stats)
+		if err != nil || !strings.Contains(string(b), tc.want) {
+			t.Fatalf("marshal=%s err=%v want %s", b, err, tc.want)
+		}
+	}
+}
+
+func TestBatchIdentityIsConnectionScoped(t *testing.T) {
+	b, err := json.Marshal(Batch{Type: BatchType, StreamID: "stream", RetainedFrom: 1, Buckets: []Bucket{{Seq: 1}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "machine_id") {
+		t.Fatal("batch must not select authenticated machine identity")
+	}
+	var decoded Batch
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Buckets[0].Seq != 1 || decoded.StreamID != "stream" {
+		t.Fatalf("bad roundtrip: %+v", decoded)
+	}
+}
+
+func TestHistoryUsesSeparateSampledValues(t *testing.T) {
+	mean, peak := 237.0, 308.0
+	h := History{Points: []Point{{StreamID: "s", Bucket: Bucket{Seq: 1, GPUTotal: &Stats{MeanWatts: &mean, PeakWatts: &peak, Samples: 30}}}}, Gaps: []Gap{}}
+	b, err := json.Marshal(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), `"power_watts"`) {
+		t.Fatal("history must not reinterpret legacy instantaneous power")
+	}
+	var decoded History
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if *decoded.Points[0].GPUTotal.PeakWatts != peak {
+		t.Fatal("lost sampled peak")
+	}
+}

--- a/scripts/smoke/power-history.sh
+++ b/scripts/smoke/power-history.sh
@@ -9,9 +9,10 @@
 #   restart during the outage, and hub recovery with unchanged replayed data
 #   and an explicitly declared sequence gap.
 #
-# THIS IS NOT HARDWARE VERIFICATION. The GPU readings come from a synthetic
-# nvidia-smi fixture written by this script; it proves the binary pipeline,
-# not a driver. No host services or credentials are touched: no host
+# By default this is NOT hardware verification: GPU readings come from a
+# synthetic nvidia-smi fixture. PHSMOKE_REAL_GPU=1 instead checks two real
+# NVIDIA GPUs through the container runtime; neither mode measures wall power.
+# No host services or credentials are touched: no host
 # credential dirs, no docker socket mount, no Compose stack, no published
 # ports. The host-side footprint is one Docker build volume (removed unless
 # KEEP=1), two containers removed on exit and, optionally, existing Go caches
@@ -27,12 +28,16 @@
 #                   mounted for the BUILD step only
 #   KEEP=1          keep the build volume (the test container is always --rm)
 #   PHSMOKE_TIMEOUT per-phase wait in seconds (default 180)
+#   PHSMOKE_REAL_GPU=1 opt into a two-NVIDIA-GPU hardware canary instead of
+#                   synthetic inputs; requires Docker GPU runtime support.
 #
 # Requires on the host: docker. Everything else runs in the container.
 set -euo pipefail
 
 P="${PHSMOKE_PREFIX:-phsmoke}"
 GO_IMAGE="${GO_IMAGE:-golang:1.25}"
+PHSMOKE_REAL_GPU="${PHSMOKE_REAL_GPU:-0}"
+[[ "$PHSMOKE_REAL_GPU" == 0 || "$PHSMOKE_REAL_GPU" == 1 ]] || { echo "invalid GPU mode" >&2; exit 2; }
 if ! [[ "$P" =~ ^[a-z0-9][a-z0-9-]{0,23}$ ]]; then
   echo "refusing: PHSMOKE_PREFIX must match [a-z0-9][a-z0-9-]{0,23}" >&2; exit 2
 fi
@@ -62,7 +67,7 @@ outer() {
   CLEAN_TMP="$(mktemp -d "${TMPDIR:-/tmp}/$P.XXXXXXXX")"
   run="$(basename "$CLEAN_TMP" | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]\n' '-')"
   vbin="$run-bin" testc="$run-test" buildc="$run-build"
-  echo "== power-history smoke (SYNTHETIC GPU fixture; real agent+hub binaries)"
+  echo "== power-history smoke (real_gpu=$PHSMOKE_REAL_GPU; real agent+hub binaries)"
   echo "   source: $repo (read-only)   run: $run   image: $GO_IMAGE"
 
   for n in "$testc" "$buildc"; do
@@ -94,9 +99,12 @@ outer() {
   docker rm -f "$CLEAN_BUILD_ID" >/dev/null; CLEAN_BUILD_ID=""
 
   echo "== run pipeline test in container $testc (loopback only, no ports, no host mounts)"
+  local gpu_args=()
+  [[ "$PHSMOKE_REAL_GPU" == 1 ]] && gpu_args+=(--gpus all -e NVIDIA_DRIVER_CAPABILITIES=utility)
   CLEAN_TEST_ID="$(docker create -i --name "$testc" \
+    --network none "${gpu_args[@]}" \
     -v "$vbin:/opt/phsmoke:ro" \
-    -e PHSMOKE_CONTAINER=1 -e PHSMOKE_TIMEOUT="${PHSMOKE_TIMEOUT:-180}" \
+    -e PHSMOKE_CONTAINER=1 -e PHSMOKE_REAL_GPU="$PHSMOKE_REAL_GPU" -e PHSMOKE_TIMEOUT="${PHSMOKE_TIMEOUT:-180}" \
     "$GO_IMAGE" bash -s -- inner)"
   docker start -a -i "$CLEAN_TEST_ID" < "$0"
   [[ "$(docker inspect -f '{{.State.ExitCode}}' "$CLEAN_TEST_ID")" == 0 ]]
@@ -159,6 +167,11 @@ inner() {
   # SYNTHETIC nvidia-smi: answers only the agent's streaming power query.
   # The legacy `-x -q` XML dump exits non-zero (no GPUs for legacy metrics),
   # which is exactly what a machine without the XML path would look like.
+  if [[ "$PHSMOKE_REAL_GPU" == 1 ]]; then
+    PHSMOKE_GPU_IDS=$(nvidia-smi --query-gpu=uuid --format=csv,noheader | paste -sd, -)
+    export PHSMOKE_GPU_IDS
+    echo "== REAL GPU canary: driver-reported sensors $PHSMOKE_GPU_IDS (not wall power)"
+  else
   cat > "$W/bin/nvidia-smi" <<'EOF'
 #!/bin/sh
 set -e
@@ -178,6 +191,7 @@ esac
 EOF
   chmod +x "$W/bin/nvidia-smi"
   echo "== fixture: $(command -v nvidia-smi) (SYNTHETIC)"
+  fi
 
   start_hub() {
     (cd "$W/hub" && exec env HUB_LISTEN=127.0.0.1:4000 PUBLIC_URL=$HUB \
@@ -236,7 +250,7 @@ EOF
   [[ -n "$TOKEN" ]] || fail "token mint failed"
   echo "   setup+login+token OK"
 
-  echo "== phase 1: agent enrolls over ws://loopback, samples SYNTHETIC GPUs, journals, uploads"
+  echo "== phase 1: agent enrolls over ws://loopback, samples GPUs (real_gpu=$PHSMOKE_REAL_GPU), journals, uploads"
   start_agent
   MID=""
   for _ in $(seq 1 60); do
@@ -300,12 +314,12 @@ EOF
   $V disjoint "$W/out/h1.json" < "$W/out/d3.json" || fail "delta after cursor overlapped the earlier window"
 
   echo "== phase 4: resource check"
-  echo "   agent RSS: $(awk '/VmRSS/{print $2" "$3}' "/proc/$AGENT_PID/status")   nvidia-smi fixture procs: $(pgrep -fc 'nvidia-smi --query-gpu' || true)"
+  echo "   agent RSS: $(awk '/VmRSS/{print $2" "$3}' "/proc/$AGENT_PID/status")   nvidia-smi streaming procs: $(pgrep -fc 'nvidia-smi --query-gpu' || true)"
   echo "   hub gaps/degraded: $(sed -n 's/.*GAPS=\([0-9]*\) DEGRADED=\([a-z]*\).*/gaps=\1 degraded=\2/p' <<<"$S2")"
   echo
-  echo "SMOKE PASS (synthetic GPU fixture; real agent+hub binaries; loopback container)"
-  echo "LIMITS: not hardware verification; ACK-loss-without-restart relies on unit/WS tests;"
-  echo "        legacy metrics XML path answered 'no GPU' by the fixture."
+  echo "SMOKE PASS (real_gpu=$PHSMOKE_REAL_GPU; real agent+hub binaries; loopback container)"
+  echo "LIMITS: no wall-power accuracy or 24h soak claim; ACK-loss-without-restart relies on unit/WS tests."
+  [[ "$PHSMOKE_REAL_GPU" == 1 ]] || echo "Synthetic fixture: NOT hardware verification; legacy XML path answered no GPU."
   stop_pid "$AGENT_PID"; stop_pid "$HUB_PID"
 }
 
@@ -328,6 +342,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 )
 
 type Stats struct {
@@ -427,8 +442,11 @@ func validate(h History, minPoints int) (maxSeq uint64, streams map[string]bool)
 		if p.ExpectedSamples != 30 {
 			die("seq %d expected_samples %d", p.Seq, p.ExpectedSamples)
 		}
-		if len(p.GPUs) != 2 || p.GPUs[0].ID != "GPU-SYNTH-0" || p.GPUs[1].ID != "GPU-SYNTH-1" {
-			die("seq %d gpus %+v (want the two synthetic sensors)", p.Seq, p.GPUs)
+		expectedIDs := []string{"GPU-SYNTH-0", "GPU-SYNTH-1"}
+		realGPU := os.Getenv("PHSMOKE_REAL_GPU") == "1"
+		if realGPU { expectedIDs = strings.Split(os.Getenv("PHSMOKE_GPU_IDS"), ",") }
+		if len(expectedIDs) != 2 || len(p.GPUs) != 2 || p.GPUs[0].ID != strings.TrimSpace(expectedIDs[0]) || p.GPUs[1].ID != strings.TrimSpace(expectedIDs[1]) {
+			die("seq %d sensor IDs do not match the two expected GPUs", p.Seq)
 		}
 		minS := 1 << 30
 		for _, g := range p.GPUs {
@@ -445,7 +463,7 @@ func validate(h History, minPoints int) (maxSeq uint64, streams map[string]bool)
 		}
 		checkStats("seq "+strconv.FormatUint(p.Seq, 10)+" gpu_total", p.GPUTotal, minS)
 		// Fixture: GPU0 in [30,90]+0.5, GPU1 in [40,120]; total peak <= 210.5.
-		if *p.GPUTotal.PeakWatts > 210.5 || *p.GPUTotal.MeanWatts < 70 {
+		if !realGPU && (*p.GPUTotal.PeakWatts > 210.5 || *p.GPUTotal.MeanWatts < 70) {
 			die("seq %d gpu_total out of fixture range: %+v", p.Seq, *p.GPUTotal)
 		}
 		if p.CPU != nil {

--- a/scripts/smoke/power-history.sh
+++ b/scripts/smoke/power-history.sh
@@ -1,0 +1,595 @@
+#!/usr/bin/env bash
+# Power-history end-to-end smoke: the REAL agent binary and the REAL hub
+# binary, built from this tree, running inside one disposable Docker
+# container on its loopback. Exercises the whole pipeline:
+#
+#   process sampling (SYNTHETIC nvidia-smi) -> 30 s accumulator -> local
+#   journal (fsync) -> WebSocket batch -> hub commit + ACK -> persisted ACK
+#   cursor -> authenticated history API, then offline journaling, an agent
+#   restart during the outage, and hub recovery with unchanged replayed data
+#   and an explicitly declared sequence gap.
+#
+# THIS IS NOT HARDWARE VERIFICATION. The GPU readings come from a synthetic
+# nvidia-smi fixture written by this script; it proves the binary pipeline,
+# not a driver. No host services or credentials are touched: no host
+# credential dirs, no docker socket mount, no Compose stack, no published
+# ports. The host-side footprint is one Docker build volume (removed unless
+# KEEP=1), two containers removed on exit and, optionally, existing Go caches
+# in. Every resource name carries a per-invocation unique suffix; a name
+# collision aborts instead of reusing or deleting anything.
+#
+# Usage (any Linux host or VM with docker; rootless is fine, no sudo):
+#   scripts/smoke/power-history.sh
+# Environment:
+#   PHSMOKE_PREFIX  name prefix ([a-z0-9][a-z0-9-]{0,23}, default phsmoke)
+#   GO_IMAGE        golang image (default golang:1.25)
+#   GOMOD_VOL / GOCACHE_VOL  optional named volumes with warm Go caches,
+#                   mounted for the BUILD step only
+#   KEEP=1          keep the build volume (the test container is always --rm)
+#   PHSMOKE_TIMEOUT per-phase wait in seconds (default 180)
+#
+# Requires on the host: docker. Everything else runs in the container.
+set -euo pipefail
+
+P="${PHSMOKE_PREFIX:-phsmoke}"
+GO_IMAGE="${GO_IMAGE:-golang:1.25}"
+if ! [[ "$P" =~ ^[a-z0-9][a-z0-9-]{0,23}$ ]]; then
+  echo "refusing: PHSMOKE_PREFIX must match [a-z0-9][a-z0-9-]{0,23}" >&2; exit 2
+fi
+
+# Cleanup-owned state is global so the EXIT trap can see it after outer()
+# returns. Only resources this invocation actually created are ever removed,
+# and containers are addressed by the ID docker returned, never by name.
+CLEAN_TMP="" CLEAN_VOL="" CLEAN_BUILD_ID="" CLEAN_TEST_ID=""
+cleanup() {
+  [[ -n "$CLEAN_TEST_ID"  ]] && docker rm -f "$CLEAN_TEST_ID"  >/dev/null 2>&1 || true
+  [[ -n "$CLEAN_BUILD_ID" ]] && docker rm -f "$CLEAN_BUILD_ID" >/dev/null 2>&1 || true
+  if [[ -n "$CLEAN_VOL" ]]; then
+    if [[ "${KEEP:-}" == "1" ]]; then echo "KEEP=1: build volume $CLEAN_VOL kept"
+    else docker volume rm -f "$CLEAN_VOL" >/dev/null 2>&1 || true; fi
+  fi
+  [[ -n "$CLEAN_TMP" ]] && rmdir "$CLEAN_TMP" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Outer driver (runs on the host / VM shell).
+# ---------------------------------------------------------------------------
+outer() {
+  local repo run vbin testc buildc
+  repo="$(cd "$(dirname "$0")/../.." && pwd)"
+  trap cleanup EXIT
+  # mktemp -d reserves the unique suffix for the life of this run.
+  CLEAN_TMP="$(mktemp -d "${TMPDIR:-/tmp}/$P.XXXXXXXX")"
+  run="$(basename "$CLEAN_TMP" | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]\n' '-')"
+  vbin="$run-bin" testc="$run-test" buildc="$run-build"
+  echo "== power-history smoke (SYNTHETIC GPU fixture; real agent+hub binaries)"
+  echo "   source: $repo (read-only)   run: $run   image: $GO_IMAGE"
+
+  for n in "$testc" "$buildc"; do
+    if docker ps -a --format '{{.Names}}' | grep -qx "$n"; then
+      echo "refusing: container $n already exists" >&2; exit 2
+    fi
+  done
+  if docker volume ls --format '{{.Name}}' | grep -qx "$vbin"; then
+    echo "refusing: volume $vbin already exists" >&2; exit 2
+  fi
+
+  local cache_args=()
+  for n in "${GOMOD_VOL:-}" "${GOCACHE_VOL:-}"; do
+    [[ -z "$n" ]] && continue
+    [[ "$n" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$ ]] || { echo "refusing: caches must be named volumes" >&2; exit 2; }
+    docker volume inspect "$n" >/dev/null || { echo "refusing: cache volume must already exist" >&2; exit 2; }
+  done
+  [[ -n "${GOMOD_VOL:-}" ]] && cache_args+=(-v "$GOMOD_VOL:/go/pkg/mod")
+  [[ -n "${GOCACHE_VOL:-}" ]] && cache_args+=(-v "$GOCACHE_VOL:/root/.cache")
+
+  echo "== build hub, agent and verifier into volume $vbin"
+  CLEAN_VOL="$(docker volume create "$vbin")"
+  CLEAN_BUILD_ID="$(docker create -i --name "$buildc" \
+    -v "$repo:/src:ro" -v "$vbin:/out" "${cache_args[@]}" \
+    -e PHSMOKE_CONTAINER=1 -e GOFLAGS=-buildvcs=false -e CGO_ENABLED=0 \
+    "$GO_IMAGE" bash -s -- build)"
+  docker start -a -i "$CLEAN_BUILD_ID" < "$0"
+  [[ "$(docker inspect -f '{{.State.ExitCode}}' "$CLEAN_BUILD_ID")" == 0 ]] || return 1
+  docker rm -f "$CLEAN_BUILD_ID" >/dev/null; CLEAN_BUILD_ID=""
+
+  echo "== run pipeline test in container $testc (loopback only, no ports, no host mounts)"
+  CLEAN_TEST_ID="$(docker create -i --name "$testc" \
+    -v "$vbin:/opt/phsmoke:ro" \
+    -e PHSMOKE_CONTAINER=1 -e PHSMOKE_TIMEOUT="${PHSMOKE_TIMEOUT:-180}" \
+    "$GO_IMAGE" bash -s -- inner)"
+  docker start -a -i "$CLEAN_TEST_ID" < "$0"
+  [[ "$(docker inspect -f '{{.State.ExitCode}}' "$CLEAN_TEST_ID")" == 0 ]]
+}
+
+# require_container refuses to run the build/inner steps anywhere but inside
+# the disposable container this script launched: inner writes /etc/bloxos and
+# runs a hub, which must never happen on a host.
+require_container() {
+  if [[ ! -f /.dockerenv || "${PHSMOKE_CONTAINER:-}" != "1" ]]; then
+    echo "refusing: '$1' step must run inside the smoke container (via the outer driver)" >&2; exit 2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Build step (inside the build container; /src ro, /out rw).
+# ---------------------------------------------------------------------------
+build() {
+  require_container build
+  # Inspect the mount flags; never write-probe the source tree.
+  if ! awk '$5 == "/src" { print $6 }' /proc/self/mountinfo | grep -Eq '(^|,)ro(,|$)'; then
+    echo "refusing: /src must be mounted read-only" >&2; exit 2
+  fi
+  set -x
+  (cd /src/hub && go build -o /out/bloxos-hub .)
+  (cd /src/agent && go build -o /out/bloxos-agent .)
+  mkdir -p /tmp/verify && write_verifier > /tmp/verify/main.go
+  (cd /tmp/verify && go build -o /out/phsmoke-verify main.go)
+  set +x
+  for f in /out/*; do printf '   %s %s bytes\n' "$f" "$(stat -c %s "$f")"; done
+}
+
+# ---------------------------------------------------------------------------
+# Inner test (inside the test container).
+# ---------------------------------------------------------------------------
+inner() {
+  require_container inner
+  [[ -x /opt/phsmoke/phsmoke-verify && -x /opt/phsmoke/bloxos-hub && -x /opt/phsmoke/bloxos-agent ]] \
+    || { echo "refusing: build volume not mounted at /opt/phsmoke" >&2; exit 2; }
+  local W=/work T="${PHSMOKE_TIMEOUT:-180}"
+  mkdir -p "$W/bin" "$W/hub" "$W/log" "$W/out"
+  export PATH="$W/bin:/opt/phsmoke:$PATH"
+  V=/opt/phsmoke/phsmoke-verify
+  HUB=http://127.0.0.1:4000
+  JWT=""
+  HUB_PID="" AGENT_PID=""
+
+  fail() { echo "SMOKE FAIL: $*" >&2; dump; exit 1; }
+  dump() {
+    { echo "---- hub.log (tail)"; tail -n 40 "$W/log/hub.log" 2>/dev/null || true
+      echo "---- agent.log (tail)"; tail -n 60 "$W/log/agent.log" 2>/dev/null || true; } >&2
+  }
+  api() { # method path [json]
+    local m=$1 p=$2 d=${3:-}
+    curl -sS -f --max-time 20 -X "$m" "$HUB$p" -H 'Content-Type: application/json' \
+      ${JWT:+-H "Authorization: Bearer $JWT"} ${d:+-d "$d"}
+  }
+  jstr() { sed -n "s/.*\"$1\":\"\([^\"]*\)\".*/\1/p" | head -n1; }
+
+  # SYNTHETIC nvidia-smi: answers only the agent's streaming power query.
+  # The legacy `-x -q` XML dump exits non-zero (no GPUs for legacy metrics),
+  # which is exactly what a machine without the XML path would look like.
+  cat > "$W/bin/nvidia-smi" <<'EOF'
+#!/bin/sh
+set -e
+# SYNTHETIC nvidia-smi fixture for scripts/smoke/power-history.sh.
+# Two fake GPUs, ~1 Hz, deterministic sawtooth so mean != peak.
+case "$*" in
+  *--query-gpu=count,index,uuid,power.draw*)
+    i=0
+    while :; do
+      p0=$(( 30 + (i % 7) * 10 )); p1=$(( 40 + (i % 5) * 20 ))
+      echo "2, 0, GPU-SYNTH-0, $p0.5"
+      echo "2, 1, GPU-SYNTH-1, $p1.0"
+      i=$((i+1)); sleep 1
+    done ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$W/bin/nvidia-smi"
+  echo "== fixture: $(command -v nvidia-smi) (SYNTHETIC)"
+
+  start_hub() {
+    (cd "$W/hub" && exec env HUB_LISTEN=127.0.0.1:4000 PUBLIC_URL=$HUB \
+      BLOXOS_JWT_SECRET=phsmoke-jwt-secret-0123456789abcdef0123456789abcdef \
+      /opt/phsmoke/bloxos-hub) >>"$W/log/hub.log" 2>&1 &
+    HUB_PID=$!
+    for _ in $(seq 1 60); do
+      curl -sf --max-time 5 "$HUB/health" >/dev/null 2>&1 && return 0
+      sleep 0.5
+    done
+    fail "hub did not become healthy"
+  }
+  start_agent() {
+    BLOXOS_HUB=ws://127.0.0.1:4000 BLOXOS_TOKEN="$TOKEN" BLOXOS_AI_SESSIONS=0 \
+      /opt/phsmoke/bloxos-agent >>"$W/log/agent.log" 2>&1 &
+    AGENT_PID=$!
+  }
+  stop_pid() { kill -TERM "$1" 2>/dev/null || true; for _ in $(seq 1 50); do kill -0 "$1" 2>/dev/null || return 0; sleep 0.1; done; kill -KILL "$1" 2>/dev/null || true; }
+
+  wait_ack() {
+    local wanted=$1 deadline=$(( $(date +%s) + T )) current
+    while :; do
+      current=$(sed -n 's/.*"acked":\([0-9]*\).*/\1/p' /etc/bloxos/power-history/state-*.json)
+      [[ "${current:-0}" -ge "$wanted" ]] && return 0
+      [[ $(date +%s) -ge $deadline ]] && fail "ACK did not persist through $wanted"
+      sleep 1
+    done
+  }
+
+  # wait_points FILE MIN_POINTS MIN_MAXSEQ : poll history until thresholds.
+  wait_points() {
+    local file=$1 minp=$2 minseq=$3 deadline=$(( $(date +%s) + T )) summ=""
+    while :; do
+      api GET "/api/machines/$MID/power/history" > "$file" || true
+      if summ=$($V summary "$minp" < "$file" 2>/dev/null); then
+        local maxseq; maxseq=$(sed -n 's/.*MAXSEQ=\([0-9]*\).*/\1/p' <<<"$summ")
+        if [[ "${maxseq:-0}" -ge "$minseq" ]]; then echo "$summ"; return 0; fi
+      fi
+      if [[ $(date +%s) -ge $deadline ]]; then
+        { echo "last verifier output: $summ"; $V summary "$minp" < "$file" || true; } >&2
+        fail "timed out waiting for $minp points / maxseq>=$minseq"
+      fi
+      sleep 5
+    done
+  }
+
+  echo "== phase 0: hub up, real first-boot setup, login, mint install token"
+  start_hub
+  # Hub runs as the container's root with its default HOME; its
+  # first-boot state stays inside the container.
+  local st; st=$(cat "$HOME/.bloxos/setup-token")
+  api POST /api/setup "{\"setup_token\":\"$st\",\"username\":\"phsmoke-admin\",\"password\":\"PhSmoke-Test-Passw0rd!2026\",\"pin\":\"123456\"}" >/dev/null || fail "setup failed"
+  JWT=$(api POST /api/auth/login '{"username":"phsmoke-admin","password":"PhSmoke-Test-Passw0rd!2026"}' | jstr token)
+  [[ -n "$JWT" ]] || fail "login returned no JWT"
+  TOKEN=$(api POST /api/tokens '{}' | jstr token)
+  [[ -n "$TOKEN" ]] || fail "token mint failed"
+  echo "   setup+login+token OK"
+
+  echo "== phase 1: agent enrolls over ws://loopback, samples SYNTHETIC GPUs, journals, uploads"
+  start_agent
+  MID=""
+  for _ in $(seq 1 60); do
+    MID=$(api GET /api/machines | $V machine-id 2>/dev/null || true)
+    [[ -n "$MID" ]] && break; sleep 1
+  done
+  [[ -n "$MID" ]] || fail "machine never registered"
+  echo "   machine id: $MID"
+  S1=$(wait_points "$W/out/h1.json" 2 2) || exit 1
+  echo "   $S1"
+  grep -q "power-history: starting stream=" "$W/log/agent.log" || fail "agent did not start power history"
+  grep -q "nvidia-smi" "$W/log/agent.log" && echo "   agent log mentions nvidia-smi: $(grep -c nvidia-smi "$W/log/agent.log") line(s)"
+  echo "   journal dir:"; find /etc/bloxos/power-history -maxdepth 1 -type f -printf '     %f %s bytes\n'
+  local acked; acked=$(cat /etc/bloxos/power-history/state-*.json)
+  echo "   persisted agent state: $acked"
+  local maxseq1; maxseq1=$(sed -n 's/.*MAXSEQ=\([0-9]*\).*/\1/p' <<<"$S1")
+  local ackn; ackn=$(sed -n 's/.*"acked":\([0-9]*\).*/\1/p' <<<"$acked")
+  wait_ack "$maxseq1"
+  ackn=$(sed -n 's/.*"acked":\([0-9]*\).*/\1/p' /etc/bloxos/power-history/state-*.json)
+  [[ "${ackn:-0}" -ge "$maxseq1" ]] || fail "ACK cursor $ackn behind hub max seq $maxseq1"
+  echo "   ACK persisted: acked=$ackn >= hub maxseq=$maxseq1"
+
+  echo "== phase 2: hub DOWN -> agent journals unacknowledged buckets offline -> agent restarted"
+  echo "            while hub is still down -> hub UP -> unacked journal replayed after reconnect"
+  stop_pid "$HUB_PID"
+  if curl -sf --max-time 2 "$HUB/health" >/dev/null 2>&1; then fail "hub still reachable after stop"; fi
+  local acked_before; acked_before=$(sed -n 's/.*"acked":\([0-9]*\).*/\1/p' /etc/bloxos/power-history/state-*.json)
+  local before_lines; before_lines=$(cat /etc/bloxos/power-history/seg-*.ndjson 2>/dev/null | wc -l)
+  echo "   hub stopped; agent state acked=$acked_before journal_records=$before_lines; waiting for offline buckets..."
+  local deadline=$(( $(date +%s) + T ))
+  while :; do
+    local unacked; unacked=$( { cat /etc/bloxos/power-history/seg-*.ndjson 2>/dev/null | grep -o '"seq":[0-9]*' || true; } | cut -d: -f2 | awk -v a="$acked_before" '$1>a' | wc -l)
+    [[ "$unacked" -ge 2 ]] && break
+    [[ $(date +%s) -ge $deadline ]] && fail "agent did not journal offline buckets"
+    sleep 5
+  done
+  stop_pid "$AGENT_PID"
+  cat /etc/bloxos/power-history/seg-*.ndjson > "$W/out/journal-offline.ndjson"
+  local last_journaled; last_journaled=$(grep -o '"seq":[0-9]*' "$W/out/journal-offline.ndjson" | cut -d: -f2 | sort -n | tail -n1)
+  local acked_mid; acked_mid=$(sed -n 's/.*"acked":\([0-9]*\).*/\1/p' /etc/bloxos/power-history/state-*.json)
+  [[ "$acked_mid" == "$acked_before" ]] || fail "ACK cursor moved while hub was down ($acked_before -> $acked_mid)"
+  echo "   offline journal: $unacked unacknowledged record(s), seqs up to $last_journaled, acked still $acked_before"
+  start_agent
+  sleep 3
+  start_hub
+  echo "   agent restarted (hub still down at the time), hub back up; waiting for replay + new buckets"
+  S2=$(wait_points "$W/out/h2.json" 3 $((last_journaled + 1))) || exit 1
+  echo "   $S2"
+  $V compare "$W/out/h1.json" --gap-after "$last_journaled" < "$W/out/h2.json" || fail "phase 2 comparison"
+  $V replayed "$W/out/journal-offline.ndjson" "$acked_before" < "$W/out/h2.json" || fail "unacked journal replay"
+  local acked_after; acked_after=$(sed -n 's/.*"acked":\([0-9]*\).*/\1/p' /etc/bloxos/power-history/state-*.json)
+  local maxseq2; maxseq2=$(sed -n 's/.*MAXSEQ=\([0-9]*\).*/\1/p' <<<"$S2")
+  wait_ack "$maxseq2"
+  acked_after=$(sed -n 's/.*"acked":\([0-9]*\).*/\1/p' /etc/bloxos/power-history/state-*.json)
+  [[ "${acked_after:-0}" -ge "$maxseq2" ]] || fail "ACK cursor $acked_after behind hub max seq $maxseq2 after replay"
+  echo "   ACK cursor after replay: $acked_after (hub max seq $maxseq2); acked-through lines in agent log: $(grep -c 'acked through' "$W/log/agent.log")"
+
+  echo "== phase 3: delta cursor from phase 1 returns only later ingestion"
+  local cursor1; cursor1=$(sed -n 's/.*CURSOR=\([0-9]*\).*/\1/p' <<<"$S1")
+  api GET "/api/machines/$MID/power/history?after=$cursor1" > "$W/out/d3.json"
+  $V disjoint "$W/out/h1.json" < "$W/out/d3.json" || fail "delta after cursor overlapped the earlier window"
+
+  echo "== phase 4: resource check"
+  echo "   agent RSS: $(awk '/VmRSS/{print $2" "$3}' "/proc/$AGENT_PID/status")   nvidia-smi fixture procs: $(pgrep -fc 'nvidia-smi --query-gpu' || true)"
+  echo "   hub gaps/degraded: $(sed -n 's/.*GAPS=\([0-9]*\) DEGRADED=\([a-z]*\).*/gaps=\1 degraded=\2/p' <<<"$S2")"
+  echo
+  echo "SMOKE PASS (synthetic GPU fixture; real agent+hub binaries; loopback container)"
+  echo "LIMITS: not hardware verification; ACK-loss-without-restart relies on unit/WS tests;"
+  echo "        legacy metrics XML path answered 'no GPU' by the fixture."
+  stop_pid "$AGENT_PID"; stop_pid "$HUB_PID"
+}
+
+# ---------------------------------------------------------------------------
+# Verifier source (Go, no dependencies). Modes:
+#   machine-id                 print the first machine id from /api/machines
+#   summary MIN                validate invariants, print POINTS= STREAMS= ...
+#   compare PREV [--gap-after N]  PREV ⊆ current byte-identical, no dups,
+#                              new points, and (optionally) a declared gap
+#                              starting at N+1 on PREV's stream
+#   disjoint FILE              no (stream,seq) of FILE appears in current
+# ---------------------------------------------------------------------------
+write_verifier() {
+cat <<'EOF'
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+)
+
+type Stats struct {
+	MeanWatts *float64 `json:"mean_watts"`
+	PeakWatts *float64 `json:"peak_watts"`
+	Samples   int      `json:"samples"`
+}
+type Sensor struct {
+	ID string `json:"id"`
+	Stats
+}
+type Bucket struct {
+	Seq             uint64   `json:"seq"`
+	StartUnixMS     int64    `json:"start_unix_ms"`
+	EndUnixMS       int64    `json:"end_unix_ms"`
+	ExpectedSamples int      `json:"expected_samples"`
+	GPUs            []Sensor `json:"gpus"`
+	GPUTotal        *Stats   `json:"gpu_total,omitempty"`
+	CPU             *Stats   `json:"cpu,omitempty"`
+	GapBefore       bool     `json:"gap_before,omitempty"`
+}
+type Point struct {
+	StreamID string `json:"stream_id"`
+	Bucket
+}
+type Gap struct {
+	StreamID string `json:"stream_id"`
+	From     uint64 `json:"from"`
+	Through  uint64 `json:"through"`
+}
+type History struct {
+	Points   []Point `json:"points"`
+	Gaps     []Gap   `json:"gaps"`
+	Cursor   uint64  `json:"cursor"`
+	Degraded bool    `json:"degraded"`
+}
+
+func die(f string, a ...any) { fmt.Fprintf(os.Stderr, "verify: "+f+"\n", a...); os.Exit(1) }
+
+func load(r io.Reader) History {
+	var h History
+	if err := json.NewDecoder(r).Decode(&h); err != nil {
+		die("decode history: %v", err)
+	}
+	return h
+}
+func loadFile(p string) History {
+	f, err := os.Open(p)
+	if err != nil {
+		die("%v", err)
+	}
+	defer f.Close()
+	return load(f)
+}
+func key(p Point) string { return p.StreamID + ":" + strconv.FormatUint(p.Seq, 10) }
+func canon(p Point) string { b, _ := json.Marshal(p.Bucket); return string(b) }
+
+func checkStats(what string, s *Stats, max int) {
+	if s.Samples < 1 || s.Samples > max {
+		die("%s samples %d outside [1,%d]", what, s.Samples, max)
+	}
+	if s.MeanWatts == nil || s.PeakWatts == nil {
+		die("%s missing mean/peak", what)
+	}
+	if *s.MeanWatts > *s.PeakWatts || *s.MeanWatts < 0 {
+		die("%s mean %v > peak %v", what, *s.MeanWatts, *s.PeakWatts)
+	}
+}
+
+func validate(h History, minPoints int) (maxSeq uint64, streams map[string]bool) {
+	if len(h.Points) < minPoints {
+		die("only %d points (< %d)", len(h.Points), minPoints)
+	}
+	seen := map[string]bool{}
+	completeWindows := 0
+	last := map[string]uint64{}
+	streams = map[string]bool{}
+	for _, p := range h.Points {
+		k := key(p)
+		if seen[k] {
+			die("duplicate %s", k)
+		}
+		seen[k] = true
+		streams[p.StreamID] = true
+		if p.Seq <= last[p.StreamID] && last[p.StreamID] != 0 {
+			die("seq not ascending in stream %s at %d", p.StreamID, p.Seq)
+		}
+		last[p.StreamID] = p.Seq
+		if p.Seq > maxSeq {
+			maxSeq = p.Seq
+		}
+		duration := p.EndUnixMS-p.StartUnixMS
+		if duration <= 0 || duration > 30000 {
+			die("seq %d invalid window %d ms", p.Seq, duration)
+		}
+		if duration == 30000 { completeWindows++ }
+		if p.ExpectedSamples != 30 {
+			die("seq %d expected_samples %d", p.Seq, p.ExpectedSamples)
+		}
+		if len(p.GPUs) != 2 || p.GPUs[0].ID != "GPU-SYNTH-0" || p.GPUs[1].ID != "GPU-SYNTH-1" {
+			die("seq %d gpus %+v (want the two synthetic sensors)", p.Seq, p.GPUs)
+		}
+		minS := 1 << 30
+		for _, g := range p.GPUs {
+			checkStats("seq "+strconv.FormatUint(p.Seq, 10)+" gpu "+g.ID, &g.Stats, 30)
+			if duration == 30000 && g.Samples < 20 {
+				die("seq %d gpu %s only %d samples (fixture is ~1 Hz)", p.Seq, g.ID, g.Samples)
+			}
+			if g.Samples < minS {
+				minS = g.Samples
+			}
+		}
+		if p.GPUTotal == nil {
+			die("seq %d has no gpu_total despite complete synthetic ticks", p.Seq)
+		}
+		checkStats("seq "+strconv.FormatUint(p.Seq, 10)+" gpu_total", p.GPUTotal, minS)
+		// Fixture: GPU0 in [30,90]+0.5, GPU1 in [40,120]; total peak <= 210.5.
+		if *p.GPUTotal.PeakWatts > 210.5 || *p.GPUTotal.MeanWatts < 70 {
+			die("seq %d gpu_total out of fixture range: %+v", p.Seq, *p.GPUTotal)
+		}
+		if p.CPU != nil {
+			checkStats("seq "+strconv.FormatUint(p.Seq, 10)+" cpu", p.CPU, 30)
+		}
+	}
+	if minPoints >= 2 && completeWindows < 2 {
+		die("need at least two complete 30s windows, got %d (clock-step partial windows allowed)", completeWindows)
+	}
+	return maxSeq, streams
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		die("mode required")
+	}
+	switch os.Args[1] {
+	case "machine-id":
+		var ms []struct {
+			ID string `json:"id"`
+		}
+		if err := json.NewDecoder(os.Stdin).Decode(&ms); err != nil || len(ms) == 0 {
+			os.Exit(1)
+		}
+		fmt.Print(ms[0].ID)
+	case "summary":
+		min, _ := strconv.Atoi(os.Args[2])
+		h := load(os.Stdin)
+		maxSeq, streams := validate(h, min)
+		fmt.Printf("POINTS=%d STREAMS=%d MAXSEQ=%d CURSOR=%d GAPS=%d DEGRADED=%v\n",
+			len(h.Points), len(streams), maxSeq, h.Cursor, len(h.Gaps), h.Degraded)
+	case "compare":
+		prev := loadFile(os.Args[2])
+		var gapAfter uint64
+		if len(os.Args) >= 5 && os.Args[3] == "--gap-after" {
+			gapAfter, _ = strconv.ParseUint(os.Args[4], 10, 64)
+		}
+		cur := load(os.Stdin)
+		curMax, curStreams := validate(cur, len(prev.Points)+1)
+		prevMax, prevStreams := validate(prev, 1)
+		if len(curStreams) != 1 || len(prevStreams) != 1 {
+			die("expected exactly one stream across restart, got prev=%d cur=%d", len(prevStreams), len(curStreams))
+		}
+		idx := map[string]string{}
+		for _, p := range cur.Points {
+			idx[key(p)] = canon(p)
+		}
+		for _, p := range prev.Points {
+			c, ok := idx[key(p)]
+			if !ok {
+				die("earlier point %s vanished", key(p))
+			}
+			if c != canon(p) {
+				die("earlier point %s changed after replay", key(p))
+			}
+		}
+		if curMax <= prevMax {
+			die("no new sequences after restart (prev max %d, cur max %d)", prevMax, curMax)
+		}
+		if gapAfter > 0 {
+			found := false
+			for _, g := range cur.Gaps {
+				if g.From == gapAfter+1 && g.Through < curMax {
+					found = true
+				}
+			}
+			if !found {
+				die("no declared gap starting at %d (restart reservation hole); gaps=%+v", gapAfter+1, cur.Gaps)
+			}
+			// Contract: the first bucket after the restart carries gap_before
+			// (collection stopped while the process was down).
+			var first *Point
+			for i := range cur.Points {
+				if cur.Points[i].Seq > gapAfter && (first == nil || cur.Points[i].Seq < first.Seq) {
+					first = &cur.Points[i]
+				}
+			}
+			if first == nil || !first.GapBefore {
+				die("first post-restart bucket must carry gap_before: %+v", first)
+			}
+		}
+		fmt.Printf("COMPARE OK: prev=%d points intact, cur=%d points, maxseq %d -> %d, gaps=%d\n",
+			len(prev.Points), len(cur.Points), prevMax, curMax, len(cur.Gaps))
+	case "replayed":
+		// Every journal record above the pre-outage ACK cursor must be on the
+		// hub byte-identical (canonical bucket JSON) after the reconnect.
+		f, err := os.Open(os.Args[2])
+		if err != nil {
+			die("%v", err)
+		}
+		ackedBefore, _ := strconv.ParseUint(os.Args[3], 10, 64)
+		cur := load(os.Stdin)
+		idx := map[uint64]string{}
+		for _, p := range cur.Points {
+			idx[p.Seq] = canon(p)
+		}
+		dec := json.NewDecoder(f)
+		n := 0
+		for dec.More() {
+			var b Bucket
+			if err := dec.Decode(&b); err != nil {
+				die("journal decode: %v", err)
+			}
+			if b.Seq <= ackedBefore {
+				continue
+			}
+			jb, _ := json.Marshal(b)
+			got, ok := idx[b.Seq]
+			if !ok {
+				die("journaled seq %d (unacked before outage) never reached the hub", b.Seq)
+			}
+			if got != string(jb) {
+				die("journaled seq %d differs on hub:\n journal %s\n hub     %s", b.Seq, jb, got)
+			}
+			n++
+		}
+		if n < 2 {
+			die("expected >=2 replayed unacked records, matched %d", n)
+		}
+		fmt.Printf("REPLAY OK: %d unacknowledged journal record(s) replayed byte-identical after reconnect\n", n)
+	case "disjoint":
+		other := loadFile(os.Args[2])
+		cur := load(os.Stdin)
+		validate(cur, 1)
+		if cur.Cursor <= other.Cursor { die("delta cursor did not advance") }
+		had := map[string]bool{}
+		for _, p := range other.Points {
+			had[key(p)] = true
+		}
+		for _, p := range cur.Points {
+			if had[key(p)] {
+				die("delta re-delivered %s", key(p))
+			}
+		}
+		fmt.Printf("DELTA OK: %d new points, cursor %d, none overlapping\n", len(cur.Points), cur.Cursor)
+	default:
+		die("unknown mode %q", os.Args[1])
+	}
+}
+EOF
+}
+
+case "${1:-}" in
+  build) build ;;
+  inner) inner ;;
+  *) outer ;;
+esac


### PR DESCRIPTION
## Summary

- Sample NVIDIA GPU and supported Linux CPU-package power independently at 1 Hz; report 30-second means, sampled peaks and coverage. Component power is explicitly not wall power.
- Persist completed windows locally for 24 hours, bounded by records and bytes. Upload bounded new/unacknowledged batches, with durable acknowledgements, deduplication and declared gaps after retention/restarts.
- Add authenticated, machine-bound hub ingestion, history storage/migration and cursor-based API; preserve existing instantaneous metrics and old-agent behavior.
- Add a per-machine Metrics power-history graph, per-GPU/combined-GPU/CPU selection, missing-data gaps, coverage, freshness and bounded diagnostic messages.
- Add shared-protocol CI coverage and an isolated real-binary smoke test with explicitly synthetic NVIDIA inputs.
- Integrate current main including #180. Advance the agent release sequence and marker to 3 for the GPU-membership correction (the prior canary candidate was release 2).

## Validation

Completed before integrating #180:

- Full hub tests and full hub race suite; hub vet.
- Full Linux agent race suite, normal/insecure-tag vet and insecure-tag tests.
- Linux amd64/arm64 and Windows amd64 builds; Windows test compilation.
- Shared protocol race tests; dashboard 17 tests, lint and production build.
- User-approved local sample-data visual preview.
- Isolated real agent + hub process smoke: four initial records/ACK 4, two additional unacknowledged records during hub outage, agent restart while offline, both records recovered unchanged, final seven distinct records/ACK 66 with a declared reservation gap, and three non-overlapping delta records. Valid clock-step partial windows are checked separately from the requirement for two complete 30-second windows.
- Smoke ShellCheck, syntax and refusal checks; disposable resources cleaned up without changing the running fleet.

Post-#180 integration on the prior release-2 candidate: full hub tests, Linux agent race tests, Windows test compilation, shared-protocol vet/race tests and targeted hub race tests passed. All test/build checks on commit `0bc3ad5` passed.

Real-hardware canary passed on the release-2 candidate on two RTX 3090 GPUs in an isolated container with networking disconnected during the test, no host credentials and no published ports. Two full 30-s windows each had all 30 samples; one idle window was 33.883 W + 37.153 W = 71.036 W combined. Two unacknowledged windows recorded during hub outage replayed unchanged after agent restart and reconnect. Final: five distinct records, ACK 66, one declared reservation gap, three non-overlapping delta records. Installed fleet agent PID/start time were unchanged. Canary container removed; evidence retained locally. The optional `PHSMOKE_REAL_GPU=1` smoke mode is included and independently reviewed. This canary is not a hardware test of the later release-3 membership correction.

## GPU-membership review correction

- Omit combined GPU totals for windows with changing device sets, including added/removed/replaced IDs and extra IDs seen only in partial iterations. Retain per-GPU and CPU readings; recover totals in the next stable window.
- Keep the hub's strict sample-count validation unchanged. Do not rewrite existing durable journal records.
- Regression coverage includes stable reordering/N/A/partial samples, changes that pass a naive count-only guard, journal reopen/replay, multi-bucket rejection without partial commit, successful ACK progression and diagnostic recovery.
- Agent release number and embedded marker advance together to 3. The release-2 hardware evidence remains labeled separately above.
- Correction validation: full Linux agent race suite and vet; Linux amd64/arm64 builds; Windows test compilation; hub power-history race tests including multi-bucket rejection/recovery. The original membership regressions failed before the fix and pass after it.

Consult the latest-head GitHub checks for CI status; local evidence does not replace those checks.

## Review / rollout limits

Ready for engineering review following the isolated real-GPU canary. Nothing in this PR is deployed to the fleet and no merge is authorized by opening it.

The default smoke uses synthetic GPU values; the separate hardware canary used real idle GPU readings. Neither establishes wall-power accuracy, a 24-hour resource soak, a Windows driver runtime check, or ACK-loss-after-commit simulation. CPU sensors were unavailable in the canary container and correctly absent. Real CPU readings and Windows driver streaming remain unverified. No artificial GPU load was generated.

See `docs/power-history.md` for storage/traffic budgets, failure boundaries and the repeatable smoke command. Credentials, CA files, update keys and release-floor state must remain intact during any canary or rollback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new agent disk/WebSocket and hub SQLite ingestion path with durability and gap semantics; additive and machine-bound, but bugs could affect telemetry fidelity or agent I/O under storage stress—not auth or credentials.
> 
> **Overview**
> Adds **component power history** end-to-end: 1 Hz GPU (streaming `nvidia-smi`) and Linux RAPL CPU sampling, **30-second windows** with per-sensor means/peaks/coverage, a **local fsync’d journal** (24h / byte caps), throttled WebSocket batches, and hub **ACK-after-commit** with stream/seq dedupe and declared retention gaps. This is intentionally separate from legacy instantaneous **`power_watts`**; UI copy is relabeled to **GPU power** where appropriate.
> 
> The hub gains migrations (`power_history_*` tables), **`ingestPowerHistory`** on the agent socket, **`GET /api/machines/:id/power/history`** (initial + `?after` cursor deltas), pruning on cleanup, and power rows removed on machine delete. The Metrics tab adds **`PowerHistory`** charts (GPU total / per-GPU / CPU) with gap/degraded handling via **`power-history.mjs`**.
> 
> **GPU-membership correction:** combined **`gpu_total` is omitted** when the device set changes mid-window (add/remove/replace or partial ticks introducing new IDs); per-GPU and CPU stats stay, totals resume in the next stable window. Agent **release marker advances to 3**.
> 
> CI adds a **`proto` job** (`go vet` + race tests for shared `proto/powerhistory`). Docs/`AGENTS.md` document semantics and failure boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95b6234df4bb2278f1a6907376fec8ca7ff63afd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->