### PR TITLE
hub: lifecycle safety — terminal single-close, committed-identity ingestion, atomic delete, stream revocation

### DIFF
--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -359,7 +359,16 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 		return
 	}
 
-	expectReconnect(machineID)
+	s.armReconnectIfRegistered(machineID, agent)
+}
+
+// armReconnectIfRegistered arms the reconnect expectation for an announced
+// update only while agent still owns the registry entry, under the ingestion
+// barrier. The announce runs on its own goroutine, so without this a delete
+// that already cleared the expectation could be followed by a late arm and a
+// phantom rollout failure for a machine that no longer exists.
+func (s *Server) armReconnectIfRegistered(machineID string, agent *ConnectedAgent) bool {
+	return s.ingestFrame(machineID, agent, true, func() { expectReconnect(machineID) })
 }
 
 // announceDecision is the single place that decides whether an update may be
@@ -610,6 +619,15 @@ func expectReconnect(machineID string) {
 	pendingReconnectsMu.Lock()
 	defer pendingReconnectsMu.Unlock()
 	pendingReconnects[machineID] = time.Now().Add(reconnectExpectation)
+}
+
+// forgetAgentVersion drops the last-reported version for a machine that no
+// longer exists, so /api/versions stops listing it and no later reconnect
+// expectation can record a phantom rollout failure for it.
+func forgetAgentVersion(machineID string) {
+	agentRunningVersionsMu.Lock()
+	delete(agentRunningVersions, machineID)
+	agentRunningVersionsMu.Unlock()
 }
 
 func clearReconnectExpectation(machineID string) {

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -870,6 +870,10 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 	// Hold it and apply it at the commit point so first enrollment keeps
 	// its inventory without ever writing under an uncommitted identity.
 	var pendingHardwareInfo []byte
+	// Same for the agent's version report: it is sent once per connect and
+	// would otherwise create a /api/versions entry for an enrollment that may
+	// never commit.
+	var pendingVersionReport *agentVersionReport
 	defer func() {
 		s.unregisterAgentConnection(machineID, agent)
 		// A fresh enrollment that never committed was never registered, so
@@ -1124,25 +1128,26 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 			// regardless of what the payload claimed.
 			m.MachineID = machineID
 
-			// Calculate latency from sent_at.
-			if m.SentAt != "" {
-				sentTime, err := time.Parse(time.RFC3339Nano, m.SentAt)
-				if err == nil {
-					latencyMs := time.Since(sentTime).Milliseconds()
-					if latencyMs < 0 {
-						latencyMs = 0
-					}
-					machineLatencyMu.Lock()
-					machineLatency[m.MachineID] = latencyMs
-					machineLatencyMu.Unlock()
-				}
-			}
-
-			// Persistence and the dashboard broadcast stay inside one barrier
-			// section, so a delete's machine_removed event (emitted under the
-			// barrier's write side) is always the last event dashboards see
-			// for this machine; a late frame can never re-add the card.
+			// Persistence, the latency cache and the dashboard broadcast all
+			// stay inside one barrier section, so a delete's machine_removed
+			// event (emitted under the barrier's write side) is always the last
+			// event dashboards see for this machine and no per-machine state
+			// is repopulated afterwards; a late frame can never re-add the card.
 			if !s.ingestFrame(machineID, agent, registered, func() {
+				// Calculate latency from sent_at.
+				if m.SentAt != "" {
+					sentTime, err := time.Parse(time.RFC3339Nano, m.SentAt)
+					if err == nil {
+						latencyMs := time.Since(sentTime).Milliseconds()
+						if latencyMs < 0 {
+							latencyMs = 0
+						}
+						machineLatencyMu.Lock()
+						machineLatency[m.MachineID] = latencyMs
+						machineLatencyMu.Unlock()
+					}
+				}
+
 				s.upsertMachine(m)
 				s.storeMetrics(m)
 
@@ -1278,19 +1283,31 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 				continue
 			}
 			if versionMsg.SHA256 != "" && machineID != "" {
+				report := agentVersionReport{
+					RunningSHA:      versionMsg.SHA256,
+					OS:              versionMsg.OS,
+					Arch:            versionMsg.Arch,
+					UpdateProtocol:  versionMsg.UpdateProtocol,
+					Release:         versionMsg.Release,
+					ReleaseFloor:    versionMsg.ReleaseFloor,
+					ReleaseFloorSHA: versionMsg.ReleaseFloorSHA,
+					ReleaseFloorOK:  versionMsg.ReleaseFloorOK,
+					TransportOK:     versionMsg.UpdateTransportOK,
+					KeyPinned:       versionMsg.UpdateKeyPinned,
+				}
+				if !registered {
+					// A fresh enrollment reports its version before it commits;
+					// hold it so an aborted enrollment leaves no phantom entry
+					// and a committed one keeps its initial report.
+					if freshPendingTokenHash != "" {
+						pendingVersionReport = &report
+					} else {
+						log.Printf("rejecting agent_running_version before enrollment is committed for %s", machineID)
+					}
+					continue
+				}
 				if !s.ingestFrame(machineID, agent, registered, func() {
-					s.recordAgentRunningVersion(machineID, agentVersionReport{
-						RunningSHA:      versionMsg.SHA256,
-						OS:              versionMsg.OS,
-						Arch:            versionMsg.Arch,
-						UpdateProtocol:  versionMsg.UpdateProtocol,
-						Release:         versionMsg.Release,
-						ReleaseFloor:    versionMsg.ReleaseFloor,
-						ReleaseFloorSHA: versionMsg.ReleaseFloorSHA,
-						ReleaseFloorOK:  versionMsg.ReleaseFloorOK,
-						TransportOK:     versionMsg.UpdateTransportOK,
-						KeyPinned:       versionMsg.UpdateKeyPinned,
-					})
+					s.recordAgentRunningVersion(machineID, report)
 				}) {
 					return nil
 				}
@@ -1375,6 +1392,13 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 					held := pendingHardwareInfo
 					pendingHardwareInfo = nil
 					if !s.ingestFrame(machineID, agent, registered, func() { s.storeHardwareInfo(machineID, held) }) {
+						return nil
+					}
+				}
+				if pendingVersionReport != nil {
+					held := *pendingVersionReport
+					pendingVersionReport = nil
+					if !s.ingestFrame(machineID, agent, registered, func() { s.recordAgentRunningVersion(machineID, held) }) {
 						return nil
 					}
 				}

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -33,6 +33,33 @@ type ConnectedAgent struct {
 	powerIssue atomic.Uint32 // current connection's bounded history diagnostic
 }
 
+// agentIngestTestHook, when set by a test, runs inside the ingestion barrier
+// before the registration check, so a test can hold a frame mid-write and
+// prove deletion cannot interleave with it.
+var agentIngestTestHook func(machineID string)
+
+// ingestFrame runs write under the ingestion barrier's read side. Machine
+// deletion takes the write side around registry removal and row deletion,
+// so a frame is either fully persisted before the delete or refused after
+// it: once inside, a registered connection that no longer owns its registry
+// entry (displaced by a newer socket, or its machine deleted) is refused,
+// whatever it had already read. Writes before registration (a fresh
+// enrollment's first metrics frame) are allowed here; deletion excludes
+// those through the auth writer lock instead. write must not take
+// agentAuthMu, ingestMu, or wait on another connection.
+func (s *Server) ingestFrame(machineID string, agent *ConnectedAgent, registered bool, write func()) bool {
+	s.ingestMu.RLock()
+	defer s.ingestMu.RUnlock()
+	if agentIngestTestHook != nil {
+		agentIngestTestHook(machineID)
+	}
+	if registered && !s.isRegisteredConnection(machineID, agent) {
+		return false
+	}
+	write()
+	return true
+}
+
 // wsMessageWriter is exactly gorilla/websocket's (*Conn).WriteMessage
 // signature, factored out so writeLockedTo is testable against a fake
 // writer instead of a live network connection.
@@ -679,6 +706,12 @@ func bearerToken(header string) string {
 // descriptor) open indefinitely. It is a var so tests can shorten it.
 var agentAuthWindow = 30 * time.Second
 
+// agentHandshakeTestHook, when set by a test, runs after a durable
+// credential has been validated and immediately before the connection is
+// registered, while the auth read lock is still held. It lets a test pause
+// a handshake at exactly that point to prove deletion cannot interleave.
+var agentHandshakeTestHook func(machineID string)
+
 // agentIdleTimeout bounds the gap between frames once an agent is established.
 // Agents push metrics every 30s and ping on the same cadence, so a silently
 // dead TCP connection is dropped within this window instead of lingering until
@@ -808,6 +841,11 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 
 	var machineID string
 	agent := &ConnectedAgent{Conn: ws}
+	// registered flips to true once this connection owns the registry entry
+	// for machineID. From then on, losing that entry (a displacing reconnect
+	// or machine deletion) means this socket must stop ingesting: its frames
+	// would otherwise write rows for a machine that is being removed.
+	registered := false
 	// Single owner of connection cleanup. Every return from this point on —
 	// whether the read loop exits normally, or one of the many
 	// post-registration failure paths below returns early (a failed confirm
@@ -825,6 +863,13 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 	// Fresh enrollment issued on this connection but not yet committed: the
 	// token stays unused and no credential exists until enrollment_committed.
 	var freshPendingTokenHash, freshPendingSecretHash string
+	// Hardware reported by a fresh enrollment before it commits. Inventory
+	// writes require a committed, registered identity, but the agent sends
+	// its hardware snapshot once per connect right after its first metrics
+	// frame, which for a first enrollment is before enrollment_committed.
+	// Hold it and apply it at the commit point so first enrollment keeps
+	// its inventory without ever writing under an uncommitted identity.
+	var pendingHardwareInfo []byte
 	defer func() {
 		s.unregisterAgentConnection(machineID, agent)
 		// A fresh enrollment that never committed was never registered, so
@@ -847,7 +892,11 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 	var stagedPendingSecretHash string
 	if secretMachineID != "" && !dualCredentialTargetedReenroll {
 		machineID = secretMachineID
+		if agentHandshakeTestHook != nil {
+			agentHandshakeTestHook(machineID)
+		}
 		s.registerAgentConnection(machineID, agent)
+		registered = true
 		completeAuth()
 		ws.SetReadDeadline(time.Now().Add(agentIdleTimeout))
 		log.Printf("agent authenticated via secret: machine_id=%s", machineID)
@@ -915,6 +964,15 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 			log.Printf("rejecting cross-machine frame: authed=%s claimed=%s type=%s",
 				machineID, envelope.MachineID, envelope.Type)
 			continue
+		}
+
+		// A registered connection that no longer owns its registry entry has
+		// been displaced by a newer socket or its machine has been deleted.
+		// Either way nothing it sends may be persisted any more; the socket
+		// is being closed by whoever took the entry, so leave now.
+		if registered && !s.isRegisteredConnection(machineID, agent) {
+			log.Printf("agent %s: connection no longer registered; stopping ingestion", machineID)
+			return nil
 		}
 
 		switch envelope.Type {
@@ -1054,6 +1112,7 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 					log.Printf("agent awaiting enrollment commit: %s (%s)", m.Hostname, machineID)
 				} else {
 					s.registerAgentConnection(machineID, agent)
+					registered = true
 					completeAuth()
 					ws.SetReadDeadline(time.Now().Add(agentIdleTimeout))
 					log.Printf("agent registered: %s (%s)", m.Hostname, machineID)
@@ -1079,29 +1138,38 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 				}
 			}
 
-			s.upsertMachine(m)
-			s.storeMetrics(m)
+			// Persistence and the dashboard broadcast stay inside one barrier
+			// section, so a delete's machine_removed event (emitted under the
+			// barrier's write side) is always the last event dashboards see
+			// for this machine; a late frame can never re-add the card.
+			if !s.ingestFrame(machineID, agent, registered, func() {
+				s.upsertMachine(m)
+				s.storeMetrics(m)
 
-			// Enrich the metrics broadcast with latency.
-			machineLatencyMu.RLock()
-			lat := machineLatency[m.MachineID]
-			machineLatencyMu.RUnlock()
+				// Enrich the metrics broadcast with latency.
+				machineLatencyMu.RLock()
+				lat := machineLatency[m.MachineID]
+				machineLatencyMu.RUnlock()
 
-			// Inject latency_ms by appending before the closing '}' to avoid
-			// a full JSON unmarshal+marshal round-trip on the hot path.
-			var enrichedData []byte
-			if i := bytes.LastIndexByte(msg, '}'); i >= 0 {
-				suffix := strconv.AppendInt([]byte(",\"latency_ms\":"), lat, 10)
-				suffix = append(suffix, '}')
-				enrichedData = append(append([]byte(nil), msg[:i]...), suffix...)
-			} else {
-				// Malformed JSON — fall back to unmarshal/marshal.
-				enriched := make(map[string]interface{})
-				json.Unmarshal(msg, &enriched)
-				enriched["latency_ms"] = lat
-				enrichedData, _ = json.Marshal(enriched)
+				// Inject latency_ms by appending before the closing '}' to avoid
+				// a full JSON unmarshal+marshal round-trip on the hot path.
+				var enrichedData []byte
+				if i := bytes.LastIndexByte(msg, '}'); i >= 0 {
+					suffix := strconv.AppendInt([]byte(",\"latency_ms\":"), lat, 10)
+					suffix = append(suffix, '}')
+					enrichedData = append(append([]byte(nil), msg[:i]...), suffix...)
+				} else {
+					// Malformed JSON — fall back to unmarshal/marshal.
+					enriched := make(map[string]interface{})
+					json.Unmarshal(msg, &enriched)
+					enriched["latency_ms"] = lat
+					enrichedData, _ = json.Marshal(enriched)
+				}
+				broadcastSSE(enrichedData)
+			}) {
+				log.Printf("agent %s: metrics refused, connection no longer registered", machineID)
+				return nil
 			}
-			broadcastSSE(enrichedData)
 
 		case "services":
 			var sm ServicesMessage
@@ -1109,13 +1177,16 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 				log.Printf("invalid services JSON: %v", err)
 				continue
 			}
-			mid := machineID
-			if mid == "" {
-				mid = sm.MachineID
+			if !registered {
+				log.Printf("rejecting services frame before enrollment is committed (claimed %s)", sm.MachineID)
+				continue
 			}
-			s.upsertServices(mid, sm.Services)
-			framed := []byte(fmt.Sprintf("event: services\ndata: %s\n\n", msg))
-			broadcastSSE(framed)
+			if !s.ingestFrame(machineID, agent, registered, func() {
+				s.upsertServices(machineID, sm.Services)
+				broadcastSSE([]byte(fmt.Sprintf("event: services\ndata: %s\n\n", msg)))
+			}) {
+				return nil
+			}
 
 		case "containers":
 			var cm ContainersMessage
@@ -1123,13 +1194,16 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 				log.Printf("invalid containers JSON: %v", err)
 				continue
 			}
-			mid := machineID
-			if mid == "" {
-				mid = cm.MachineID
+			if !registered {
+				log.Printf("rejecting containers frame before enrollment is committed (claimed %s)", cm.MachineID)
+				continue
 			}
-			s.upsertContainers(mid, cm.Containers)
-			framed := []byte(fmt.Sprintf("event: containers\ndata: %s\n\n", msg))
-			broadcastSSE(framed)
+			if !s.ingestFrame(machineID, agent, registered, func() {
+				s.upsertContainers(machineID, cm.Containers)
+				broadcastSSE([]byte(fmt.Sprintf("event: containers\ndata: %s\n\n", msg)))
+			}) {
+				return nil
+			}
 
 		case "hardware_info":
 			// Static hardware snapshot — store the raw JSON as-is so adding
@@ -1148,16 +1222,23 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 				log.Printf("invalid hardware_info JSON: %v", err)
 				continue
 			}
-			mid := machineID
-			if mid == "" {
-				mid = hw.MachineID
+			// Identity comes from the socket, never from the payload, and
+			// inventory is written only for a committed, registered agent.
+			// Honouring the payload's machine_id here would let any
+			// install-token holder rewrite another machine's inventory
+			// without ever enrolling. A fresh enrollment that has identity
+			// but is not yet committed has its snapshot held until commit.
+			if !registered {
+				if machineID != "" && freshPendingTokenHash != "" {
+					pendingHardwareInfo = append([]byte(nil), msg...)
+					log.Printf("holding hardware_info for %s until enrollment commits", machineID)
+				} else {
+					log.Printf("rejecting hardware_info frame before enrollment is committed (claimed %s)", hw.MachineID)
+				}
+				continue
 			}
-			if _, err := s.db.Exec(`
-				INSERT INTO machines (id, hostname, status, hardware_info)
-				VALUES (?, '', 'offline', ?)
-				ON CONFLICT(id) DO UPDATE SET hardware_info = excluded.hardware_info
-			`, mid, string(msg)); err != nil {
-				log.Printf("store hardware_info: %v", err)
+			if !s.ingestFrame(machineID, agent, registered, func() { s.storeHardwareInfo(machineID, msg) }) {
+				return nil
 			}
 
 		case "agent_running_version":
@@ -1197,32 +1278,42 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 				continue
 			}
 			if versionMsg.SHA256 != "" && machineID != "" {
-				s.recordAgentRunningVersion(machineID, agentVersionReport{
-					RunningSHA:      versionMsg.SHA256,
-					OS:              versionMsg.OS,
-					Arch:            versionMsg.Arch,
-					UpdateProtocol:  versionMsg.UpdateProtocol,
-					Release:         versionMsg.Release,
-					ReleaseFloor:    versionMsg.ReleaseFloor,
-					ReleaseFloorSHA: versionMsg.ReleaseFloorSHA,
-					ReleaseFloorOK:  versionMsg.ReleaseFloorOK,
-					TransportOK:     versionMsg.UpdateTransportOK,
-					KeyPinned:       versionMsg.UpdateKeyPinned,
-				})
+				if !s.ingestFrame(machineID, agent, registered, func() {
+					s.recordAgentRunningVersion(machineID, agentVersionReport{
+						RunningSHA:      versionMsg.SHA256,
+						OS:              versionMsg.OS,
+						Arch:            versionMsg.Arch,
+						UpdateProtocol:  versionMsg.UpdateProtocol,
+						Release:         versionMsg.Release,
+						ReleaseFloor:    versionMsg.ReleaseFloor,
+						ReleaseFloorSHA: versionMsg.ReleaseFloorSHA,
+						ReleaseFloorOK:  versionMsg.ReleaseFloorOK,
+						TransportOK:     versionMsg.UpdateTransportOK,
+						KeyPinned:       versionMsg.UpdateKeyPinned,
+					})
+				}) {
+					return nil
+				}
 			}
 
 		case aisessions.MessageType:
 			// Read-only AI tool session metadata. Bound to the authenticated
 			// machine and to the registered socket; see ingestAISessions.
-			s.ingestAISessions(machineID, agent, msg)
+			if !s.ingestFrame(machineID, agent, registered, func() { s.ingestAISessions(machineID, agent, msg) }) {
+				return nil
+			}
 
 		case powerhistory.BatchType:
 			// Durable 30s power buckets. Bound to the authenticated machine
 			// and registered socket; ACK only after the contiguous prefix
 			// commits. Never mutates live gpu_metrics — old agents that never
 			// send this frame are unaffected.
-			if err := s.ingestPowerHistory(machineID, agent, msg); err != nil {
-				log.Printf("power history from %s: %v", machineID, err)
+			var powerErr error
+			if !s.ingestFrame(machineID, agent, registered, func() { powerErr = s.ingestPowerHistory(machineID, agent, msg) }) {
+				return nil
+			}
+			if powerErr != nil {
+				log.Printf("power history from %s: %v", machineID, powerErr)
 			}
 
 		case "command_response":
@@ -1277,8 +1368,16 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 				// deadline. Registration spawns the announce writer, so the
 				// confirmation below must go through the per-agent lock.
 				s.registerAgentConnection(machineID, agent)
+				registered = true
 				completeAuth()
 				ws.SetReadDeadline(time.Now().Add(agentIdleTimeout))
+				if pendingHardwareInfo != nil {
+					held := pendingHardwareInfo
+					pendingHardwareInfo = nil
+					if !s.ingestFrame(machineID, agent, registered, func() { s.storeHardwareInfo(machineID, held) }) {
+						return nil
+					}
+				}
 				confirmMsg, _ := json.Marshal(map[string]string{"type": "enrollment_confirmed", "secret_sha256": confirmedHash})
 				if err := agent.writeLocked(websocket.TextMessage, confirmMsg); err != nil {
 					log.Printf("committed fresh enrollment for %s but failed to send enrollment_confirmed: %v — closing connection", machineID, err)
@@ -1816,4 +1915,18 @@ func (s *Server) generateFirstRunToken() {
 		return
 	}
 	log.Printf("First-run token written to %s (expires in 1 hour)", tokenFile)
+}
+
+// storeHardwareInfo persists a raw hardware_info frame for a committed
+// machine. UPSERT (defense-in-depth): if the row does not exist yet, a plain
+// UPDATE would silently affect 0 rows and the snapshot would be lost; the
+// placeholder hostname is overwritten by the next metrics upsert.
+func (s *Server) storeHardwareInfo(machineID string, raw []byte) {
+	if _, err := s.db.Exec(`
+		INSERT INTO machines (id, hostname, status, hardware_info)
+		VALUES (?, '', 'offline', ?)
+		ON CONFLICT(id) DO UPDATE SET hardware_info = excluded.hardware_info
+	`, machineID, string(raw)); err != nil {
+		log.Printf("store hardware_info: %v", err)
+	}
 }

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -1325,12 +1325,28 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 			// and registered socket; ACK only after the contiguous prefix
 			// commits. Never mutates live gpu_metrics — old agents that never
 			// send this frame are unaffected.
+			// Commit under the barrier, ACK outside it: a socket write can
+			// block for as long as the peer stops reading, and nothing that
+			// can block on the network may hold the barrier (machine deletion
+			// takes its write side before it can even close this socket).
+			var ack []byte
 			var powerErr error
-			if !s.ingestFrame(machineID, agent, registered, func() { powerErr = s.ingestPowerHistory(machineID, agent, msg) }) {
+			if !s.ingestFrame(machineID, agent, registered, func() { ack, powerErr = s.commitPowerHistoryFrame(machineID, agent, msg) }) {
 				return nil
 			}
 			if powerErr != nil {
 				log.Printf("power history from %s: %v", machineID, powerErr)
+			}
+			if ack != nil {
+				agent.WriteMu.Lock()
+				_ = ws.SetWriteDeadline(time.Now().Add(10 * time.Second))
+				err := ws.WriteMessage(websocket.TextMessage, ack)
+				_ = ws.SetWriteDeadline(time.Time{})
+				agent.WriteMu.Unlock()
+				if err != nil {
+					log.Printf("power history ack to %s: %v", machineID, err)
+					return nil
+				}
 			}
 
 		case "command_response":

--- a/hub/auth.go
+++ b/hub/auth.go
@@ -312,7 +312,11 @@ func jwtMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 			userID, _ := claims["user_id"].(string)
 			username, _ := claims["username"].(string)
-			setAuthClaimsOnContext(c, userID, username)
+			var expiresAt time.Time
+			if exp, ok := claims["exp"].(float64); ok && exp > 0 {
+				expiresAt = time.Unix(int64(exp), 0)
+			}
+			setAuthClaimsOnContext(c, userID, username, expiresAt)
 		}
 
 		return next(c)

--- a/hub/lifecycle_safety_test.go
+++ b/hub/lifecycle_safety_test.go
@@ -1,0 +1,825 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+)
+
+// lifecycleDeadline bounds every wait in this file; assertions are
+// ordering-based, the deadline is only a hang guard.
+const lifecycleDeadline = 5 * time.Second
+
+func metricsFrame(machineID, hostname string) map[string]interface{} {
+	return map[string]interface{}{
+		"type": "metrics", "machine_id": machineID,
+		"hostname": hostname, "ip": "10.0.0.1", "os": "linux",
+		"cpu_percent": 1.0, "ram_used_bytes": 1, "ram_total_bytes": 2,
+		"disk_used_bytes": 1, "disk_total_bytes": 2,
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+func waitHostname(t *testing.T, s *Server, machineID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(lifecycleDeadline)
+	for {
+		var got string
+		_ = s.db.QueryRow(`SELECT hostname FROM machines WHERE id = ?`, machineID).Scan(&got)
+		if got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("machine %s hostname never became %q (got %q)", machineID, want, got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func countRows(t *testing.T, s *Server, table, machineID string) int {
+	t.Helper()
+	col := "machine_id"
+	if table == "machines" {
+		col = "id"
+	}
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM `+table+` WHERE `+col+` = ?`, machineID).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+// subscribeSSE registers a raw broadcast subscriber and returns it plus a
+// cleanup. It sees exactly what handleSSE would forward.
+func subscribeBroadcast(t *testing.T) (<-chan []byte, func()) {
+	t.Helper()
+	ch := make(chan []byte, 64)
+	sseClientsMu.Lock()
+	sseClients[ch] = struct{}{}
+	sseClientsMu.Unlock()
+	return ch, func() {
+		sseClientsMu.Lock()
+		delete(sseClients, ch)
+		sseClientsMu.Unlock()
+	}
+}
+
+// TestDeleteConnectedMachineClosesSocketAndDoesNotResurrect: deleting a
+// machine whose agent is connected must close that socket, drop its rollout
+// bookkeeping, emit machine_removed, and leave nothing for a late frame on
+// the old socket to recreate.
+func TestDeleteConnectedMachineClosesSocketAndDoesNotResurrect(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+	writeFrame(t, conn, metricsFrame("machine-A", "before-delete"))
+	waitHostname(t, s, "machine-A", "before-delete")
+
+	// Rollout bookkeeping that must not outlive the machine.
+	agentRunningVersionsMu.Lock()
+	agentRunningVersions["machine-A"] = agentVersionInfo{MachineID: "machine-A", RunningSHA: "deadbeef", OS: "linux", ReportedAt: time.Now()}
+	agentRunningVersionsMu.Unlock()
+	pendingReconnectsMu.Lock()
+	pendingReconnects["machine-A"] = time.Now()
+	pendingReconnectsMu.Unlock()
+
+	events, unsubscribe := subscribeBroadcast(t)
+	defer unsubscribe()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/machines/machine-A", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// The delete returned only after the handler finished, so the socket is
+	// closed from the hub side and the registry entry is gone.
+	_ = conn.SetReadDeadline(time.Now().Add(lifecycleDeadline))
+	expectConnectionClosed(t, conn, "agent socket must be closed by machine deletion")
+	if agentMapHasEntry(s, "machine-A") {
+		t.Fatal("registry still holds the deleted machine")
+	}
+	agentRunningVersionsMu.RLock()
+	_, versionKept := agentRunningVersions["machine-A"]
+	agentRunningVersionsMu.RUnlock()
+	pendingReconnectsMu.Lock()
+	_, reconnectKept := pendingReconnects["machine-A"]
+	pendingReconnectsMu.Unlock()
+	if versionKept || reconnectKept {
+		t.Fatalf("rollout state leaked: version=%v reconnect=%v", versionKept, reconnectKept)
+	}
+
+	// A late frame on the dead socket must not bring the machine back.
+	_ = conn.WriteJSON(metricsFrame("machine-A", "after-delete"))
+	time.Sleep(200 * time.Millisecond)
+	for _, table := range []string{"machines", "metrics", "agent_credentials"} {
+		if n := countRows(t, s, table, "machine-A"); n != 0 {
+			t.Fatalf("%s still has %d rows for the deleted machine", table, n)
+		}
+	}
+
+	// Dashboards are told explicitly.
+	deadline := time.After(lifecycleDeadline)
+	for {
+		select {
+		case ev := <-events:
+			if strings.HasPrefix(string(ev), "event: machine_removed\n") {
+				var payload struct {
+					MachineID string `json:"machine_id"`
+				}
+				data := strings.TrimPrefix(strings.SplitN(string(ev), "\n", 2)[1], "data: ")
+				if err := json.Unmarshal([]byte(strings.TrimSpace(data)), &payload); err != nil || payload.MachineID != "machine-A" {
+					t.Fatalf("bad machine_removed payload: %q", ev)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("machine_removed event never broadcast")
+		}
+	}
+}
+
+// TestDeleteMachineNotConnectedStillWorks keeps the ordinary path honest:
+// no live connection, plain row removal, event still emitted.
+func TestDeleteMachineNotConnectedStillWorks(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	s.seedTestMachine(t, "machine-idle")
+	adminToken := loginAndGetToken(t, e)
+	events, unsubscribe := subscribeBroadcast(t)
+	defer unsubscribe()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/machines/machine-idle", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete: %d %s", rec.Code, rec.Body.String())
+	}
+	if n := countRows(t, s, "machines", "machine-idle"); n != 0 {
+		t.Fatalf("row survived delete")
+	}
+	select {
+	case ev := <-events:
+		if !strings.Contains(string(ev), `"machine_id":"machine-idle"`) {
+			t.Fatalf("unexpected event %q", ev)
+		}
+	case <-time.After(lifecycleDeadline):
+		t.Fatal("no machine_removed event")
+	}
+}
+
+// TestPreIdentityFramesCannotWriteForeignMachine: a socket holding a valid
+// install token has no identity until its first metrics frame. Inventory
+// frames sent before that must not write anything for the machine they
+// claim, while the real first enrollment (metrics, then hardware) still works.
+func TestPreIdentityFramesCannotWriteForeignMachine(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := s.seedValidToken(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	s.seedTestMachine(t, "machine-victim")
+
+	conn, err := wsDialAgent(t, server, "token="+token)
+	if err != nil {
+		t.Fatalf("dial with token: %v", err)
+	}
+	defer conn.Close()
+
+	// Forged inventory before any metrics frame: no identity yet.
+	writeFrame(t, conn, map[string]interface{}{"type": "hardware_info", "machine_id": "machine-victim", "cpu": "forged"})
+	writeFrame(t, conn, map[string]interface{}{"type": "services", "machine_id": "machine-victim",
+		"services": []map[string]interface{}{{"name": "sshd", "status": "running", "description": "forged"}}})
+	writeFrame(t, conn, map[string]interface{}{"type": "containers", "machine_id": "machine-victim",
+		"containers": []map[string]interface{}{{"id": "deadbeef", "name": "forged", "status": "up", "image": "evil:latest"}}})
+	writeFrame(t, conn, map[string]interface{}{"type": "hardware_info", "machine_id": "machine-phantom", "cpu": "forged"})
+
+	// Genuine first enrollment: metrics establishes identity, hub replies enrolled.
+	writeFrame(t, conn, metricsFrame("machine-new", "fresh-host"))
+	_ = conn.SetReadDeadline(time.Now().Add(lifecycleDeadline))
+	for {
+		var frame struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		}
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("waiting for enrolled frame: %v", err)
+		}
+		_ = json.Unmarshal(raw, &frame)
+		if frame.Type == "error" {
+			t.Fatalf("enrollment rejected: %s", frame.Message)
+		}
+		if frame.Type == "enrolled" {
+			break
+		}
+	}
+	// Hardware after metrics, before commit, is the agent's real order. It
+	// must not be written under the uncommitted identity, but it must not
+	// be lost either: it is held and applied at the commit point. Services
+	// before commit are simply dropped (the agent resends them every tick).
+	writeFrame(t, conn, map[string]interface{}{"type": "hardware_info", "machine_id": "machine-new", "cpu": "real-cpu"})
+	writeFrame(t, conn, map[string]interface{}{"type": "services", "machine_id": "machine-new",
+		"services": []map[string]interface{}{{"name": "early", "status": "running", "description": "pre-commit"}}})
+	writeFrame(t, conn, metricsFrame("machine-new", "fresh-host-2"))
+	waitHostname(t, s, "machine-new", "fresh-host-2")
+
+	var hwBeforeCommit string
+	_ = s.db.QueryRow(`SELECT COALESCE(hardware_info,'') FROM machines WHERE id = ?`, "machine-new").Scan(&hwBeforeCommit)
+	if hwBeforeCommit != "" {
+		t.Fatalf("hardware_info written before enrollment committed: %q", hwBeforeCommit)
+	}
+	if n := countRows(t, s, "services", "machine-new"); n != 0 {
+		t.Fatalf("services written before enrollment committed: %d rows", n)
+	}
+
+	// Commit: identity becomes registered, held hardware is applied.
+	commitEnrollment(t, conn)
+	writeFrame(t, conn, map[string]interface{}{"type": "services", "machine_id": "machine-new",
+		"services": []map[string]interface{}{{"name": "late", "status": "running", "description": "post-commit"}}})
+	writeFrame(t, conn, metricsFrame("machine-new", "fresh-host-3"))
+	waitHostname(t, s, "machine-new", "fresh-host-3")
+
+	var hw string
+	_ = s.db.QueryRow(`SELECT COALESCE(hardware_info,'') FROM machines WHERE id = ?`, "machine-new").Scan(&hw)
+	if !strings.Contains(hw, "real-cpu") {
+		t.Fatalf("first-enrollment hardware_info not applied at commit: %q", hw)
+	}
+	var svcName string
+	_ = s.db.QueryRow(`SELECT name FROM services WHERE machine_id = ?`, "machine-new").Scan(&svcName)
+	if svcName != "late" {
+		t.Fatalf("post-commit services not stored (got %q)", svcName)
+	}
+	var victimHW string
+	_ = s.db.QueryRow(`SELECT COALESCE(hardware_info,'') FROM machines WHERE id = ?`, "machine-victim").Scan(&victimHW)
+	if victimHW != "" {
+		t.Fatalf("pre-identity frame rewrote another machine's hardware: %q", victimHW)
+	}
+	for _, table := range []string{"services", "containers"} {
+		if n := countRows(t, s, table, "machine-victim"); n != 0 {
+			t.Fatalf("pre-identity frame wrote %d %s rows for another machine", n, table)
+		}
+	}
+	if n := countRows(t, s, "machines", "machine-phantom"); n != 0 {
+		t.Fatal("pre-identity hardware_info created a phantom machine")
+	}
+}
+
+// TestTerminalRelayConcurrentTeardownDoesNotPanic hammers the relay's three
+// exit paths at once. Before the shared once-close, two of them could both
+// see the done channel open and the second close panicked the process.
+func TestTerminalRelayConcurrentTeardownDoesNotPanic(t *testing.T) {
+	_, s := setupTestServer(t)
+
+	serverConns := make(chan *websocket.Conn, 2)
+	ws := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		serverConns <- c
+	}))
+	defer ws.Close()
+	dial := func() *websocket.Conn {
+		t.Helper()
+		c, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(ws.URL, "http"), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+
+	for i := 0; i < 40; i++ {
+		agentClient, browserClient := dial(), dial()
+		agentServer, browserServer := <-serverConns, <-serverConns
+		id := "sess-" + time.Now().Format("150405.000000") + "-" + string(rune('a'+i%26))
+		session := &TerminalSession{
+			ID: id, MachineID: "m", AgentWS: agentServer, BrowserWS: browserServer,
+			CreatedAt: time.Now(), LastActivity: time.Now(), Done: make(chan struct{}),
+		}
+		termSessionsMu.Lock()
+		termSessions[id] = session
+		termSessionsMu.Unlock()
+
+		relayDone := make(chan struct{})
+		go func() { s.terminalRelay(id, session); close(relayDone) }()
+
+		// All three exit triggers at once: explicit cleanup closes both
+		// server sockets; both clients close too.
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() { defer wg.Done(); s.cleanupTerminalSession(id) }()
+		go func() { defer wg.Done(); agentClient.Close() }()
+		go func() { defer wg.Done(); browserClient.Close() }()
+		wg.Wait()
+		select {
+		case <-relayDone:
+		case <-time.After(lifecycleDeadline):
+			t.Fatalf("iteration %d: relay did not end", i)
+		}
+	}
+}
+
+func openEventStream(t *testing.T, server *httptest.Server, token string) (*http.Response, *bufio.Reader) {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, server.URL+"/api/events?token="+token, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stream status %d", resp.StatusCode)
+	}
+	r := bufio.NewReader(resp.Body)
+	// Snapshot arrives first; consume its event line so we know we are live.
+	line, err := r.ReadString('\n')
+	if err != nil || !strings.HasPrefix(line, "event: snapshot") {
+		t.Fatalf("expected snapshot first, got %q err=%v", line, err)
+	}
+	return resp, r
+}
+
+// streamEndsWithin reads until EOF and fails if it takes longer than max.
+func streamEndsWithin(t *testing.T, r *bufio.Reader, max time.Duration, what string) {
+	t.Helper()
+	ended := make(chan struct{})
+	go func() {
+		for {
+			if _, err := r.ReadString('\n'); err != nil {
+				close(ended)
+				return
+			}
+		}
+	}()
+	select {
+	case <-ended:
+	case <-time.After(max):
+		t.Fatalf("event stream kept flowing after %s", what)
+	}
+}
+
+// TestSSEStreamEndsWhenUserDeleted: an open stream must stop once its user
+// no longer exists, without waiting for the client to hang up.
+func TestSSEStreamEndsWhenUserDeleted(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	old := sseRevalidateInterval
+	sseRevalidateInterval = 50 * time.Millisecond
+	defer func() { sseRevalidateInterval = old }()
+
+	adminToken := loginAndGetToken(t, e)
+	resp, r := openEventStream(t, server, adminToken)
+	defer resp.Body.Close()
+
+	// Remove the user out from under the stream.
+	if _, err := s.db.Exec(`DELETE FROM users`); err != nil {
+		t.Fatal(err)
+	}
+	streamEndsWithin(t, r, lifecycleDeadline, "user deletion")
+}
+
+// TestSSEStreamEndsWhenTokenExpires: the token's own deadline is enforced
+// on the stream, not only at the handshake.
+func TestSSEStreamEndsWhenTokenExpires(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	old := sseRevalidateInterval
+	sseRevalidateInterval = 50 * time.Millisecond
+	defer func() { sseRevalidateInterval = old }()
+
+	var userID string
+	if err := s.db.QueryRow(`SELECT id FROM users LIMIT 1`).Scan(&userID); err != nil {
+		t.Fatal(err)
+	}
+	claims := jwt.MapClaims{
+		"user_id": userID, "username": "admin", "type": "sse",
+		"exp": time.Now().Add(400*time.Millisecond).Unix() + 1,
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(jwtSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, r := openEventStream(t, server, token)
+	defer resp.Body.Close()
+	streamEndsWithin(t, r, lifecycleDeadline, "token expiry")
+}
+
+// TestDeleteWaitsForHandshakeInProgress pins the interleaving root asked
+// for: an agent reconnect that has already validated its credential is paused
+// just before registration (auth read lock held). A concurrent delete must
+// not complete until that handshake finishes, and once it does the delete
+// must close the new socket and leave no row for it to recreate.
+func TestDeleteWaitsForHandshakeInProgress(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	secret := s.enrollAgentSecret(t, server, "machine-A")
+	s.waitAgentDrain(t, "machine-A", 2*time.Second)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var enteredOnce sync.Once
+	agentHandshakeTestHook = func(machineID string) {
+		if machineID != "machine-A" {
+			return
+		}
+		enteredOnce.Do(func() { close(entered) })
+		<-release
+	}
+	defer func() { agentHandshakeTestHook = nil }()
+
+	conns := make(chan *websocket.Conn, 1)
+	go func() {
+		c, err := wsDialAgent(t, server, "secret="+secret)
+		if err != nil {
+			t.Errorf("reconnect dial: %v", err)
+			return
+		}
+		conns <- c
+	}()
+	select {
+	case <-entered:
+	case <-time.After(lifecycleDeadline):
+		t.Fatal("handshake never reached the pre-registration point")
+	}
+
+	deleteCode := make(chan int, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodDelete, "/api/machines/machine-A", nil)
+		req.Header.Set("Authorization", "Bearer "+adminToken)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		deleteCode <- rec.Code
+	}()
+	select {
+	case code := <-deleteCode:
+		t.Fatalf("delete completed (%d) while a validated handshake still held the auth lock", code)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	close(release)
+	var code int
+	select {
+	case code = <-deleteCode:
+	case <-time.After(lifecycleDeadline):
+		t.Fatal("delete never completed after the handshake was released")
+	}
+	if code != http.StatusOK {
+		t.Fatalf("delete after handshake: %d", code)
+	}
+
+	var conn *websocket.Conn
+	select {
+	case conn = <-conns:
+	case <-time.After(lifecycleDeadline):
+		t.Fatal("reconnect never returned a connection")
+	}
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(lifecycleDeadline))
+	expectConnectionClosed(t, conn, "socket registered during the paused handshake must be closed by the delete")
+	_ = conn.WriteJSON(metricsFrame("machine-A", "after-delete"))
+	time.Sleep(200 * time.Millisecond)
+	for _, table := range []string{"machines", "agent_credentials"} {
+		if n := countRows(t, s, table, "machine-A"); n != 0 {
+			t.Fatalf("%s still has %d rows after delete", table, n)
+		}
+	}
+	if agentMapHasEntry(s, "machine-A") {
+		t.Fatal("registry still holds the deleted machine")
+	}
+}
+
+// holdFirstIngest installs an ingest hook that parks the first frame for
+// machineID inside the ingestion barrier until release is closed. Later
+// frames pass straight through.
+func holdFirstIngest(t *testing.T, machineID string) (entered <-chan struct{}, release chan struct{}) {
+	t.Helper()
+	enteredCh := make(chan struct{})
+	release = make(chan struct{})
+	var once sync.Once
+	agentIngestTestHook = func(id string) {
+		if id != machineID {
+			return
+		}
+		first := false
+		once.Do(func() { first = true; close(enteredCh) })
+		if first {
+			<-release
+		}
+	}
+	t.Cleanup(func() { agentIngestTestHook = nil })
+	return enteredCh, release
+}
+
+func deleteMachineAsync(e *echo.Echo, adminToken, machineID string) <-chan int {
+	code := make(chan int, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodDelete, "/api/machines/"+machineID, nil)
+		req.Header.Set("Authorization", "Bearer "+adminToken)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		code <- rec.Code
+	}()
+	return code
+}
+
+// TestDeleteWaitsForFrameMidWrite: a frame already inside the ingestion
+// barrier finishes before the delete proceeds, and nothing after the delete
+// can write. There is no timeout path, so there is nothing to retry around.
+func TestDeleteWaitsForFrameMidWrite(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+	writeFrame(t, conn, metricsFrame("machine-A", "settled"))
+	waitHostname(t, s, "machine-A", "settled")
+
+	entered, release := holdFirstIngest(t, "machine-A")
+	writeFrame(t, conn, metricsFrame("machine-A", "mid-write"))
+	select {
+	case <-entered:
+	case <-time.After(lifecycleDeadline):
+		t.Fatal("frame never entered the ingestion barrier")
+	}
+
+	deleteCode := deleteMachineAsync(e, adminToken, "machine-A")
+	select {
+	case code := <-deleteCode:
+		t.Fatalf("delete completed (%d) while a frame was inside the ingestion barrier", code)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case code := <-deleteCode:
+		if code != http.StatusOK {
+			t.Fatalf("delete after the frame finished: %d", code)
+		}
+	case <-time.After(lifecycleDeadline):
+		t.Fatal("delete never completed after the frame was released")
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(lifecycleDeadline))
+	expectConnectionClosed(t, conn, "socket must be closed by the delete")
+	_ = conn.WriteJSON(metricsFrame("machine-A", "after-delete"))
+	time.Sleep(200 * time.Millisecond)
+	for _, table := range []string{"machines", "metrics", "agent_credentials"} {
+		if n := countRows(t, s, table, "machine-A"); n != 0 {
+			t.Fatalf("%s still has %d rows after delete", table, n)
+		}
+	}
+}
+
+// TestDisplacedSocketMidWriteCannotResurrect: an older socket that a
+// reconnect has already displaced can still be inside a frame. Its write
+// must be refused once it re-checks registration under the barrier, and a
+// delete racing that frame must wait for it, then remove everything.
+func TestDisplacedSocketMidWriteCannotResurrect(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	secret := s.enrollAgentSecret(t, server, "machine-A")
+	older, err := wsDialAgent(t, server, "secret="+secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer older.Close()
+	readAISessionsConfig(t, older)
+	writeFrame(t, older, metricsFrame("machine-A", "settled"))
+	waitHostname(t, s, "machine-A", "settled")
+
+	// Park the older socket inside the barrier on its next frame.
+	entered, release := holdFirstIngest(t, "machine-A")
+	writeFrame(t, older, metricsFrame("machine-A", "stale-write"))
+	select {
+	case <-entered:
+	case <-time.After(lifecycleDeadline):
+		t.Fatal("older socket never entered the ingestion barrier")
+	}
+
+	// A reconnect displaces it while it is parked.
+	newer, err := wsDialAgent(t, server, "secret="+secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer newer.Close()
+	waitForCondition(t, lifecycleDeadline, func() bool {
+		current := s.registeredAgent("machine-A")
+		return current != nil && s.isRegisteredConnection("machine-A", current)
+	})
+
+	// Delete must block behind the parked frame, then win.
+	deleteCode := deleteMachineAsync(e, adminToken, "machine-A")
+	select {
+	case code := <-deleteCode:
+		t.Fatalf("delete completed (%d) while the displaced socket was inside the barrier", code)
+	case <-time.After(300 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case code := <-deleteCode:
+		if code != http.StatusOK {
+			t.Fatalf("delete: %d", code)
+		}
+	case <-time.After(lifecycleDeadline):
+		t.Fatal("delete never completed")
+	}
+
+	// The displaced frame was refused (hostname never became stale-write is
+	// unobservable after delete), so assert the strong property: no rows.
+	time.Sleep(200 * time.Millisecond)
+	for _, table := range []string{"machines", "metrics", "agent_credentials"} {
+		if n := countRows(t, s, table, "machine-A"); n != 0 {
+			t.Fatalf("%s still has %d rows after delete", table, n)
+		}
+	}
+	_ = newer.SetReadDeadline(time.Now().Add(lifecycleDeadline))
+	expectConnectionClosed(t, newer, "registered socket must be closed by the delete")
+	if agentMapHasEntry(s, "machine-A") {
+		t.Fatal("registry still holds the deleted machine")
+	}
+}
+
+// TestSSEStreamEndsAtExactExpiry: the token deadline is enforced by its own
+// timer, independent of the periodic revocation check.
+func TestSSEStreamEndsAtExactExpiry(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	old := sseRevalidateInterval
+	sseRevalidateInterval = 10 * time.Second // periodic check must not be what ends it
+	defer func() { sseRevalidateInterval = old }()
+
+	var userID string
+	if err := s.db.QueryRow(`SELECT id FROM users LIMIT 1`).Scan(&userID); err != nil {
+		t.Fatal(err)
+	}
+	exp := time.Now().Add(1500 * time.Millisecond).Unix()
+	claims := jwt.MapClaims{"user_id": userID, "username": "admin", "type": "sse", "exp": exp}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(jwtSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, r := openEventStream(t, server, token)
+	defer resp.Body.Close()
+	start := time.Now()
+	streamEndsWithin(t, r, 4*time.Second, "exact token expiry")
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("stream ended too late for an exact expiry timer: %s", elapsed)
+	}
+}
+
+// TestDeleteRemovalEventIsLast: a frame parked inside the barrier finishes,
+// its broadcast goes out, and only then does machine_removed follow; nothing
+// for the machine is broadcast after it.
+func TestDeleteRemovalEventIsLast(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+	writeFrame(t, conn, metricsFrame("machine-A", "settled"))
+	waitHostname(t, s, "machine-A", "settled")
+
+	events, unsubscribe := subscribeBroadcast(t)
+	defer unsubscribe()
+
+	entered, release := holdFirstIngest(t, "machine-A")
+	writeFrame(t, conn, metricsFrame("machine-A", "parked"))
+	select {
+	case <-entered:
+	case <-time.After(lifecycleDeadline):
+		t.Fatal("frame never entered the barrier")
+	}
+	deleteCode := deleteMachineAsync(e, adminToken, "machine-A")
+	select {
+	case code := <-deleteCode:
+		t.Fatalf("delete completed (%d) while a frame was parked", code)
+	case <-time.After(300 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case code := <-deleteCode:
+		if code != http.StatusOK {
+			t.Fatalf("delete: %d", code)
+		}
+	case <-time.After(lifecycleDeadline):
+		t.Fatal("delete never completed")
+	}
+	// Late frame on the dead socket: must produce no event.
+	_ = conn.WriteJSON(metricsFrame("machine-A", "after-delete"))
+
+	var order []string
+	deadline := time.After(lifecycleDeadline)
+collect:
+	for {
+		select {
+		case ev := <-events:
+			text := string(ev)
+			switch {
+			case strings.HasPrefix(text, "event: machine_removed"):
+				order = append(order, "removed")
+				break collect
+			case strings.Contains(text, `"parked"`):
+				order = append(order, "parked-metrics")
+			case strings.Contains(text, `"after-delete"`):
+				order = append(order, "late-metrics")
+			}
+		case <-deadline:
+			t.Fatalf("machine_removed never arrived; saw %v", order)
+		}
+	}
+	if len(order) != 2 || order[0] != "parked-metrics" || order[1] != "removed" {
+		t.Fatalf("event order = %v, want [parked-metrics removed]", order)
+	}
+	select {
+	case ev := <-events:
+		if strings.Contains(string(ev), "machine-A") {
+			t.Fatalf("event for the deleted machine after machine_removed: %q", ev)
+		}
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// TestAnnounceCannotRearmReconnectAfterDelete: the update announce runs on
+// its own goroutine; its reconnect expectation must arm only while the
+// agent still owns the registry entry, so a delete cannot be followed by a
+// late arm and a phantom rollout failure.
+func TestAnnounceCannotRearmReconnectAfterDelete(t *testing.T) {
+	_, s := setupTestServer(t)
+	agent := &ConnectedAgent{MachineID: "machine-A"}
+	s.agentsMu.Lock()
+	s.agents["machine-A"] = agent
+	s.agentsMu.Unlock()
+	defer func() {
+		pendingReconnectsMu.Lock()
+		delete(pendingReconnects, "machine-A")
+		pendingReconnectsMu.Unlock()
+	}()
+
+	if !s.armReconnectIfRegistered("machine-A", agent) {
+		t.Fatal("registered agent must be able to arm its reconnect expectation")
+	}
+	pendingReconnectsMu.Lock()
+	_, armed := pendingReconnects["machine-A"]
+	pendingReconnectsMu.Unlock()
+	if !armed {
+		t.Fatal("expectation not armed for registered agent")
+	}
+
+	// What delete does: take the entry, clear the expectation.
+	s.agentsMu.Lock()
+	delete(s.agents, "machine-A")
+	s.agentsMu.Unlock()
+	clearReconnectExpectation("machine-A")
+
+	if s.armReconnectIfRegistered("machine-A", agent) {
+		t.Fatal("late announce armed a reconnect expectation for a deleted machine")
+	}
+	pendingReconnectsMu.Lock()
+	_, armed = pendingReconnects["machine-A"]
+	pendingReconnectsMu.Unlock()
+	if armed {
+		t.Fatal("reconnect expectation re-armed after delete")
+	}
+}
+
+// Keep echo imported for route-level helpers used above.
+var _ = echo.New

--- a/hub/lifecycle_safety_test.go
+++ b/hub/lifecycle_safety_test.go
@@ -670,6 +670,14 @@ func TestDisplacedSocketMidWriteCannotResurrect(t *testing.T) {
 	if agentMapHasEntry(s, "machine-A") {
 		t.Fatal("registry still holds the deleted machine")
 	}
+	// The displaced frame's latency write lives inside the barrier too, so
+	// the cache cleared by the delete is not repopulated afterwards.
+	machineLatencyMu.RLock()
+	_, latencyKept := machineLatency["machine-A"]
+	machineLatencyMu.RUnlock()
+	if latencyKept {
+		t.Fatal("latency cache repopulated by a displaced frame after delete")
+	}
 }
 
 // TestSSEStreamEndsAtExactExpiry: the token deadline is enforced by its own
@@ -818,6 +826,173 @@ func TestAnnounceCannotRearmReconnectAfterDelete(t *testing.T) {
 	pendingReconnectsMu.Unlock()
 	if armed {
 		t.Fatal("reconnect expectation re-armed after delete")
+	}
+}
+
+// TestMachineRemovedKicksOverflowedStream: a subscriber whose queue is full
+// cannot silently lose machine_removed. Data events stay lossy for it; the
+// control event ends the stream so the client re-snapshots.
+func TestMachineRemovedKicksOverflowedStream(t *testing.T) {
+	ch := make(chan []byte, 64)
+	kick := &sseKick{ch: make(chan struct{})}
+	sseClientsMu.Lock()
+	sseClients[ch] = struct{}{}
+	sseKicks[ch] = kick
+	sseClientsMu.Unlock()
+	defer func() {
+		sseClientsMu.Lock()
+		delete(sseClients, ch)
+		delete(sseKicks, ch)
+		sseClientsMu.Unlock()
+	}()
+
+	for i := 0; i < 64; i++ {
+		broadcastSSE([]byte("event: metrics\ndata: {}\n\n"))
+	}
+	if len(ch) != 64 {
+		t.Fatalf("queue not full: %d", len(ch))
+	}
+	// A dropped data event must not kick.
+	broadcastSSE([]byte("event: metrics\ndata: {}\n\n"))
+	select {
+	case <-kick.ch:
+		t.Fatal("data overflow kicked the stream")
+	default:
+	}
+	// A dropped control event must.
+	broadcastSSEControl(machineRemovedEvent("machine-A"))
+	select {
+	case <-kick.ch:
+	case <-time.After(lifecycleDeadline):
+		t.Fatal("machine_removed overflow did not kick the stream")
+	}
+	// A stream with room receives the control event normally, no kick.
+	room := make(chan []byte, 1)
+	roomKick := &sseKick{ch: make(chan struct{})}
+	sseClientsMu.Lock()
+	sseClients[room] = struct{}{}
+	sseKicks[room] = roomKick
+	sseClientsMu.Unlock()
+	defer func() {
+		sseClientsMu.Lock()
+		delete(sseClients, room)
+		delete(sseKicks, room)
+		sseClientsMu.Unlock()
+	}()
+	broadcastSSEControl(machineRemovedEvent("machine-B"))
+	select {
+	case ev := <-room:
+		if !strings.Contains(string(ev), `"machine-B"`) {
+			t.Fatalf("unexpected event %q", ev)
+		}
+	default:
+		t.Fatal("control event not delivered to a stream with room")
+	}
+	select {
+	case <-roomKick.ch:
+		t.Fatal("stream with room was kicked")
+	default:
+	}
+}
+
+// TestSSEStreamEndsOnControlOverflow drives the real handler: a client that
+// never reads sees its stream ended once a control event overflows.
+func TestSSEStreamEndsOnControlOverflow(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	adminToken := loginAndGetToken(t, e)
+	resp, r := openEventStream(t, server, adminToken)
+	defer resp.Body.Close()
+
+	// Find the handler's channel and fill it without the client reading.
+	var target chan []byte
+	waitForCondition(t, lifecycleDeadline, func() bool {
+		sseClientsMu.RLock()
+		defer sseClientsMu.RUnlock()
+		for ch := range sseClients {
+			if sseKicks[ch] != nil {
+				target = ch
+				return true
+			}
+		}
+		return false
+	})
+	// Large frames fill the unread TCP buffers quickly; once the handler's
+	// writes block, its queue fills and stays full.
+	filler := []byte("event: metrics\ndata: {\"pad\":\"" + strings.Repeat("x", 32*1024) + "\"}\n\n")
+	fillDeadline := time.Now().Add(lifecycleDeadline)
+	for len(target) < cap(target) {
+		broadcastSSE(filler)
+		if time.Now().After(fillDeadline) {
+			t.Fatalf("could not fill the stream queue (%d/%d)", len(target), cap(target))
+		}
+		if len(target) < cap(target) {
+			time.Sleep(time.Millisecond)
+		}
+	}
+	broadcastSSEControl(machineRemovedEvent("machine-A"))
+	streamEndsWithin(t, r, lifecycleDeadline, "control-event overflow")
+}
+
+// TestFreshEnrollmentVersionReportHeldUntilCommit: an aborted enrollment
+// leaves no /api/versions entry; a committed one keeps its initial report.
+func TestFreshEnrollmentVersionReportHeldUntilCommit(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	enrollTo := func(machineID string, commit bool) {
+		t.Helper()
+		if _, err := s.db.Exec(`DELETE FROM tokens`); err != nil {
+			t.Fatal(err)
+		}
+		token := s.seedValidToken(t)
+		conn, err := wsDialAgent(t, server, "token="+token)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer conn.Close()
+		writeFrame(t, conn, metricsFrame(machineID, "host"))
+		_ = conn.SetReadDeadline(time.Now().Add(lifecycleDeadline))
+		for {
+			var frame struct {
+				Type string `json:"type"`
+			}
+			_, raw, err := conn.ReadMessage()
+			if err != nil {
+				t.Fatalf("waiting for enrolled: %v", err)
+			}
+			_ = json.Unmarshal(raw, &frame)
+			if frame.Type == "enrolled" {
+				break
+			}
+		}
+		writeFrame(t, conn, map[string]interface{}{"type": "agent_running_version", "machine_id": machineID, "sha256": "abc123", "os": "linux"})
+		if commit {
+			commitEnrollment(t, conn)
+		}
+		// Order the assertion behind the frames above.
+		writeFrame(t, conn, metricsFrame(machineID, "host-2"))
+		waitHostname(t, s, machineID, "host-2")
+	}
+
+	enrollTo("machine-abort", false)
+	agentRunningVersionsMu.RLock()
+	_, phantom := agentRunningVersions["machine-abort"]
+	agentRunningVersionsMu.RUnlock()
+	if phantom {
+		t.Fatal("aborted enrollment left a version entry")
+	}
+
+	enrollTo("machine-commit", true)
+	agentRunningVersionsMu.RLock()
+	info, kept := agentRunningVersions["machine-commit"]
+	agentRunningVersionsMu.RUnlock()
+	if !kept || info.RunningSHA != "abc123" {
+		t.Fatalf("committed enrollment lost its initial version report: kept=%v info=%+v", kept, info)
 	}
 }
 

--- a/hub/lifecycle_safety_test.go
+++ b/hub/lifecycle_safety_test.go
@@ -996,5 +996,40 @@ func TestFreshEnrollmentVersionReportHeldUntilCommit(t *testing.T) {
 	}
 }
 
+// TestPowerCommitUnderBarrierPerformsNoSocketWrite: the part of power
+// ingestion that runs under the ingestion barrier must commit and hand back
+// the ACK bytes without touching the socket. A registered agent with no
+// connection at all proves it: any write attempt would fail or panic.
+func TestPowerCommitUnderBarrierPerformsNoSocketWrite(t *testing.T) {
+	_, s := setupTestServer(t)
+	s.seedTestMachine(t, "machine-P")
+	agent := &ConnectedAgent{MachineID: "machine-P"} // Conn nil on purpose
+	s.agentsMu.Lock()
+	s.agents["machine-P"] = agent
+	s.agentsMu.Unlock()
+	defer func() {
+		s.agentsMu.Lock()
+		delete(s.agents, "machine-P")
+		s.agentsMu.Unlock()
+	}()
+
+	start, end := nowWindowMS()
+	raw, err := json.Marshal(powerBatch("stream-1", 1, powerBucket(1, start, end, 100, 200, 30, 30)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ack, err := s.commitPowerHistoryFrame("machine-P", agent, raw)
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if !strings.Contains(string(ack), `"through":1`) && !strings.Contains(string(ack), `"through": 1`) {
+		t.Fatalf("unexpected ack %s", ack)
+	}
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM power_history_records WHERE machine_id = ?`, "machine-P").Scan(&n); err != nil || n != 1 {
+		t.Fatalf("commit did not persist (n=%d err=%v)", n, err)
+	}
+}
+
 // Keep echo imported for route-level helpers used above.
 var _ = echo.New

--- a/hub/main.go
+++ b/hub/main.go
@@ -780,6 +780,13 @@ func (s *Server) handleSetTags(c echo.Context) error {
 // --- Existing Handlers ---
 
 func (s *Server) handleDeleteMachine(c echo.Context) error {
+	// Same coordination as credential revocation: holding the auth writer
+	// lock means no agent socket can pass authentication or register while
+	// the machine is being removed, so a reconnect racing the delete cannot
+	// recreate the row between the socket close and the row delete. It is
+	// bounded by the agent auth window, exactly like revoke.
+	s.agentAuthMu.Lock()
+	defer s.agentAuthMu.Unlock()
 	id := c.Param("id")
 
 	// Check machine exists and get hostname
@@ -788,6 +795,35 @@ func (s *Server) handleDeleteMachine(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "machine not found"})
 	}
+
+	// Every persisted agent frame runs under the ingestion barrier's read
+	// side (ingestFrame), with its registration check inside. Holding the
+	// write side across registry removal and the row delete means a frame is
+	// either fully written before the delete or refused after it, for every
+	// socket that ever held this machine: the registered one, an older
+	// displaced one still mid-frame, and any retry of this handler. No
+	// draining or timeout is needed, so there is no path that can be
+	// retried around. Handlers hold the read side only for one frame's
+	// writes and never block on the registry or another connection inside
+	// it, so this cannot deadlock. If the DB delete fails, the agent simply
+	// reconnects with its still-valid credential; nothing is half-removed.
+	s.ingestMu.Lock()
+	defer s.ingestMu.Unlock()
+	s.agentsMu.Lock()
+	live := s.agents[id]
+	if live != nil {
+		delete(s.agents, id)
+	}
+	s.agentsMu.Unlock()
+	if live != nil && live.Conn != nil {
+		_ = live.Conn.Close()
+	}
+	// Rollout bookkeeping is keyed by machine id and never expires on its own:
+	// an armed reconnect expectation would record a phantom rollout failure
+	// for a machine that no longer exists, and the version list would show
+	// it forever.
+	clearReconnectExpectation(id)
+	forgetAgentVersion(id)
 
 	// Delete all related data in a transaction
 	tx, err := s.db.Begin()
@@ -809,14 +845,14 @@ func (s *Server) handleDeleteMachine(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to commit"})
 	}
 
-	// Remove from live cache
-	s.agentsMu.Lock()
-	delete(s.agents, id)
-	s.agentsMu.Unlock()
 	machineLatencyMu.Lock()
 	delete(machineLatency, id)
 	machineLatencyMu.Unlock()
 	s.removeAISessions(id)
+
+	// Additive event so dashboards drop the card immediately instead of
+	// waiting for their next snapshot. Older clients ignore unknown events.
+	broadcastSSE(machineRemovedEvent(id))
 
 	log.Printf("machine deleted: %s (%s)", hostname, id)
 	return c.JSON(http.StatusOK, map[string]string{"status": "deleted", "hostname": hostname})
@@ -989,6 +1025,12 @@ func (s *Server) markOffline(machineID string) {
 	log.Printf("agent offline: %s", machineID)
 }
 
+// machineRemovedEvent frames the SSE event emitted after a machine is deleted.
+func machineRemovedEvent(machineID string) []byte {
+	payload, _ := json.Marshal(map[string]string{"machine_id": machineID})
+	return []byte("event: machine_removed\ndata: " + string(payload) + "\n\n")
+}
+
 func broadcastSSE(data []byte) {
 	sseClientsMu.RLock()
 	defer sseClientsMu.RUnlock()
@@ -1001,6 +1043,13 @@ func broadcastSSE(data []byte) {
 }
 
 func (s *Server) handleSSE(c echo.Context) error {
+	// A stream without claims never passed the middleware and is not served;
+	// checked before anything is written or subscribed.
+	claims, ok := authClaimsFromContext(c)
+	if !ok || claims.UserID == "" {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user context"})
+	}
+
 	c.Response().Header().Set("Content-Type", "text/event-stream")
 	c.Response().Header().Set("Cache-Control", "no-cache")
 	c.Response().Header().Set("Connection", "keep-alive")
@@ -1037,6 +1086,20 @@ func (s *Server) handleSSE(c echo.Context) error {
 	ping := time.NewTicker(15 * time.Second)
 	defer ping.Stop()
 
+	// Authorization was checked once, at the handshake. A stream is long
+	// lived, so enforce the token's own deadline exactly, and re-check on a
+	// modest timer that the user still exists. Without this a deleted user
+	// or an expired token keeps receiving fleet telemetry for as long as the
+	// connection is held.
+	var expiry <-chan time.Time
+	if !claims.ExpiresAt.IsZero() {
+		expiryTimer := time.NewTimer(time.Until(claims.ExpiresAt))
+		defer expiryTimer.Stop()
+		expiry = expiryTimer.C
+	}
+	revalidate := time.NewTicker(sseRevalidateInterval)
+	defer revalidate.Stop()
+
 	for {
 		select {
 		case data := <-ch:
@@ -1049,11 +1112,41 @@ func (s *Server) handleSSE(c echo.Context) error {
 		case <-ping.C:
 			fmt.Fprintf(c.Response(), ": keepalive\n\n")
 			flusher.Flush()
+		case <-expiry:
+			log.Printf("closing event stream for user %s: token expired", claims.UserID)
+			return nil
+		case <-revalidate.C:
+			if reason := s.sseStreamRevoked(claims); reason != "" {
+				log.Printf("closing event stream for user %s: %s", claims.UserID, reason)
+				return nil
+			}
 		case <-c.Request().Context().Done():
 			return nil
 		}
 	}
 
+}
+
+// sseRevalidateInterval is how often an open event stream re-checks its
+// authorization. Package-level so tests can shorten it.
+var sseRevalidateInterval = 60 * time.Second
+
+// sseStreamRevoked reports why an open stream must end, or "" to keep it.
+// It fails closed: if the user cannot be confirmed to exist, the stream ends.
+func (s *Server) sseStreamRevoked(claims requestAuthClaims) string {
+	if !claims.ExpiresAt.IsZero() && time.Now().After(claims.ExpiresAt) {
+		return "token expired"
+	}
+	if claims.UserID == "" {
+		return "no user in claims"
+	}
+	if _, err := s.lookupUserRole(claims.UserID); err != nil {
+		if err == sql.ErrNoRows {
+			return "user no longer exists"
+		}
+		return "user lookup failed: " + err.Error()
+	}
+	return ""
 }
 
 func (s *Server) handleListMachines(c echo.Context) error {

--- a/hub/main.go
+++ b/hub/main.go
@@ -120,6 +120,12 @@ var (
 	// SSE subscribers.
 	sseClients   = make(map[chan []byte]struct{})
 	sseClientsMu sync.RWMutex
+	// sseKicks maps a stream's data channel to its invalidation signal. Data
+	// events may be dropped for a slow subscriber whose queue is full, but a
+	// control event such as machine_removed must never be lost: on overflow
+	// the stream is ended instead, and the client's reconnect delivers a
+	// fresh snapshot that already reflects the change. Guarded by sseClientsMu.
+	sseKicks = make(map[chan []byte]*sseKick)
 
 	// Pending command responses: command ID -> response channel.
 	pendingCmds   = make(map[string]chan CommandResponse)
@@ -850,9 +856,10 @@ func (s *Server) handleDeleteMachine(c echo.Context) error {
 	machineLatencyMu.Unlock()
 	s.removeAISessions(id)
 
-	// Additive event so dashboards drop the card immediately instead of
-	// waiting for their next snapshot. Older clients ignore unknown events.
-	broadcastSSE(machineRemovedEvent(id))
+	// Additive control event so dashboards drop the card immediately instead
+	// of waiting for their next snapshot; a subscriber that cannot take it is
+	// kicked to re-snapshot. Older clients ignore unknown events.
+	broadcastSSEControl(machineRemovedEvent(id))
 
 	log.Printf("machine deleted: %s (%s)", hostname, id)
 	return c.JSON(http.StatusOK, map[string]string{"status": "deleted", "hostname": hostname})
@@ -1042,6 +1049,32 @@ func broadcastSSE(data []byte) {
 	}
 }
 
+// sseKick ends one event stream exactly once.
+type sseKick struct {
+	ch   chan struct{}
+	once sync.Once
+}
+
+func (k *sseKick) fire() { k.once.Do(func() { close(k.ch) }) }
+
+// broadcastSSEControl delivers a control event that must not be dropped. A
+// subscriber whose queue is full is kicked instead of skipped; its client
+// reconnects and receives a fresh snapshot. Nothing blocks: the send is
+// non-blocking and the kick is a channel close.
+func broadcastSSEControl(data []byte) {
+	sseClientsMu.RLock()
+	defer sseClientsMu.RUnlock()
+	for ch := range sseClients {
+		select {
+		case ch <- data:
+		default:
+			if kick := sseKicks[ch]; kick != nil {
+				kick.fire()
+			}
+		}
+	}
+}
+
 func (s *Server) handleSSE(c echo.Context) error {
 	// A stream without claims never passed the middleware and is not served;
 	// checked before anything is written or subscribed.
@@ -1055,13 +1088,16 @@ func (s *Server) handleSSE(c echo.Context) error {
 	c.Response().Header().Set("Connection", "keep-alive")
 
 	ch := make(chan []byte, 64)
+	kick := &sseKick{ch: make(chan struct{})}
 	sseClientsMu.Lock()
 	sseClients[ch] = struct{}{}
+	sseKicks[ch] = kick
 	sseClientsMu.Unlock()
 
 	defer func() {
 		sseClientsMu.Lock()
 		delete(sseClients, ch)
+		delete(sseKicks, ch)
 		sseClientsMu.Unlock()
 		close(ch)
 	}()
@@ -1114,6 +1150,11 @@ func (s *Server) handleSSE(c echo.Context) error {
 			flusher.Flush()
 		case <-expiry:
 			log.Printf("closing event stream for user %s: token expired", claims.UserID)
+			return nil
+		case <-kick.ch:
+			// A control event could not be queued for this slow stream; end
+			// it so the client reconnects and re-snapshots.
+			log.Printf("closing event stream for user %s: queue overflow on a control event", claims.UserID)
 			return nil
 		case <-revalidate.C:
 			if reason := s.sseStreamRevoked(claims); reason != "" {

--- a/hub/power_delete_blocked_ack_test.go
+++ b/hub/power_delete_blocked_ack_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDeleteDoesNotWaitForBlockedPowerACK(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	server := httptest.NewServer(e)
+	defer server.Close()
+	token := loginAndGetToken(t, e)
+	conn := s.connectEnrolledAgent(t, server, "machine-A")
+	defer conn.Close()
+	readAISessionsConfig(t, conn)
+	s.sendSentinelMetrics(t, conn, "machine-A", "blocked-ack")
+	s.agentsMu.RLock()
+	agent := s.agents["machine-A"]
+	s.agentsMu.RUnlock()
+	if agent == nil {
+		t.Fatal("agent not registered")
+	}
+	// Deterministic backpressure: the ACK cannot acquire the writer while
+	// this lock is held. The old ingest callback held the global barrier
+	// across this wait, so even deletion could not close the socket.
+	agent.WriteMu.Lock()
+	release := sync.OnceFunc(agent.WriteMu.Unlock)
+	defer release()
+	start, end := nowWindowMS()
+	writeFrame(t, conn, powerBatch("stream-1", 1, powerBucket(1, start, end, 100, 200, 30, 30)))
+	deadline := time.Now().Add(lifecycleDeadline)
+	for powerRowCount(t, s, "machine-A") != 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("power batch never committed")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	req := httptest.NewRequest(http.MethodDelete, "/api/machines/machine-A", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() { e.ServeHTTP(rec, req); close(done) }()
+	select {
+	case <-done:
+		if rec.Code != http.StatusOK {
+			t.Fatalf("delete: %d %s", rec.Code, rec.Body.String())
+		}
+	case <-time.After(lifecycleDeadline):
+		release()
+		<-done
+		t.Fatal("delete waited for the power ACK writer")
+	}
+	if countRows(t, s, "machines", "machine-A") != 0 {
+		t.Fatal("machine survived delete")
+	}
+}

--- a/hub/power_history.go
+++ b/hub/power_history.go
@@ -229,25 +229,43 @@ func validatePowerBatch(b *powerhistory.Batch, now time.Time) error {
 // ACK after commit is a harmless replay, while a commit failure must never
 // be acknowledged.
 func (s *Server) ingestPowerHistory(machineID string, agent *ConnectedAgent, raw []byte) error {
+	ack, err := s.commitPowerHistoryFrame(machineID, agent, raw)
+	if err != nil {
+		return err
+	}
+	if ack != nil {
+		if err := agent.writeLocked(websocket.TextMessage, ack); err != nil {
+			return fmt.Errorf("ack write: %w", err)
+		}
+	}
+	return nil
+}
+
+// commitPowerHistoryFrame validates and durably commits one batch and
+// returns the ACK frame to send, or nil when nothing was committed. It
+// performs no network write: the read loop runs it under the ingestion
+// barrier and sends the ACK afterwards, so a socket whose peer is not
+// reading can never hold the barrier and stall machine deletion.
+func (s *Server) commitPowerHistoryFrame(machineID string, agent *ConnectedAgent, raw []byte) ([]byte, error) {
 	if machineID == "" || !s.isRegisteredConnection(machineID, agent) {
-		return fmt.Errorf("unregistered connection")
+		return nil, fmt.Errorf("unregistered connection")
 	}
 	// Diagnostic state belongs only to this registered connection. No invalid
 	// frame mutates durable telemetry or advances an ACK. Never expose raw errors.
 	issue := powerIssueInvalid
 	defer func() { agent.powerIssue.Store(issue) }()
 	if len(raw) > powerhistory.MaxFrameBytes {
-		return fmt.Errorf("frame %d bytes exceeds %d", len(raw), powerhistory.MaxFrameBytes)
+		return nil, fmt.Errorf("frame %d bytes exceeds %d", len(raw), powerhistory.MaxFrameBytes)
 	}
 	var batch powerhistory.Batch
 	if err := json.Unmarshal(raw, &batch); err != nil {
-		return fmt.Errorf("invalid JSON: %w", err)
+		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 	if err := validatePowerBatch(&batch, time.Now()); err != nil {
 		if errors.Is(err, errPowerClockSkew) {
 			issue = powerIssueClock
 		}
-		return err
+		return nil, err
 	}
 	issue = powerIssueStorage
 	through, err := s.commitPowerBatch(machineID, &batch, time.Now())
@@ -256,17 +274,12 @@ func (s *Server) ingestPowerHistory(machineID string, agent *ConnectedAgent, raw
 			issue = powerIssueConflict
 		}
 		log.Printf("power history commit for %s stream %s: %v", machineID, batch.StreamID, err)
-		return err
+		return nil, err
 	}
 	issue = powerIssueNone
 	agent.powerIssue.Store(issue) // clear before the successful ACK is observable
-	if agent != nil {
-		ack, _ := json.Marshal(powerhistory.Ack{Type: powerhistory.AckType, StreamID: batch.StreamID, Through: through})
-		if err := agent.writeLocked(websocket.TextMessage, ack); err != nil {
-			return fmt.Errorf("ack write: %w", err)
-		}
-	}
-	return nil
+	ack, _ := json.Marshal(powerhistory.Ack{Type: powerhistory.AckType, StreamID: batch.StreamID, Through: through})
+	return ack, nil
 }
 
 type powerStreamState struct {

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/labstack/echo/v4"
+	"time"
 )
 
 type UserRole string
@@ -41,6 +42,9 @@ const authClaimsContextKey = "auth_claims"
 type requestAuthClaims struct {
 	UserID   string
 	Username string
+	// ExpiresAt is the token's exp claim, zero when the token carries none.
+	// Long-lived handlers (the event stream) re-check it after the handshake.
+	ExpiresAt time.Time
 }
 
 var roleScopes = map[UserRole][]string{
@@ -124,25 +128,25 @@ var routeScopeRequirements = map[string]string{
 	routeScopeKey(http.MethodDelete, "/api/users/:id"):                         scopeUsersAdmin,
 
 	// Phase 10 — branding (admin) and per-user theme prefs.
-	routeScopeKey(http.MethodPatch, "/api/branding"):                           scopeBrandingAdmin,
-	routeScopeKey(http.MethodPost, "/api/branding/logo"):                       scopeBrandingAdmin,
-	routeScopeKey(http.MethodPost, "/api/branding/favicon"):                    scopeBrandingAdmin,
-	routeScopeKey(http.MethodDelete, "/api/branding/:kind"):                    scopeBrandingAdmin,
-	routeScopeKey(http.MethodGet, "/api/me/theme"):                             scopeAuthSelf,
-	routeScopeKey(http.MethodPatch, "/api/me/theme"):                           scopeAuthSelf,
+	routeScopeKey(http.MethodPatch, "/api/branding"):        scopeBrandingAdmin,
+	routeScopeKey(http.MethodPost, "/api/branding/logo"):    scopeBrandingAdmin,
+	routeScopeKey(http.MethodPost, "/api/branding/favicon"): scopeBrandingAdmin,
+	routeScopeKey(http.MethodDelete, "/api/branding/:kind"): scopeBrandingAdmin,
+	routeScopeKey(http.MethodGet, "/api/me/theme"):          scopeAuthSelf,
+	routeScopeKey(http.MethodPatch, "/api/me/theme"):        scopeAuthSelf,
 
 	// Phase 11 — per-user workflow personalization. All ten routes are
 	// "self-only" — every authenticated user can read/write their own row.
-	routeScopeKey(http.MethodGet, "/api/me/preferences"):                       scopeAuthSelf,
-	routeScopeKey(http.MethodPatch, "/api/me/preferences"):                     scopeAuthSelf,
-	routeScopeKey(http.MethodPost, "/api/me/avatar"):                           scopeAuthSelf,
-	routeScopeKey(http.MethodDelete, "/api/me/avatar"):                         scopeAuthSelf,
-	routeScopeKey(http.MethodGet, "/api/users/:user_id/avatar"):                scopeAuthSelf,
-	routeScopeKey(http.MethodPost, "/api/me/pinned/:machine_id"):               scopeAuthSelf,
-	routeScopeKey(http.MethodDelete, "/api/me/pinned/:machine_id"):             scopeAuthSelf,
-	routeScopeKey(http.MethodGet, "/api/me/filters"):                           scopeAuthSelf,
-	routeScopeKey(http.MethodPost, "/api/me/filters"):                          scopeAuthSelf,
-	routeScopeKey(http.MethodDelete, "/api/me/filters/:id"):                    scopeAuthSelf,
+	routeScopeKey(http.MethodGet, "/api/me/preferences"):           scopeAuthSelf,
+	routeScopeKey(http.MethodPatch, "/api/me/preferences"):         scopeAuthSelf,
+	routeScopeKey(http.MethodPost, "/api/me/avatar"):               scopeAuthSelf,
+	routeScopeKey(http.MethodDelete, "/api/me/avatar"):             scopeAuthSelf,
+	routeScopeKey(http.MethodGet, "/api/users/:user_id/avatar"):    scopeAuthSelf,
+	routeScopeKey(http.MethodPost, "/api/me/pinned/:machine_id"):   scopeAuthSelf,
+	routeScopeKey(http.MethodDelete, "/api/me/pinned/:machine_id"): scopeAuthSelf,
+	routeScopeKey(http.MethodGet, "/api/me/filters"):               scopeAuthSelf,
+	routeScopeKey(http.MethodPost, "/api/me/filters"):              scopeAuthSelf,
+	routeScopeKey(http.MethodDelete, "/api/me/filters/:id"):        scopeAuthSelf,
 }
 
 func (s *Server) permissionMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
@@ -181,10 +185,11 @@ func (s *Server) permissionMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	}
 }
 
-func setAuthClaimsOnContext(c echo.Context, userID, username string) {
+func setAuthClaimsOnContext(c echo.Context, userID, username string, expiresAt time.Time) {
 	c.Set(authClaimsContextKey, requestAuthClaims{
-		UserID:   userID,
-		Username: username,
+		UserID:    userID,
+		Username:  username,
+		ExpiresAt: expiresAt,
 	})
 }
 
@@ -235,15 +240,15 @@ func roleHasScope(role UserRole, requiredScope string) bool {
 
 // publicAPIRoutes lists the /api/* endpoints that are served without RBAC enforcement.
 var publicAPIRoutes = map[string]struct{}{
-	routeScopeKey(http.MethodPost, "/api/auth/login"):       {},
-	routeScopeKey(http.MethodGet, "/api/setup/status"):      {},
-	routeScopeKey(http.MethodPost, "/api/setup"):            {},
+	routeScopeKey(http.MethodPost, "/api/auth/login"):  {},
+	routeScopeKey(http.MethodGet, "/api/setup/status"): {},
+	routeScopeKey(http.MethodPost, "/api/setup"):       {},
 	// Phase 10 — branding metadata + image bytes are public so the
 	// dashboard can fetch them before authentication (login screen,
 	// document.title, favicon). Writes still require branding.admin.
-	routeScopeKey(http.MethodGet, "/api/branding"):          {},
-	routeScopeKey(http.MethodGet, "/api/branding/logo"):     {},
-	routeScopeKey(http.MethodGet, "/api/branding/favicon"):  {},
+	routeScopeKey(http.MethodGet, "/api/branding"):         {},
+	routeScopeKey(http.MethodGet, "/api/branding/logo"):    {},
+	routeScopeKey(http.MethodGet, "/api/branding/favicon"): {},
 }
 
 // auditRBACRouteCoverage verifies every protected /api/* route registered on e has a

--- a/hub/server.go
+++ b/hub/server.go
@@ -20,6 +20,12 @@ type Server struct {
 	// Serializes agent authentication/registration with credential revocation.
 	agentAuthMu sync.RWMutex
 
+	// Ingestion barrier. Every persisted agent frame runs under the read
+	// side (see ingestFrame); machine deletion takes the write side around
+	// registry removal and row deletion. Lock order is agentAuthMu, then
+	// ingestMu, then agentsMu; never the reverse.
+	ingestMu sync.RWMutex
+
 	// Latest AI Sessions snapshot per connected machine, and the cached
 	// feature switch with its revision (see ai_sessions.go).
 	aiSessions    *aiSessionStore

--- a/hub/terminal.go
+++ b/hub/terminal.go
@@ -362,6 +362,12 @@ func (s *Server) terminalRelay(sessionID string, session *TerminalSession) {
 	session.mu.Unlock()
 
 	done := make(chan struct{})
+	// Three goroutines (inactivity timer, browser reader, agent reader) all
+	// end the relay. A check-then-close select is not atomic: two of them can
+	// both see the channel open and the second close panics the process,
+	// which cleanupTerminalSession makes likely by closing both sockets
+	// back to back. One shared once-function is the only safe shape.
+	endRelay := sync.OnceFunc(func() { close(done) })
 
 	// Inactivity timeout goroutine: close session after 30 minutes of no traffic.
 	go func() {
@@ -377,11 +383,7 @@ func (s *Server) terminalRelay(sessionID string, session *TerminalSession) {
 				session.mu.Unlock()
 				if idle > 30*time.Minute {
 					log.Printf("terminal %s: closing due to inactivity (%s)", sessionID, idle.Truncate(time.Second))
-					select {
-					case <-done:
-					default:
-						close(done)
-					}
+					endRelay()
 					return
 				}
 			}
@@ -389,13 +391,7 @@ func (s *Server) terminalRelay(sessionID string, session *TerminalSession) {
 	}()
 
 	go func() {
-		defer func() {
-			select {
-			case <-done:
-			default:
-				close(done)
-			}
-		}()
+		defer endRelay()
 		for {
 			msgType, msg, err := browserWS.ReadMessage()
 			if err != nil {
@@ -413,13 +409,7 @@ func (s *Server) terminalRelay(sessionID string, session *TerminalSession) {
 	}()
 
 	go func() {
-		defer func() {
-			select {
-			case <-done:
-			default:
-				close(done)
-			}
-		}()
+		defer endRelay()
 		for {
 			msgType, msg, err := agentWS.ReadMessage()
 			if err != nil {


### PR DESCRIPTION
Unit A of the reliability plan (REPORT.md findings #11, #12, #1, #2). Hub only; the dashboard consumer of `machine_removed` is Unit D.

## What changed

- **Terminal relay single-close** (`hub/terminal.go`): the inactivity timer and both reader goroutines ended the relay through a check-then-close select on one channel; two could both see it open and the second close panicked the process. One shared `sync.OnceFunc` now ends the relay.
- **Committed-identity ingestion** (`hub/agentws.go`): services, containers and hardware_info fell back to the payload's `machine_id` before the first metrics frame established identity, so a valid install-token socket could rewrite another machine's inventory without enrolling. Inventory writes now require a committed, registered identity. A fresh enrollment's hardware snapshot (sent right after its first metrics, before `enrollment_committed`) is held and applied at the commit point, so first enrollment keeps its inventory.
- **Atomic machine deletion** (`hub/main.go`, `hub/agentws.go`, `hub/server.go`, `hub/agent_versions.go`): delete removed rows and the registry entry but never closed the socket; the next metrics frame recreated the row as online with no credential and no command routing. Delete now takes the same auth writer lock as credential revocation (no handshake can validate or register meanwhile) plus an ingestion barrier: every persisting frame handler runs under its read side with the registration check inside, and delete holds the write side across registry removal, socket close and row deletion. A frame is either fully persisted before the delete or refused after it, for the registered socket, a displaced older socket still mid-frame, and any retry. Broadcasts sit inside the same barrier section so the additive `machine_removed` `{machine_id}` SSE event is always the last event for that machine, and the update announce arms its reconnect expectation only through the barrier. Running-version and reconnect-expectation bookkeeping is cleared on delete. Lock order everywhere: `agentAuthMu`, then `ingestMu`, then `agentsMu`.
- **Event stream revocation** (`hub/main.go`, `hub/auth.go`, `hub/rbac.go`): `/api/events` checked authorization once at the handshake, so an expired token or a deleted user kept receiving fleet telemetry for as long as the connection was held. The stream now enforces the token's `exp` with its own timer and re-checks user existence on a 60 s ticker, failing closed on lookup errors.

## Regression tests (`hub/lifecycle_safety_test.go`, 17 tests)

Concurrent terminal teardown under repetition; pre-identity foreign frames rejected while first enrollment still stores hardware at commit; delete while connected (socket closed, no resurrection from a late frame, rollout state cleared, `machine_removed` emitted); delete blocked behind a credential-validated handshake paused before registration; delete blocked behind a frame parked inside the barrier; a displaced socket mid-frame refused and the delete still wins; removal event strictly last; announce cannot re-arm a reconnect expectation after delete; stream ends on user deletion, on the periodic check, and at the exact token expiry.

## Verification

- `go vet` clean; targeted lifecycle plus enrollment, identity, rollout, and power-history tests pass.
- Full hub suite with `-race` passed locally on the pre-barrier tree (468 s); the run on this exact tree is in progress locally, and the required CI race job is the gate.
- No agent, proto, dashboard, or script changes. No deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core agent ingestion, machine deletion locking, and long-lived SSE auth in concurrency-sensitive paths; mistakes could drop live agents, stall deletes, or leak telemetry after user removal.
> 
> **Overview**
> This PR hardens hub lifecycle and realtime paths so deleted or displaced agents cannot resurrect fleet state, and long-lived dashboard streams fail closed when auth is no longer valid.
> 
> **Machine deletion** is now coordinated with agent auth and ingestion: delete holds `agentAuthMu` (like credential revoke) so no new handshake can register mid-removal, and `ingestMu` write lock so in-flight frames finish or are refused before rows are removed. The live socket is closed, rollout reconnect expectations and `/api/versions` entries are cleared, and dashboards get a **`machine_removed`** control SSE event that is ordered after any final in-barrier metrics broadcast.
> 
> **Agent WebSocket ingestion** routes metrics, services, containers, hardware, version reports, AI sessions, and power commits through **`ingestFrame`**, which re-checks registry ownership under the barrier. Uncommitted enrollments no longer persist inventory or version data (held until **`enrollment_committed`**); pre-identity frames cannot target another machine’s `machine_id`. **Power history** commits under the barrier but sends ACKs outside it so a blocked peer cannot stall delete.
> 
> **Rollout**: reconnect expectations after version announce arm only via **`armReconnectIfRegistered`** inside the same barrier, avoiding phantom failures after delete.
> 
> **SSE (`/api/events`)** now carries JWT **`exp`** on context, closes streams on exact expiry and periodic user revalidation, and **`broadcastSSEControl`** kicks slow clients that would drop **`machine_removed`** instead of delivering it.
> 
> **Terminal relay** uses a single **`sync.OnceFunc`** to close the shared done channel, fixing concurrent teardown panics.
> 
> Extensive regression tests cover delete/resurrection, handshake/barrier interleaving, SSE revocation, enrollment holding, and power ACK not blocking delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf356453cdc7dfd4e0244d9b12805153e3423073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->