### PR TITLE
fix: consistent backup and identity-preserving restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -56,6 +57,9 @@ jobs:
 
       - name: Run hub tests
         run: go test -count=1 ./...
+
+      - name: Test backup failure and restart handling
+        run: python3 ../scripts/test_backup_compose.py
 
   # A real gate as of issue #60: the hub's DB handle and agent registry now live
   # on a Server instance, so tests build isolated servers instead of reassigning

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,13 @@ on:
       - ".dockerignore"
       - "docker/**"
       - "scripts/smoke/**"
+      - "scripts/backup-compose.sh"
+      - "hub/**"
+      - "agent/**"
+      - "proto/**"
+      - "dashboard/**"
       - ".github/workflows/docker.yml"
+      - ".github/workflows/ci.yml"
   push:
     tags: ["v*"]
   workflow_dispatch:
@@ -25,6 +31,13 @@ env:
   DASHBOARD_IMAGE: ghcr.io/${{ github.repository_owner }}/bloxos-dashboard
 
 jobs:
+  # A release tag must pass the same full suite as a PR, at the tag's exact
+  # commit. A green older main/PR run does not validate a new tagged tree.
+  verify-release:
+    name: Release verification
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/ci.yml
+
   # Builds both images for the runner's platform and enrolls the runner as an
   # agent through the Compose stack (scripts/smoke/compose-enroll.sh). Gates
   # publishing and checks container-related pull requests.
@@ -65,7 +78,7 @@ jobs:
   # behind the default tags.
   publish:
     name: Publish images
-    needs: smoke
+    needs: [smoke, verify-release]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you've ever opened five browser tabs to check on five machines, this is for y
 ## What you actually get
 
 ### Live, not polled
-Metrics stream over WebSocket from agent to hub, then push to your browser via SSE. CPU, RAM, GPU usage, GPU power, thermals, network throughput, disk I/O — all updating multiple times per second. No 15-second scrape intervals. No "did it just freeze or is it just slow." When a value changes, you see it change.
+Metrics stream over WebSocket from agent to hub, then push to your browser via SSE. The normal agent snapshot cadence is 30 seconds, with on-demand refresh. Freshness indicators distinguish current readings from stale data. Power history samples component sensors locally every second and uploads 30-second averages and sampled peaks; this is not a wall-power meter.
 
 ### Real hardware inventory
 Every agent collects DMI data, RAM modules (manufacturer, speed, slot, ECC status), GPU devices (model, VRAM, driver), PCI bus, network adapters, disks, BIOS, and motherboard. The fleet-wide `/inventory` page is sortable, filterable, groupable, and exports to CSV / JSON / Markdown. The first time you use it to find "every machine with less than 32GB RAM" in three seconds, you'll understand why it's there.
@@ -44,7 +44,7 @@ Every agent collects DMI data, RAM modules (manufacturer, speed, slot, ECC statu
 xterm.js, theme-aware, stable 360px pane. Hit a machine, get a real shell. No SSH key juggling, no port forwarding, no "what was the IP again." The terminal session belongs to the operator's auth context, not the machine's.
 
 ### Two operating systems, one dashboard
-The Linux agent and the Windows agent speak the same WebSocket protocol to the same hub. The Windows agent registers itself as a Windows Service via SCM, collects hardware via WMI, and supports the same auto-update flow. From the dashboard, a Windows machine and a Linux machine look and behave identically.
+The Linux agent and the Windows agent speak the same WebSocket protocol to the same hub. The Windows agent registers itself as a Windows Service via SCM, collects hardware via WMI, and supports signed auto-update. Web terminal access is Linux-only; Windows enrollment and re-enrollment use generated PowerShell commands.
 
 ### Signed auto-update and recovery
 Protocol-v1 agents accept an update only when its Ed25519 release signature verifies against their pinned key and the transport is permitted. Protocol-0 agents require a deliberately limited migration hop to reach protocol v1, because signature verification cannot be retrofitted into an already-running binary; the hub permits that hop only over TLS or loopback. After migration, the agent is withheld until its update key is pinned through a trusted provisioning path.
@@ -56,7 +56,7 @@ Both platforms use a `.prev` file for recovery, but their behavior differs:
 - **Linux** verifies the update, replaces the executable atomically, and exits for systemd to restart it. An `OnFailure` recovery unit can automatically restore `.prev` after repeated startup failure.
 - **Windows** attempts to snapshot `.prev`, downloads to `<exe>.new`, and writes `<exe>.pending` with the expected `sha256` and `signature`. On the SCM restart, `applyPendingUpdate` hashes `.new`, compares the SHA, and verifies the signature against the pinned key before spawning the swap helper. `performUpdateWindows` exits with code `1` to trigger that SCM restart. The helper attempts `move /Y` before deleting the marker, but marker deletion is unconditional; Windows has no automatic rollback, so restoring `.prev` remains manual.
 
-A circuit breaker pauses fleet rollout after two failures in five minutes. Signatures still have no downgrade or monotonicity protection: a previously valid `(os, sha)` pair remains valid indefinitely ([#145](https://github.com/bokiko/bloxos/issues/145)).
+A circuit breaker pauses fleet rollout after two failures in five minutes. Protocol-2 agents persist a signed release-number/SHA floor before replacing their executable: older builds are rejected, and the same release number is accepted only for identical bytes. Protocol-1 agents do not enforce this floor. Never delete the floor during reinstall, key rotation, or recovery; see [AGENTS.md](AGENTS.md) for the compatibility contract.
 
 You push an update to the hub and the fleet moves to the new version on its own. On Linux, a bad build can also recover automatically.
 
@@ -70,7 +70,7 @@ Five themes — BloxOS (default), Solarized, Dracula, Nord, Tokyo Night — each
 Command palette opens on `Cmd+K` (or `Ctrl+K`). Jump to any machine by name, run any action, open any setting, search inventory, switch themes. The palette is how operators actually use the system once they know it exists.
 
 ### One-file database
-SQLite. The whole system — users, machines, metrics history, inventory, branding, preferences, saved filters, notes — lives in `bloxos.db`. Backup is `cp bloxos.db backup.db`. Restore is the inverse. No replication setup, no migration nightmares, no "which Postgres version are we on."
+SQLite keeps users, machines, history, inventory, branding, preferences and notes together. The hub uses WAL, so a live copy of `bloxos.db` alone is **not a safe backup**. Preserve the database and the hub's signing/JWT identity plus the proxy CA using the [backup and restore procedure](docs/backup-restore.md).
 
 ### Built for operators, not viewers
 - Notes per machine (markdown-ish, URL auto-link)
@@ -148,11 +148,37 @@ environment variable read by the Go hub and agent.
 | `ProgramFiles` | Windows-provided | Used to discover NVIDIA tooling; normally never overridden. |
 | `NEXT_PUBLIC_HUB_URL` | Dashboard | Hub origin when dashboard and hub are not same-origin. |
 
-## Quick start from source
+## Quick start: Compose hub
 
-> **Status:** BloxOS is pre-1.0. The polished public installer is still in
-> progress. This path builds the hub and Linux agent from source and keeps the
-> first enrollment on loopback.
+Use the [supported Compose deployment](docker/README.md) on a Docker host:
+
+```bash
+git clone https://github.com/bokiko/bloxos.git
+cd bloxos/docker
+cp .env.example .env
+# Edit .env: set HUB_HOST to this machine's hostname or IP (no scheme/port).
+docker compose up -d --build
+docker compose exec hub cat /data/.bloxos/setup-token
+```
+
+Open `https://<HUB_HOST>` and use the setup token to create your account. The
+stack uses an internal CA; the container guide explains browser trust. Choose
+**Add Machine** and copy the generated Linux one-line command or Windows
+PowerShell command to that machine. Installing a hub and enrolling a machine
+are different operations; an enrollment command does not install another hub.
+
+Build from your chosen tested revision for current source. A green main build
+does not mean that the same revision is published as `latest` or deployed on
+your host. When using published images, pin an available version and verify
+its revision; do not assume an older release has the current source features.
+Back up before upgrading. The hub also serves agent updates, so upgrading it
+can update enrolled machines, not just the dashboard.
+
+## Native development from source
+
+> This alternative is for Linux development on amd64. The supported Compose
+> build packages both Linux architectures and Windows. A one-line public hub
+> installer is separate work; machine onboarding already ships.
 
 ### 1. Clone and build
 
@@ -173,8 +199,9 @@ To build the Windows agent artifact:
 (cd agent && GOOS=windows GOARCH=amd64 go build -o ../bin/bloxos-agent.exe .)
 ```
 
-Windows enrollment is under active rework and is intentionally not documented
-as a runnable installer flow yet.
+For Windows enrollment, use the generated command in **Add Machine → Windows**.
+The Compose image already includes the Windows artifact. Native development
+must set `BLOXOS_AGENT_BINARY_WINDOWS` to a trusted root-owned artifact path.
 
 ### 2. Configure and run the hub
 
@@ -209,16 +236,15 @@ admin account.
 ### 4. Enroll the local Linux agent
 
 In the dashboard, choose **Add Machine → Linux** and run the generated command
-on this same machine. The loopback quick start avoids a remote first-contact
-trust decision while the public bootstrap flow is being reworked. The agent
+on this same machine. This development path keeps first enrollment on loopback. The agent
 uses its one-time token once, stores a durable machine secret, and then appears
 in the fleet.
 
 For a LAN deployment, terminate TLS in front of the hub, set `PUBLIC_URL` to
 that trusted HTTPS origin, set `ALLOWED_ORIGINS` to the dashboard origin, and
-keep `BLOXOS_AGENT_BINARY` on an explicit absolute path. A safe cold-start
-bootstrap for a private or self-signed CA remains tracked in
-[#150](https://github.com/bokiko/bloxos/issues/150).
+keep `BLOXOS_AGENT_BINARY` on an explicit absolute path. The supported Compose
+path supplies the private-CA fingerprint and verified leaf-key pin in generated
+onboarding commands; do not replace this with an unverified download-and-run command.
 
 ### 5. Production builds and sample services
 
@@ -253,7 +279,7 @@ sudo systemctl enable --now bloxos-hub bloxos-dashboard bloxos-agent
 | Real-time | WebSocket (agent ↔ hub), SSE (hub ↔ browser) |
 | Deployment | Single Go binary for the hub, single binary for each agent, Next.js dashboard behind Caddy/systemd |
 
-No Docker required. No Kubernetes. No Redis. No Postgres. No external services. A hub binary, agent binaries, a dashboard service, and a SQLite file.
+Compose is the supported packaged hub deployment; native services remain an alternative. No Kubernetes, Redis or Postgres is required.
 
 ---
 
@@ -263,9 +289,9 @@ BloxOS is **pre-1.0** and currently powering the author's homelab fleet of ~10 m
 
 **What's solid:**
 - Hub, Linux agent, Windows agent — all three run continuously on my fleet
-- Auto-update with rollback — battle-tested through several agent updates
+- Signed auto-update with monotonic protection on protocol-2 agents; recovery differs by OS
 - Hardware inventory, metrics, terminal, RBAC, themes, branding — all working
-- ~20,000 lines of dashboard code, ~5,000 lines of Go across hub and agents
+- Metadata-only AI session monitoring and 24-hour component power history
 
 **What's not done:**
 - Polished public one-line hub installer
@@ -273,15 +299,14 @@ BloxOS is **pre-1.0** and currently powering the author's homelab fleet of ~10 m
 - Historical metrics retention beyond the live ring buffer
 - Custom alert rules UI (alerts exist; the rule editor isn't shipped)
 - Audit log
-- Backup/restore tooling beyond "copy the SQLite file"
-- Docker packaging
+- Broader disaster-recovery automation (a consistent backup helper and clean restore procedure ship)
 
 **What's planned for v1.0:**
 - Polished installer flow for hub and agents
 - Documentation site
 - Mobile responsive pass
 - Custom alert rules editor
-- Per-machine power tracking chart (GPU first, total system later)
+- Longer-term history beyond the shipped 24-hour component power chart
 
 See [the roadmap](#roadmap) for what's coming after v1.0.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -61,10 +61,9 @@ Operations:
   images `docker compose pull && docker compose up -d`. The hub and the
   agents it serves come from the same commit; connected agents that have
   pinned the update key self-update.
-- Back up the `bloxos-data` volume (database, secrets, setup token,
-  update-signing key) and the `caddy-data` volume (the CA). Losing the
-  signing key strands agent self-update; losing the CA invalidates the
-  certificate every enrolled agent pinned, and each must be re-enrolled.
+- Use the [consistent backup and clean restore procedure](../docs/backup-restore.md)
+  for the database, secrets, signing key and Caddy CA/configuration. Do not copy
+  only the live SQLite file or delete volumes to repair a failed upgrade.
 - Root certificate for browsers:
   `docker compose exec caddy cat /data/caddy/pki/authorities/local/root.crt`.
 - Logs: `docker compose logs -f hub`.
@@ -76,8 +75,10 @@ a disposable Linux host with Docker, systemd, and passwordless sudo it
 brings the stack up, completes setup through the API, mints an install
 token, runs the generated Linux command on that same host so it enrolls as
 an agent, asserts the machine is online with the CA pinned, then removes
-the agent and the stack. CI runs it on pull requests that touch the
-container files and before publishing images on a tag. Locally:
+the agent and the stack. It also backs up and restores the initialized hub
+with its original state/identity into a temporary network-isolated project.
+CI runs it on source/container changes, and tags must pass both smoke and the
+full CI suite on their exact commit before publishing images. Locally:
 
 ```bash
 SMOKE_CONFIRM_DISPOSABLE=1 HUB_HOST=<this host's IP> scripts/smoke/compose-enroll.sh

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -16,12 +16,22 @@ bash ../scripts/backup-compose.sh /absolute/path/to/new-backup-directory
 # bash ../scripts/backup-compose.sh /absolute/path/to/new-backup-directory -p my-bloxos -f compose.yaml -f override.yaml
 ```
 
-Requires Docker Compose, Bash, tar and `shasum`. The destination must not
-exist. The script stops hub and Caddy, copies their complete state, then
+Requires Docker Compose, Bash, Python3, tar and `shasum`. The destination must
+not exist; its parent must be owned by the invoking OS user and not writable
+by group/others (use a private backup directory, not `/tmp` directly).
+The script stops hub and Caddy, copies their complete state, then
 restarts only services that were running before the backup. Agents reconnect
 when the hub returns; the dashboard can temporarily show disconnected data.
 No volume, database, release floor, or key is deleted. A failure leaves the
-partial directory for inspection; a complete backup has `SHA256SUMS`.
+partial directory for inspection; a complete backup has an atomically finalized
+`SHA256SUMS` with all five entries verified. `.pending` is not complete.
+
+Overlapping backups of the same hub are refused using an exclusive, stopped
+Docker lock container; it never runs code and has no network. Normal exit
+removes it. A killed client/daemon failure can leave this lock behind: inspect
+the `bloxos-backup-lock-<hub-container-id>` container and verify no backup is
+still active before removing that exact lock container with `docker rm -v`.
+Do not remove the hub container or replace the stack during a backup.
 
 This procedure assumes the shipped `/data` and `/config` mounts have no other
 writers. Do not run another hub against the same database. Prevent another

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,104 @@
+# Backup and restore
+
+## Compose (supported deployment)
+
+Use a brief maintenance window. The hub uses SQLite WAL: copying only
+`bloxos.db` while it is running can miss committed data. The database alone is
+also not the hub's identity. Keep the **whole hub data directory**, Caddy data
+(including the original CA private key), and Caddy configuration together.
+
+From the deployment's `docker/` directory, with the same environment and
+Compose options you normally use:
+
+```bash
+bash ../scripts/backup-compose.sh /absolute/path/to/new-backup-directory
+# For a named project/override, append your usual global options:
+# bash ../scripts/backup-compose.sh /absolute/path/to/new-backup-directory -p my-bloxos -f compose.yaml -f override.yaml
+```
+
+Requires Docker Compose, Bash, tar and `shasum`. The destination must not
+exist. The script stops hub and Caddy, copies their complete state, then
+restarts only services that were running before the backup. Agents reconnect
+when the hub returns; the dashboard can temporarily show disconnected data.
+No volume, database, release floor, or key is deleted. A failure leaves the
+partial directory for inspection; a complete backup has `SHA256SUMS`.
+
+This procedure assumes the shipped `/data` and `/config` mounts have no other
+writers. Do not run another hub against the same database. Prevent another
+operator/orchestrator from restarting the stack during the maintenance window.
+Custom external signing-key mounts, environment-supplied JWT secrets, external
+databases, and custom proxy deployments require their corresponding state too.
+Separately save `.env`, override files and externally mounted keys in your
+encrypted backup store. The rendered configuration and container metadata in
+the backup are private reference material; they may contain credentials.
+
+Copy the backup to encrypted off-host storage. Checksums detect accidental
+damage, not a malicious replacement; restore only your own trusted archives.
+Test restoration periodically. Losing the update-signing key or CA can strand
+enrolled agents; never generate replacements as a shortcut during recovery.
+
+## Restore into a clean, isolated Compose project
+
+Do not extract over an existing deployment. Keep the original volumes and
+backup unchanged until the restored app has been validated. On a replacement
+host, install the same tested BloxOS revision/images and recover your original
+`.env`, overrides and external secrets. Do not upgrade during disaster recovery.
+Keep the replacement isolated from enrolled machines until validation is done:
+starting a hub with newer served agent bytes can initiate fleet updates.
+
+Verify the archives first:
+
+```bash
+cd /absolute/path/to/backup-directory
+shasum -a 256 -c SHA256SUMS
+```
+
+In the recovered checkout's `docker/` directory, use a **new, unused project
+name**, without overrides that reuse existing/external volume names. Set
+`HUB_HOST` to the original hostname and arrange isolated DNS/routing for the
+test. Build or pull the original images before continuing. `create` must not
+be replaced by `up`: nothing may write to the volumes before restoration.
+
+```bash
+export COMPOSE_PROJECT_NAME=bloxos-restore-test
+docker compose create
+hub=$(docker compose ps -a -q hub)
+caddy=$(docker compose ps -a -q caddy)
+# Verify both containers are stopped and inspect their Mounts. All three
+# named volumes must be newly created for this project, not production volumes.
+docker inspect "$hub" "$caddy"
+```
+
+Only after verifying these exact targets, restore with ownership preserved:
+
+```bash
+backup=/absolute/path/to/backup-directory
+docker cp -a - "$hub:/data" < "$backup/hub-data.tar"
+docker cp -a - "$caddy:/data" < "$backup/caddy-data.tar"
+docker cp -a - "$caddy:/config" < "$backup/caddy-config.tar"
+docker compose up -d
+docker compose ps
+```
+
+Verify login with an existing account (not first-boot setup), expected machine
+rows/history/settings, and the original CA certificate and update public key.
+Use an isolated test agent to verify reconnect/update trust. Do not share a
+live agent's credentials with a second agent or reset any agent's signed
+release floor. Keep the old deployment stopped when switching the original
+hostname to its replacement; do not run two hubs with cloned identity against
+the fleet. Resume live traffic only after the checks pass.
+
+If an extraction fails, keep the target stopped. Do not start a partially
+restored stack or retry over partially populated volumes; use another fresh
+project and retain the failed target for inspection.
+
+## Native deployment
+
+Stop the hub service and any other database writers. Back up its whole working
+data directory (including any `bloxos.db-wal`/`bloxos.db-shm` files), the hub
+service account's `.bloxos` directory, environment/service configuration,
+external signing keys, branding storage and reverse-proxy CA/configuration.
+Paths differ from Compose: inspect your service unit and configuration.
+Preserve ownership and permissions. Restart the original service afterward.
+Restore only while the replacement is stopped, on the same tested build.
+Never delete WAL files to make a backup or force a database to open.

--- a/scripts/backup-compose.sh
+++ b/scripts/backup-compose.sh
@@ -13,6 +13,10 @@ shift
 compose() { docker compose "$@"; }
 compose_options=("$@")
 
+# The destination's parent must not let another OS user replace the newly
+# created private directory with a symlink. Same-user hostile processes are
+# outside this local backup boundary (they can already read its private keys).
+python3 -c 'import os,stat,sys; p=os.path.dirname(os.path.abspath(sys.argv[1])); s=os.stat(p); sys.exit(0 if s.st_uid == os.getuid() and not s.st_mode & 0o022 else "Backup parent must be owned by this user and not group/world writable")' "$destination"
 # No overwrite, including an existing empty directory or symlink.
 mkdir -m 700 -- "$destination"
 destination=$(cd "$destination" && pwd)
@@ -23,18 +27,12 @@ if [[ -z "$hub" || -z "$caddy" || "$hub" == *$'\n'* || "$caddy" == *$'\n'* ]]; t
   exit 1
 fi
 
-# Save rendered configuration privately: it can contain credentials. This is
-# reference material, not an automatically executable restore configuration.
-compose "${compose_options[@]}" config > "$destination/compose-config.yaml"
-docker inspect "$hub" "$caddy" > "$destination/containers.json"
+# Docker container names are exclusive on the daemon, including across
+# separate clients/OS users. This stopped, network-less lock container never
+# executes the hub. Acquire BEFORE observing service running state: otherwise
+# overlapping backups can restart the other's supposedly stopped database.
+lock=$(docker create --name "bloxos-backup-lock-$hub" --network none --entrypoint /bin/true "$(docker inspect -f '{{.Image}}' "$hub")")
 restart=()
-for service in hub caddy; do
-  container=$hub
-  [[ "$service" == caddy ]] && container=$caddy
-  if [[ $(docker inspect -f '{{.State.Running}}' "$container") == true ]]; then
-    restart+=("$container")
-  fi
-done
 resume() {
   result=$?
   trap - EXIT
@@ -44,12 +42,27 @@ resume() {
       result=1
     fi
   fi
+  if ! docker rm -v "$lock" > /dev/null; then
+    echo "Could not remove backup lock container $lock; inspect it before another backup." >&2
+    result=1
+  fi
   [[ $result -eq 0 ]] || echo "Backup failed or services need attention; inspect $destination." >&2
   exit "$result"
 }
 trap resume EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
+# Save rendered configuration privately: it can contain credentials. This is
+# reference material, not an automatically executable restore configuration.
+compose "${compose_options[@]}" config > "$destination/compose-config.yaml"
+docker inspect "$hub" "$caddy" > "$destination/containers.json"
+for service in hub caddy; do
+  container=$hub
+  [[ "$service" == caddy ]] && container=$caddy
+  if [[ $(docker inspect -f '{{.State.Running}}' "$container") == true ]]; then
+    restart+=("$container")
+  fi
+done
 compose "${compose_options[@]}" stop hub caddy
 for container in "$hub" "$caddy"; do
   [[ $(docker inspect -f '{{.State.Running}}' "$container") == false ]]
@@ -64,6 +77,10 @@ docker cp "$caddy:/config/." - > "$destination/caddy-config.tar"
 for archive in hub-data caddy-data caddy-config; do
   tar -tf "$destination/$archive.tar" > /dev/null
 done
-(cd "$destination" && shasum -a 256 hub-data.tar caddy-data.tar caddy-config.tar compose-config.yaml containers.json > SHA256SUMS)
+(cd "$destination" &&
+  shasum -a 256 hub-data.tar caddy-data.tar caddy-config.tar compose-config.yaml containers.json > SHA256SUMS.pending &&
+  python3 -c 'from pathlib import Path; p=Path("SHA256SUMS.pending"); lines=p.read_text().splitlines(); expected=["hub-data.tar","caddy-data.tar","caddy-config.tar","compose-config.yaml","containers.json"]; assert len(lines)==5 and all(len(line.split())==2 and len(line.split()[0])==64 and all(c in "0123456789abcdef" for c in line.split()[0]) and line.split()[1]==name for line,name in zip(lines,expected))' &&
+  shasum -a 256 -c SHA256SUMS.pending > /dev/null &&
+  mv SHA256SUMS.pending SHA256SUMS)
 echo "Backup complete: $destination (contains private keys; keep it private and encrypted off-host)."
 echo "Also retain your deployment .env, override files, and any externally mounted keys; see docs/backup-restore.md."

--- a/scripts/backup-compose.sh
+++ b/scripts/backup-compose.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Consistent, offline backup of the shipped Compose deployment.
+# Run from docker/; extra arguments are Compose global options (e.g. -p NAME).
+set -euo pipefail
+umask 077
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: bash ../scripts/backup-compose.sh NEW_BACKUP_DIRECTORY [compose options...]" >&2
+  exit 2
+fi
+destination=$1
+shift
+compose() { docker compose "$@"; }
+compose_options=("$@")
+
+# No overwrite, including an existing empty directory or symlink.
+mkdir -m 700 -- "$destination"
+destination=$(cd "$destination" && pwd)
+hub=$(compose "${compose_options[@]}" ps -a -q hub)
+caddy=$(compose "${compose_options[@]}" ps -a -q caddy)
+if [[ -z "$hub" || -z "$caddy" || "$hub" == *$'\n'* || "$caddy" == *$'\n'* ]]; then
+  echo "Expected exactly one existing hub and Caddy container; backup incomplete." >&2
+  exit 1
+fi
+
+# Save rendered configuration privately: it can contain credentials. This is
+# reference material, not an automatically executable restore configuration.
+compose "${compose_options[@]}" config > "$destination/compose-config.yaml"
+docker inspect "$hub" "$caddy" > "$destination/containers.json"
+restart=()
+for service in hub caddy; do
+  container=$hub
+  [[ "$service" == caddy ]] && container=$caddy
+  if [[ $(docker inspect -f '{{.State.Running}}' "$container") == true ]]; then
+    restart+=("$container")
+  fi
+done
+resume() {
+  result=$?
+  trap - EXIT
+  if [[ ${#restart[@]} -gt 0 ]]; then
+    if ! docker start "${restart[@]}"; then
+      echo "Could not restart the original services. Run docker compose start and inspect health." >&2
+      result=1
+    fi
+  fi
+  [[ $result -eq 0 ]] || echo "Backup failed or services need attention; inspect $destination." >&2
+  exit "$result"
+}
+trap resume EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+compose "${compose_options[@]}" stop hub caddy
+for container in "$hub" "$caddy"; do
+  [[ $(docker inspect -f '{{.State.Running}}' "$container") == false ]]
+done
+
+# Copy complete stopped directories, not just the main SQLite file. This
+# preserves any WAL and the file-backed JWT, setup and update-signing identity.
+# Docker transports the archives even when the daemon is on another host.
+docker cp "$hub:/data/." - > "$destination/hub-data.tar"
+docker cp "$caddy:/data/." - > "$destination/caddy-data.tar"
+docker cp "$caddy:/config/." - > "$destination/caddy-config.tar"
+for archive in hub-data caddy-data caddy-config; do
+  tar -tf "$destination/$archive.tar" > /dev/null
+done
+(cd "$destination" && shasum -a 256 hub-data.tar caddy-data.tar caddy-config.tar compose-config.yaml containers.json > SHA256SUMS)
+echo "Backup complete: $destination (contains private keys; keep it private and encrypted off-host)."
+echo "Also retain your deployment .env, override files, and any externally mounted keys; see docs/backup-restore.md."

--- a/scripts/smoke/compose-backup.py
+++ b/scripts/smoke/compose-backup.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Restore the disposable enrollment stack, with no host ports or network.
+
+Run after compose-enroll has initialized its stack, before cleanup. Only the
+fresh project created here is removed; the source stack and backup are kept.
+"""
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import tarfile
+import tempfile
+import time
+import uuid
+
+
+def run(*args, **kwargs):
+    return subprocess.run(args, check=True, **kwargs)
+
+
+def output(*args):
+    return subprocess.check_output(args)
+
+
+def contents(data):
+    with tarfile.open(fileobj=io.BytesIO(data)) as archive:
+        return {m.name.removeprefix('./'): (m.uid, m.gid, m.mode, hashlib.sha256(archive.extractfile(m).read()).hexdigest())
+                for m in archive if m.isfile()}
+
+
+def main():
+    if os.environ.get('SMOKE_CONFIRM_DISPOSABLE') != '1':
+        raise SystemExit('Requires SMOKE_CONFIRM_DISPOSABLE=1; source must be the disposable enrollment stack.')
+    root = Path(__file__).resolve().parents[2]
+    source = ['docker', 'compose', '--project-directory', str(root / 'docker')]
+    ids = {service: output(*source, 'ps', '-a', '-q', service).decode().strip() for service in ('hub', 'caddy')}
+    assert all(ids.values()), 'source stack missing'
+    specs = {service: json.loads(output('docker', 'inspect', container))[0] for service, container in ids.items()}
+    # Retain backups for failure diagnosis; they contain test-only secrets.
+    scratch = Path(tempfile.mkdtemp(prefix='bloxos-backup-smoke-'))
+    scratch.chmod(0o700)
+    backup = scratch / 'backup'
+    run('bash', str(root / 'scripts/backup-compose.sh'), str(backup), '--project-directory', str(root / 'docker'))
+    name = 'bloxos-restore-' + uuid.uuid4().hex[:12]
+    config = {
+        'name': name,
+        'services': {
+            'hub': {'image': specs['hub']['Image'], 'network_mode': 'none',
+                    'environment': specs['hub']['Config']['Env'],
+                    'volumes': ['hub-data:/data', 'caddy-data:/caddy:ro']},
+            'caddy': {'image': specs['caddy']['Image'], 'network_mode': 'none',
+                      'volumes': ['caddy-data:/data', 'caddy-config:/config']},
+        },
+        'volumes': {'hub-data': {}, 'caddy-data': {}, 'caddy-config': {}},
+    }
+    path = scratch / 'restore.json'
+    path.touch(mode=0o600)
+    path.write_text(json.dumps(config))
+    restore = ['docker', 'compose', '-p', name, '-f', str(path)]
+    try:
+        run(*restore, 'create', '--no-build')
+        targets = {service: output(*restore, 'ps', '-a', '-q', service).decode().strip() for service in ids}
+        for service, directory, archive in [('hub', '/data', 'hub-data'), ('caddy', '/data', 'caddy-data'), ('caddy', '/config', 'caddy-config')]:
+            target = targets[service] + ':' + directory
+            data = (backup / (archive + '.tar')).read_bytes()
+            assert not contents(output('docker', 'cp', target + '/.', '-')), 'target unexpectedly populated'
+            run('docker', 'cp', '-a', '-', target, input=data)
+            assert contents(data) == contents(output('docker', 'cp', target + '/.', '-')), 'restored bytes/ownership differ'
+        # Start only the restored hub. network_mode:none prevents a cloned
+        # poller/identity from reaching any real device, even on a reused VM.
+        run('docker', 'start', targets['hub'])
+        for attempt in range(30):
+            probe = subprocess.run(['docker', 'exec', targets['hub'], 'wget', '-qO-', 'http://127.0.0.1:4000/health'], capture_output=True)
+            if probe.returncode == 0:
+                break
+            time.sleep(1)
+        else:
+            raise RuntimeError('restored hub did not become healthy')
+        status = json.loads(output('docker', 'exec', targets['hub'], 'wget', '-qO-', 'http://127.0.0.1:4000/api/setup/status'))
+        assert status['needs_setup'] is False, 'restored hub lost its existing admin'
+        print('BACKUP RESTORE PASS: all archive bytes, ownership, identity and initialized hub survive restore; backup:', backup)
+    finally:
+        # Exact unique project above, never the source project. No external
+        # volumes exist in this generated config. Backup is kept for diagnosis.
+        run(*restore, 'down', '-v')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/smoke/compose-backup.py
+++ b/scripts/smoke/compose-backup.py
@@ -43,6 +43,17 @@ def main():
     scratch.chmod(0o700)
     backup = scratch / 'backup'
     run('bash', str(root / 'scripts/backup-compose.sh'), str(backup), '--project-directory', str(root / 'docker'))
+    manifest = (backup / 'SHA256SUMS').read_text().splitlines()
+    assert len(manifest) == 5, 'incomplete checksum manifest'
+    run('shasum', '-a', '256', '-c', 'SHA256SUMS', cwd=backup)
+    # A competing client on this same daemon must not stop/restart anything.
+    lock = output('docker', 'create', '--name', 'bloxos-backup-lock-' + ids['hub'], '--network', 'none', '--entrypoint', '/bin/true', specs['hub']['Image']).decode().strip()
+    try:
+        competing = subprocess.run(['bash', str(root / 'scripts/backup-compose.sh'), str(scratch / 'competing'), '--project-directory', str(root / 'docker')], capture_output=True)
+        assert competing.returncode != 0, 'concurrent backup was accepted'
+        assert json.loads(output('docker', 'inspect', ids['hub']))[0]['State']['Running'], 'competing backup stopped source'
+    finally:
+        run('docker', 'rm', '-v', lock)
     name = 'bloxos-restore-' + uuid.uuid4().hex[:12]
     config = {
         'name': name,

--- a/scripts/smoke/compose-enroll.sh
+++ b/scripts/smoke/compose-enroll.sh
@@ -146,4 +146,7 @@ done
 [[ "$NEW_PID" != 0 && "$NEW_PID" != "$OLD_PID" ]] || fail "agent did not restart"
 [[ "$(systemctl is-active bloxos-agent)" == active ]] || fail "restarted agent not active"
 
-echo "SMOKE PASS: agent enrolled through the Compose stack at $HUB; self-restart returned 202 and a new active agent process"
+echo "== consistent backup and isolated restore"
+python3 "$COMPOSE_DIR/../scripts/smoke/compose-backup.py"
+
+echo "SMOKE PASS: agent enrolled through the Compose stack at $HUB; self-restart returned 202 and a new active agent process; backup restored with original identity"

--- a/scripts/test_backup_compose.py
+++ b/scripts/test_backup_compose.py
@@ -1,0 +1,103 @@
+"""Fast failure-path tests; real Docker restore is a separate acceptance gate."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+FAKE_DOCKER = r'''#!/usr/bin/env python3
+import io, json, os, sys, tarfile
+from pathlib import Path
+p = Path(os.environ['FAKE_STATE'])
+s = json.loads(p.read_text())
+a = sys.argv[1:]
+s['calls'].append(a)
+if a[:1] == ['compose']:
+    a = a[1:]
+    if a[:1] == ['ps']:
+        print(a[-1] + '-id')
+    elif a == ['config']:
+        print('services: {}')
+    elif a[:1] == ['stop']:
+        s['running'] = []
+elif a[:2] == ['inspect', '-f']:
+    print('true' if a[-1] in s['running'] else 'false')
+elif a[:1] == ['inspect']:
+    print('[]')
+elif a[:1] == ['start']:
+    s['running'].extend(a[1:])
+elif a[:1] == ['cp']:
+    if s.get('fail_copy'):
+        p.write_text(json.dumps(s))
+        sys.exit(42)
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode='w') as archive:
+        entry = tarfile.TarInfo('proof')
+        entry.size = 4
+        archive.addfile(entry, io.BytesIO(b'kept'))
+    sys.stdout.buffer.write(output.getvalue())
+p.write_text(json.dumps(s))
+'''
+
+
+class BackupTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.state = self.root / 'state.json'
+        docker = self.root / 'docker'
+        docker.write_text(FAKE_DOCKER)
+        docker.chmod(0o700)
+        self.destination = self.root / 'backup'
+
+    def run_backup(self, running=('hub-id', 'caddy-id'), fail_copy=False):
+        self.state.write_text(json.dumps({'running': list(running), 'calls': [], 'fail_copy': fail_copy}))
+        env = dict(os.environ, PATH=str(self.root) + os.pathsep + os.environ['PATH'], FAKE_STATE=str(self.state))
+        result = subprocess.run(['bash', str(Path(__file__).with_name('backup-compose.sh')), str(self.destination)],
+                                env=env, capture_output=True, text=True)
+        return result, json.loads(self.state.read_text())
+
+    def test_complete_backup_is_private_and_restarts_original_containers(self):
+        result, state = self.run_backup()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue((self.destination / 'SHA256SUMS').is_file())
+        self.assertEqual(self.destination.stat().st_mode & 0o777, 0o700)
+        self.assertEqual((self.destination / 'hub-data.tar').stat().st_mode & 0o777, 0o600)
+        self.assertEqual(state['running'], ['hub-id', 'caddy-id'])
+        stop = state['calls'].index(['compose', 'stop', 'hub', 'caddy'])
+        copy = next(i for i, call in enumerate(state['calls']) if call[0] == 'cp')
+        self.assertLess(stop, copy)
+        self.assertIn(['start', 'hub-id', 'caddy-id'], state['calls'])
+
+    def test_copy_failure_restores_service_state_and_has_no_completion_manifest(self):
+        result, state = self.run_backup(fail_copy=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.destination / 'SHA256SUMS').exists())
+        self.assertEqual(state['running'], ['hub-id', 'caddy-id'])
+
+    def test_stopped_services_stay_stopped(self):
+        result, state = self.run_backup(running=())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(state['running'], [])
+        self.assertFalse(any(call[0] == 'start' for call in state['calls']))
+
+    def test_no_dependency_start_when_only_caddy_was_running(self):
+        result, state = self.run_backup(running=('caddy-id',))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(state['running'], ['caddy-id'])
+
+    def test_existing_destination_is_untouched(self):
+        self.destination.mkdir()
+        marker = self.destination / 'keep'
+        marker.write_text('original')
+        result, state = self.run_backup()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(marker.read_text(), 'original')
+        self.assertEqual(state['calls'], [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test_backup_compose.py
+++ b/scripts/test_backup_compose.py
@@ -23,9 +23,19 @@ if a[:1] == ['compose']:
     elif a[:1] == ['stop']:
         s['running'] = []
 elif a[:2] == ['inspect', '-f']:
-    print('true' if a[-1] in s['running'] else 'false')
+    if a[2] == '{{.Image}}': print('fake-image')
+    else: print('true' if a[-1] in s['running'] else 'false')
 elif a[:1] == ['inspect']:
     print('[]')
+elif a[:1] == ['create']:
+    if s.get('locked'):
+        p.write_text(json.dumps(s))
+        sys.exit(23)
+    s['locked'] = True
+    print('owned-lock-id')
+elif a[:1] == ['rm']:
+    assert a == ['rm', '-v', 'owned-lock-id']
+    s['locked'] = False
 elif a[:1] == ['start']:
     s['running'].extend(a[1:])
 elif a[:1] == ['cp']:
@@ -53,8 +63,8 @@ class BackupTests(unittest.TestCase):
         docker.chmod(0o700)
         self.destination = self.root / 'backup'
 
-    def run_backup(self, running=('hub-id', 'caddy-id'), fail_copy=False):
-        self.state.write_text(json.dumps({'running': list(running), 'calls': [], 'fail_copy': fail_copy}))
+    def run_backup(self, running=('hub-id', 'caddy-id'), fail_copy=False, locked=False):
+        self.state.write_text(json.dumps({'running': list(running), 'calls': [], 'fail_copy': fail_copy, 'locked': locked}))
         env = dict(os.environ, PATH=str(self.root) + os.pathsep + os.environ['PATH'], FAKE_STATE=str(self.state))
         result = subprocess.run(['bash', str(Path(__file__).with_name('backup-compose.sh')), str(self.destination)],
                                 env=env, capture_output=True, text=True)
@@ -67,6 +77,7 @@ class BackupTests(unittest.TestCase):
         self.assertEqual(self.destination.stat().st_mode & 0o777, 0o700)
         self.assertEqual((self.destination / 'hub-data.tar').stat().st_mode & 0o777, 0o600)
         self.assertEqual(state['running'], ['hub-id', 'caddy-id'])
+        self.assertFalse(state['locked'])
         stop = state['calls'].index(['compose', 'stop', 'hub', 'caddy'])
         copy = next(i for i, call in enumerate(state['calls']) if call[0] == 'cp')
         self.assertLess(stop, copy)
@@ -96,6 +107,30 @@ class BackupTests(unittest.TestCase):
         result, state = self.run_backup()
         self.assertNotEqual(result.returncode, 0)
         self.assertEqual(marker.read_text(), 'original')
+        self.assertEqual(state['calls'], [])
+
+    def test_overlapping_backup_is_refused_before_any_stop(self):
+        result, state = self.run_backup(locked=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(state['locked'])
+        self.assertFalse(any(call[0] in ('rm', 'cp', 'start') or 'stop' in call for call in state['calls']))
+
+    def test_partial_manifest_is_never_published_even_if_checksum_tool_returns_success(self):
+        checksum = self.root / 'shasum'
+        checksum.write_text('#!/bin/sh\nprintf "%064d  hub-data.tar\\n" 0\n')
+        checksum.chmod(0o700)
+        result, state = self.run_backup()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.destination / 'SHA256SUMS').exists())
+        self.assertTrue((self.destination / 'SHA256SUMS.pending').exists())
+        self.assertFalse(state['locked'])
+        self.assertEqual(state['running'], ['hub-id', 'caddy-id'])
+
+    def test_shared_writable_parent_is_refused_before_docker(self):
+        self.root.chmod(0o777)
+        result, state = self.run_backup()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.destination.exists())
         self.assertEqual(state['calls'], [])
 
 


### PR DESCRIPTION
## Summary

- Replace the unsafe live SQLite-only backup advice with a stopped-stack helper and clean, ownership-preserving restore procedure covering database/WAL, JWT/setup/signing identity and Caddy CA/config.
- Preserve original service running state on success/failure, refuse destination overwrite, keep private partial backups for diagnosis.
- Add five failure-path tests and a real network-isolated Compose restore smoke gate that checks every regular file's bytes/owner/mode and starts the restored initialized hub.
- Trigger Compose smoke on hub/agent/proto/dashboard changes. Require reusable full CI plus smoke on the exact release-tag commit before publishing images.
- Correct functional deployment/onboarding, 30-second telemetry, Windows terminal limitation and protocol-2 rollback-floor documentation. No visual redesign.

## Validation

- Five backup unit tests pass; Bash syntax and diff checks pass.
- actionlint v1.7.12 validates both changed workflows.
- Real disposable Linux Docker backup and fresh isolated restore passed: SQLite integrity; exact user, machine identity and durable credential rows; identical file-backed identity and CA; restored files UID/GID65532 mode600; healthy hub with needs_setup=false.
- New compose-backup.py smoke executed successfully against that disposable initialized stack; exact archive contents/ownership preserved, no network access for restored hub, only its uniquely created temporary volumes cleaned up. Backup retained.
- No production fleet deployment, agent update, live volume deletion or published release.

## Review / scope

Unit F of the approved reliability plan (finding3 and functional release/integration documentation). Independent engineer review and exact-head CI must complete before merge. Local Qwen/DeepSeek were consulted; their archive-path/ownership claims were contradicted by the real restore, so no unsafe root extraction or ownership weakening was adopted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Backup stops hub/Caddy briefly and touches identity-critical state; release publishing now depends on full CI at the tag, which changes the release path but reduces shipping untested tags.
> 
> **Overview**
> Replaces “copy `bloxos.db`” guidance with a **stopped-stack Compose backup** (`scripts/backup-compose.sh`) that archives hub/Caddy data and config, uses a Docker lock to block overlapping runs, atomically publishes `SHA256SUMS`, and restores prior container running state on success or failure. **`docs/backup-restore.md`** documents backup, checksum verification, and clean isolated restore.
> 
> **CI/release:** `ci.yml` is **`workflow_call`**-able and the hub job runs **`scripts/test_backup_compose.py`** (fake Docker failure-path tests). Compose smoke (`compose-enroll.sh`) now runs **`compose-backup.py`** for a network-isolated restore check. **`docker.yml`** widens PR path filters, adds **`verify-release`** (full CI on `v*` tags), and blocks image **publish** until smoke and that suite pass on the tag commit.
> 
> **Docs:** README and `docker/README.md` promote Compose quick start, WAL-safe backup links, telemetry cadence, Windows terminal limits, and protocol-2 update-floor behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54af271f056fde3b3f8ad55a39842deb02bfa440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->