### PR TITLE
feat: three live dashboard layouts with per-user colors

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -23,7 +23,7 @@
     "lucide-react": "^1.41.0",
     "next": "16.2.12",
     "react": "19.2.8",
-    "react-dom": "19.2.6",
+    "react-dom": "19.2.8",
     "recharts": "^3.10.1",
     "shadcn": "^4.21.0",
     "tailwind-merge": "^3.6.0",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: ^1.8.0
-        version: 1.8.0(@types/react@19.2.18)(date-fns@3.6.0)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+        version: 1.8.0(@types/react@19.2.18)(date-fns@3.6.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tremor/react':
         specifier: ^3.18.7
-        version: 3.18.7(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+        version: 3.18.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -34,28 +34,28 @@ importers:
         version: 2.1.1
       cmdk:
         specifier: ^1.1.1
-        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       framer-motion:
         specifier: ^12.43.0
-        version: 12.43.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+        version: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       geist:
         specifier: ^1.7.2
-        version: 1.7.2(next@16.2.12(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.8))(react@19.2.8))
+        version: 1.7.2(next@16.2.12(@babel/core@7.29.7)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       lucide-react:
         specifier: ^1.41.0
         version: 1.41.0(react@19.2.8)
       next:
         specifier: 16.2.12
-        version: 16.2.12(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+        version: 16.2.12(@babel/core@7.29.7)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: 19.2.6
-        version: 19.2.6(react@19.2.8)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       recharts:
         specifier: ^3.10.1
-        version: 3.10.1(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react-is@18.3.1)(react@19.2.8)(redux@5.0.1)
+        version: 3.10.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@18.3.1)(react@19.2.8)(redux@5.0.1)
       shadcn:
         specifier: ^4.21.0
         version: 4.21.0(typescript@6.0.3)
@@ -2948,10 +2948,10 @@ packages:
       date-fns: ^2.28.0 || ^3.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
-  react-dom@19.2.6:
-    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
-      react: ^19.2.6
+      react: ^19.2.8
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3741,25 +3741,25 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@base-ui/react@1.8.0(@types/react@19.2.18)(date-fns@3.6.0)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@base-ui/react@1.8.0(@types/react@19.2.18)(date-fns@3.6.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@base-ui/utils': 0.4.0(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
-      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@base-ui/utils': 0.4.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@floating-ui/utils': 0.2.12
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       date-fns: 3.6.0
 
-  '@base-ui/utils@0.4.0(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@base-ui/utils@0.4.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@floating-ui/utils': 0.2.12
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       reselect: 5.3.0
       use-sync-external-store: 1.6.0(react@19.2.8)
     optionalDependencies:
@@ -3867,44 +3867,44 @@ snapshots:
       '@floating-ui/core': 1.8.0
       '@floating-ui/utils': 0.2.12
 
-  '@floating-ui/react-dom@1.3.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@floating-ui/react-dom@1.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@floating-ui/dom': 1.8.0
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
-  '@floating-ui/react-dom@2.1.9(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@floating-ui/dom': 1.8.0
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
-  '@floating-ui/react@0.19.2(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@floating-ui/react@0.19.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@floating-ui/react-dom': 1.3.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@floating-ui/react-dom': 1.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       aria-hidden: 1.2.6
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       tabbable: 6.4.0
 
-  '@floating-ui/react@0.26.28(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@floating-ui/react@0.26.28(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@floating-ui/utils': 0.2.12
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@headlessui/react@2.2.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@headlessui/react@2.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@floating-ui/react': 0.26.28(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
-      '@react-aria/focus': 3.22.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
-      '@react-aria/interactions': 3.28.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
-      '@tanstack/react-virtual': 3.13.24(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@floating-ui/react': 0.26.28(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@react-aria/focus': 3.22.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@react-aria/interactions': 3.28.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/react-virtual': 3.13.24(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
   '@hono/node-server@2.1.1(hono@4.13.7)':
     dependencies:
@@ -4144,37 +4144,37 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.8)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.18)(react@19.2.8)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.18)(react@19.2.8)
       aria-hidden: 1.2.6
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       react-remove-scroll: 2.7.2(@types/react@19.2.18)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.3(@types/react@19.2.18)
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@19.2.8)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.3(@types/react@19.2.18)
@@ -4185,13 +4185,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.3(@types/react@19.2.18)
@@ -4203,40 +4203,40 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.3(@types/react@19.2.18)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.8)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.3(@types/react@19.2.18)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.3(@types/react@19.2.18)
 
-  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.3(@types/react@19.2.18)
@@ -4289,20 +4289,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@react-aria/focus@3.22.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@react-aria/focus@3.22.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@swc/helpers': 0.5.21
       react: 19.2.8
-      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
-      react-dom: 19.2.6(react@19.2.8)
+      react-aria: 3.48.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
-  '@react-aria/interactions@3.28.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@react-aria/interactions@3.28.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@react-types/shared': 3.34.0(react@19.2.8)
       '@swc/helpers': 0.5.21
       react: 19.2.8
-      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
-      react-dom: 19.2.6(react@19.2.8)
+      react-aria: 3.48.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
   '@react-types/shared@3.34.0(react@19.2.8)':
     dependencies:
@@ -4407,24 +4407,24 @@ snapshots:
       postcss: 8.5.25
       tailwindcss: 4.3.3
 
-  '@tanstack/react-virtual@3.13.24(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-virtual@3.13.24(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/virtual-core': 3.14.0
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
   '@tanstack/virtual-core@3.14.0': {}
 
-  '@tremor/react@3.18.7(react-dom@19.2.6(react@19.2.8))(react@19.2.8)':
+  '@tremor/react@3.18.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@floating-ui/react': 0.19.2(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
-      '@headlessui/react': 2.2.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@floating-ui/react': 0.19.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@headlessui/react': 2.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       date-fns: 3.6.0
       react: 19.2.8
       react-day-picker: 8.10.1(date-fns@3.6.0)(react@19.2.8)
-      react-dom: 19.2.6(react@19.2.8)
-      react-transition-state: 2.3.3(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
-      recharts: 2.15.4(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
+      react-transition-state: 2.3.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      recharts: 2.15.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tailwind-merge: 2.6.1
 
   '@ts-morph/common@0.27.0':
@@ -4880,14 +4880,14 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8):
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.18)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -5600,14 +5600,14 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  framer-motion@12.43.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8):
+  framer-motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       motion-dom: 12.43.0
       motion-utils: 12.39.0
       tslib: 2.8.1
     optionalDependencies:
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
   fresh@2.0.0: {}
 
@@ -5635,9 +5635,9 @@ snapshots:
 
   fuzzysort@3.1.0: {}
 
-  geist@1.7.2(next@16.2.12(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)):
+  geist@1.7.2(next@16.2.12(@babel/core@7.29.7)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
     dependencies:
-      next: 16.2.12(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      next: 16.2.12(@babel/core@7.29.7)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   generator-function@2.0.1: {}
 
@@ -6157,7 +6157,7 @@ snapshots:
     dependencies:
       content-type: 2.1.0
 
-  next@16.2.12(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.8))(react@19.2.8):
+  next@16.2.12(@babel/core@7.29.7)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.2.12
       '@swc/helpers': 0.5.15
@@ -6165,7 +6165,7 @@ snapshots:
       caniuse-lite: 1.0.30001806
       postcss: 8.5.25
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.8)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.12
@@ -6418,7 +6418,7 @@ snapshots:
       iconv-lite: 0.7.3
       unpipe: 1.0.0
 
-  react-aria@3.48.0(react-dom@19.2.6(react@19.2.8))(react@19.2.8):
+  react-aria@3.48.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@internationalized/date': 3.12.1
       '@internationalized/number': 3.6.6
@@ -6428,7 +6428,7 @@ snapshots:
       aria-hidden: 1.2.6
       clsx: 2.1.1
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       react-stately: 3.46.0(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
 
@@ -6437,7 +6437,7 @@ snapshots:
       date-fns: 3.6.0
       react: 19.2.8
 
-  react-dom@19.2.6(react@19.2.8):
+  react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
@@ -6474,13 +6474,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  react-smooth@4.0.4(react-dom@19.2.6(react@19.2.8))(react@19.2.8):
+  react-smooth@4.0.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       fast-equals: 5.4.0
       prop-types: 15.8.1
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
-      react-transition-group: 4.4.5(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
+      react-transition-group: 4.4.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   react-stately@3.46.0(react@19.2.8):
     dependencies:
@@ -6500,19 +6500,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  react-transition-group@4.4.5(react-dom@19.2.6(react@19.2.8))(react@19.2.8):
+  react-transition-group@4.4.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@babel/runtime': 7.29.7
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
-  react-transition-state@2.3.3(react-dom@19.2.6(react@19.2.8))(react@19.2.8):
+  react-transition-state@2.3.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
   react@19.2.8: {}
 
@@ -6528,20 +6528,20 @@ snapshots:
     dependencies:
       decimal.js-light: 2.5.1
 
-  recharts@2.15.4(react-dom@19.2.6(react@19.2.8))(react@19.2.8):
+  recharts@2.15.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       clsx: 2.1.1
       eventemitter3: 4.0.7
       lodash: 4.18.1
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       react-is: 18.3.1
-      react-smooth: 4.0.4(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
+      react-smooth: 4.0.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       recharts-scale: 0.4.5
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
-  recharts@3.10.1(@types/react@19.2.18)(react-dom@19.2.6(react@19.2.8))(react-is@18.3.1)(react@19.2.8)(redux@5.0.1):
+  recharts@3.10.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@18.3.1)(react@19.2.8)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)
       clsx: 2.1.1
@@ -6550,7 +6550,7 @@ snapshots:
       eventemitter3: 5.0.4
       immer: 11.1.15
       react: 19.2.8
-      react-dom: 19.2.6(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       react-is: 18.3.1
       react-redux: 9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1)
       reselect: 5.2.0

--- a/dashboard/src/app/design-layouts.css
+++ b/dashboard/src/app/design-layouts.css
@@ -1,0 +1,387 @@
+/* ============================================================================
+ * BloxOS live dashboard layouts — Operations Wall, Grove Workspace,
+ * Precision Console — ported from docs/themes/index.html.
+ *
+ * Scope and safety
+ * ----------------
+ * Every rule is scoped under html[data-layout="wall"|"grove"|"console"], set
+ * by DesignContext. Classic (data-layout="classic" or unset) receives NONE of
+ * this and keeps the existing dashboard verbatim. Class names are prefixed
+ * (lw-/lg-/lc-/ld-) so they cannot collide with Tailwind utilities or existing
+ * component classes.
+ *
+ * Color variants (nine total = 3 layouts x 3 colors)
+ * --------------------------------------------------
+ * The twelve palette variables are namespaced --ld-* so they never override
+ * the app's own tokens (--surface/--text/--blox/--status) used by the reused
+ * inner components. Original is a FIXED palette (the approved mockup), not OS
+ * mode dependent; Bright is a fixed light palette; Dark a fixed near-black one.
+ * DesignContext also sets .light (Bright) / .dark (Original, Dark) on <html>
+ * so the reused inner components (machine cards, tables, gauges) follow a
+ * matching scheme via the app tokens.
+ *
+ * Status semantics
+ * ----------------
+ * Machine status always uses the app's semantic --status-* tokens, never the
+ * decorative --ld-good. There is no single "all healthy" color (AGENTS.md:
+ * missing sensors are unavailable, not zero; no false all-healthy status).
+ * ========================================================================== */
+
+/* ---- Palette variable sets ------------------------------------------------ */
+
+/* Operations Wall — Original (midnight-blue mockup) */
+html[data-layout="wall"] {
+  --ld-ink: #e7edf8; --ld-secondary: #a4b3ca; --ld-muted: #94a3bc;
+  --ld-canvas: #10151f; --ld-panel: #1c2534; --ld-panel-alt: #19212e;
+  --ld-edge: #ffffff14; --ld-track: #0e1624;
+  --ld-accent: #8eaaff; --ld-accent-soft: #8faeff2e; --ld-good: #95d8bb; --ld-on-accent: #0b1425;
+}
+html[data-layout="wall"][data-design-color="bright"] {
+  --ld-ink: #202d44; --ld-secondary: #526480; --ld-muted: #60718a;
+  --ld-canvas: #f1f5fb; --ld-panel: #ffffff; --ld-panel-alt: #e9eff9;
+  --ld-edge: #d7e0ee; --ld-track: #dfe7f3;
+  --ld-accent: #4c6dba; --ld-accent-soft: #cad8fb; --ld-good: #286c52; --ld-on-accent: #ffffff;
+}
+html[data-layout="wall"][data-design-color="dark"] {
+  --ld-ink: #e3e9f5; --ld-secondary: #adbbd2; --ld-muted: #8395b2;
+  --ld-canvas: #080c14; --ld-panel: #101724; --ld-panel-alt: #0c1220;
+  --ld-edge: #263147; --ld-track: #202d44;
+  --ld-accent: #8aa8ee; --ld-accent-soft: #354f80; --ld-good: #8ad6b6; --ld-on-accent: #0b1425;
+}
+
+/* Grove Workspace — Original (evergreen mockup) */
+html[data-layout="grove"] {
+  --ld-ink: #e0ecdf; --ld-secondary: #a8bfab; --ld-muted: #819487;
+  --ld-canvas: #0d1714; --ld-panel: #1a2a21; --ld-panel-alt: #111e18;
+  --ld-edge: #29372e; --ld-track: #263b27;
+  --ld-accent: #c2f27d; --ld-accent-soft: #354a23; --ld-good: #96cda0; --ld-on-accent: #132115;
+}
+html[data-layout="grove"][data-design-color="bright"] {
+  --ld-ink: #203b2b; --ld-secondary: #496551; --ld-muted: #587461;
+  --ld-canvas: #f5f7ef; --ld-panel: #fffef9; --ld-panel-alt: #eaf0df;
+  --ld-edge: #d7dfcb; --ld-track: #dfe7d3;
+  --ld-accent: #537e2c; --ld-accent-soft: #d1e5ad; --ld-good: #33724e; --ld-on-accent: #ffffff;
+}
+html[data-layout="grove"][data-design-color="dark"] {
+  --ld-ink: #e0ecdf; --ld-secondary: #a8bfab; --ld-muted: #859f8a;
+  --ld-canvas: #080f0b; --ld-panel: #101b13; --ld-panel-alt: #0b140d;
+  --ld-edge: #293c2b; --ld-track: #263b27;
+  --ld-accent: #a6cf6c; --ld-accent-soft: #354a23; --ld-good: #96cda0; --ld-on-accent: #15210e;
+}
+
+/* Precision Console — Original (graphite mockup) */
+html[data-layout="console"] {
+  --ld-ink: #dde4f0; --ld-secondary: #a5b4cc; --ld-muted: #909baf;
+  --ld-canvas: #11141a; --ld-panel: #191f29; --ld-panel-alt: #1b1f28;
+  --ld-edge: #303644; --ld-track: #323c50;
+  --ld-accent: #9fb5ff; --ld-accent-soft: #35405e; --ld-good: #91ceb0; --ld-on-accent: #10182a;
+}
+html[data-layout="console"][data-design-color="bright"] {
+  --ld-ink: #242e40; --ld-secondary: #53637b; --ld-muted: #617089;
+  --ld-canvas: #f3f4f7; --ld-panel: #ffffff; --ld-panel-alt: #e9edf4;
+  --ld-edge: #d2dae6; --ld-track: #dfe5ef;
+  --ld-accent: #536bb5; --ld-accent-soft: #c7d3f4; --ld-good: #317154; --ld-on-accent: #ffffff;
+}
+html[data-layout="console"][data-design-color="dark"] {
+  --ld-ink: #dde4f0; --ld-secondary: #a5b4cc; --ld-muted: #8495ae;
+  --ld-canvas: #080a10; --ld-panel: #10141d; --ld-panel-alt: #0b0f17;
+  --ld-edge: #283043; --ld-track: #252f43;
+  --ld-accent: #94a8dd; --ld-accent-soft: #35405e; --ld-good: #91ceb0; --ld-on-accent: #10182a;
+}
+
+/* ---- Remap the app tokens so reused content and dialogs inherit the palette -
+ * Tailwind utilities (bg-blox-card, text-blox-text, ...) resolve through
+ * --color-blox-* -> the base tokens below. Remapping the base tokens on the
+ * root element (so portalled dialogs inherit too) makes every reused
+ * component adopt the active layout palette instead of the default BloxOS
+ * light/dark. --ld-* already carries the active color, so this follows it.
+ * Status tokens are deliberately NOT remapped here — they are set explicitly
+ * below to stay semantic and distinct. Classic is excluded. */
+html[data-layout="wall"],
+html[data-layout="grove"],
+html[data-layout="console"] {
+  --surface-sunken: var(--ld-panel-alt);
+  --surface-base: var(--ld-canvas);
+  --surface-raised: var(--ld-panel);
+  --surface-elevated: var(--ld-panel-alt);
+  --surface-overlay: var(--ld-panel);
+
+  --text-primary: var(--ld-ink);
+  --text-secondary: var(--ld-secondary);
+  --text-tertiary: var(--ld-muted);
+  --text-disabled: color-mix(in srgb, var(--ld-muted) 60%, transparent);
+
+  --border-subtle: var(--ld-edge);
+  --border-default: var(--ld-edge);
+  --border-strong: color-mix(in srgb, var(--ld-ink) 22%, transparent);
+
+  --accent: var(--ld-accent);
+  --accent-hover: var(--ld-accent);
+  --accent-subtle: var(--ld-accent-soft);
+  --accent-foreground: var(--ld-on-accent);
+}
+
+/* ---- Status tokens: five distinct, scheme-appropriate states in all 9 combos.
+ * Defined per data-design-color so they never depend on the presence of a
+ * .light/.dark class. Never collapse to one "healthy" color (AGENTS.md). */
+html[data-layout="wall"]:not([data-design-color="bright"]),
+html[data-layout="grove"]:not([data-design-color="bright"]),
+html[data-layout="console"]:not([data-design-color="bright"]) {
+  --status-ok: oklch(0.74 0.16 158); --status-ok-tint: oklch(0.74 0.16 158 / 0.10);
+  --status-warning: oklch(0.8 0.16 75); --status-warning-tint: oklch(0.8 0.16 75 / 0.10);
+  --status-critical: oklch(0.7 0.21 25); --status-critical-tint: oklch(0.7 0.21 25 / 0.10);
+  --status-stale: oklch(0.66 0.07 285); --status-stale-tint: oklch(0.66 0.07 285 / 0.10);
+  --status-offline: oklch(0.66 0.02 240); --status-offline-tint: oklch(0.5 0.01 240 / 0.4);
+  --success: var(--status-ok); --success-subtle: var(--status-ok-tint);
+  --warning: var(--status-warning); --warning-subtle: var(--status-warning-tint);
+  --danger: var(--status-critical); --danger-subtle: var(--status-critical-tint);
+}
+html[data-layout="wall"][data-design-color="bright"],
+html[data-layout="grove"][data-design-color="bright"],
+html[data-layout="console"][data-design-color="bright"] {
+  --status-ok: oklch(0.52 0.15 158); --status-ok-tint: oklch(0.52 0.15 158 / 0.12);
+  --status-warning: oklch(0.54 0.14 65); --status-warning-tint: oklch(0.54 0.14 65 / 0.12);
+  --status-critical: oklch(0.52 0.22 27); --status-critical-tint: oklch(0.52 0.22 27 / 0.12);
+  --status-stale: oklch(0.5 0.08 285); --status-stale-tint: oklch(0.5 0.08 285 / 0.12);
+  --status-offline: oklch(0.53 0.02 240); --status-offline-tint: oklch(0.53 0.02 240 / 0.14);
+  --success: var(--status-ok); --success-subtle: var(--status-ok-tint);
+  --warning: var(--status-warning); --warning-subtle: var(--status-warning-tint);
+  --danger: var(--status-critical); --danger-subtle: var(--status-critical-tint);
+}
+
+/* ---- Shared primitives (scoped to any non-classic layout) ----------------- */
+:is([data-layout="wall"], [data-layout="grove"], [data-layout="console"]) .ld-shell {
+  min-height: 100vh;
+  background: var(--ld-canvas);
+  color: var(--ld-ink);
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+.ld-label { font-size: 11px; letter-spacing: .2px; color: var(--ld-secondary); font-weight: 450; }
+.ld-mono { font-family: var(--font-mono), ui-monospace, monospace; font-variant-numeric: tabular-nums; }
+.ld-unit { font-size: .4em; opacity: .65; margin-left: 4px; }
+.ld-note { font-size: 10px; color: var(--ld-muted); }
+.ld-bar { height: 6px; background: var(--ld-track); border-radius: 5px; overflow: hidden; }
+.ld-bar > i { display: block; height: 100%; background: var(--ld-accent); border-radius: 5px; }
+/* Status dot uses the real per-status token supplied inline as --dot. */
+.ld-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--dot, var(--ld-good)); }
+.ld-rank-item { margin-top: 22px; }
+.ld-rank-item > div:first-child { display: flex; justify-content: space-between; font-size: 11px; color: var(--ld-ink); margin-bottom: 9px; gap: 10px; }
+
+/* ===========================================================================
+ * 01 — Operations Wall: open canvas, responsive bento grid.
+ * ========================================================================= */
+[data-layout="wall"] .lw {
+  background: radial-gradient(ellipse at 18% 0%, color-mix(in srgb, var(--ld-accent) 8%, transparent), transparent 55%), var(--ld-canvas);
+  padding: 28px clamp(20px, 4vw, 64px) 30px;
+}
+[data-layout="wall"] .lw-head { max-width: 1480px; margin: 0 auto; display: flex; align-items: center; gap: 16px; padding-bottom: 22px; border-bottom: 1px solid var(--ld-edge); flex-wrap: wrap; }
+[data-layout="wall"] .lw-nav { display: flex; align-items: center; gap: 2px; flex-wrap: wrap; }
+[data-layout="wall"] .lw-nav a { display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px; border-radius: 9px; font-size: 12px; color: var(--ld-secondary); text-decoration: none; }
+[data-layout="wall"] .lw-nav a:hover { color: var(--ld-ink); background: color-mix(in srgb, var(--ld-accent) 12%, transparent); }
+[data-layout="wall"] .lw-nav a.is-active { color: var(--ld-ink); background: var(--ld-accent-soft); }
+[data-layout="wall"] .lw-actions { margin-left: auto; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+[data-layout="wall"] .lw-content { max-width: 1480px; margin: 26px auto 0; }
+[data-layout="wall"] .lw-intro { max-width: 1480px; margin: 4px auto 26px; display: flex; justify-content: space-between; align-items: center; gap: 15px; }
+[data-layout="wall"] .lw-intro h1 { font-size: 30px; letter-spacing: -1.2px; font-weight: 550; color: var(--ld-ink); }
+[data-layout="wall"] .lw-intro p { font-size: 12px; color: var(--ld-secondary); margin-top: 8px; }
+[data-layout="wall"] .lw-scope { font-size: 11px; color: var(--ld-secondary); border: 1px solid var(--ld-edge); border-radius: 9px; padding: 10px 13px; background: var(--ld-panel); }
+[data-layout="wall"] .lw-grid { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 18px; max-width: 1480px; margin: auto; }
+[data-layout="wall"] .lw-tile { background: var(--ld-panel); border: 1px solid var(--ld-edge); border-radius: 19px; padding: 24px; position: relative; min-width: 0; overflow: hidden; box-shadow: 0 8px 30px #0000000a; }
+[data-layout="wall"] .lw-tile .ld-label { letter-spacing: .2px; }
+[data-layout="wall"] .lw-fleet { grid-column: span 6; display: flex; flex-direction: column; min-height: 206px; background: linear-gradient(120deg, var(--ld-panel-alt), var(--ld-panel)); border-color: var(--ld-edge); }
+[data-layout="wall"] .lw-fleet-reading { display: flex; align-items: baseline; gap: 12px; margin-top: 17px; }
+[data-layout="wall"] .lw-massive { font-size: 64px; letter-spacing: -4px; line-height: 1; font-weight: 500; color: var(--ld-ink); }
+[data-layout="wall"] .lw-denominator { font-size: 15px; color: var(--ld-secondary); }
+[data-layout="wall"] .lw-fleet-bottom { margin-top: 20px; font-size: 11px; color: var(--ld-secondary); display: flex; gap: 8px; align-items: center; }
+/* Availability ring — the accent arc is bound to --pct (real onlinePct); an
+   unknown/zero value leaves a full track (empty ring), never a false full. */
+[data-layout="wall"] .lw-orbit { position: absolute; right: 28px; top: 30px; width: 140px; height: 140px; border-radius: 50%; display: grid; place-items: center; background: conic-gradient(var(--ld-accent) calc(var(--pct, 0) * 1%), var(--ld-track) 0); }
+[data-layout="wall"] .lw-orbit::before { content: ""; position: absolute; inset: 12px; border-radius: 50%; background: var(--ld-panel); }
+[data-layout="wall"] .lw-orbit span { position: relative; z-index: 1; font-size: 21px; color: var(--ld-ink); letter-spacing: -.6px; text-align: center; }
+[data-layout="wall"] .lw-orbit small { display: block; font-size: 8px; letter-spacing: 1px; color: var(--ld-secondary); margin-top: 5px; }
+[data-layout="wall"] .lw-sessions { grid-column: span 3; }
+[data-layout="wall"] .lw-alerts { grid-column: span 3; }
+[data-layout="wall"] .lw-card-icon { position: absolute; top: 21px; right: 22px; width: 29px; height: 29px; border: 1px solid var(--ld-edge); border-radius: 9px; display: grid; place-items: center; color: var(--ld-accent); background: var(--ld-panel-alt); }
+[data-layout="wall"] .lw-card-icon svg { width: 15px; height: 15px; }
+[data-layout="wall"] .lw-stat-big { font-size: 49px; font-weight: 450; letter-spacing: -2px; display: block; line-height: 1.2; margin: 25px 0 11px; color: var(--ld-ink); }
+[data-layout="wall"] .lw-sessions p, [data-layout="wall"] .lw-alerts p { font-size: 11px; color: var(--ld-secondary); }
+[data-layout="wall"] .lw-resources { grid-column: span 6; }
+[data-layout="wall"] .lw-resource-bars { display: grid; gap: 23px; margin-top: 27px; }
+[data-layout="wall"] .lw-resource-row { display: grid; grid-template-columns: 90px 1fr 45px; gap: 16px; align-items: center; font-size: 11px; color: var(--ld-secondary); }
+[data-layout="wall"] .lw-resource-row strong { text-align: right; font-size: 12px; font-weight: 500; color: var(--ld-ink); font-variant-numeric: tabular-nums; }
+[data-layout="wall"] .lw-ranks { grid-column: span 6; display: grid; grid-template-columns: 1fr 1fr; gap: 25px; }
+[data-layout="wall"] .lw-ranks > div + div { border-left: 1px solid var(--ld-edge); padding-left: 25px; }
+[data-layout="wall"] .lw-ranks h2 { font-size: 12px; color: var(--ld-secondary); font-weight: 500; }
+[data-layout="wall"] .lw-foot-tile { grid-column: span 2; background: var(--ld-panel-alt); }
+[data-layout="wall"] .lw-foot-tile .lw-big { font-size: 39px; font-weight: 450; letter-spacing: -1.8px; margin-top: 40px; white-space: nowrap; color: var(--ld-ink); }
+[data-layout="wall"] .lw-foot-tile p { font-size: 10px; color: var(--ld-secondary); margin-top: 13px; line-height: 1.6; }
+[data-layout="wall"] .lw-machines { grid-column: span 8; padding: 24px; }
+[data-layout="wall"] .lw-machine { display: grid; grid-template-columns: minmax(0, 1fr) 52px 52px 52px; gap: 20px; align-items: center; font-size: 11px; margin-top: 14px; color: var(--ld-ink); text-decoration: none; }
+[data-layout="wall"] a.lw-machine:hover { color: var(--ld-accent); }
+[data-layout="wall"] .lw-machine small { display: block; color: var(--ld-secondary); font-size: 9px; margin-top: 5px; }
+[data-layout="wall"] .lw-machine span:not(:first-child) { text-align: right; font-variant-numeric: tabular-nums; color: var(--ld-secondary); }
+[data-layout="wall"] .lw-machine-head { padding-bottom: 11px; border-bottom: 1px solid var(--ld-edge); margin-top: 20px; color: var(--ld-muted); font-size: 9px; letter-spacing: .6px; }
+[data-layout="wall"] .lw-empty { color: var(--ld-secondary); font-size: 12px; padding: 24px 0; text-align: center; }
+
+/* ===========================================================================
+ * 02 — Grove Workspace: sidebar, analytics column, context rail.
+ * ========================================================================= */
+[data-layout="grove"] .lg { display: grid; grid-template-columns: 232px minmax(0, 1fr) 300px; min-height: 100vh; background: var(--ld-canvas); }
+[data-layout="grove"] .lg.lg-norail { grid-template-columns: 232px minmax(0, 1fr); }
+/* Mobile top bar is desktop-hidden; the @700 block flips it to flex and hides
+   the sidebar, so exactly one nav + action cluster is visible per breakpoint. */
+[data-layout="grove"] .lg-mobilebar { display: none; }
+[data-layout="grove"] .lg-actions { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+[data-layout="grove"] .lg-brand { display: flex; align-items: center; gap: 10px; margin-bottom: 26px; }
+[data-layout="grove"] .lg-sidebar { border-right: 1px solid var(--ld-edge); padding: 26px 18px; display: flex; flex-direction: column; background: var(--ld-panel-alt); position: sticky; top: 0; height: 100vh; }
+[data-layout="grove"] .lg-navlabel { font-size: 9px; letter-spacing: 2px; color: var(--ld-secondary); margin: 24px 12px 10px; }
+[data-layout="grove"] .lg-navitem { padding: 12px 14px; color: var(--ld-secondary); font-size: 12px; margin-bottom: 4px; display: flex; align-items: center; gap: 12px; border-radius: 30px; text-decoration: none; transition: background .12s, color .12s; }
+[data-layout="grove"] .lg-navitem:hover { color: var(--ld-ink); background: color-mix(in srgb, var(--ld-accent) 12%, transparent); }
+[data-layout="grove"] .lg-navitem.is-active { background: var(--ld-accent); color: var(--ld-on-accent); }
+[data-layout="grove"] .lg-navicon { width: 16px; height: 16px; display: grid; place-items: center; }
+[data-layout="grove"] .lg-sidebar-foot { margin-top: auto; font-size: 11px; color: var(--ld-secondary); padding: 24px 12px 0; line-height: 1.8; }
+[data-layout="grove"] .lg-main { padding: 30px 30px 40px; min-width: 0; }
+[data-layout="grove"] .lg-top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 26px; gap: 16px; }
+[data-layout="grove"] .lg-top h1 { font-size: 26px; font-weight: 400; letter-spacing: -1px; color: var(--ld-ink); }
+[data-layout="grove"] .lg-top p { color: var(--ld-secondary); font-size: 11px; margin-top: 8px; }
+[data-layout="grove"] .lg-hero { display: grid; grid-template-columns: 1.1fr 1fr; gap: 22px; align-items: center; border-bottom: 1px solid var(--ld-edge); padding-bottom: 28px; }
+[data-layout="grove"] .lg-online { font-size: 72px; font-weight: 400; letter-spacing: -5px; margin: 10px 0 4px; color: var(--ld-ink); }
+[data-layout="grove"] .lg-online span { font-size: 22px; letter-spacing: -1px; color: var(--ld-secondary); }
+[data-layout="grove"] .lg-hero p { font-size: 11px; color: var(--ld-secondary); }
+/* Availability ring bound to --pct (real onlinePct); empty track when unknown. */
+[data-layout="grove"] .lg-orb { width: 165px; height: 165px; margin: auto; border-radius: 50%; background: conic-gradient(var(--ld-accent) calc(var(--pct, 0) * 1%), var(--ld-track) 0); padding: 14px; box-shadow: 0 0 0 13px color-mix(in srgb, var(--ld-accent) 9%, transparent), 0 0 0 28px color-mix(in srgb, var(--ld-accent) 4%, transparent); }
+[data-layout="grove"] .lg-orb-core { background: var(--ld-panel); border-radius: 50%; height: 100%; display: flex; align-items: center; justify-content: center; flex-direction: column; }
+[data-layout="grove"] .lg-orb-core strong { font-size: 30px; font-weight: 400; color: var(--ld-ink); }
+[data-layout="grove"] .lg-orb-core small { font-size: 9px; color: var(--ld-secondary); margin-top: 6px; }
+[data-layout="grove"] .lg-health { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin: 24px 0; }
+[data-layout="grove"] .lg-health article { background: var(--ld-panel); border: 1px solid var(--ld-edge); border-radius: 18px; padding: 18px 16px; }
+[data-layout="grove"] .lg-health small { color: var(--ld-secondary); font-size: 10px; }
+[data-layout="grove"] .lg-health strong { display: block; font-size: 25px; font-weight: 400; margin: 12px 0; color: var(--ld-ink); }
+[data-layout="grove"] .lg-health .ld-bar { height: 4px; }
+[data-layout="grove"] .lg-ranks { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin: 28px 0; }
+[data-layout="grove"] .lg-ranks h2 { font-size: 12px; color: var(--ld-ink); font-weight: 500; }
+[data-layout="grove"] .lg-fleet { border-top: 1px solid var(--ld-edge); padding-top: 24px; }
+[data-layout="grove"] .lg-fleet > h2 { font-size: 13px; color: var(--ld-ink); margin-bottom: 6px; }
+[data-layout="grove"] .lg-machine { display: grid; grid-template-columns: 1.5fr 1fr; align-items: center; gap: 12px; padding: 16px 0; border-bottom: 1px solid var(--ld-edge); text-decoration: none; }
+[data-layout="grove"] .lg-machine strong { font-size: 12px; font-weight: 500; color: var(--ld-ink); display: flex; align-items: center; gap: 8px; }
+[data-layout="grove"] .lg-machine small { display: block; font-size: 9px; color: var(--ld-secondary); margin-top: 6px; }
+[data-layout="grove"] .lg-machine .lg-values { font-size: 10px; color: var(--ld-secondary); text-align: right; font-variant-numeric: tabular-nums; }
+[data-layout="grove"] .lg-rail { padding: 30px 22px; background: var(--ld-panel-alt); border-left: 1px solid var(--ld-edge); position: sticky; top: 0; height: 100vh; overflow: auto; }
+[data-layout="grove"] .lg-rail > h2 { color: var(--ld-ink); margin-bottom: 22px; font-size: 13px; }
+[data-layout="grove"] .lg-session-hero { background: var(--ld-accent-soft); color: var(--ld-ink); padding: 24px; border-radius: 24px; margin-bottom: 16px; }
+[data-layout="grove"] .lg-session-hero strong { font-size: 60px; letter-spacing: -4px; font-weight: 400; display: block; margin: 14px 0 6px; }
+[data-layout="grove"] .lg-rail-card { border: 1px solid var(--ld-edge); border-radius: 22px; padding: 20px; margin: 14px 0; }
+[data-layout="grove"] .lg-rail-card .lg-reading { font-size: 34px; margin: 14px 0 8px; letter-spacing: -1px; color: var(--ld-ink); }
+[data-layout="grove"] .lg-rail-card p { font-size: 10px; color: var(--ld-secondary); line-height: 1.7; }
+
+/* ===========================================================================
+ * 03 — Precision Console: icon rail, tabs, table-first, instrument row.
+ * ========================================================================= */
+[data-layout="console"] .lc { display: grid; grid-template-columns: 65px 1fr; min-height: 100vh; background: var(--ld-canvas); }
+[data-layout="console"] .lc-rail { background: var(--ld-panel-alt); border-right: 1px solid var(--ld-edge); display: flex; align-items: center; flex-direction: column; padding: 22px 0; gap: 20px; position: sticky; top: 0; height: 100vh; }
+[data-layout="console"] .lc-rail .lc-mark { color: var(--ld-accent); margin-bottom: 18px; line-height: 0; }
+[data-layout="console"] .lc-rail a { color: var(--ld-muted); width: 38px; height: 38px; border-radius: 8px; display: grid; place-items: center; text-decoration: none; }
+[data-layout="console"] .lc-rail a:hover { color: var(--ld-ink); }
+[data-layout="console"] .lc-rail a.is-active { color: var(--ld-ink); background: var(--ld-accent-soft); }
+[data-layout="console"] .lc-body { min-width: 0; }
+[data-layout="console"] .lc-head { padding: 18px 30px; display: flex; align-items: center; border-bottom: 1px solid var(--ld-edge); gap: 20px; flex-wrap: wrap; }
+[data-layout="console"] .lc-tabs { display: flex; gap: 22px; font-size: 11px; flex-wrap: wrap; min-width: 0; }
+[data-layout="console"] .lc-tabs a { color: var(--ld-secondary); text-decoration: none; }
+[data-layout="console"] .lc-tabs a:hover { color: var(--ld-ink); }
+[data-layout="console"] .lc-tabs a.is-active { color: var(--ld-ink); }
+[data-layout="console"] .lc-actions { margin-left: auto; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+[data-layout="console"] .lc-content { padding: 30px; }
+[data-layout="console"] .lc-heading { display: flex; justify-content: space-between; align-items: end; margin-bottom: 24px; gap: 16px; }
+[data-layout="console"] .lc-heading h1 { font-size: 24px; font-weight: 500; color: var(--ld-ink); }
+[data-layout="console"] .lc-heading p { font-size: 11px; color: var(--ld-secondary); margin-top: 8px; }
+[data-layout="console"] .lc-heading > span { font: 10px var(--font-mono, monospace); color: var(--ld-secondary); }
+[data-layout="console"] .lc-ticker { display: grid; grid-template-columns: repeat(6, 1fr); border: 1px solid var(--ld-edge); border-radius: 6px; margin-bottom: 24px; background: var(--ld-panel); }
+[data-layout="console"] .lc-ticker-cell { padding: 18px 20px; border-right: 1px solid var(--ld-edge); }
+[data-layout="console"] .lc-ticker-cell:last-child { border-right: 0; }
+[data-layout="console"] .lc-ticker-cell small { display: block; color: var(--ld-secondary); font-size: 9px; text-transform: uppercase; letter-spacing: 1px; }
+[data-layout="console"] .lc-ticker-cell strong { font: 26px var(--font-mono, monospace); display: block; margin-top: 10px; color: var(--ld-ink); }
+[data-layout="console"] .lc-ticker-cell p { font-size: 9px; color: var(--ld-secondary); margin-top: 8px; }
+[data-layout="console"] .lc-table-wrap { border: 1px solid var(--ld-edge); border-radius: 6px; overflow: auto; }
+[data-layout="console"] .lc-table-title { padding: 16px 20px; background: var(--ld-panel-alt); display: flex; justify-content: space-between; align-items: center; }
+[data-layout="console"] .lc-table-title h2 { font-size: 12px; color: var(--ld-ink); }
+[data-layout="console"] .lc-table-title span { font: 10px var(--font-mono, monospace); color: var(--ld-secondary); }
+[data-layout="console"] table.lc-table { width: 100%; border-collapse: collapse; white-space: nowrap; background: var(--ld-panel); }
+[data-layout="console"] .lc-table th { text-align: left; font-size: 9px; color: var(--ld-secondary); letter-spacing: 1px; text-transform: uppercase; font-weight: 400; padding: 14px 20px; background: var(--ld-panel-alt); }
+[data-layout="console"] .lc-table td { padding: 18px 20px; border-top: 1px solid var(--ld-edge); font-size: 12px; color: var(--ld-ink); }
+[data-layout="console"] .lc-table td small { display: block; font-size: 10px; color: var(--ld-secondary); margin-top: 6px; }
+[data-layout="console"] .lc-table td.lc-number { font: 13px var(--font-mono, monospace); }
+[data-layout="console"] .lc-table a { color: inherit; text-decoration: none; }
+[data-layout="console"] .lc-table a:hover { color: var(--ld-accent); }
+[data-layout="console"] .lc-meter { width: 60px; margin-top: 8px; height: 3px; background: var(--ld-track); }
+[data-layout="console"] .lc-meter i { display: block; height: 100%; background: var(--ld-accent); }
+[data-layout="console"] .lc-lower { display: grid; grid-template-columns: 1.1fr 1fr 1fr; gap: 18px; margin-top: 22px; }
+[data-layout="console"] .lc-instrument { border: 1px solid var(--ld-edge); border-radius: 6px; padding: 20px; background: var(--ld-panel); }
+[data-layout="console"] .lc-instrument h2 { color: var(--ld-secondary); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; }
+[data-layout="console"] .lc-instrument .ld-rank-item { font-family: var(--font-mono, monospace); }
+[data-layout="console"] .lc-thermal { display: flex; align-items: center; gap: 18px; margin-top: 20px; }
+[data-layout="console"] .lc-thermal-reading { font: 42px var(--font-mono, monospace); letter-spacing: -3px; color: var(--ld-ink); }
+[data-layout="console"] .lc-thermal p { font-size: 10px; color: var(--ld-secondary); line-height: 1.8; }
+[data-layout="console"] .lc-bottom { display: flex; justify-content: space-between; margin-top: 22px; color: var(--ld-secondary); font: 10px var(--font-mono, monospace); }
+[data-layout="console"] .lc-empty { padding: 24px 20px; color: var(--ld-secondary); font-size: 12px; }
+
+/* ---- Shared brand marks --------------------------------------------------- */
+:is([data-layout="wall"], [data-layout="grove"], [data-layout="console"]) .ld-mark { display: block; flex-shrink: 0; color: var(--ld-accent); }
+:is([data-layout="wall"], [data-layout="grove"], [data-layout="console"]) .ld-wordmark { font-weight: 650; letter-spacing: -.8px; line-height: 1; color: var(--ld-ink); }
+
+/* ===========================================================================
+ * Responsive — ported from the study breakpoints.
+ * ========================================================================= */
+@media (max-width: 1100px) {
+  [data-layout="grove"] .lg { grid-template-columns: 180px minmax(0, 1fr); }
+  [data-layout="grove"] .lg-rail { grid-column: 2; position: static; height: auto; display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; padding: 20px; }
+  [data-layout="grove"] .lg-rail > h2, [data-layout="grove"] .lg-rail > .ld-note { display: none; }
+  [data-layout="grove"] .lg-session-hero, [data-layout="grove"] .lg-rail-card { margin: 0; }
+  [data-layout="grove"] .lg-session-hero strong { font-size: 40px; }
+  [data-layout="wall"] .lw-grid { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+  [data-layout="wall"] .lw-fleet { grid-column: span 6; grid-row: auto; }
+  [data-layout="wall"] .lw-sessions, [data-layout="wall"] .lw-alerts { grid-column: span 3; }
+  [data-layout="wall"] .lw-resources, [data-layout="wall"] .lw-ranks { grid-column: span 6; }
+  [data-layout="wall"] .lw-foot-tile { grid-column: span 3; }
+  [data-layout="wall"] .lw-machines { grid-column: span 6; }
+  [data-layout="console"] .lc-lower { grid-template-columns: 1fr 1fr; }
+  [data-layout="console"] .lc-lower .lc-instrument:first-child { grid-column: span 2; }
+  [data-layout="grove"] .lg-health { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 800px) {
+  [data-layout="wall"] .lw-fleet { grid-column: span 12; }
+  [data-layout="wall"] .lw-sessions, [data-layout="wall"] .lw-alerts { grid-column: span 6; }
+  [data-layout="wall"] .lw-resources, [data-layout="wall"] .lw-ranks { grid-column: span 12; }
+  [data-layout="wall"] .lw-foot-tile { grid-column: span 6; }
+  [data-layout="wall"] .lw-machines { grid-column: span 12; }
+  [data-layout="wall"] .lw-scope { display: none; }
+}
+@media (max-width: 700px) {
+  [data-layout="wall"] .lw { padding: 20px 14px; }
+  [data-layout="wall"] .lw-ranks { grid-template-columns: 1fr; gap: 24px; }
+  [data-layout="wall"] .lw-ranks > div + div { border-left: 0; border-top: 1px solid var(--ld-edge); padding: 20px 0 0; }
+  [data-layout="grove"] .lg { grid-template-columns: 1fr; min-height: auto; }
+  [data-layout="grove"] .lg-sidebar { display: none; }
+  /* The sidebar is hidden on mobile, so the compact top bar carries the full
+     navigation and the shell actions — destinations and actions are never
+     lost, only re-placed. */
+  [data-layout="grove"] .lg-mobilebar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; padding: 12px 14px; background: var(--ld-panel-alt); border-bottom: 1px solid var(--ld-edge); position: sticky; top: 0; z-index: 20; }
+  [data-layout="grove"] .lg-mnav { display: flex; gap: 2px; overflow-x: auto; flex: 1 1 100%; order: 3; }
+  [data-layout="grove"] .lg-mnav a { display: inline-flex; align-items: center; gap: 6px; padding: 8px 10px; border-radius: 20px; font-size: 12px; color: var(--ld-secondary); text-decoration: none; white-space: nowrap; }
+  [data-layout="grove"] .lg-mnav a:hover { color: var(--ld-ink); }
+  [data-layout="grove"] .lg-mnav a.is-active { background: var(--ld-accent); color: var(--ld-on-accent); }
+  [data-layout="grove"] .lg-mobilebar .lg-actions { margin-left: auto; }
+  [data-layout="grove"] .lg-main { padding: 22px 16px; }
+  [data-layout="grove"] .lg-rail { grid-column: 1; grid-template-columns: 1fr; }
+  [data-layout="grove"] .lg-hero { grid-template-columns: 1fr; }
+  [data-layout="grove"] .lg-health { grid-template-columns: repeat(2, 1fr); }
+  [data-layout="grove"] .lg-ranks { grid-template-columns: 1fr; }
+  [data-layout="console"] .lc { grid-template-columns: 1fr; }
+  [data-layout="console"] .lc-rail { flex-direction: row; height: auto; position: static; padding: 12px; gap: 12px; overflow: auto; }
+  [data-layout="console"] .lc-rail .lc-mark { margin-bottom: 0; }
+  [data-layout="console"] .lc-content { padding: 20px 14px; }
+  [data-layout="console"] .lc-ticker { grid-template-columns: repeat(3, 1fr); }
+  [data-layout="console"] .lc-ticker-cell { border-bottom: 1px solid var(--ld-edge); }
+  [data-layout="console"] .lc-lower { grid-template-columns: 1fr; }
+  [data-layout="console"] .lc-lower .lc-instrument:first-child { grid-column: auto; }
+  [data-layout="wall"] .lw-machine { grid-template-columns: 1fr 40px 40px 40px; gap: 8px; }
+}

--- a/dashboard/src/app/design-pages.css
+++ b/dashboard/src/app/design-pages.css
@@ -1,0 +1,40 @@
+/* The selected global navigation surrounds existing route contents. Keep their
+ * local action bars (refresh, Add User, revoke/reboot, breadcrumbs) functional,
+ * but make them contextual toolbars instead of a second sticky global header.
+ * Classic receives no overrides. */
+html:is([data-layout="wall"], [data-layout="grove"], [data-layout="console"]) [data-design-page] {
+  min-height: 0;
+  min-width: 0;
+  background: transparent;
+}
+html:is([data-layout="wall"], [data-layout="grove"], [data-layout="console"]) [data-design-page] > header {
+  position: static;
+  background: transparent;
+  backdrop-filter: none;
+  z-index: auto;
+}
+html:is([data-layout="wall"], [data-layout="grove"], [data-layout="console"]) [data-design-page] > header > div {
+  height: auto;
+  min-height: 3rem;
+  padding-top: .5rem;
+  padding-bottom: .5rem;
+  flex-wrap: wrap;
+  gap: .75rem;
+}
+html:is([data-layout="wall"], [data-layout="grove"], [data-layout="console"]) [data-design-page] > header > div > div {
+  flex-wrap: wrap;
+}
+
+/* Existing inventory/detail tab bars were sized for a full-width canvas.
+ * Wrap instead of clipping any destination in the narrower design shells. */
+html:is([data-layout="wall"], [data-layout="grove"], [data-layout="console"]) [data-design-page] [role="tablist"] {
+  max-width: 100%;
+  height: auto;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+html:is([data-layout="wall"], [data-layout="grove"], [data-layout="console"]) [data-design-page] [role="tab"] {
+  height: auto;
+  min-height: 2rem;
+  flex: 0 1 auto;
+}

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -2,6 +2,7 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "./design-themes.css";
+@import "./design-layouts.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/dashboard/src/app/inventory/page.tsx
+++ b/dashboard/src/app/inventory/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { AppShell } from "@/components/shell/AppShell";
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
@@ -80,6 +81,10 @@ function timeSince(isoOrMs: string): string {
 }
 
 export default function InventoryPage() {
+  return <AppShell><InventoryContent /></AppShell>;
+}
+
+function InventoryContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { isAuthenticated } = useAuth();
@@ -129,7 +134,7 @@ export default function InventoryPage() {
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25, ease: "easeOut" }}
-      className="min-h-screen bg-blox-bg"
+      className="min-h-screen bg-blox-bg" data-design-page
     >
       {/* Top sticky bar */}
       <header className="sticky top-0 z-50 bg-blox-bg/80 backdrop-blur-xl border-b border-blox-border/50">

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -65,7 +65,12 @@ const themeBootstrapScript = `
     var design = 'classic', designColor = 'original';
     try {
       var token = localStorage.getItem('bloxos_token');
-      var user = token ? JSON.parse(atob(token.split('.')[1])).user_id : null;
+      var user = null;
+      if (token) {
+        var encoded = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+        var binary = atob(encoded.padEnd(Math.ceil(encoded.length / 4) * 4, '='));
+        user = JSON.parse(new TextDecoder().decode(Uint8Array.from(binary, function(c) { return c.charCodeAt(0); }))).user_id;
+      }
       var saved = JSON.parse(localStorage.getItem('bloxos-design:' + (typeof user === 'string' ? user : 'guest')) || '{}');
       if (['wall','grove','console'].indexOf(saved.layout) !== -1) {
         design = saved.layout;

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import "./design-pages.css";
 import { ToastProvider } from "@/components/Toast";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { SSEProvider } from "@/contexts/SSEContext";
 import { ThemeProvider } from "@/contexts/ThemeContext";
+import { DesignProvider } from "@/contexts/DesignContext";
 import { BrandingProvider } from "@/contexts/BrandingContext";
 import { PreferencesProvider } from "@/contexts/PreferencesContext";
 import { VersionsProvider } from "@/contexts/VersionsContext";
@@ -58,7 +60,24 @@ const themeBootstrapScript = `
       resolved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     }
 
+    // Layout colors are independent of Classic's palette/mode. Read only this
+    // account's cache; never paint a previous account's design after logout.
+    var design = 'classic', designColor = 'original';
+    try {
+      var token = localStorage.getItem('bloxos_token');
+      var user = token ? JSON.parse(atob(token.split('.')[1])).user_id : null;
+      var saved = JSON.parse(localStorage.getItem('bloxos-design:' + (typeof user === 'string' ? user : 'guest')) || '{}');
+      if (['wall','grove','console'].indexOf(saved.layout) !== -1) {
+        design = saved.layout;
+        var color = saved.colors && saved.colors[design];
+        if (['original','bright','dark'].indexOf(color) !== -1) designColor = color;
+        name = 'bloxos';
+        resolved = designColor === 'bright' ? 'light' : 'dark';
+      }
+    } catch (e) {}
     var root = document.documentElement;
+    root.dataset.layout = design;
+    root.dataset.designColor = designColor;
     var classes = root.classList;
     // Strip any prior theme-* class so toggles are clean.
     Array.prototype.slice.call(classes).forEach(function(c) {
@@ -97,6 +116,7 @@ export default function RootLayout({
             can still observe theme classes set on <html>. */}
         <AuthProvider>
           <ThemeProvider>
+            <DesignProvider>
             <BrandingProvider>
               {/* Phase 11 — PreferencesProvider sits inside AuthProvider
                   (it reads the JWT for user_id) but outside the SSE/data
@@ -120,6 +140,7 @@ export default function RootLayout({
                 </ErrorBoundary>
               </PreferencesProvider>
             </BrandingProvider>
+            </DesignProvider>
           </ThemeProvider>
         </AuthProvider>
       </body>

--- a/dashboard/src/app/machine/[id]/page.tsx
+++ b/dashboard/src/app/machine/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { AppShell } from "@/components/shell/AppShell";
 
 import { useEffect, useState, useCallback, useRef, use, useMemo } from "react";
 import Link from "next/link";
@@ -132,6 +133,10 @@ function getStatus(data: MachineData, now: number): MachineStatus {
 }
 
 export default function MachineDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  return <AppShell><MachineDetailContent params={params} /></AppShell>;
+}
+
+function MachineDetailContent({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const { getMachine } = useSSE();
   const [baseData, setBaseData] = useState<MachineData | null>(null);
@@ -475,7 +480,7 @@ export default function MachineDetailPage({ params }: { params: Promise<{ id: st
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25, ease: "easeOut" }}
-      className="min-h-screen bg-blox-bg"
+      className="min-h-screen bg-blox-bg" data-design-page
     >
       {/* Delete dialog */}
       <Dialog open={showDeleteConfirm} onOpenChange={(o) => { if (!o) setShowDeleteConfirm(false); }}>

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -46,6 +46,12 @@ import { BrandedHeader } from "@/components/BrandedHeader";
 import { FleetOverview } from "@/components/FleetOverview";
 import { useToast } from "@/components/Toast";
 import { bulkCommandFeedback, selectionAfterBulkAttempt } from "@/lib/command-feedback.mjs";
+import { useDesign } from "@/contexts/DesignContext";
+import { AppShell } from "@/components/shell/AppShell";
+import { OPEN_ALERTS, OPEN_COMMAND, API_MACHINES_CHANGED } from "@/components/shell/ShellActions";
+import { FleetWall } from "@/components/fleet/FleetWall";
+import { FleetGrove, FleetGroveRail } from "@/components/fleet/FleetGrove";
+import { FleetConsole } from "@/components/fleet/FleetConsole";
 
 type SortOption = "name" | "status" | "cpu" | "gpu_temp";
 type StatusFilter = "all" | "live" | "warning" | "critical" | "offline" | "stale";
@@ -80,10 +86,17 @@ const sortLabels: Record<SortOption, string> = {
   gpu_temp: "GPU Temp",
 };
 
-export default function Home() {
+function DashboardContent() {
   const { addToast } = useToast();
   const { machines: liveMachines, connected, hasReceivedData, alerts, setAlerts, setAlertCount, refreshMachine, refreshFleet } = useSSE();
   const { authFetch, hasScope } = useAuth();
+  // One shared controller serves every layout. Classic renders its own header
+  // and the FleetPulse/overview summary; the live layouts render their summary
+  // composition instead. The machine-management section below (search, filter,
+  // sort, tags, saved filters, grid/list, bulk, delete, API edit) is present in
+  // ALL layouts — the layout only changes the summary, never the tooling.
+  const { layout } = useDesign();
+  const isClassic = layout === "classic";
   const canCreateInstallTokens = hasScope("install_tokens.admin");
   const canManageAPIMachines = hasScope("api_machines.admin");
   const canControlFleet = hasScope("fleet.control");
@@ -149,7 +162,14 @@ export default function Home() {
     },
     [changeSort],
   );
-  const [alertPanelOpen, setAlertPanelOpen] = useState(false);
+  // Lazy-init from a cross-route ?panel=alerts request. Safe to read window
+  // here: this controller only mounts client-side after AppShell is ready
+  // (the shell renders a loading frame during SSR/first paint), so there is no
+  // hydration mismatch and no setState-in-effect.
+  const [alertPanelOpen, setAlertPanelOpen] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return new URLSearchParams(window.location.search).get("panel") === "alerts";
+  });
   const [addMachineOpen, setAddMachineOpen] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkLoading, setBulkLoading] = useState(false);
@@ -157,7 +177,9 @@ export default function Home() {
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [addAPIMachineOpen, setAddAPIMachineOpen] = useState(false);
   const [commandOpen, setCommandOpen] = useState(false);
-  useCommandPaletteHotkey(setCommandOpen);
+  // In non-classic layouts the shell owns the command palette and its hotkey;
+  // disable the local hotkey so exactly one ⌘K listener is active.
+  useCommandPaletteHotkey(setCommandOpen, isClassic);
   const [editAPIMachine, setEditAPIMachine] = useState<EditableAPIMachine | null>(null);
   const [apiMachines, setApiMachines] = useState<EditableAPIMachine[]>([]);
 
@@ -174,6 +196,26 @@ export default function Home() {
       // ignore
     }
   }, [authFetch]);
+
+  // Shell-forwarded events: open the alert panel in place (same-route),
+  // pick up a cross-route request via /?panel=alerts on mount, and refresh the
+  // API-machine config list after any shell-owned Add API save so the list
+  // stays consistent wherever the add happened.
+  useEffect(() => {
+    const openAlerts = () => setAlertPanelOpen(true);
+    const reloadAPI = () => void loadAPIMachines();
+    window.addEventListener(OPEN_ALERTS, openAlerts);
+    window.addEventListener(API_MACHINES_CHANGED, reloadAPI);
+    // The panel was already opened by the lazy initial state; just tidy the
+    // URL so a refresh doesn't reopen it.
+    if (new URLSearchParams(window.location.search).get("panel") === "alerts") {
+      window.history.replaceState(null, "", window.location.pathname);
+    }
+    return () => {
+      window.removeEventListener(OPEN_ALERTS, openAlerts);
+      window.removeEventListener(API_MACHINES_CHANGED, reloadAPI);
+    };
+  }, [loadAPIMachines]);
 
   useEffect(() => {
     let active = true;
@@ -400,9 +442,10 @@ export default function Home() {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.25 }}
-      className="min-h-screen bg-blox-bg"
+      className={isClassic ? "min-h-screen bg-blox-bg" : ""}
     >
-      {/* Header */}
+      {/* Header — classic only; the live layouts get the shared shell chrome. */}
+      {isClassic && (
       <header className="fleet-header sticky top-0 z-50 bg-blox-bg/80 backdrop-blur-xl border-b border-blox-border/50">
         <div className="max-w-[1600px] mx-auto px-4 sm:px-6 min-h-14 py-2 sm:py-0 sm:h-14 flex flex-wrap sm:flex-nowrap items-center justify-between gap-2 sm:gap-4">
           {/* Brand */}
@@ -493,18 +536,26 @@ export default function Home() {
           </div>
         </div>
       </header>
+      )}
 
-      {/* Fleet Pulse Strip — sits directly below the header */}
-      <FleetPulse onAlertsClick={() => setAlertPanelOpen(true)} />
-
-      {/* Needs-Attention stripe — only renders when problems exist */}
-      <NeedsAttention machines={machines} />
-
-      {/* Fleet Overview — gauges and resource attribution */}
-      {machines.length > 0 && hasReceivedData && (
-        <div className="max-w-[1600px] mx-auto px-4 sm:px-6 pt-6">
-          <FleetOverview machines={machines} />
-        </div>
+      {/* Fleet summary — classic shows the pulse strip + gauges; the live
+          layouts render their own composition as the summary. */}
+      {isClassic ? (
+        <>
+          <FleetPulse onAlertsClick={() => setAlertPanelOpen(true)} />
+          <NeedsAttention machines={machines} />
+          {machines.length > 0 && hasReceivedData && (
+            <div className="max-w-[1600px] mx-auto px-4 sm:px-6 pt-6">
+              <FleetOverview machines={machines} />
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          {layout === "wall" && <FleetWall />}
+          {layout === "grove" && <FleetGrove />}
+          {layout === "console" && <FleetConsole />}
+        </>
       )}
 
       {/* Degraded connection banner — surfaces SSE disconnect inline so it isn't
@@ -524,6 +575,16 @@ export default function Home() {
           </motion.div>
         )}
       </AnimatePresence>
+
+      {/* Machine management — the full working list and its controls. Present
+          in every layout; the layout only changes the summary above. Labelled
+          so it is distinct from any compact register in the summary. */}
+      <section aria-label="Machine management">
+      {!isClassic && (
+        <div className="max-w-[1600px] mx-auto px-4 sm:px-6 pt-6 -mb-2">
+          <h2 className="text-sm font-semibold text-text-primary uppercase tracking-wider">Manage machines</h2>
+        </div>
+      )}
 
       {/* Bulk action bar */}
       <AnimatePresence>
@@ -589,7 +650,9 @@ export default function Home() {
             />
             <button
               type="button"
-              onClick={() => setCommandOpen(true)}
+              onClick={() =>
+                isClassic ? setCommandOpen(true) : window.dispatchEvent(new CustomEvent(OPEN_COMMAND))
+              }
               className="absolute right-2 top-1/2 -translate-y-1/2 hidden sm:flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-mono text-blox-muted bg-blox-bg border border-blox-border rounded hover:text-blox-text transition-colors"
               aria-label="Open command palette"
               title="Open command palette (⌘K)"
@@ -722,7 +785,10 @@ export default function Home() {
             className="grid auto-rows-fr justify-start"
             style={{
               gap: "var(--grid-gap)",
-              gridTemplateColumns: "repeat(auto-fill, minmax(var(--grid-min-col), 360px))",
+              // min(100%, …) clamps the column to the container at very narrow
+              // widths (≤320px) so a fixed 260–300px min never overflows; the
+              // desktop track is unchanged.
+              gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, var(--grid-min-col)), 360px))",
             }}
           >
             {!hasReceivedData && machines.length === 0 && !isDemo && (
@@ -921,6 +987,7 @@ export default function Home() {
           </div>
         )}
       </main>
+      </section>
 
       {/* Delete confirmation dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={(o) => { if (!o) setDeleteTarget(null); }}>
@@ -967,17 +1034,19 @@ export default function Home() {
         onAcknowledgeAll={handleAcknowledgeAll}
       />
 
-      <AddMachineModal
-        open={addMachineOpen}
-        onClose={() => setAddMachineOpen(false)}
-      />
-
-      {addAPIMachineOpen && (
-        <AddAPIMachineModal
-          open={addAPIMachineOpen}
-          onClose={() => setAddAPIMachineOpen(false)}
-          onSaved={handleAPIMachineSaved}
-        />
+      {/* Add-machine flows: classic owns them here; the live layouts get them
+          from the shell chrome (single owner, no duplicate modals). */}
+      {isClassic && (
+        <>
+          <AddMachineModal open={addMachineOpen} onClose={() => setAddMachineOpen(false)} />
+          {addAPIMachineOpen && (
+            <AddAPIMachineModal
+              open={addAPIMachineOpen}
+              onClose={() => setAddAPIMachineOpen(false)}
+              onSaved={handleAPIMachineSaved}
+            />
+          )}
+        </>
       )}
 
       {editAPIMachine && (
@@ -989,13 +1058,15 @@ export default function Home() {
         />
       )}
 
-      <CommandPalette
-        open={commandOpen}
-        onOpenChange={setCommandOpen}
-        onAddMachine={canCreateInstallTokens ? () => setAddMachineOpen(true) : undefined}
-        onAddAPIMachine={canManageAPIMachines ? () => setAddAPIMachineOpen(true) : undefined}
-        onOpenAlerts={() => setAlertPanelOpen(true)}
-      />
+      {isClassic && (
+        <CommandPalette
+          open={commandOpen}
+          onOpenChange={setCommandOpen}
+          onAddMachine={canCreateInstallTokens ? () => setAddMachineOpen(true) : undefined}
+          onAddAPIMachine={canManageAPIMachines ? () => setAddAPIMachineOpen(true) : undefined}
+          onOpenAlerts={() => setAlertPanelOpen(true)}
+        />
+      )}
     </motion.div>
   );
 }
@@ -1040,5 +1111,24 @@ function GlobalRefreshButton({
     >
       <RefreshCw className={`w-4 h-4 ${refreshing ? "animate-spin" : ""}`} />
     </Button>
+  );
+}
+
+/* ============================================================================
+ * Home — one shared controller (DashboardContent) inside the shell.
+ *
+ * The controller holds every machine-management control and handler once and
+ * renders in every layout; the layout only changes the summary above the
+ * management section. AppShell provides the navigation chrome and, for the
+ * live layouts, owns the global action modals and the command palette (so the
+ * controller disables its local ⌘K there). Grove's context rail is supplied to
+ * the shell as a slot. Classic renders AppShell as a passthrough.
+ * ========================================================================== */
+export default function Home() {
+  const { layout } = useDesign();
+  return (
+    <AppShell rail={layout === "grove" ? <FleetGroveRail /> : undefined}>
+      <DashboardContent />
+    </AppShell>
   );
 }

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { AppShell } from "@/components/shell/AppShell";
 
 // AI Sessions — fleet-wide live view. Read-only.
 //
@@ -27,6 +28,10 @@ import { isSnapshotStale, sortMachines, summarize } from "@/lib/ai-sessions";
 import { cn } from "@/lib/utils";
 
 export default function SessionsPage() {
+  return <AppShell><SessionsContent /></AppShell>;
+}
+
+function SessionsContent() {
   const { enabled, hasLoaded, loading, error, staleAfterSeconds, machines, refresh } = useAISessions();
   const { connected } = useSSE();
   const { hasScope } = useAuth();
@@ -106,7 +111,7 @@ export default function SessionsPage() {
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25, ease: "easeOut" }}
-      className="min-h-screen bg-blox-bg"
+      className="min-h-screen bg-blox-bg" data-design-page
     >
       <header className="sticky top-0 z-50 bg-blox-bg/80 backdrop-blur-xl border-b border-blox-border/50">
         <div className="max-w-[1200px] mx-auto px-4 sm:px-6 h-12 flex items-center justify-between">

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { AppShell } from "@/components/shell/AppShell";
 
 // Phase 10/11 — settings page.
 //
@@ -26,6 +27,10 @@ const SETTINGS_TABS = ["profile", "preferences", "theme", "branding", "ai-sessio
 type SettingsTab = (typeof SETTINGS_TABS)[number];
 
 export default function SettingsPage() {
+  return <AppShell><SettingsContent /></AppShell>;
+}
+
+function SettingsContent() {
   const { hasScope } = useAuth();
   const searchParams = useSearchParams();
   const canEditBranding = hasScope("branding.admin");
@@ -39,7 +44,7 @@ export default function SettingsPage() {
       : "profile";
 
   return (
-    <div className="min-h-screen bg-blox-bg">
+    <div className="min-h-screen bg-blox-bg" data-design-page>
       <header className="sticky top-0 z-40 bg-blox-bg/80 backdrop-blur-xl border-b border-blox-border/50">
         <div className="max-w-[1100px] mx-auto px-4 sm:px-6 h-14 flex items-center gap-3">
           <Link

--- a/dashboard/src/app/users/page.tsx
+++ b/dashboard/src/app/users/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { AppShell } from "@/components/shell/AppShell";
 
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
@@ -49,6 +50,10 @@ function timeSince(iso: string): string {
 }
 
 export default function UsersPage() {
+  return <AppShell><UsersContent /></AppShell>;
+}
+
+function UsersContent() {
   const router = useRouter();
   const { hasScope, authFetch, isAuthenticated, role: myRole } = useAuth();
   const canManage = isAuthenticated && hasScope("users.admin");
@@ -160,7 +165,7 @@ export default function UsersPage() {
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25, ease: "easeOut" }}
-      className="min-h-screen bg-blox-bg"
+      className="min-h-screen bg-blox-bg" data-design-page
     >
       <header className="sticky top-0 z-50 bg-blox-bg/80 backdrop-blur-xl border-b border-blox-border/50">
         <div className="max-w-[1200px] mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">

--- a/dashboard/src/app/versions/page.tsx
+++ b/dashboard/src/app/versions/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { AppShell } from "@/components/shell/AppShell";
 
 import { useEffect } from "react";
 import Link from "next/link";
@@ -114,6 +115,10 @@ function AgentBinaryCard({
 }
 
 export default function VersionsPage() {
+  return <AppShell><VersionsContent /></AppShell>;
+}
+
+function VersionsContent() {
   const { data, loading, error, refresh, pauseRollout, resumeRollout } = useVersions();
   const { hasScope } = useAuth();
   const canManageRollout = hasScope("fleet.admin");
@@ -172,7 +177,7 @@ export default function VersionsPage() {
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25, ease: "easeOut" }}
-      className="min-h-screen bg-blox-bg"
+      className="min-h-screen bg-blox-bg" data-design-page
     >
       {/* Top nav */}
       <header className="sticky top-0 z-50 bg-blox-bg/80 backdrop-blur-xl border-b border-blox-border/50">

--- a/dashboard/src/components/CommandPalette.tsx
+++ b/dashboard/src/components/CommandPalette.tsx
@@ -12,6 +12,7 @@ import {
 import { useAuth } from "@/contexts/AuthContext";
 import { useSSE } from "@/contexts/SSEContext";
 import { useTheme } from "@/contexts/ThemeContext";
+import { useDesign } from "@/contexts/DesignContext";
 import {
   Monitor,
   Server,
@@ -47,6 +48,7 @@ export function CommandPalette({
   const { isAuthenticated, hasScope, logout } = useAuth();
   const { machines } = useSSE();
   const { setMode } = useTheme();
+  const { layout, setColor } = useDesign();
   const [search, setSearch] = useState("");
 
   // Clear search in the close event handler instead of a useEffect — avoids
@@ -204,30 +206,59 @@ export function CommandPalette({
               </Command.Group>
             )}
 
-            {/* Theme */}
-            <Command.Group heading="Theme">
-              <Command.Item
-                value="theme light mode"
-                onSelect={() => runCommand(() => setMode("light"))}
-              >
-                <Sun />
-                <span>Switch to light mode</span>
-              </Command.Item>
-              <Command.Item
-                value="theme dark mode"
-                onSelect={() => runCommand(() => setMode("dark"))}
-              >
-                <Moon />
-                <span>Switch to dark mode</span>
-              </Command.Item>
-              <Command.Item
-                value="theme system auto mode"
-                onSelect={() => runCommand(() => setMode("system"))}
-              >
-                <MonitorSmartphone />
-                <span>Use system mode</span>
-              </Command.Item>
-            </Command.Group>
+            {/* Theme (classic) / Color (live layouts). In a live layout the
+                light/dark/system mode is fixed by the chosen color, so the
+                palette offers the three design colors instead — otherwise the
+                mode actions would have no visible effect. */}
+            {layout === "classic" ? (
+              <Command.Group heading="Theme">
+                <Command.Item
+                  value="theme light mode"
+                  onSelect={() => runCommand(() => setMode("light"))}
+                >
+                  <Sun />
+                  <span>Switch to light mode</span>
+                </Command.Item>
+                <Command.Item
+                  value="theme dark mode"
+                  onSelect={() => runCommand(() => setMode("dark"))}
+                >
+                  <Moon />
+                  <span>Switch to dark mode</span>
+                </Command.Item>
+                <Command.Item
+                  value="theme system auto mode"
+                  onSelect={() => runCommand(() => setMode("system"))}
+                >
+                  <MonitorSmartphone />
+                  <span>Use system mode</span>
+                </Command.Item>
+              </Command.Group>
+            ) : (
+              <Command.Group heading="Color">
+                <Command.Item
+                  value="color original default"
+                  onSelect={() => runCommand(() => setColor("original"))}
+                >
+                  <Monitor />
+                  <span>Original colors</span>
+                </Command.Item>
+                <Command.Item
+                  value="color bright light"
+                  onSelect={() => runCommand(() => setColor("bright"))}
+                >
+                  <Sun />
+                  <span>Bright colors</span>
+                </Command.Item>
+                <Command.Item
+                  value="color dark"
+                  onSelect={() => runCommand(() => setColor("dark"))}
+                >
+                  <Moon />
+                  <span>Dark colors</span>
+                </Command.Item>
+              </Command.Group>
+            )}
 
             {/* Account */}
             <Command.Group heading="Account">
@@ -250,8 +281,12 @@ export function CommandPalette({
  * Hook that wires up Cmd+K (or Ctrl+K) globally.
  * Use it once at the page level to open the palette.
  */
-export function useCommandPaletteHotkey(setOpen: (open: boolean) => void) {
+export function useCommandPaletteHotkey(setOpen: (open: boolean) => void, enabled: boolean = true) {
   useEffect(() => {
+    // `enabled` lets exactly one owner hold the ⌘K listener. In the non-classic
+    // layouts the shell owns the command palette, so the dashboard passes
+    // false to avoid a duplicate listener.
+    if (!enabled) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
@@ -260,5 +295,5 @@ export function useCommandPaletteHotkey(setOpen: (open: boolean) => void) {
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [setOpen]);
+  }, [setOpen, enabled]);
 }

--- a/dashboard/src/components/DesignSettings.tsx
+++ b/dashboard/src/components/DesignSettings.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useDesign, type Layout } from "@/contexts/DesignContext";
+import { DESIGN_COLORS } from "@/lib/design-prefs.mjs";
+import { cn } from "@/lib/utils";
+
+const designs: { id: Layout; name: string; description: string }[] = [
+  { id: "classic", name: "Classic", description: "The familiar BloxOS dashboard and its original palettes." },
+  { id: "wall", name: "Operations Wall", description: "An open canvas of fleet health, resources and machines." },
+  { id: "grove", name: "Grove Workspace", description: "Sidebar navigation, central analytics and a live context rail." },
+  { id: "console", name: "Precision Console", description: "A compact, table-first workspace with telemetry instruments." },
+];
+
+function DesignPreview({ layout }: { layout: Layout }) {
+  return <svg viewBox="0 0 240 120" aria-hidden="true" className="w-full rounded-md mb-3 bg-blox-bg text-blox-blue border border-blox-border">
+    {layout === "grove" ? <>
+      <rect x="7" y="7" width="37" height="106" rx="5" fill="currentColor" opacity=".25" />
+      <rect x="51" y="7" width="128" height="43" rx="7" fill="currentColor" opacity=".45" />
+      <rect x="186" y="7" width="47" height="106" rx="5" fill="currentColor" opacity=".2" />
+      {[57,77,97].map(y => <rect key={y} x="51" y={y} width="128" height="14" rx="4" fill="currentColor" opacity=".2" />)}
+    </> : layout === "console" ? <>
+      <rect x="7" y="7" width="17" height="106" rx="3" fill="currentColor" opacity=".5" />
+      <rect x="31" y="7" width="202" height="14" rx="3" fill="currentColor" opacity=".25" />
+      {[28,44,60,76].map(y => <rect key={y} x="31" y={y} width="202" height="10" rx="2" fill="currentColor" opacity=".2" />)}
+      {[31,101,171].map(x => <rect key={x} x={x} y="93" width="62" height="20" rx="3" fill="currentColor" opacity=".4" />)}
+    </> : <>
+      <rect x="7" y="7" width="226" height="12" rx="4" fill="currentColor" opacity=".2" />
+      <rect x="7" y="26" width="110" height="40" rx={layout === "wall" ? 10 : 4} fill="currentColor" opacity=".5" />
+      {[124,182].map(x => <rect key={x} x={x} y="26" width="51" height="40" rx="7" fill="currentColor" opacity=".25" />)}
+      <rect x="7" y="73" width="226" height="40" rx="7" fill="currentColor" opacity=".2" />
+    </>}
+  </svg>;
+}
+
+export function DesignSettings({ compact = false }: { compact?: boolean }) {
+  const { layout, color, ready, saving, error, setLayout, setColor } = useDesign();
+  return <section aria-label="Dashboard design" className={compact ? "px-2 py-2 space-y-2" : "space-y-3"}>
+    <h2 className="text-sm font-semibold text-blox-text">Design</h2>
+    {!compact && <p className="text-xs text-blox-muted">Choose a layout, then its color. Your choice follows your account.</p>}
+    <div className={compact ? "grid grid-cols-2 gap-1" : "grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3"}>
+      {designs.map(design => <button key={design.id} type="button" disabled={!ready}
+        aria-label={`Use ${design.name} design`} aria-pressed={layout === design.id} onClick={() => setLayout(design.id)}
+        className={cn("text-left rounded-lg border transition-colors disabled:opacity-50", compact ? "px-2 py-2 text-xs" : "p-3", layout === design.id ? "border-blox-blue bg-blox-blue/10 ring-1 ring-blox-blue/40" : "border-blox-border bg-blox-card hover:border-blox-blue/50")}>
+        {!compact && <DesignPreview layout={design.id} />}
+        <span className="font-medium text-blox-text">{design.name}</span>
+        {!compact && <p className="text-xs text-blox-muted mt-1">{design.description}</p>}
+      </button>)}
+    </div>
+    {layout !== "classic" && <div role="group" aria-label="Design color" className="flex flex-wrap gap-2">
+      {DESIGN_COLORS.map(option => <button key={option} type="button" aria-pressed={color === option}
+        aria-label={`Use ${option} design color`} onClick={() => setColor(option)} disabled={!ready}
+        className={cn("px-3 py-2 text-xs rounded-md border capitalize", color === option ? "border-blox-blue text-blox-blue bg-blox-blue/10" : "border-blox-border text-blox-muted")}>{option}</button>)}
+    </div>}
+    {saving && <p role="status" className="text-xs text-blox-muted">Saving design…</p>}
+    {error && <p role="status" className="text-xs text-status-warning max-w-xs">{error}</p>}
+  </section>;
+}

--- a/dashboard/src/components/Terminal.tsx
+++ b/dashboard/src/components/Terminal.tsx
@@ -5,6 +5,7 @@ import { Terminal as XTerm, ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { useTheme } from "@/contexts/ThemeContext";
+import { useDesign } from "@/contexts/DesignContext";
 import { getHubWsBaseUrl } from "@/lib/session";
 import "@xterm/xterm/css/xterm.css";
 
@@ -75,9 +76,10 @@ export function Terminal({ sessionId, browserToken, onDisconnect }: TerminalProp
   const wsRef = useRef<WebSocket | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const [status, setStatus] = useState<"connecting" | "connected" | "disconnected">("connecting");
-  // Phase 10 — context renamed to resolvedMode; alias to keep the rest of
-  // the file unchanged.
-  const { resolvedMode: resolvedTheme } = useTheme();
+  // Follow the active design's fixed color scheme; Classic keeps its own mode.
+  const { resolvedMode } = useTheme();
+  const { layout, color } = useDesign();
+  const resolvedTheme = layout === "classic" ? resolvedMode : color === "bright" ? "light" : "dark";
 
   const cleanup = useCallback(() => {
     if (wsRef.current) {

--- a/dashboard/src/components/UserMenu.tsx
+++ b/dashboard/src/components/UserMenu.tsx
@@ -17,11 +17,14 @@ import {
 import { Button } from "@/components/ui/button";
 import { Avatar } from "@/components/Avatar";
 import { cn } from "@/lib/utils";
+import { DesignSettings } from "@/components/DesignSettings";
+import { useDesign } from "@/contexts/DesignContext";
 
 export function UserMenu() {
   const router = useRouter();
   const { logout, hasScope, role } = useAuth();
   const { themeName, setTheme } = useTheme();
+  const { layout } = useDesign();
   const { preferences, myAvatarURL } = usePreferences();
   const canManageUsers = hasScope("users.admin");
   const displayName = preferences.display_name || "Account";
@@ -57,11 +60,13 @@ export function UserMenu() {
         </div>
         <DropdownMenuSeparator className="bg-blox-border" />
 
+        <DesignSettings compact />
+
         {/* Quick theme tiles use the shared registry so new palettes remain
             available here too. Each tile is part of a wrapping grid
             preview; clicking applies the theme immediately. The "Theme"
             label is wrapped in DropdownMenuGroup to satisfy Base UI #31. */}
-        <DropdownMenuGroup>
+        {layout === "classic" && <><DropdownMenuGroup>
           <DropdownMenuLabel className="text-blox-muted text-[10px] uppercase tracking-wider">
             Theme
           </DropdownMenuLabel>
@@ -93,6 +98,7 @@ export function UserMenu() {
             })}
           </div>
         </div>
+        </>}
         <DropdownMenuSeparator className="bg-blox-border" />
 
         <DropdownMenuItem

--- a/dashboard/src/components/fleet/FleetConsole.tsx
+++ b/dashboard/src/components/fleet/FleetConsole.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+// Precision Console body — ticker + machine table + instrument row, over the
+// shared fleet model. Real SSE data only; unavailable readings render "N/A".
+
+import Link from "next/link";
+import type { CSSProperties } from "react";
+import { useFleetData } from "./useFleetData";
+import { pct, pct1, statusOf, statusVar, ramPct, diskPct, type Metric, type RankRow } from "./fleetModel";
+
+function Cell({ label, value, unit, sub }: { label: string; value: string; unit?: string; sub: string }) {
+  return (
+    <div className="lc-ticker-cell">
+      <small>{label}</small>
+      <strong>
+        {value}
+        {unit && <span className="ld-unit">{unit}</span>}
+      </strong>
+      <p>{sub}</p>
+    </div>
+  );
+}
+
+function Instrument({ title, rows }: { title: string; rows: RankRow[] }) {
+  return (
+    <section className="lc-instrument">
+      <h2>{title}</h2>
+      {rows.length === 0 && <p className="ld-note">No data reported</p>}
+      {rows.map((r) => (
+        <div className="ld-rank-item" key={r.machineId}>
+          <div>
+            <span>{r.name}</span>
+            <span>{pct1(r.value)}</span>
+          </div>
+          <div className="ld-bar">
+            <i style={{ width: `${Math.min(100, r.value)}%` }} />
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function num(value: Metric, unit = "%"): string {
+  return value === null ? "N/A" : `${Math.round(value)}${unit}`;
+}
+
+export function FleetConsole() {
+  const { sorted, agg, sessionCount, sessionMachines, alertsCount, hasReceivedData } = useFleetData();
+  const onlineSub =
+    agg.total === 0 ? (hasReceivedData ? "No machines" : "Waiting for telemetry") : agg.online === agg.total ? "All reporting" : "Some offline";
+
+  return (
+    <>
+      <header className="lc-heading">
+        <div>
+          <h1>Fleet control</h1>
+          <p>Machine-level detail. Shared resource visibility.</p>
+        </div>
+        <span>WORKSPACE / ALL MACHINES</span>
+      </header>
+
+      <div className="lc-ticker">
+        <Cell label="Online" value={`${agg.online}`} unit={`/ ${agg.total}`} sub={onlineSub} />
+        <Cell label="Avg CPU" value={num(agg.avgCpu, "")} unit={agg.avgCpu === null ? "" : "%"} sub="Fleet average" />
+        <Cell label="Avg RAM" value={num(agg.avgRam, "")} unit={agg.avgRam === null ? "" : "%"} sub="Fleet average" />
+        <Cell label="GPU power" value={agg.gpuPowerTotal === null ? "N/A" : `${Math.round(agg.gpuPowerTotal)}`} unit={agg.gpuPowerTotal === null ? "" : "W"} sub={agg.gpuPowerTotal !== null && !agg.gpuPowerComplete ? "Partial telemetry" : "Component telemetry"} />
+        <Cell label="AI Sessions" value={sessionCount === null ? "N/A" : `${sessionCount}`} sub={sessionCount === null ? "Unavailable" : `On ${sessionMachines} machine${sessionMachines !== 1 ? "s" : ""}`} />
+        <Cell label="Alerts" value={`${alertsCount}`} sub={alertsCount === 0 ? "No active alerts" : "Need attention"} />
+      </div>
+
+      <section className="lc-table-wrap">
+        <div className="lc-table-title">
+          <h2>Machine inventory</h2>
+          <span>{sorted.length} RECORDS</span>
+        </div>
+        <table className="lc-table">
+          <thead>
+            <tr>
+              <th>Machine / Platform</th>
+              <th>Status</th>
+              <th>CPU</th>
+              <th>RAM</th>
+              <th>Disk</th>
+              <th>Hardware</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((m) => {
+              const s = statusOf(m);
+              const meter = (v: Metric) => (
+                <>
+                  {pct(v)}
+                  <div className="lc-meter">{v !== null && <i style={{ width: `${Math.min(100, v)}%` }} />}</div>
+                </>
+              );
+              return (
+                <tr key={m.machine_id}>
+                  <td>
+                    <Link href={`/machine/${m.machine_id}`}>
+                      {m.hostname || m.machine_id}
+                      <small>{m.os || "unknown OS"}</small>
+                    </Link>
+                  </td>
+                  <td>
+                    <span className="ld-dot" style={{ "--dot": statusVar(s) } as CSSProperties} />{" "}
+                    {s === "live" ? "Online" : s.charAt(0).toUpperCase() + s.slice(1)}
+                  </td>
+                  <td className="lc-number">{meter(typeof m.cpu_percent === "number" ? m.cpu_percent : null)}</td>
+                  <td className="lc-number">{meter(ramPct(m))}</td>
+                  <td className="lc-number">{meter(diskPct(m))}</td>
+                  <td>{m.gpus && m.gpus.length > 0 ? m.gpus[0].name : "CPU worker"}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        {sorted.length === 0 && <div className="lc-empty">No machines yet</div>}
+      </section>
+
+      <div className="lc-lower">
+        <section className="lc-instrument">
+          <h2>GPU telemetry</h2>
+          <div className="lc-thermal">
+            <div className="lc-thermal-reading">
+              {agg.maxGpuTemp === null ? "N/A" : Math.round(agg.maxGpuTemp)}
+              {agg.maxGpuTemp !== null && <span className="ld-unit">°C</span>}
+            </div>
+            <p>
+              MAX GPU TEMPERATURE
+              <br />
+              Avg GPU utilization &nbsp; {num(agg.avgGpuUtil)}
+              <br />
+              Avg VRAM usage &nbsp; {num(agg.avgVram)}
+            </p>
+          </div>
+        </section>
+        <Instrument title="Top GPU utilization" rows={agg.topGpu} />
+        <Instrument title="Top VRAM usage" rows={agg.topVram} />
+      </div>
+
+      <div className="lc-bottom">
+        <span>
+          {agg.total} MACHINES / {agg.online} ONLINE
+        </span>
+        <span>PRECISION CONSOLE</span>
+      </div>
+    </>
+  );
+}

--- a/dashboard/src/components/fleet/FleetConsole.tsx
+++ b/dashboard/src/components/fleet/FleetConsole.tsx
@@ -48,7 +48,15 @@ function num(value: Metric, unit = "%"): string {
 export function FleetConsole() {
   const { sorted, agg, sessionCount, sessionMachines, alertsCount, hasReceivedData } = useFleetData();
   const onlineSub =
-    agg.total === 0 ? (hasReceivedData ? "No machines" : "Waiting for telemetry") : agg.online === agg.total ? "All reporting" : "Some offline";
+    agg.total === 0
+      ? hasReceivedData
+        ? "No machines"
+        : "Waiting for telemetry"
+      : agg.stale > 0
+        ? `${agg.stale} stale`
+        : agg.online === agg.total
+          ? "All reporting"
+          : "Some offline";
 
   return (
     <>
@@ -61,7 +69,7 @@ export function FleetConsole() {
       </header>
 
       <div className="lc-ticker">
-        <Cell label="Online" value={`${agg.online}`} unit={`/ ${agg.total}`} sub={onlineSub} />
+        <Cell label="Connected" value={`${agg.online}`} unit={`/ ${agg.total}`} sub={onlineSub} />
         <Cell label="Avg CPU" value={num(agg.avgCpu, "")} unit={agg.avgCpu === null ? "" : "%"} sub="Fleet average" />
         <Cell label="Avg RAM" value={num(agg.avgRam, "")} unit={agg.avgRam === null ? "" : "%"} sub="Fleet average" />
         <Cell label="GPU power" value={agg.gpuPowerTotal === null ? "N/A" : `${Math.round(agg.gpuPowerTotal)}`} unit={agg.gpuPowerTotal === null ? "" : "W"} sub={agg.gpuPowerTotal !== null && !agg.gpuPowerComplete ? "Partial telemetry" : "Component telemetry"} />
@@ -141,7 +149,7 @@ export function FleetConsole() {
 
       <div className="lc-bottom">
         <span>
-          {agg.total} MACHINES / {agg.online} ONLINE
+          {agg.total} MACHINES / {agg.online} CONNECTED
         </span>
         <span>PRECISION CONSOLE</span>
       </div>

--- a/dashboard/src/components/fleet/FleetGrove.tsx
+++ b/dashboard/src/components/fleet/FleetGrove.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+// Grove Workspace body + context rail, over the shared fleet model.
+
+import Link from "next/link";
+import type { CSSProperties } from "react";
+import { useFleetData } from "./useFleetData";
+import { pct, pct1, statusOf, statusVar, ramPct, type Metric, type RankRow } from "./fleetModel";
+
+function HealthCard({ label, value }: { label: string; value: Metric }) {
+  return (
+    <article>
+      <small>{label}</small>
+      <strong>
+        {value === null ? "N/A" : Math.round(value)}
+        {value !== null && <span className="ld-unit">%</span>}
+      </strong>
+      <div className="ld-bar">{value !== null && <i style={{ width: `${Math.min(100, value)}%` }} />}</div>
+    </article>
+  );
+}
+
+function Ranks({ title, rows }: { title: string; rows: RankRow[] }) {
+  return (
+    <section>
+      <h2>{title}</h2>
+      {rows.length === 0 && <p className="ld-note">No data reported</p>}
+      {rows.map((r) => (
+        <div className="ld-rank-item" key={r.machineId}>
+          <div>
+            <span>{r.name}</span>
+            <span>{pct1(r.value)}</span>
+          </div>
+          <div className="ld-bar">
+            <i style={{ width: `${Math.min(100, r.value)}%` }} />
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+export function FleetGrove() {
+  const { sorted, agg, hasReceivedData } = useFleetData();
+  const connectivity =
+    agg.total === 0
+      ? hasReceivedData
+        ? "No machines"
+        : "Waiting for telemetry"
+      : agg.online === agg.total
+        ? "All machines reporting"
+        : `${agg.total - agg.online} not reporting`;
+  return (
+    <>
+      <header className="lg-top">
+        <div>
+          <h1>Fleet overview</h1>
+          <p>A little space to see the whole picture.</p>
+        </div>
+      </header>
+
+      <section className="lg-hero">
+        <div>
+          <div className="ld-label">Connected machines</div>
+          <div className="lg-online">
+            {agg.online} <span>/ {agg.total}</span>
+          </div>
+          <p>{connectivity}</p>
+        </div>
+        <div className="lg-orb" style={{ "--pct": agg.onlinePct ?? 0 } as CSSProperties}>
+          <div className="lg-orb-core">
+            <strong>
+              {agg.onlinePct === null ? "N/A" : Math.round(agg.onlinePct)}
+              {agg.onlinePct !== null && <span style={{ fontSize: 14 }}>%</span>}
+            </strong>
+            <small>FLEET ONLINE</small>
+          </div>
+        </div>
+      </section>
+
+      <div className="lg-health">
+        <HealthCard label="Avg CPU" value={agg.avgCpu} />
+        <HealthCard label="Avg RAM" value={agg.avgRam} />
+        <HealthCard label="Avg GPU util" value={agg.avgGpuUtil} />
+        <HealthCard label="Avg VRAM" value={agg.avgVram} />
+      </div>
+
+      <div className="lg-ranks">
+        <Ranks title="Top GPU utilization" rows={agg.topGpu} />
+        <Ranks title="Top VRAM usage" rows={agg.topVram} />
+      </div>
+
+      <section className="lg-fleet">
+        <h2>Your machines</h2>
+        {sorted.length === 0 && <p className="ld-note">No machines yet</p>}
+        {sorted.map((m) => {
+          const s = statusOf(m);
+          return (
+            <Link className="lg-machine" href={`/machine/${m.machine_id}`} key={m.machine_id}>
+              <div>
+                <strong>
+                  <span className="ld-dot" style={{ "--dot": statusVar(s) } as CSSProperties} />
+                  {m.hostname || m.machine_id}
+                </strong>
+                <small>
+                  {(m.os || "unknown OS")}
+                  {m.gpus && m.gpus.length > 0 ? ` · ${m.gpus[0].name}` : ""}
+                </small>
+              </div>
+              <div className="lg-values">
+                {pct(typeof m.cpu_percent === "number" ? m.cpu_percent : null)} CPU &nbsp;
+                {pct(ramPct(m))} RAM
+                <small>{s === "offline" ? "Offline" : "Online"}</small>
+              </div>
+            </Link>
+          );
+        })}
+      </section>
+      <p className="ld-note">Grove Workspace</p>
+    </>
+  );
+}
+
+export function FleetGroveRail() {
+  const { agg, sessionCount, sessionMachines, alertsCount } = useFleetData();
+  return (
+    <>
+      <h2>At this moment</h2>
+      <article className="lg-session-hero">
+        <div className="ld-label">AI Sessions</div>
+        <strong>{sessionCount === null ? "N/A" : sessionCount}</strong>
+        <small>
+          {sessionCount === null
+            ? "Monitoring unavailable"
+            : sessionCount === 0
+              ? "No active sessions"
+              : `Running on ${sessionMachines} machine${sessionMachines !== 1 ? "s" : ""}`}
+        </small>
+      </article>
+      <article className="lg-rail-card">
+        <div className="ld-label">Max GPU temperature</div>
+        <div className="lg-reading">
+          {agg.maxGpuTemp === null ? "N/A" : Math.round(agg.maxGpuTemp)}
+          {agg.maxGpuTemp !== null && <span className="ld-unit">°C</span>}
+        </div>
+        <p>Maximum across the fleet.</p>
+      </article>
+      <article className="lg-rail-card">
+        <div className="ld-label">Fleet GPU power</div>
+        <div className="lg-reading">
+          {agg.gpuPowerTotal === null ? "N/A" : Math.round(agg.gpuPowerTotal)}
+          {agg.gpuPowerTotal !== null && <span className="ld-unit">W</span>}
+        </div>
+        <p>{agg.gpuPowerTotal !== null && !agg.gpuPowerComplete ? "Partial — some devices not reporting." : "Component telemetry."}</p>
+      </article>
+      <article className="lg-rail-card">
+        <div className="ld-label">Active alerts</div>
+        <div className="lg-reading">{alertsCount}</div>
+        <p>
+          <span className="ld-dot" style={{ "--dot": statusVar(alertsCount === 0 ? "live" : "warning") } as CSSProperties} />
+          {alertsCount === 0 ? " No active alerts." : ` ${alertsCount} needing attention.`}
+        </p>
+      </article>
+    </>
+  );
+}

--- a/dashboard/src/components/fleet/FleetGrove.tsx
+++ b/dashboard/src/components/fleet/FleetGrove.tsx
@@ -47,9 +47,11 @@ export function FleetGrove() {
       ? hasReceivedData
         ? "No machines"
         : "Waiting for telemetry"
-      : agg.online === agg.total
-        ? "All machines reporting"
-        : `${agg.total - agg.online} not reporting`;
+      : agg.stale > 0
+        ? `${agg.online} connected, ${agg.stale} stale`
+        : agg.online === agg.total
+          ? "All machines reporting"
+          : `${agg.total - agg.online} not reporting`;
   return (
     <>
       <header className="lg-top">
@@ -73,7 +75,7 @@ export function FleetGrove() {
               {agg.onlinePct === null ? "N/A" : Math.round(agg.onlinePct)}
               {agg.onlinePct !== null && <span style={{ fontSize: 14 }}>%</span>}
             </strong>
-            <small>FLEET ONLINE</small>
+            <small>CONNECTED</small>
           </div>
         </div>
       </section>

--- a/dashboard/src/components/fleet/FleetWall.tsx
+++ b/dashboard/src/components/fleet/FleetWall.tsx
@@ -46,9 +46,13 @@ export function FleetWall() {
       ? hasReceivedData
         ? "No machines"
         : "Waiting for telemetry"
-      : agg.online === agg.total
-        ? "All systems connected"
-        : `${agg.total - agg.online} not reporting`;
+      : agg.stale > 0
+        ? `${agg.online} connected, ${agg.stale} stale`
+        : agg.online === agg.total
+          ? "All systems connected"
+          : `${agg.total - agg.online} not reporting`;
+  const connectivityStatus =
+    agg.total === 0 ? "offline" : agg.online < agg.total ? "warning" : agg.stale > 0 ? "stale" : "live";
 
   return (
     <>
@@ -65,23 +69,20 @@ export function FleetWall() {
           <h2 className="ld-label">Connected machines</h2>
           <div className="lw-fleet-reading">
             <strong className="lw-massive">{agg.online}</strong>
-            <span className="lw-denominator">/ {agg.total} online</span>
+            <span className="lw-denominator">/ {agg.total} connected</span>
           </div>
           <div className="lw-fleet-bottom">
-            <span
-              className="ld-dot"
-              style={{ "--dot": statusVar(agg.total > 0 && agg.online === agg.total ? "live" : agg.total === 0 ? "offline" : "warning") } as CSSProperties}
-            />
+            <span className="ld-dot" style={{ "--dot": statusVar(connectivityStatus) } as CSSProperties} />
             {connectivity}
           </div>
           <div
             className="lw-orbit"
-            aria-label={`${pct(agg.onlinePct)} fleet online`}
+            aria-label={`${pct(agg.onlinePct)} fleet connected`}
             style={{ "--pct": agg.onlinePct ?? 0 } as CSSProperties}
           >
             <span>
               {pct(agg.onlinePct)}
-              <small>FLEET ONLINE</small>
+              <small>CONNECTED</small>
             </span>
           </div>
         </article>

--- a/dashboard/src/components/fleet/FleetWall.tsx
+++ b/dashboard/src/components/fleet/FleetWall.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+// Operations Wall body — bento grid of fleet readings over the shared model.
+// Real SSE data only; unavailable aggregates render "N/A", never zero.
+
+import Link from "next/link";
+import { Bot, ShieldCheck } from "lucide-react";
+import type { CSSProperties } from "react";
+import { useFleetData } from "./useFleetData";
+import { pct, pct1, statusOf, statusVar, ramPct, diskPct, type Metric, type RankRow } from "./fleetModel";
+
+function ResourceRow({ label, value }: { label: string; value: Metric }) {
+  return (
+    <div className="lw-resource-row">
+      <span>{label}</span>
+      <div className="ld-bar">{value !== null && <i style={{ width: `${Math.min(100, value)}%` }} />}</div>
+      <strong>{pct(value)}</strong>
+    </div>
+  );
+}
+
+function Ranks({ title, rows }: { title: string; rows: RankRow[] }) {
+  return (
+    <div>
+      <h2>{title}</h2>
+      {rows.length === 0 && <div className="lw-empty">No data reported</div>}
+      {rows.map((r) => (
+        <div className="ld-rank-item" key={r.machineId}>
+          <div>
+            <span>{r.name}</span>
+            <span>{pct1(r.value)}</span>
+          </div>
+          <div className="ld-bar">
+            <i style={{ width: `${Math.min(100, r.value)}%` }} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function FleetWall() {
+  const { sorted, agg, sessionCount, sessionMachines, alertsCount, hasReceivedData } = useFleetData();
+  const connectivity =
+    agg.total === 0
+      ? hasReceivedData
+        ? "No machines"
+        : "Waiting for telemetry"
+      : agg.online === agg.total
+        ? "All systems connected"
+        : `${agg.total - agg.online} not reporting`;
+
+  return (
+    <>
+      <div className="lw-intro">
+        <div>
+          <h1>A clear view of your fleet.</h1>
+          <p>Compute, activity and health — together in one place.</p>
+        </div>
+        <span className="lw-scope">All machines&nbsp; · &nbsp;{agg.total}</span>
+      </div>
+
+      <div className="lw-grid">
+        <article className="lw-tile lw-fleet">
+          <h2 className="ld-label">Connected machines</h2>
+          <div className="lw-fleet-reading">
+            <strong className="lw-massive">{agg.online}</strong>
+            <span className="lw-denominator">/ {agg.total} online</span>
+          </div>
+          <div className="lw-fleet-bottom">
+            <span
+              className="ld-dot"
+              style={{ "--dot": statusVar(agg.total > 0 && agg.online === agg.total ? "live" : agg.total === 0 ? "offline" : "warning") } as CSSProperties}
+            />
+            {connectivity}
+          </div>
+          <div
+            className="lw-orbit"
+            aria-label={`${pct(agg.onlinePct)} fleet online`}
+            style={{ "--pct": agg.onlinePct ?? 0 } as CSSProperties}
+          >
+            <span>
+              {pct(agg.onlinePct)}
+              <small>FLEET ONLINE</small>
+            </span>
+          </div>
+        </article>
+
+        <article className="lw-tile lw-sessions">
+          <h2 className="ld-label">AI Sessions</h2>
+          <div className="lw-card-icon" aria-hidden="true">
+            <Bot />
+          </div>
+          <strong className="lw-stat-big">{sessionCount === null ? "N/A" : sessionCount}</strong>
+          <p>
+            {sessionCount === null
+              ? "Monitoring unavailable"
+              : sessionCount === 0
+                ? "No active sessions"
+                : `Running on ${sessionMachines} machine${sessionMachines !== 1 ? "s" : ""}`}
+          </p>
+        </article>
+
+        <article className="lw-tile lw-alerts">
+          <h2 className="ld-label">Active alerts</h2>
+          <div className="lw-card-icon" aria-hidden="true">
+            <ShieldCheck />
+          </div>
+          <strong className="lw-stat-big">{alertsCount}</strong>
+          <p>{alertsCount === 0 ? "No active alerts" : `${alertsCount} needing attention`}</p>
+        </article>
+
+        <article className="lw-tile lw-resources">
+          <h2 className="ld-label">Fleet resource utilization</h2>
+          <div className="lw-resource-bars">
+            <ResourceRow label="CPU" value={agg.avgCpu} />
+            <ResourceRow label="RAM" value={agg.avgRam} />
+            <ResourceRow label="GPU util" value={agg.avgGpuUtil} />
+            <ResourceRow label="VRAM" value={agg.avgVram} />
+          </div>
+        </article>
+
+        <article className="lw-tile lw-ranks">
+          <Ranks title="Top GPU utilization" rows={agg.topGpu} />
+          <Ranks title="Top VRAM usage" rows={agg.topVram} />
+        </article>
+
+        <article className="lw-tile lw-foot-tile">
+          <h2 className="ld-label">Max GPU temp</h2>
+          <div className="lw-big">
+            {agg.maxGpuTemp === null ? "N/A" : Math.round(agg.maxGpuTemp)}
+            {agg.maxGpuTemp !== null && <span className="ld-unit">°C</span>}
+          </div>
+          <p>Hottest GPU across your fleet</p>
+        </article>
+
+        <article className="lw-tile lw-foot-tile">
+          <h2 className="ld-label">GPU power</h2>
+          <div className="lw-big">
+            {agg.gpuPowerTotal === null ? "N/A" : Math.round(agg.gpuPowerTotal)}
+            {agg.gpuPowerTotal !== null && <span className="ld-unit">W</span>}
+          </div>
+          <p>
+            {agg.gpuPowerTotal === null
+              ? "Component telemetry"
+              : agg.gpuPowerComplete
+                ? "Fleet total · component telemetry"
+                : "Reported so far · partial telemetry"}
+          </p>
+        </article>
+
+        <article className="lw-tile lw-machines">
+          <h2 className="ld-label">Machine register</h2>
+          <div className="lw-machine lw-machine-head">
+            <span>HOST / PLATFORM</span>
+            <span>CPU</span>
+            <span>RAM</span>
+            <span>DISK</span>
+          </div>
+          {sorted.length === 0 && <div className="lw-empty">No machines yet</div>}
+          {sorted.map((m) => {
+            const s = statusOf(m);
+            return (
+              <Link className="lw-machine" href={`/machine/${m.machine_id}`} key={m.machine_id}>
+                <span>
+                  <span className="ld-dot" style={{ "--dot": statusVar(s), marginRight: 7 } as CSSProperties} />
+                  {m.hostname || m.machine_id}
+                  <small>
+                    {(m.os || "unknown OS")}
+                    {m.gpus && m.gpus.length > 0 ? ` · ${m.gpus[0].name}` : ""}
+                  </small>
+                </span>
+                <span>{pct(typeof m.cpu_percent === "number" ? m.cpu_percent : null)}</span>
+                <span>{pct(ramPct(m))}</span>
+                <span>{pct(diskPct(m))}</span>
+              </Link>
+            );
+          })}
+        </article>
+      </div>
+      <p className="ld-note" style={{ maxWidth: 1480, margin: "23px auto 0" }}>
+        Operations Wall
+      </p>
+    </>
+  );
+}

--- a/dashboard/src/components/fleet/fleetModel.ts
+++ b/dashboard/src/components/fleet/fleetModel.ts
@@ -31,6 +31,9 @@ export interface FleetAggregate {
   total: number;
   /** Connected machines (not offline); includes stale. */
   online: number;
+  /** Connected but not fresh (30–120s since last report). A subset of online.
+   * Summary text must surface this and never claim "all reporting" when > 0. */
+  stale: number;
   onlinePct: Metric;
   avgCpu: Metric;
   avgRam: Metric;
@@ -118,6 +121,7 @@ export function machineMaxTemp(m: MachineMetrics): Metric {
 export function aggregate(machines: MachineMetrics[], now: number = Date.now()): FleetAggregate {
   const valid = machines.filter((m) => m && typeof m.machine_id === "string");
   const online = valid.filter((m) => statusOf(m) !== "offline").length;
+  const stale = valid.filter((m) => statusOf(m) === "stale").length;
   const fresh = valid.filter((m) => isFreshMetrics(m.last_seen, now));
 
   const cpu = fresh.map((m) => m.cpu_percent).filter((v): v is number => Number.isFinite(v) && v >= 0);
@@ -184,6 +188,7 @@ export function aggregate(machines: MachineMetrics[], now: number = Date.now()):
   return {
     total: valid.length,
     online,
+    stale,
     onlinePct: valid.length ? (online / valid.length) * 100 : null,
     avgCpu: mean(cpu),
     avgRam: mean(ram),

--- a/dashboard/src/components/fleet/fleetModel.ts
+++ b/dashboard/src/components/fleet/fleetModel.ts
@@ -1,0 +1,219 @@
+// Shared fleet aggregation for the live dashboard layouts (Operations Wall,
+// Grove Workspace, Precision Console). Every value is derived from real SSE
+// machine data. An aggregate with no underlying readings is `null` and is
+// rendered as "N/A" — never a fabricated zero or a false all-healthy state
+// (AGENTS.md: missing sensors are unavailable, not zero).
+//
+// Metrics use FRESH machines only (freshness via the shared isFreshMetrics
+// cutoff): stale and offline machines are connected but their readings are
+// aged, so they never contribute to averages, temps, power or the rankings.
+// The "online" count is the broader connected count (includes stale) and is
+// labelled as connected. GPU aggregates prefer per-device `gpus[]` data and
+// only fall back to the legacy machine-level fields; CPU-only machines are
+// excluded from GPU stats rather than diluting them with zeros. GPU power is
+// summed only from devices that report it and flagged partial when not every
+// device did — it is never presented as a complete fleet total when partial.
+
+import { classifyMachine, isFreshMetrics, hasGpuData } from "../../lib/fleet-metrics.mjs";
+import type { MachineMetrics } from "@/lib/demo-data";
+import type { MachineStatus } from "@/components/StatusBadge";
+
+/** A metric that may be unknown/unavailable. null renders as "N/A". */
+export type Metric = number | null;
+
+export interface RankRow {
+  name: string;
+  machineId: string;
+  value: number;
+}
+
+export interface FleetAggregate {
+  total: number;
+  /** Connected machines (not offline); includes stale. */
+  online: number;
+  onlinePct: Metric;
+  avgCpu: Metric;
+  avgRam: Metric;
+  avgGpuUtil: Metric;
+  avgVram: Metric;
+  maxGpuTemp: Metric;
+  gpuPowerTotal: Metric;
+  /** True only when every fresh GPU device reported power. Otherwise the
+   * total above is a partial sum and must not be labelled a complete total. */
+  gpuPowerComplete: boolean;
+  topGpu: RankRow[];
+  topVram: RankRow[];
+}
+
+function mean(nums: number[]): Metric {
+  return nums.length ? nums.reduce((a, b) => a + b, 0) / nums.length : null;
+}
+
+export function statusOf(m: MachineMetrics): MachineStatus {
+  return classifyMachine(m).status as MachineStatus;
+}
+
+function finiteOrNull(v: number): Metric {
+  return Number.isFinite(v) ? v : null;
+}
+
+export function ramPct(m: MachineMetrics): Metric {
+  const total = m.ram_total_bytes ?? 0;
+  if (!(total > 0)) return null;
+  return finiteOrNull(((m.ram_used_bytes ?? 0) / total) * 100);
+}
+
+export function diskPct(m: MachineMetrics): Metric {
+  const total = m.disk_total_bytes ?? 0;
+  if (!(total > 0)) return null;
+  return finiteOrNull(((m.disk_used_bytes ?? 0) / total) * 100);
+}
+
+/** GPU utilization for one machine — mean across its devices, preferring the
+ * per-device gpus[] array. A CPU-only machine (no gpus[] and no other GPU
+ * signal) is null even if it reports gpu_util_percent=0, so it never counts
+ * as a GPU at zero utilization. */
+export function machineGpuUtil(m: MachineMetrics): Metric {
+  if (m.gpus && m.gpus.length > 0) {
+    const vals = m.gpus.map((g) => g.util_percent).filter((v) => Number.isFinite(v) && v >= 0);
+    return vals.length ? mean(vals) : null;
+  }
+  if (hasGpuData(m) && Number.isFinite(m.gpu_util_percent) && (m.gpu_util_percent as number) >= 0) {
+    return m.gpu_util_percent as number;
+  }
+  return null;
+}
+
+/** VRAM usage % for one machine — summed across devices (used/total),
+ * preferring gpus[]; null when no VRAM is reported. */
+export function machineVramPct(m: MachineMetrics): Metric {
+  if (m.gpus && m.gpus.length > 0) {
+    let used = 0;
+    let total = 0;
+    for (const g of m.gpus) {
+      if ((g.mem_total_bytes ?? 0) > 0) {
+        used += g.mem_used_bytes ?? 0;
+        total += g.mem_total_bytes;
+      }
+    }
+    return total > 0 ? finiteOrNull((used / total) * 100) : null;
+  }
+  const total = m.gpu_vram_total_bytes ?? 0;
+  if (!(total > 0)) return null;
+  return finiteOrNull(((m.gpu_vram_used_bytes ?? 0) / total) * 100);
+}
+
+/** Hottest GPU on one machine, preferring per-device temps; null if none. */
+export function machineMaxTemp(m: MachineMetrics): Metric {
+  let t: number | null = null;
+  if (m.gpus) {
+    for (const g of m.gpus) {
+      if (Number.isFinite(g.temp_c) && g.temp_c > 0) t = Math.max(t ?? 0, g.temp_c);
+    }
+  }
+  if (t === null && Number.isFinite(m.gpu_temp) && (m.gpu_temp as number) > 0) t = m.gpu_temp as number;
+  return t;
+}
+
+export function aggregate(machines: MachineMetrics[], now: number = Date.now()): FleetAggregate {
+  const valid = machines.filter((m) => m && typeof m.machine_id === "string");
+  const online = valid.filter((m) => statusOf(m) !== "offline").length;
+  const fresh = valid.filter((m) => isFreshMetrics(m.last_seen, now));
+
+  const cpu = fresh.map((m) => m.cpu_percent).filter((v): v is number => Number.isFinite(v) && v >= 0);
+  const ram = fresh.map(ramPct).filter((v): v is number => v !== null);
+
+  // GPU aggregates are sampled PER DEVICE (matching computeFleetMetrics): a
+  // machine with two GPUs contributes two samples, so unequal GPU counts
+  // weight the fleet average by device rather than by machine. CPU-only
+  // machines contribute nothing. Power counts any finite reading including 0.
+  const gpuUtil: number[] = [];
+  const vram: number[] = [];
+  const temps: number[] = [];
+  let power = 0;
+  let powerDevices = 0;
+  let gpuDevices = 0;
+  for (const m of fresh) {
+    if (m.gpus && m.gpus.length > 0) {
+      for (const g of m.gpus) {
+        gpuDevices += 1;
+        if (Number.isFinite(g.util_percent) && g.util_percent >= 0) gpuUtil.push(g.util_percent);
+        if ((g.mem_total_bytes ?? 0) > 0) {
+          const v = ((g.mem_used_bytes ?? 0) / g.mem_total_bytes) * 100;
+          if (Number.isFinite(v)) vram.push(v);
+        }
+        if (Number.isFinite(g.temp_c) && g.temp_c > 0) temps.push(g.temp_c);
+        if (Number.isFinite(g.power_watts) && g.power_watts >= 0) {
+          power += g.power_watts;
+          powerDevices += 1;
+        }
+      }
+    } else if (hasGpuData(m)) {
+      // Legacy machine-level GPU fields (one implied device, no power field).
+      gpuDevices += 1;
+      if (Number.isFinite(m.gpu_util_percent) && (m.gpu_util_percent as number) >= 0) {
+        gpuUtil.push(m.gpu_util_percent as number);
+      }
+      const vt = m.gpu_vram_total_bytes ?? 0;
+      if (vt > 0) {
+        const v = ((m.gpu_vram_used_bytes ?? 0) / vt) * 100;
+        if (Number.isFinite(v)) vram.push(v);
+      }
+      if (Number.isFinite(m.gpu_temp) && (m.gpu_temp as number) > 0) temps.push(m.gpu_temp as number);
+    }
+  }
+
+  const rank = (selector: (m: MachineMetrics) => Metric): RankRow[] =>
+    fresh
+      .map((m) => ({ name: m.hostname ?? m.machine_id, machineId: m.machine_id, value: selector(m) }))
+      .filter((r): r is RankRow => r.value !== null)
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 3);
+
+  return {
+    total: valid.length,
+    online,
+    onlinePct: valid.length ? (online / valid.length) * 100 : null,
+    avgCpu: mean(cpu),
+    avgRam: mean(ram),
+    avgGpuUtil: mean(gpuUtil),
+    avgVram: mean(vram),
+    maxGpuTemp: temps.length ? Math.max(...temps) : null,
+    gpuPowerTotal: powerDevices > 0 ? power : null,
+    gpuPowerComplete: gpuDevices > 0 && powerDevices === gpuDevices,
+    topGpu: rank(machineGpuUtil),
+    topVram: rank(machineVramPct),
+  };
+}
+
+export function pct(value: Metric): string {
+  return value === null ? "N/A" : `${Math.round(value)}%`;
+}
+
+export function pct1(value: Metric): string {
+  return value === null ? "N/A" : `${value.toFixed(1)}%`;
+}
+
+export function formatBytes(bytes: number | undefined | null): string {
+  if (!bytes || bytes === 0) return "0";
+  const gb = bytes / 1024 ** 3;
+  if (gb >= 1) return `${gb.toFixed(0)} GB`;
+  const mb = bytes / 1024 ** 2;
+  return `${mb.toFixed(0)} MB`;
+}
+
+export function timeSince(ms: number): string {
+  const sec = Math.floor((Date.now() - ms) / 1000);
+  if (sec < 5) return "just now";
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  return `${hr}h ago`;
+}
+
+/** The app's semantic status token for a machine, as a CSS var reference for
+ * inline `--dot`. Keeps status meaning consistent across every layout. */
+export function statusVar(status: MachineStatus): string {
+  return `var(--status-${status === "live" ? "ok" : status})`;
+}

--- a/dashboard/src/components/fleet/fleetModel.ts
+++ b/dashboard/src/components/fleet/fleetModel.ts
@@ -126,7 +126,15 @@ export function aggregate(machines: MachineMetrics[], now: number = Date.now()):
   // GPU aggregates are sampled PER DEVICE (matching computeFleetMetrics): a
   // machine with two GPUs contributes two samples, so unequal GPU counts
   // weight the fleet average by device rather than by machine. CPU-only
-  // machines contribute nothing. Power counts any finite reading including 0.
+  // machines contribute nothing.
+  //
+  // GPU power is special: the agent's parseNvValue serializes an unknown/"N/A"
+  // reading as 0 (agent/main.go), so on the wire 0 W is indistinguishable from
+  // "not reported". Only a strictly positive reading is treated as an
+  // observation. A total is therefore reported only when at least one device
+  // reported >0; it is complete only when EVERY GPU device did. All-zero or
+  // no-reading fleets are unavailable (null), never a false 0 W total, and a
+  // mix of positive and zero is a partial sum.
   const gpuUtil: number[] = [];
   const vram: number[] = [];
   const temps: number[] = [];
@@ -143,7 +151,10 @@ export function aggregate(machines: MachineMetrics[], now: number = Date.now()):
           if (Number.isFinite(v)) vram.push(v);
         }
         if (Number.isFinite(g.temp_c) && g.temp_c > 0) temps.push(g.temp_c);
-        if (Number.isFinite(g.power_watts) && g.power_watts >= 0) {
+        // Strictly > 0: a 0 may be a real idle draw or an unknown serialized as
+        // 0, and the legacy wire cannot tell them apart, so 0 never counts as a
+        // power observation.
+        if (Number.isFinite(g.power_watts) && g.power_watts > 0) {
           power += g.power_watts;
           powerDevices += 1;
         }

--- a/dashboard/src/components/fleet/useFleetData.ts
+++ b/dashboard/src/components/fleet/useFleetData.ts
@@ -28,7 +28,7 @@ export interface FleetData {
  * tick re-derives freshness so machines age to stale/offline even if the SSE
  * stream goes quiet, matching FleetOverview's clock. */
 export function useFleetData(): FleetData {
-  const { machines: live, hasReceivedData, alerts } = useSSE();
+  const { machines: live, hasReceivedData, alertCount } = useSSE();
   const ai = useAISessions();
 
   const [now, setNow] = useState(() => Date.now());
@@ -90,7 +90,10 @@ export function useFleetData(): FleetData {
     agg,
     sessionCount,
     sessionMachines,
-    alertsCount: alerts.length,
+    // The SSE alert count is maintained independently and can arrive before or
+    // during a failed GET /api/alerts, so it is the reliable source — not the
+    // length of the alerts array, which is empty until that fetch succeeds.
+    alertsCount: alertCount,
     isDemo,
     hasReceivedData,
     isEmpty: machines.length === 0,

--- a/dashboard/src/components/fleet/useFleetData.ts
+++ b/dashboard/src/components/fleet/useFleetData.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSSE } from "@/contexts/SSEContext";
+import { useAISessions } from "@/contexts/AISessionsContext";
+import { DEMO_MODE } from "@/lib/session";
+import { demoMachines, type MachineMetrics } from "@/lib/demo-data";
+import { STATUS_ORDER } from "@/components/StatusBadge";
+import { aggregate, statusOf, type FleetAggregate, type Metric } from "./fleetModel";
+
+export interface FleetData {
+  machines: MachineMetrics[];
+  /** Problem-first ordering (critical -> warning -> offline -> stale -> live). */
+  sorted: MachineMetrics[];
+  agg: FleetAggregate;
+  /** Live AI session count, or null when monitoring is off/failed/not loaded. */
+  sessionCount: Metric;
+  sessionMachines: number;
+  alertsCount: number;
+  isDemo: boolean;
+  hasReceivedData: boolean;
+  /** No machines are known yet (waiting for telemetry). */
+  isEmpty: boolean;
+}
+
+/** Single source of truth for the live layout bodies. Everything is real SSE
+ * data through the existing providers; nothing is fabricated. A one-second
+ * tick re-derives freshness so machines age to stale/offline even if the SSE
+ * stream goes quiet, matching FleetOverview's clock. */
+export function useFleetData(): FleetData {
+  const { machines: live, hasReceivedData, alerts } = useSSE();
+  const ai = useAISessions();
+
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const isDemo = DEMO_MODE && !hasReceivedData && live.length === 0;
+  const source = isDemo ? demoMachines : live;
+
+  const machines = useMemo(
+    () => source.filter((m) => m && typeof m.machine_id === "string"),
+    [source],
+  );
+
+  // `now` is threaded in so freshness re-evaluates on the tick, not only when
+  // the machine list changes.
+  const agg = useMemo(() => aggregate(machines, now), [machines, now]);
+
+  const sorted = useMemo(
+    () =>
+      [...machines].sort(
+        (a, b) =>
+          STATUS_ORDER[statusOf(a)] - STATUS_ORDER[statusOf(b)] ||
+          (a.hostname ?? "").localeCompare(b.hostname ?? ""),
+      ),
+    // `now` re-sorts as machines age even when SSE is quiet; statusOf reads the
+    // wall clock internally, so it is a deliberate extra dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [machines, now],
+  );
+
+  const { sessionCount, sessionMachines } = useMemo(() => {
+    // AI Sessions is metadata-only and can be switched off fleet-wide. When it
+    // is off, has not loaded, or the last fetch errored, the count is
+    // unavailable — never reported as zero active sessions. Per-machine
+    // freshness (receivedAtLocal vs staleAfterSeconds) means a machine whose
+    // reports have gone stale does not keep claiming active sessions.
+    if (ai.enabled !== true || !ai.hasLoaded || ai.error) {
+      return { sessionCount: null as Metric, sessionMachines: 0 };
+    }
+    const staleMs = Math.max(0, ai.staleAfterSeconds) * 1000;
+    let count = 0;
+    let withSessions = 0;
+    for (const m of ai.machines.values()) {
+      const fresh = Number.isFinite(m.receivedAtLocal) && now - m.receivedAtLocal <= staleMs;
+      if (fresh && m.sessions.length > 0) {
+        count += m.sessions.length;
+        withSessions += 1;
+      }
+    }
+    return { sessionCount: count as Metric, sessionMachines: withSessions };
+  }, [ai.enabled, ai.hasLoaded, ai.error, ai.staleAfterSeconds, ai.machines, now]);
+
+  return {
+    machines,
+    sorted,
+    agg,
+    sessionCount,
+    sessionMachines,
+    alertsCount: alerts.length,
+    isDemo,
+    hasReceivedData,
+    isEmpty: machines.length === 0,
+  };
+}

--- a/dashboard/src/components/settings/ThemeSettings.tsx
+++ b/dashboard/src/components/settings/ThemeSettings.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/contexts/ThemeContext";
 import { ThemePreview } from "@/components/ThemePreview";
 import { cn } from "@/lib/utils";
+import { DesignSettings } from "@/components/DesignSettings";
+import { useDesign } from "@/contexts/DesignContext";
 
 const MODE_OPTIONS: { value: ThemeMode; label: string; Icon: typeof Sun }[] = [
   { value: "light", label: "Light", Icon: Sun },
@@ -25,9 +27,12 @@ const ORDER: ThemeName[] = ["bloxos", "mission-control", "graphite", "verdant", 
 
 export function ThemeSettings() {
   const { themeName, themeMode, setTheme, setMode } = useTheme();
+  const { layout } = useDesign();
 
   return (
     <div className="space-y-8">
+      <DesignSettings />
+      {layout === "classic" && <>
       <section>
         <h2 className="text-sm font-semibold text-blox-text mb-1">Mode</h2>
         <p className="text-xs text-blox-muted mb-3">
@@ -60,7 +65,7 @@ export function ThemeSettings() {
       <section>
         <h2 className="text-sm font-semibold text-blox-text mb-1">Theme</h2>
         <p className="text-xs text-blox-muted mb-4">
-          Choose a visual design or a classic palette. Dark-only designs always use dark mode.
+          Choose a palette for Classic. Dark-only palettes always use dark mode.
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           {ORDER.map((name) => {
@@ -104,6 +109,7 @@ export function ThemeSettings() {
           })}
         </div>
       </section>
+      </>}
     </div>
   );
 }

--- a/dashboard/src/components/shell/AppShell.tsx
+++ b/dashboard/src/components/shell/AppShell.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+// Shared authenticated navigation shell. Classic is a pure passthrough so the
+// existing pages (their own headers, modals and behavior) are untouched. The
+// three live layouts render persistent navigation chrome — Wall header, Grove
+// sidebar (+ optional context rail), Console icon rail + tabs — around the
+// page content, so navigation does not vanish on a machine click. The chrome's
+// global actions and modals are owned by ShellActionsProvider and reachable on
+// every route, including mobile.
+
+import { type ReactNode } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { RefreshCw, Plus, Server, Command } from "lucide-react";
+import { useDesign } from "@/contexts/DesignContext";
+import { useAuth } from "@/contexts/AuthContext";
+import { useSSE } from "@/contexts/SSEContext";
+import { BrandedHeader } from "@/components/BrandedHeader";
+import { BloxosMark } from "@/components/BloxosMark";
+import { UserMenu } from "@/components/UserMenu";
+import { useBranding } from "@/contexts/BrandingContext";
+import { Button } from "@/components/ui/button";
+import { NAV_ITEMS, isNavActive } from "@/components/shell/navItems";
+import { ShellActionsProvider, useShellActions } from "@/components/shell/ShellActions";
+
+export function AppShell({ children, rail }: { children: ReactNode; rail?: ReactNode }) {
+  const { layout, ready } = useDesign();
+
+  // Bounded neutral frame while the design preference resolves. Identical on
+  // server and first client render (hydration-safe); the microtask cache flips
+  // `ready` before paint for returning users.
+  if (!ready) {
+    return (
+      <div className="min-h-screen bg-blox-bg flex items-center justify-center" aria-busy="true">
+        <div className="h-6 w-6 rounded-full border-2 border-blox-border border-t-blox-blue animate-spin" aria-label="Loading" />
+      </div>
+    );
+  }
+
+  if (layout === "classic") return <>{children}</>;
+
+  return (
+    <ShellActionsProvider>
+      {layout === "wall" && <WallChrome>{children}</WallChrome>}
+      {layout === "grove" && <GroveChrome rail={rail}>{children}</GroveChrome>}
+      {layout === "console" && <ConsoleChrome>{children}</ConsoleChrome>}
+    </ShellActionsProvider>
+  );
+}
+
+function useVisibleNav() {
+  const { hasScope } = useAuth();
+  return NAV_ITEMS.filter((item) => !item.scope || hasScope(item.scope));
+}
+
+/* ---- Shared action cluster ------------------------------------------------ */
+function ShellRefreshButton() {
+  const { hasScope } = useAuth();
+  const { refreshFleet } = useSSE();
+  const canControlFleet = hasScope("fleet.control");
+  return (
+    <button
+      type="button"
+      onClick={() => canControlFleet && void refreshFleet()}
+      disabled={!canControlFleet}
+      title={canControlFleet ? "Refresh fleet metrics" : "Refresh requires operator role"}
+      aria-label="Refresh fleet metrics"
+      className="inline-flex items-center justify-center w-9 h-9 rounded-md text-text-secondary hover:text-text-primary hover:bg-border-subtle disabled:opacity-40 transition-colors"
+    >
+      <RefreshCw className="w-4 h-4" />
+    </button>
+  );
+}
+
+function ShellActionCluster() {
+  const { openAddMachine, openAddAPIMachine, openCommandPalette } = useShellActions();
+  return (
+    <>
+      <ShellRefreshButton />
+      <button
+        type="button"
+        onClick={openCommandPalette}
+        title="Open command palette (⌘K)"
+        aria-label="Open command palette"
+        className="inline-flex items-center justify-center w-9 h-9 rounded-md text-text-secondary hover:text-text-primary hover:bg-border-subtle transition-colors"
+      >
+        <Command className="w-4 h-4" />
+      </button>
+      {openAddAPIMachine && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={openAddAPIMachine}
+          className="text-text-secondary hover:text-text-primary gap-1.5 text-xs"
+          title="Add API-polled machine (Proxmox / Synology)"
+        >
+          <Server className="w-3.5 h-3.5" />
+          <span className="hidden sm:inline">API</span>
+        </Button>
+      )}
+      {openAddMachine && (
+        <Button
+          size="sm"
+          onClick={openAddMachine}
+          className="bg-accent text-accent-foreground hover:bg-accent-hover gap-1.5 text-xs"
+          title="Add a machine via install token"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          <span className="hidden sm:inline">Add Machine</span>
+          <span className="sm:hidden">Add</span>
+        </Button>
+      )}
+      <UserMenu />
+    </>
+  );
+}
+
+/* ---- 01 Operations Wall: top header ------------------------------------- */
+function WallChrome({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const nav = useVisibleNav();
+  return (
+    <div className="ld-shell lw">
+      <header className="lw-head">
+        <BrandedHeader size="compact" />
+        <nav className="lw-nav" aria-label="Primary">
+          {nav.map(({ href, label, Icon }) => (
+            <Link
+              key={href}
+              href={href}
+              aria-label={label}
+              title={label}
+              className={isNavActive(pathname, href) ? "is-active" : ""}
+            >
+              <Icon className="w-3.5 h-3.5" />
+              <span className="hidden md:inline">{label.replace(" overview", "")}</span>
+            </Link>
+          ))}
+        </nav>
+        <div className="lw-actions">
+          <ShellActionCluster />
+        </div>
+      </header>
+      <div className="lw-content">{children}</div>
+    </div>
+  );
+}
+
+/* ---- 02 Grove Workspace: sidebar + optional context rail ---------------- */
+function GroveChrome({ children, rail }: { children: ReactNode; rail?: ReactNode }) {
+  const pathname = usePathname();
+  const nav = useVisibleNav();
+  const workspace = nav.filter((n) => n.group === "workspace");
+  const manage = nav.filter((n) => n.group === "manage");
+  return (
+    <div className="ld-shell">
+      {/* Mobile top bar: the sidebar is hidden below 700px, so the full nav and
+          the shell actions live here instead — never dropped. */}
+      <header className="lg-mobilebar">
+        <BrandedHeader size="compact" />
+        <div className="lg-actions">
+          <ShellActionCluster />
+        </div>
+        <nav className="lg-mnav" aria-label="Primary">
+          {nav.map(({ href, label, Icon }) => (
+            <Link key={href} href={href} aria-label={label} className={isNavActive(pathname, href) ? "is-active" : ""}>
+              <Icon className="w-3.5 h-3.5" />
+              {label.replace(" overview", "")}
+            </Link>
+          ))}
+        </nav>
+      </header>
+      <div className={`lg${rail ? "" : " lg-norail"}`}>
+      <aside className="lg-sidebar" aria-label="Primary navigation">
+        <div className="lg-brand">
+          <BrandedHeader size="compact" />
+        </div>
+        <div className="lg-navlabel">WORKSPACE</div>
+        {workspace.map(({ href, label, Icon }) => (
+          <Link key={href} href={href} className={`lg-navitem${isNavActive(pathname, href) ? " is-active" : ""}`}>
+            <Icon className="lg-navicon w-4 h-4" />
+            {label}
+          </Link>
+        ))}
+        {manage.length > 0 && <div className="lg-navlabel">MANAGE</div>}
+        {manage.map(({ href, label, Icon }) => (
+          <Link key={href} href={href} className={`lg-navitem${isNavActive(pathname, href) ? " is-active" : ""}`}>
+            <Icon className="lg-navicon w-4 h-4" />
+            {label}
+          </Link>
+        ))}
+        <div className="lg-sidebar-foot">
+          <div className="lg-actions">
+            <ShellActionCluster />
+          </div>
+        </div>
+      </aside>
+      <div className="lg-main">{children}</div>
+      {rail && <aside className="lg-rail">{rail}</aside>}
+      </div>
+    </div>
+  );
+}
+
+/* ---- 03 Precision Console: icon rail + tabs ----------------------------- */
+function ConsoleChrome({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const nav = useVisibleNav();
+  const { logoUrl, branding } = useBranding();
+  return (
+    <div className="ld-shell lc">
+      <aside className="lc-rail" aria-label="Primary navigation">
+        <Link href="/" className="lc-mark" aria-label={branding.title || "Fleet"}>
+          {logoUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={logoUrl} alt={branding.title || "BloxOS"} className="ld-mark w-8 h-8 object-contain" />
+          ) : (
+            <BloxosMark className="ld-mark w-8 h-8" />
+          )}
+        </Link>
+        {nav.map(({ href, label, Icon }) => (
+          <Link key={href} href={href} className={isNavActive(pathname, href) ? "is-active" : ""} title={label} aria-label={label}>
+            <Icon className="w-4 h-4" />
+          </Link>
+        ))}
+      </aside>
+      <div className="lc-body">
+        <header className="lc-head">
+          <BrandedHeader size="compact" />
+          <nav className="lc-tabs" aria-label="Primary">
+            {nav.map(({ href, label }) => (
+              <Link key={href} href={href} className={isNavActive(pathname, href) ? "is-active" : ""}>
+                {label.replace(" overview", "")}
+              </Link>
+            ))}
+          </nav>
+          <div className="lc-actions">
+            <ShellActionCluster />
+          </div>
+        </header>
+        <main className="lc-content">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/shell/ShellActions.tsx
+++ b/dashboard/src/components/shell/ShellActions.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+// Global actions for the non-classic layouts, mounted once by AppShell so
+// Add Machine / Add API machine / the command palette are reachable from
+// every authenticated route (and on mobile). Modal ownership lives here; the
+// action paths are the same ones the classic dashboard uses. Cross-route
+// side effects are broadcast as window events so whichever page owns the
+// affected list refreshes consistently no matter where the action fired.
+
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import { AddMachineModal } from "@/components/AddMachineModal";
+import { AddAPIMachineModal } from "@/components/AddAPIMachineModal";
+import { CommandPalette, useCommandPaletteHotkey } from "@/components/CommandPalette";
+
+export const API_MACHINES_CHANGED = "bloxos:api-machines-changed";
+export const OPEN_ALERTS = "bloxos:open-alerts";
+export const OPEN_COMMAND = "bloxos:open-command";
+
+interface ShellActionsValue {
+  canCreateInstallTokens: boolean;
+  canManageAPIMachines: boolean;
+  openAddMachine?: () => void;
+  openAddAPIMachine?: () => void;
+  openCommandPalette: () => void;
+}
+
+const Context = createContext<ShellActionsValue | null>(null);
+
+export function useShellActions(): ShellActionsValue {
+  const ctx = useContext(Context);
+  if (!ctx) throw new Error("useShellActions must be used within ShellActionsProvider");
+  return ctx;
+}
+
+export function ShellActionsProvider({ children }: { children: ReactNode }) {
+  const { hasScope } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+  const canCreateInstallTokens = hasScope("install_tokens.admin");
+  const canManageAPIMachines = hasScope("api_machines.admin");
+
+  const [addMachineOpen, setAddMachineOpen] = useState(false);
+  const [addAPIMachineOpen, setAddAPIMachineOpen] = useState(false);
+  const [commandOpen, setCommandOpen] = useState(false);
+  useCommandPaletteHotkey(setCommandOpen);
+
+  const openAddMachine = useCallback(() => setAddMachineOpen(true), []);
+  const openAddAPIMachine = useCallback(() => setAddAPIMachineOpen(true), []);
+  const openCommandPalette = useCallback(() => setCommandOpen(true), []);
+
+  // The dashboard manager's inline ⌘K button (rendered in the page, not the
+  // chrome) asks the shell-owned palette to open via this event.
+  useEffect(() => {
+    const open = () => setCommandOpen(true);
+    window.addEventListener(OPEN_COMMAND, open);
+    return () => window.removeEventListener(OPEN_COMMAND, open);
+  }, []);
+
+  const openAlerts = useCallback(() => {
+    // Alerts live on the fleet dashboard. If we are there, open in place;
+    // otherwise navigate to it with a flag the dashboard reads on mount.
+    if (pathname === "/") window.dispatchEvent(new CustomEvent(OPEN_ALERTS));
+    else router.push("/?panel=alerts");
+  }, [pathname, router]);
+
+  const onAPIMachineSaved = useCallback(() => {
+    if (typeof window !== "undefined") window.dispatchEvent(new CustomEvent(API_MACHINES_CHANGED));
+  }, []);
+
+  const value: ShellActionsValue = {
+    canCreateInstallTokens,
+    canManageAPIMachines,
+    openAddMachine: canCreateInstallTokens ? openAddMachine : undefined,
+    openAddAPIMachine: canManageAPIMachines ? openAddAPIMachine : undefined,
+    openCommandPalette,
+  };
+
+  return (
+    <Context.Provider value={value}>
+      {children}
+
+      <AddMachineModal open={addMachineOpen} onClose={() => setAddMachineOpen(false)} />
+      {addAPIMachineOpen && (
+        <AddAPIMachineModal
+          open={addAPIMachineOpen}
+          onClose={() => setAddAPIMachineOpen(false)}
+          onSaved={onAPIMachineSaved}
+        />
+      )}
+      <CommandPalette
+        open={commandOpen}
+        onOpenChange={setCommandOpen}
+        onAddMachine={value.openAddMachine}
+        onAddAPIMachine={value.openAddAPIMachine}
+        onOpenAlerts={openAlerts}
+      />
+    </Context.Provider>
+  );
+}

--- a/dashboard/src/components/shell/navItems.tsx
+++ b/dashboard/src/components/shell/navItems.tsx
@@ -1,0 +1,28 @@
+import { LayoutGrid, Boxes, Bot, GitCompareArrows, Settings, Users, type LucideIcon } from "lucide-react";
+
+// The authenticated routes surfaced by every non-classic layout's navigation
+// (Grove sidebar, Console icon rail + tabs, Wall header). Order matches the
+// study. `scope`, when set, hides the item for users without that permission.
+export interface NavItem {
+  href: string;
+  label: string;
+  Icon: LucideIcon;
+  group: "workspace" | "manage";
+  scope?: string;
+}
+
+export const NAV_ITEMS: NavItem[] = [
+  { href: "/", label: "Fleet overview", Icon: LayoutGrid, group: "workspace" },
+  { href: "/inventory", label: "Inventory", Icon: Boxes, group: "workspace" },
+  { href: "/sessions", label: "AI Sessions", Icon: Bot, group: "workspace" },
+  { href: "/versions", label: "Versions", Icon: GitCompareArrows, group: "workspace" },
+  { href: "/settings", label: "Settings", Icon: Settings, group: "manage" },
+  { href: "/users", label: "Users", Icon: Users, group: "manage", scope: "users.admin" },
+];
+
+// A route is active when the pathname equals it, or (for non-root routes) is
+// nested under it. "/" only matches exactly and its own machine detail pages.
+export function isNavActive(pathname: string, href: string): boolean {
+  if (href === "/") return pathname === "/" || pathname.startsWith("/machine/");
+  return pathname === href || pathname.startsWith(href + "/");
+}

--- a/dashboard/src/contexts/AuthContext.tsx
+++ b/dashboard/src/contexts/AuthContext.tsx
@@ -4,7 +4,7 @@ import { createContext, useContext, useEffect, useRef, useState, useCallback, Re
 import { useRouter, usePathname } from "next/navigation";
 import { ChangePasswordModal } from "@/components/ChangePasswordModal";
 import { HUB_URL, dispatchAuthChanged, getStoredToken } from "@/lib/session";
-import { shouldLogoutOn401, storageAuthAction, tokenRemovalApplies } from "@/lib/auth-session.mjs";
+import { shouldLogoutOn401, storageAuthAction, tokenRemovalApplies, decodeJWTPayload } from "@/lib/auth-session.mjs";
 
 export type UserRole = "admin" | "operator" | "viewer";
 
@@ -47,8 +47,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const stored = localStorage.getItem("bloxos_token");
     if (stored) {
       try {
-        const payload = JSON.parse(atob(stored.split(".")[1]));
-        if (payload.exp * 1000 > Date.now()) {
+        const payload = decodeJWTPayload(stored);
+        if (payload?.exp * 1000 > Date.now()) {
           // eslint-disable-next-line react-hooks/set-state-in-effect
           setToken(stored);
           setRole(normalizeRole(localStorage.getItem("bloxos_role")));

--- a/dashboard/src/contexts/DesignContext.tsx
+++ b/dashboard/src/contexts/DesignContext.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useTheme, applyToDocument } from "@/contexts/ThemeContext";
 import { HUB_URL, getStoredToken } from "@/lib/session";
 import { userIDFromToken } from "@/lib/auth-session.mjs";
-import { normalizeDesign, readDesign, writeDesign, hasDesignCache, type Layout, type DesignColor, type DesignPreferences } from "@/lib/design-prefs.mjs";
+import { normalizeDesign, readDesign, writeDesign, hasDesignCache, hasPendingDesign, markDesignSynced, type Layout, type DesignColor, type DesignPreferences } from "@/lib/design-prefs.mjs";
 
 export type { Layout, DesignColor };
 interface DesignValue {
@@ -59,6 +59,13 @@ export function DesignProvider({ children }: { children: ReactNode }) {
       setError(null);
       setSaving(false);
       if (!token || token !== getStoredToken()) return;
+      // Never replace an advertised browser-local save with an older server
+      // value after a reload. Keep it (and the retry warning) until a selection
+      // successfully syncs. Any selection sends the complete snapshot again.
+      if (hasPendingDesign(localStorage, userID)) {
+        setError("Saved in this browser only. Select your choice again to retry account sync.");
+        return;
+      }
       const timeout = setTimeout(() => controller.abort(), 5000);
       try {
         const response = await fetchDesign({ signal: controller.signal });
@@ -100,7 +107,7 @@ export function DesignProvider({ children }: { children: ReactNode }) {
     if (!ready || token !== getStoredToken()) return;
     const edit = ++revision.current;
     current.current = next;
-    writeDesign(localStorage, userID, next);
+    writeDesign(localStorage, userID, next, !!token);
     setState({ owner: userID, prefs: next, ready: true });
     setError(null);
     if (!token) return;
@@ -117,7 +124,10 @@ export function DesignProvider({ children }: { children: ReactNode }) {
           body: JSON.stringify(next), signal: AbortSignal.timeout(5000),
         });
         if (!response.ok) throw new Error("save failed");
-        if (token === getStoredToken() && edit === revision.current) setError(null);
+        if (token === getStoredToken() && edit === revision.current) {
+          markDesignSynced(localStorage, userID, next);
+          setError(null);
+        }
       } catch {
         if (token === getStoredToken()) setError("Saved in this browser only. Select your choice again to retry account sync.");
       } finally {

--- a/dashboard/src/contexts/DesignContext.tsx
+++ b/dashboard/src/contexts/DesignContext.tsx
@@ -72,6 +72,15 @@ export function DesignProvider({ children }: { children: ReactNode }) {
         if (!response.ok) throw new Error("Design sync unavailable; using this browser’s saved choice.");
         const remote = normalizeDesign(await response.json());
         if (cancelled || token !== getStoredToken() || revision.current !== initialRevision) return;
+        // Another tab can create an unsynced local edit while this GET runs.
+        // Its revision counter is independent, so inspect the shared cache too.
+        if (hasPendingDesign(localStorage, userID)) {
+          const pending = readDesign(localStorage, userID);
+          current.current = pending;
+          setState({ owner: userID, prefs: pending, ready: true });
+          setError("Saved in this browser only. Select your choice again to retry account sync.");
+          return;
+        }
         current.current = remote;
         writeDesign(localStorage, userID, remote);
         setState({ owner: userID, prefs: remote, ready: true });

--- a/dashboard/src/contexts/DesignContext.tsx
+++ b/dashboard/src/contexts/DesignContext.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useTheme, applyToDocument } from "@/contexts/ThemeContext";
 import { HUB_URL, getStoredToken } from "@/lib/session";
 import { userIDFromToken } from "@/lib/auth-session.mjs";
-import { normalizeDesign, readDesign, writeDesign, type Layout, type DesignColor, type DesignPreferences } from "@/lib/design-prefs.mjs";
+import { normalizeDesign, readDesign, writeDesign, hasDesignCache, type Layout, type DesignColor, type DesignPreferences } from "@/lib/design-prefs.mjs";
 
 export type { Layout, DesignColor };
 interface DesignValue {
@@ -52,7 +52,10 @@ export function DesignProvider({ children }: { children: ReactNode }) {
       if (cancelled) return;
       const cached = readDesign(localStorage, userID);
       current.current = cached;
-      setState({ owner: userID, prefs: cached, ready: !token });
+      // Returning users can use their account-scoped choice immediately while
+      // the server reconciles in the background. A cold account still waits in
+      // the neutral frame instead of rendering the wrong Classic chrome.
+      setState({ owner: userID, prefs: cached, ready: !token || hasDesignCache(localStorage, userID) });
       setError(null);
       setSaving(false);
       if (!token || token !== getStoredToken()) return;
@@ -76,6 +79,9 @@ export function DesignProvider({ children }: { children: ReactNode }) {
   }, [token, userID, fetchDesign]);
 
   useEffect(() => {
+    // Keep the pre-hydration choice until this account's cache/server resolves.
+    // In particular, never paint the default Classic over a known saved design.
+    if (!ready) return;
     const root = document.documentElement;
     root.dataset.layout = prefs.layout;
     root.dataset.designColor = color;
@@ -88,7 +94,7 @@ export function DesignProvider({ children }: { children: ReactNode }) {
       root.classList.add(mode);
       root.style.colorScheme = mode;
     }
-  }, [prefs.layout, color, themeName, resolvedMode]);
+  }, [ready, prefs.layout, color, themeName, resolvedMode]);
 
   const update = useCallback((next: DesignPreferences) => {
     if (!ready || token !== getStoredToken()) return;

--- a/dashboard/src/contexts/DesignContext.tsx
+++ b/dashboard/src/contexts/DesignContext.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useTheme, applyToDocument } from "@/contexts/ThemeContext";
+import { HUB_URL, getStoredToken } from "@/lib/session";
+import { userIDFromToken } from "@/lib/auth-session.mjs";
+import { normalizeDesign, readDesign, writeDesign, type Layout, type DesignColor, type DesignPreferences } from "@/lib/design-prefs.mjs";
+
+export type { Layout, DesignColor };
+interface DesignValue {
+  layout: Layout;
+  color: DesignColor;
+  ready: boolean;
+  saving: boolean;
+  error: string | null;
+  setLayout: (layout: Layout) => void;
+  setColor: (color: DesignColor) => void;
+}
+const Context = createContext<DesignValue | null>(null);
+
+export function DesignProvider({ children }: { children: ReactNode }) {
+  const { token, logout } = useAuth();
+  const userID = userIDFromToken(token);
+  const { themeName, resolvedMode } = useTheme();
+  const [state, setState] = useState<{ owner: string | null; prefs: DesignPreferences; ready: boolean }>({ owner: null, prefs: normalizeDesign(null), ready: false });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const current = useRef(normalizeDesign(null));
+  const revision = useRef(0);
+  const queue = useRef(Promise.resolve());
+  const ready = state.ready && state.owner === userID;
+  const prefs = ready ? state.prefs : normalizeDesign(null);
+  const color = prefs.layout === "classic" ? "original" : prefs.colors[prefs.layout];
+
+  // Bind both queued and in-flight requests to the login that initiated them.
+  // Another tab may change storage at any time; never borrow its credentials.
+  const fetchDesign = useCallback(async (init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    if (token) headers.set("Authorization", `Bearer ${token}`);
+    const response = await fetch(`${HUB_URL}/api/me/design`, { ...init, headers });
+    if (response.status === 401 && token && token === getStoredToken()) logout();
+    return response;
+  }, [token, logout]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+    const initialRevision = ++revision.current;
+    // A microtask gives SSR and the first client render the same neutral shell.
+    void Promise.resolve().then(async () => {
+      if (cancelled) return;
+      const cached = readDesign(localStorage, userID);
+      current.current = cached;
+      setState({ owner: userID, prefs: cached, ready: !token });
+      setError(null);
+      setSaving(false);
+      if (!token || token !== getStoredToken()) return;
+      const timeout = setTimeout(() => controller.abort(), 5000);
+      try {
+        const response = await fetchDesign({ signal: controller.signal });
+        if (!response.ok) throw new Error("Design sync unavailable; using this browser’s saved choice.");
+        const remote = normalizeDesign(await response.json());
+        if (cancelled || token !== getStoredToken() || revision.current !== initialRevision) return;
+        current.current = remote;
+        writeDesign(localStorage, userID, remote);
+        setState({ owner: userID, prefs: remote, ready: true });
+      } catch {
+        if (!cancelled && revision.current === initialRevision) setError("Design sync unavailable; using this browser’s saved choice.");
+      } finally {
+        clearTimeout(timeout);
+        if (!cancelled && token === getStoredToken()) setState(previous => ({ ...previous, ready: true }));
+      }
+    });
+    return () => { cancelled = true; controller.abort(); };
+  }, [token, userID, fetchDesign]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.dataset.layout = prefs.layout;
+    root.dataset.designColor = color;
+    if (prefs.layout === "classic") {
+      applyToDocument(themeName, resolvedMode);
+    } else {
+      Array.from(root.classList).filter(c => c.startsWith("theme-")).forEach(c => root.classList.remove(c));
+      root.classList.remove("light", "dark");
+      const mode = color === "bright" ? "light" : "dark";
+      root.classList.add(mode);
+      root.style.colorScheme = mode;
+    }
+  }, [prefs.layout, color, themeName, resolvedMode]);
+
+  const update = useCallback((next: DesignPreferences) => {
+    if (!ready || token !== getStoredToken()) return;
+    const edit = ++revision.current;
+    current.current = next;
+    writeDesign(localStorage, userID, next);
+    setState({ owner: userID, prefs: next, ready: true });
+    setError(null);
+    if (!token) return;
+    setSaving(true);
+    // Serialize changes so slow earlier saves cannot overwrite the last choice.
+    // Check the captured login before dispatch, not only after the response.
+    queue.current = queue.current.catch(() => {}).then(async () => {
+      if (token !== getStoredToken()) return;
+      try {
+        const response = await fetchDesign({
+          method: "PATCH", headers: { "Content-Type": "application/json" },
+          // Each queued snapshot carries prior choices too, repairing an earlier
+          // failed save when a later selection succeeds.
+          body: JSON.stringify(next), signal: AbortSignal.timeout(5000),
+        });
+        if (!response.ok) throw new Error("save failed");
+        if (token === getStoredToken() && edit === revision.current) setError(null);
+      } catch {
+        if (token === getStoredToken()) setError("Saved in this browser only. Select your choice again to retry account sync.");
+      } finally {
+        if (token === getStoredToken() && edit === revision.current) setSaving(false);
+      }
+    });
+  }, [ready, token, userID, fetchDesign]);
+
+  const setLayout = useCallback((layout: Layout) => {
+    update({ ...current.current, layout });
+  }, [update]);
+  const setColor = useCallback((nextColor: DesignColor) => {
+    const layout = current.current.layout;
+    if (layout === "classic") return;
+    update({ ...current.current, colors: { ...current.current.colors, [layout]: nextColor } });
+  }, [update]);
+
+  return <Context.Provider value={{ layout: prefs.layout, color, ready, saving, error, setLayout, setColor }}>{children}</Context.Provider>;
+}
+
+export function useDesign() {
+  const context = useContext(Context);
+  if (!context) throw new Error("useDesign requires DesignProvider");
+  return context;
+}

--- a/dashboard/src/contexts/SSEContext.tsx
+++ b/dashboard/src/contexts/SSEContext.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { userIDFromToken } from "@/lib/auth-session.mjs";
 
 import {
   createContext,
@@ -149,12 +150,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
       userIDRef.current = null;
       return;
     }
-    try {
-      const payload = JSON.parse(atob(token.split(".")[1]));
-      userIDRef.current = payload.user_id ?? null;
-    } catch {
-      userIDRef.current = null;
-    }
+    userIDRef.current = userIDFromToken(token);
     const [writer, flush, cancel] = makeDebouncedWriter(userIDRef.current);
     cacheWriterRef.current = writer;
     cacheFlushRef.current = flush;

--- a/dashboard/src/contexts/ThemeContext.tsx
+++ b/dashboard/src/contexts/ThemeContext.tsx
@@ -181,7 +181,7 @@ function getSystemMode(): ResolvedMode {
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
-function applyToDocument(name: ThemeName, resolved: ResolvedMode) {
+export function applyToDocument(name: ThemeName, resolved: ResolvedMode) {
   if (typeof document === "undefined") return;
   const root = document.documentElement;
   // Strip any pre-existing theme-* class so toggles are clean.
@@ -259,6 +259,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // Apply theme + mode classes to <html>. This is a side-effect on an
   // external system (the DOM), which is the canonical use case for useEffect.
   useEffect(() => {
+    if (document.documentElement.dataset.layout && document.documentElement.dataset.layout !== "classic") return;
     applyToDocument(themeName, resolvedMode);
   }, [themeName, resolvedMode]);
 

--- a/dashboard/src/lib/auth-session.mjs
+++ b/dashboard/src/lib/auth-session.mjs
@@ -1,16 +1,22 @@
 
 // userIDFromToken reads user_id from a JWT payload without touching storage.
 // The hub signs with user_id, not sub — see hub/auth.go.
-export function userIDFromToken(token) {
+export function decodeJWTPayload(token) {
   if (!token) return null;
   try {
     const parts = token.split(".");
     if (parts.length < 2) return null;
-    const payload = JSON.parse(atob(parts[1]));
-    return typeof payload.user_id === "string" ? payload.user_id : null;
+    const encoded = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const binary = atob(encoded.padEnd(Math.ceil(encoded.length / 4) * 4, "="));
+    const payload = JSON.parse(new TextDecoder().decode(Uint8Array.from(binary, c => c.charCodeAt(0))));
+    return payload;
   } catch {
     return null;
   }
+}
+export function userIDFromToken(token) {
+  const payload = decodeJWTPayload(token);
+  return typeof payload?.user_id === "string" && payload.user_id !== "" ? payload.user_id : null;
 }
 // Auth session transition policy — pure decisions shared by AuthContext so
 // the tricky cases (stale in-flight 401 vs. fresh login, cross-tab storage

--- a/dashboard/src/lib/auth-session.test.mjs
+++ b/dashboard/src/lib/auth-session.test.mjs
@@ -10,6 +10,14 @@ test("401 logs out only when the failing request still carries the current token
   assert.equal(shouldLogoutOn401(null, null), false);
   assert.equal(shouldLogoutOn401("", null), false);
 });
+test("JWT base64url and UTF-8 payloads retain distinct account identities", () => {
+  for (const username of ['x>', 'x?', 'مستخدم', '🦊']) {
+    const body = {user_id:'user-'+username, username};
+    const payload = Buffer.from(JSON.stringify(body)).toString('base64url');
+    assert.equal(userIDFromToken(`aaa.${payload}.bbb`), body.user_id);
+  }
+  for (const payload of ['-', '_', '%%%%']) assert.equal(userIDFromToken(`aaa.${payload}.bbb`), null);
+});
 
 test("storage events map to logout or login-sync precisely", () => {
   assert.equal(storageAuthAction("bloxos_token", null), "logout");

--- a/dashboard/src/lib/design-bootstrap.test.mjs
+++ b/dashboard/src/lib/design-bootstrap.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import {runInNewContext} from 'node:vm';
+import {userIDFromToken} from './auth-session.mjs';
+
+test('actual inline bootstrap selects base64url account cache, never dirty guest cache', () => {
+  const layout = readFileSync(new URL('../app/layout.tsx', import.meta.url),'utf8');
+  const source = layout.match(/const themeBootstrapScript = `([\s\S]*?)`\.trim\(\);/)[1];
+  let sawURLAlphabet = false;
+  for (const username of ['x>', 'x?', '🦊', 'مستخدم']) {
+    const user = 'account-'+username;
+    const payload = Buffer.from(JSON.stringify({user_id:user,username,exp:2000000000})).toString('base64url');
+    sawURLAlphabet ||= /[-_]/.test(payload);
+    const token = `header.${payload}.signature`;
+    assert.equal(userIDFromToken(token),user);
+    const items = new Map([
+      ['bloxos_token',token],
+      ['bloxos-design:'+user,JSON.stringify({layout:'grove',colors:{grove:'bright'}})],
+      ['bloxos-design:guest',JSON.stringify({layout:'console',colors:{console:'dark'},pendingSync:true})],
+    ]);
+    const root={dataset:{},style:{},classList:{add(){},remove(){}}};
+    runInNewContext(source,{atob,TextDecoder,Uint8Array,localStorage:{getItem:key=>items.get(key)??null},document:{documentElement:root},window:{matchMedia:()=>({matches:true})}});
+    assert.equal(root.dataset.layout,'grove');
+    assert.equal(root.dataset.designColor,'bright');
+  }
+  assert.ok(sawURLAlphabet,'fixtures must exercise - or _ in the JWT payload');
+});

--- a/dashboard/src/lib/design-fleet-model.test.mjs
+++ b/dashboard/src/lib/design-fleet-model.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { aggregate } from '../components/fleet/fleetModel.ts';
+
+const cpuOnly = () => ({machine_id:'cpu',hostname:'cpu',last_seen:Date.now(),cpu_percent:40,ram_used_bytes:4,ram_total_bytes:8,disk_used_bytes:2,disk_total_bytes:8,gpus:[],gpu_util_percent:0,gpu_vram_total_bytes:0,gpu_temp:0});
+const gpuMachine = () => ({...cpuOnly(),machine_id:'gpu',hostname:'gpu',gpus:[
+ {name:'GPU0',util_percent:20,mem_used_bytes:2,mem_total_bytes:8,temp_c:60,power_watts:100},
+ {name:'GPU1',util_percent:80,mem_used_bytes:6,mem_total_bytes:8,temp_c:75,power_watts:200},
+]});
+test('new layouts report unavailable GPU telemetry for CPU-only and empty fleets',()=>{
+ for(const machines of [[],[cpuOnly()]]){
+  const result=aggregate(machines);
+  for(const key of ['avgGpuUtil','avgVram','maxGpuTemp','gpuPowerTotal'])assert.equal(result[key],null,key);
+  assert.deepEqual(result.topGpu,[]);assert.deepEqual(result.topVram,[]);
+ }
+ assert.equal(aggregate([]).onlinePct,null);
+});
+test('new layouts use every GPU and do not dilute GPU averages with CPU-only machines',()=>{
+ const result=aggregate([cpuOnly(),gpuMachine()]);
+ assert.equal(result.avgGpuUtil,50);assert.equal(result.avgVram,50);
+ assert.equal(result.maxGpuTemp,75);assert.equal(result.gpuPowerTotal,300);
+ assert.equal(result.topGpu.length,1);assert.equal(result.topGpu[0].machineId,'gpu');
+});
+test('stale and offline machines cannot contribute to current resource or power readings',()=>{
+ const stale={...gpuMachine(),last_seen:Date.now()-40000};
+ const offline={...gpuMachine(),machine_id:'offline',last_seen:Date.now()-180000};
+ const result=aggregate([stale,offline]);
+ for(const key of ['avgCpu','avgRam','avgGpuUtil','avgVram','maxGpuTemp','gpuPowerTotal'])assert.equal(result[key],null,key);
+ assert.deepEqual(result.topGpu,[]);
+ assert.deepEqual(result.topVram,[]);
+});
+test('fleet averages count GPUs, not machine averages, when device counts differ',()=>{
+ const second={...gpuMachine(),machine_id:'single',gpus:[{name:'GPU0',util_percent:100,mem_used_bytes:8,mem_total_bytes:8,temp_c:70,power_watts:50}]};
+ const result=aggregate([gpuMachine(),second]);
+ assert.ok(Math.abs(result.avgGpuUtil-200/3)<1e-9);
+ assert.ok(Math.abs(result.avgVram-200/3)<1e-9);
+ assert.equal(result.gpuPowerTotal,350);
+});
+test('partial GPU power must not be presented as a complete fleet total; valid zero survives',()=>{
+ const machine=gpuMachine();delete machine.gpus[1].power_watts;
+ const partial=aggregate([machine]);
+ assert.equal(partial.gpuPowerComplete,false);
+ assert.equal(partial.gpuPowerTotal,100);
+ machine.gpus.forEach(g=>{g.power_watts=0;g.util_percent=0;});
+ assert.equal(aggregate([machine]).gpuPowerTotal,0);
+ assert.equal(aggregate([machine]).avgGpuUtil,0);
+});
+test('non-finite readings are unavailable, not NaN output',()=>{
+ const machine={...cpuOnly(),cpu_percent:NaN,ram_used_bytes:Infinity};
+ const result=aggregate([machine]);assert.equal(result.avgCpu,null);assert.equal(result.avgRam,null);
+});

--- a/dashboard/src/lib/design-fleet-model.test.mjs
+++ b/dashboard/src/lib/design-fleet-model.test.mjs
@@ -61,6 +61,27 @@ test('legacy GPU power: only >0 is observed; mixed is partial; all-zero/absent i
  const idle=gpuMachine();idle.gpus.forEach(g=>{g.util_percent=0;});
  assert.equal(aggregate([idle]).avgGpuUtil,0);
 });
+test('stale machines count as connected but are surfaced separately, never as reporting',()=>{
+ const stale={...gpuMachine(),last_seen:Date.now()-60000};
+ // All stale: connected but every one is stale, so no "all reporting".
+ const allStale=aggregate([stale]);
+ assert.equal(allStale.total,1);
+ assert.equal(allStale.online,1);
+ assert.equal(allStale.stale,1);
+ assert.equal(allStale.onlinePct,100);
+ // Mixed fresh + stale: both connected, one stale.
+ const fresh={...gpuMachine(),machine_id:'fresh',last_seen:Date.now()};
+ const mixed=aggregate([fresh,stale]);
+ assert.equal(mixed.total,2);
+ assert.equal(mixed.online,2);
+ assert.equal(mixed.stale,1);
+ // Offline is neither connected nor stale.
+ const offline={...gpuMachine(),machine_id:'off',last_seen:Date.now()-180000};
+ const withOffline=aggregate([fresh,stale,offline]);
+ assert.equal(withOffline.total,3);
+ assert.equal(withOffline.online,2);
+ assert.equal(withOffline.stale,1);
+});
 test('non-finite readings are unavailable, not NaN output',()=>{
  const machine={...cpuOnly(),cpu_percent:NaN,ram_used_bytes:Infinity};
  const result=aggregate([machine]);assert.equal(result.avgCpu,null);assert.equal(result.avgRam,null);

--- a/dashboard/src/lib/design-fleet-model.test.mjs
+++ b/dashboard/src/lib/design-fleet-model.test.mjs
@@ -36,14 +36,30 @@ test('fleet averages count GPUs, not machine averages, when device counts differ
  assert.ok(Math.abs(result.avgVram-200/3)<1e-9);
  assert.equal(result.gpuPowerTotal,350);
 });
-test('partial GPU power must not be presented as a complete fleet total; valid zero survives',()=>{
- const machine=gpuMachine();delete machine.gpus[1].power_watts;
- const partial=aggregate([machine]);
- assert.equal(partial.gpuPowerComplete,false);
- assert.equal(partial.gpuPowerTotal,100);
- machine.gpus.forEach(g=>{g.power_watts=0;g.util_percent=0;});
- assert.equal(aggregate([machine]).gpuPowerTotal,0);
- assert.equal(aggregate([machine]).avgGpuUtil,0);
+test('legacy GPU power: only >0 is observed; mixed is partial; all-zero/absent is unavailable',()=>{
+ // All devices report a positive draw -> complete total.
+ const all=aggregate([gpuMachine()]);
+ assert.equal(all.gpuPowerTotal,300);
+ assert.equal(all.gpuPowerComplete,true);
+ // One device omits the reading -> partial, only the observed device counts.
+ const missing=gpuMachine();delete missing.gpus[1].power_watts;
+ const partialMissing=aggregate([missing]);
+ assert.equal(partialMissing.gpuPowerTotal,100);
+ assert.equal(partialMissing.gpuPowerComplete,false);
+ // A 0 is ambiguous (the agent serializes "N/A" power as 0), so it is not an
+ // observation: mixed positive + zero is a partial sum, never complete.
+ const mixed=gpuMachine();mixed.gpus[1].power_watts=0;
+ const partialZero=aggregate([mixed]);
+ assert.equal(partialZero.gpuPowerTotal,100);
+ assert.equal(partialZero.gpuPowerComplete,false);
+ // Every device reads 0 -> entirely ambiguous -> unavailable, never a 0 W total.
+ const allZero=gpuMachine();allZero.gpus.forEach(g=>{g.power_watts=0;});
+ const zeroResult=aggregate([allZero]);
+ assert.equal(zeroResult.gpuPowerTotal,null);
+ assert.equal(zeroResult.gpuPowerComplete,false);
+ // Non-power GPU readings are unaffected: 0% utilization stays a valid reading.
+ const idle=gpuMachine();idle.gpus.forEach(g=>{g.util_percent=0;});
+ assert.equal(aggregate([idle]).avgGpuUtil,0);
 });
 test('non-finite readings are unavailable, not NaN output',()=>{
  const machine={...cpuOnly(),cpu_percent:NaN,ram_used_bytes:Infinity};

--- a/dashboard/src/lib/design-prefs.d.mts
+++ b/dashboard/src/lib/design-prefs.d.mts
@@ -1,0 +1,9 @@
+export type Layout = 'classic' | 'wall' | 'grove' | 'console';
+export type DesignColor = 'original' | 'bright' | 'dark';
+export interface DesignPreferences { layout: Layout; colors: Record<Exclude<Layout, 'classic'>, DesignColor>; }
+export const DESIGN_LAYOUTS: readonly Layout[];
+export const DESIGN_COLORS: readonly DesignColor[];
+export function normalizeDesign(value: unknown): DesignPreferences;
+export function designCacheKey(userID: string | null): string;
+export function readDesign(storage: Pick<Storage, 'getItem'>, userID: string | null): DesignPreferences;
+export function writeDesign(storage: Pick<Storage, 'setItem'>, userID: string | null, value: DesignPreferences): void;

--- a/dashboard/src/lib/design-prefs.d.mts
+++ b/dashboard/src/lib/design-prefs.d.mts
@@ -5,5 +5,6 @@ export const DESIGN_LAYOUTS: readonly Layout[];
 export const DESIGN_COLORS: readonly DesignColor[];
 export function normalizeDesign(value: unknown): DesignPreferences;
 export function designCacheKey(userID: string | null): string;
+export function hasDesignCache(storage: Pick<Storage, 'getItem'>, userID: string | null): boolean;
 export function readDesign(storage: Pick<Storage, 'getItem'>, userID: string | null): DesignPreferences;
 export function writeDesign(storage: Pick<Storage, 'setItem'>, userID: string | null, value: DesignPreferences): void;

--- a/dashboard/src/lib/design-prefs.d.mts
+++ b/dashboard/src/lib/design-prefs.d.mts
@@ -7,4 +7,6 @@ export function normalizeDesign(value: unknown): DesignPreferences;
 export function designCacheKey(userID: string | null): string;
 export function hasDesignCache(storage: Pick<Storage, 'getItem'>, userID: string | null): boolean;
 export function readDesign(storage: Pick<Storage, 'getItem'>, userID: string | null): DesignPreferences;
-export function writeDesign(storage: Pick<Storage, 'setItem'>, userID: string | null, value: DesignPreferences): void;
+export function hasPendingDesign(storage: Pick<Storage, 'getItem'>, userID: string | null): boolean;
+export function writeDesign(storage: Pick<Storage, 'setItem'>, userID: string | null, value: DesignPreferences, pendingSync?: boolean): void;
+export function markDesignSynced(storage: Pick<Storage, 'getItem' | 'setItem'>, userID: string | null, value: DesignPreferences): void;

--- a/dashboard/src/lib/design-prefs.mjs
+++ b/dashboard/src/lib/design-prefs.mjs
@@ -1,0 +1,18 @@
+export const DESIGN_LAYOUTS = ['classic', 'wall', 'grove', 'console'];
+export const DESIGN_COLORS = ['original', 'bright', 'dark'];
+export function normalizeDesign(value) {
+  return {
+    layout: DESIGN_LAYOUTS.includes(value?.layout) ? value.layout : 'classic',
+    colors: Object.fromEntries(['wall', 'grove', 'console'].map(key =>
+      [key, DESIGN_COLORS.includes(value?.colors?.[key]) ? value.colors[key] : 'original'])),
+  };
+}
+export function designCacheKey(userID) { return `bloxos-design:${userID || 'guest'}`; }
+export function readDesign(storage, userID) {
+  try { return normalizeDesign(JSON.parse(storage.getItem(designCacheKey(userID)))); }
+  catch { return normalizeDesign(null); }
+}
+export function writeDesign(storage, userID, value) {
+  try { storage.setItem(designCacheKey(userID), JSON.stringify(normalizeDesign(value))); }
+  catch { /* Appearance remains usable with blocked/full storage. */ }
+}

--- a/dashboard/src/lib/design-prefs.mjs
+++ b/dashboard/src/lib/design-prefs.mjs
@@ -8,6 +8,10 @@ export function normalizeDesign(value) {
   };
 }
 export function designCacheKey(userID) { return `bloxos-design:${userID || 'guest'}`; }
+export function hasDesignCache(storage, userID) {
+  try { return DESIGN_LAYOUTS.includes(JSON.parse(storage.getItem(designCacheKey(userID)))?.layout); }
+  catch { return false; }
+}
 export function readDesign(storage, userID) {
   try { return normalizeDesign(JSON.parse(storage.getItem(designCacheKey(userID)))); }
   catch { return normalizeDesign(null); }

--- a/dashboard/src/lib/design-prefs.mjs
+++ b/dashboard/src/lib/design-prefs.mjs
@@ -16,7 +16,17 @@ export function readDesign(storage, userID) {
   try { return normalizeDesign(JSON.parse(storage.getItem(designCacheKey(userID)))); }
   catch { return normalizeDesign(null); }
 }
-export function writeDesign(storage, userID, value) {
-  try { storage.setItem(designCacheKey(userID), JSON.stringify(normalizeDesign(value))); }
+export function hasPendingDesign(storage, userID) {
+  try { return hasDesignCache(storage, userID) && JSON.parse(storage.getItem(designCacheKey(userID)))?.pendingSync === true; }
+  catch { return false; }
+}
+export function writeDesign(storage, userID, value, pendingSync = false) {
+  try { storage.setItem(designCacheKey(userID), JSON.stringify({ ...normalizeDesign(value), ...(pendingSync ? {pendingSync: true} : {}) })); }
   catch { /* Appearance remains usable with blocked/full storage. */ }
+}
+export function markDesignSynced(storage, userID, sent) {
+  // A different tab may have saved a newer local choice while this request ran.
+  if (JSON.stringify(readDesign(storage, userID)) === JSON.stringify(normalizeDesign(sent))) {
+    writeDesign(storage, userID, sent);
+  }
 }

--- a/dashboard/src/lib/design-prefs.test.mjs
+++ b/dashboard/src/lib/design-prefs.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { DESIGN_LAYOUTS, DESIGN_COLORS, normalizeDesign, readDesign, writeDesign, hasDesignCache } from './design-prefs.mjs';
+import { DESIGN_LAYOUTS, DESIGN_COLORS, normalizeDesign, readDesign, writeDesign, hasDesignCache, hasPendingDesign, markDesignSynced } from './design-prefs.mjs';
 
 test('designs and colors are independent and have exactly nine new combinations', () => {
   assert.equal((DESIGN_LAYOUTS.length - 1) * DESIGN_COLORS.length, 9);
@@ -39,4 +39,19 @@ test('cache is account-scoped and unavailable storage is harmless', () => {
   const blocked = { getItem() { throw Error('denied'); }, setItem() { throw Error('full'); } };
   assert.equal(readDesign(blocked, 'one').layout, 'classic');
   assert.doesNotThrow(() => writeDesign(blocked, 'one', one));
+});
+test('unsynced choices survive reads and only their matching acknowledgement clears dirty state', () => {
+  const items = new Map();
+  const storage = { getItem: key => items.get(key), setItem: (key, value) => items.set(key, value) };
+  const old = normalizeDesign({layout:'wall'}), newer = normalizeDesign({layout:'grove'});
+  writeDesign(storage, 'one', old, true);
+  assert.equal(hasPendingDesign(storage, 'one'), true);
+  assert.deepEqual(readDesign(storage, 'one'), old);
+  assert.equal(hasPendingDesign(storage, 'two'), false);
+  writeDesign(storage, 'one', newer, true);
+  markDesignSynced(storage, 'one', old);
+  assert.equal(hasPendingDesign(storage, 'one'), true);
+  assert.deepEqual(readDesign(storage, 'one'), newer);
+  markDesignSynced(storage, 'one', newer);
+  assert.equal(hasPendingDesign(storage, 'one'), false);
 });

--- a/dashboard/src/lib/design-prefs.test.mjs
+++ b/dashboard/src/lib/design-prefs.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { DESIGN_LAYOUTS, DESIGN_COLORS, normalizeDesign, readDesign, writeDesign } from './design-prefs.mjs';
+import { DESIGN_LAYOUTS, DESIGN_COLORS, normalizeDesign, readDesign, writeDesign, hasDesignCache } from './design-prefs.mjs';
 
 test('designs and colors are independent and have exactly nine new combinations', () => {
   assert.equal((DESIGN_LAYOUTS.length - 1) * DESIGN_COLORS.length, 9);
@@ -9,6 +9,19 @@ test('designs and colors are independent and have exactly nine new combinations'
     assert.equal(prefs.layout, layout);
     assert.equal(prefs.colors.grove, color);
   }
+});
+test('only a valid cache for the current account enables immediate rendering', () => {
+  const items = new Map();
+  const storage = { getItem: key => items.get(key), setItem: (key, value) => items.set(key, value) };
+  assert.equal(hasDesignCache(storage, 'one'), false);
+  writeDesign(storage, 'one', normalizeDesign({layout: 'grove'}));
+  assert.equal(hasDesignCache(storage, 'one'), true);
+  assert.equal(hasDesignCache(storage, 'two'), false);
+  for (const bad of ['{', 'null', '{"layout":"unknown"}']) {
+    items.set('bloxos-design:two', bad);
+    assert.equal(hasDesignCache(storage, 'two'), false);
+  }
+  assert.equal(hasDesignCache({ getItem() { throw Error('denied'); } }, 'one'), false);
 });
 test('unknown and corrupt preferences fall back to Classic, never a new design', () => {
   for (const value of [null, [], 'wall', { layout: 'verdant', colors: { wall: 'system' } }]) {

--- a/dashboard/src/lib/design-prefs.test.mjs
+++ b/dashboard/src/lib/design-prefs.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DESIGN_LAYOUTS, DESIGN_COLORS, normalizeDesign, readDesign, writeDesign } from './design-prefs.mjs';
+
+test('designs and colors are independent and have exactly nine new combinations', () => {
+  assert.equal((DESIGN_LAYOUTS.length - 1) * DESIGN_COLORS.length, 9);
+  for (const layout of DESIGN_LAYOUTS) for (const color of DESIGN_COLORS) {
+    const prefs = normalizeDesign({ layout, colors: { wall: color, grove: color, console: color } });
+    assert.equal(prefs.layout, layout);
+    assert.equal(prefs.colors.grove, color);
+  }
+});
+test('unknown and corrupt preferences fall back to Classic, never a new design', () => {
+  for (const value of [null, [], 'wall', { layout: 'verdant', colors: { wall: 'system' } }]) {
+    assert.deepEqual(normalizeDesign(value), { layout: 'classic', colors: { wall: 'original', grove: 'original', console: 'original' } });
+  }
+});
+test('cache is account-scoped and unavailable storage is harmless', () => {
+  const items = new Map();
+  const storage = { getItem: key => items.get(key), setItem: (key, value) => items.set(key, value) };
+  const one = normalizeDesign({ layout: 'grove', colors: { grove: 'bright', wall: 'dark' } });
+  writeDesign(storage, 'one', one);
+  assert.deepEqual(readDesign(storage, 'one'), one);
+  assert.equal(readDesign(storage, 'two').layout, 'classic');
+  assert.equal(readDesign(storage, null).layout, 'classic');
+  const blocked = { getItem() { throw Error('denied'); }, setItem() { throw Error('full'); } };
+  assert.equal(readDesign(blocked, 'one').layout, 'classic');
+  assert.doesNotThrow(() => writeDesign(blocked, 'one', one));
+});

--- a/dashboard/src/lib/runtime-dependencies.test.mjs
+++ b/dashboard/src/lib/runtime-dependencies.test.mjs
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+test('React and React DOM use matching versions, including error-page rendering', () => {
+  const { dependencies } = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8'));
+  assert.equal(dependencies.react, dependencies['react-dom']);
+});

--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -25,8 +25,10 @@ Classic; selecting a new layout does not replace their old palette preference.
 
 Design preferences are saved locally per account and synced through
 `GET/PATCH /api/me/design`. The hub validates the four layout names and three
-color choices, updating only the authenticated user's row. On a cold load a
-neutral loading frame resolves the preference; a failed sync falls back to the
+color choices, updating only the authenticated user's row. Returning users see
+their account-scoped cached choice immediately while the server reconciles in
+the background. Without a valid cache, a neutral loading frame resolves the
+preference; a failed sync falls back to the
 cached choice with a visible warning and does not block using the app. Failed
 saves remain local and are reported instead of being presented as synced.
 

--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -30,7 +30,10 @@ their account-scoped cached choice immediately while the server reconciles in
 the background. Without a valid cache, a neutral loading frame resolves the
 preference; a failed sync falls back to the
 cached choice with a visible warning and does not block using the app. Failed
-saves remain local and are reported instead of being presented as synced.
+saves remain local across reloads and are reported instead of being presented as
+synced. Reselect a choice to retry syncing the complete local design. Zero GPU
+power on the legacy wire is ambiguous (unsupported sensors also report zero),
+so it is treated as unavailable, not proof of a complete zero-watt total.
 
 ## Reference studies
 

--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -1,4 +1,36 @@
-# BloxOS layout studies
+# BloxOS designs and colors
+
+## Live application
+
+Choose **Account menu → Design** or **Settings → Theme → Design**. Select a
+layout, then **Original**, **Bright**, or **Dark**. Each layout remembers its own
+color. Original reproduces the design study's fixed palette; Bright and Dark
+are explicit choices, not operating-system modes. There are nine combinations.
+
+- **Operations Wall:** open summary panels, resource bars and a machine register.
+- **Grove Workspace:** sidebar navigation, central analytics and a context rail.
+- **Precision Console:** compact navigation, a table-first fleet and instruments.
+
+The layouts use live fleet data and the existing permissions and action paths.
+Selected navigation and colors continue onto machine details, inventory,
+versions, AI sessions, users and settings. Those pages retain their working
+contents and contextual controls. Empty/missing telemetry is unavailable, not
+an invented zero; stale readings are excluded from current aggregates. GPU
+power is component telemetry, not wall power, and incomplete readings are
+explicitly labelled partial.
+
+**Classic** retains the previous dashboard and all eight palettes below. Its
+light/dark/system controls apply only to Classic. Existing accounts default to
+Classic; selecting a new layout does not replace their old palette preference.
+
+Design preferences are saved locally per account and synced through
+`GET/PATCH /api/me/design`. The hub validates the four layout names and three
+color choices, updating only the authenticated user's row. On a cold load a
+neutral loading frame resolves the preference; a failed sync falls back to the
+cached choice with a visible warning and does not block using the app. Failed
+saves remain local and are reported instead of being presented as synced.
+
+## Reference studies
 
 The revised [interactive comparison](index.html) contains three structurally distinct
 proposals built from the same sample fleet data:
@@ -10,10 +42,9 @@ proposals built from the same sample fleet data:
 - **Precision Console:** narrow tool rail, horizontal navigation, compact status
   strip and a machine table with telemetry instruments below.
 
-These are design proposals, not integrated application layouts. The previous
-implementation below changes palettes and styling only, and does not implement
-the revised compositions. The HTML preview is self-contained, responsive, and
-uses one shared data object for the three machine and resource presentations.
+The HTML preview is a self-contained reference with illustrative data, not the
+running application. It uses one shared data object for all three presentations.
+The live implementation described above connects these compositions to BloxOS.
 
 ## Color variants
 
@@ -44,8 +75,8 @@ The comparison is self-contained, with its own layout styles.
 | Graphite | Tactile charcoal console | Sculpted panels, inset highlights, cast shadows, mint accents, monospaced readings |
 | Verdant | Organic forest workspace | Broad curved panels, pill actions, lime fleet summary, lighter sans-serif figures |
 
-In the application, choose **Settings → Theme** to select a design. All three are
-dark-only. The existing BloxOS default and the four other existing palette choices are
+In the application, choose **Classic → Theme** to select these older palettes.
+All three are dark-only. The existing BloxOS default and the four other existing palette choices are
 preserved. The selected design uses the existing local and per-user server
 preferences, including the initial pre-hydration theme bootstrap.
 
@@ -67,8 +98,8 @@ image, third-party branding, financial widget, or unrelated CRM data is included
 - `dashboard/src/components/ThemePreview.tsx`: dashboard thumbnails in the picker.
 - `hub/user_prefs.go`: server acceptance of the three new preference names.
 
-The HTML comparison is illustrative, not a replacement implementation of the
-application. Browser visual verification remains required before release.
+The HTML comparison remains illustrative. Browser verification of the actual
+application is the release gate, not merely a screenshot of this reference.
 
 ## BloxOS logo
 

--- a/hub/design_prefs.go
+++ b/hub/design_prefs.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+var designColumns = map[string]string{"wall": "wall_color", "grove": "grove_color", "console": "console_color"}
+
+func validDesignLayout(v string) bool { return v == "classic" || designColumns[v] != "" }
+func validDesignColor(v string) bool  { return v == "original" || v == "bright" || v == "dark" }
+
+type designPrefs struct {
+	Layout string            `json:"layout"`
+	Colors map[string]string `json:"colors"`
+}
+
+func (s *Server) handleGetMyDesign(c echo.Context) error {
+	claims, ok := authClaimsFromContext(c)
+	if !ok || claims.UserID == "" {
+		return echo.NewHTTPError(http.StatusUnauthorized)
+	}
+	var layout, wall, grove, console string
+	err := s.db.QueryRow(`SELECT dashboard_layout, wall_color, grove_color, console_color FROM users WHERE id = ?`, claims.UserID).Scan(&layout, &wall, &grove, &console)
+	if err == sql.ErrNoRows {
+		return echo.NewHTTPError(http.StatusNotFound)
+	}
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "could not load design")
+	}
+	if !validDesignLayout(layout) {
+		layout = "classic"
+	}
+	colors := map[string]string{"wall": wall, "grove": grove, "console": console}
+	for k, v := range colors {
+		if !validDesignColor(v) {
+			colors[k] = "original"
+		}
+	}
+	return c.JSON(http.StatusOK, designPrefs{Layout: layout, Colors: colors})
+}
+
+// Partial writes preserve other layouts' colors, legacy palettes and other users.
+func (s *Server) handlePatchMyDesign(c echo.Context) error {
+	claims, ok := authClaimsFromContext(c)
+	if !ok || claims.UserID == "" {
+		return echo.NewHTTPError(http.StatusUnauthorized)
+	}
+	var body struct {
+		Layout *string           `json:"layout"`
+		Colors map[string]string `json:"colors"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(c.Request().Body, 2049))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid design preferences")
+	}
+	if err := decoder.Decode(new(any)); err != io.EOF {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid design preferences")
+	}
+	if body.Layout == nil && len(body.Colors) == 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "no design fields to update")
+	}
+	sets := []string{}
+	args := []any{}
+	if body.Layout != nil {
+		if !validDesignLayout(*body.Layout) {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid layout")
+		}
+		sets = append(sets, "dashboard_layout = ?")
+		args = append(args, *body.Layout)
+	}
+	for layout, color := range body.Colors {
+		column, exists := designColumns[layout]
+		if !exists || !validDesignColor(color) {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid layout color")
+		}
+		sets = append(sets, column+" = ?")
+		args = append(args, color)
+	}
+	args = append(args, claims.UserID)
+	result, err := s.db.Exec("UPDATE users SET "+strings.Join(sets, ", ")+" WHERE id = ?", args...)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "could not save design")
+	}
+	if count, err := result.RowsAffected(); err != nil || count != 1 {
+		return echo.NewHTTPError(http.StatusNotFound)
+	}
+	return s.handleGetMyDesign(c)
+}

--- a/hub/design_prefs_test.go
+++ b/hub/design_prefs_test.go
@@ -49,6 +49,11 @@ func TestDesignPreferences(t *testing.T) {
 		}
 	}
 	got := request(viewer, http.MethodPatch, `{"layout":"classic"}`, 200)
+	// Re-selecting an active choice must succeed, including an unchanged full
+	// snapshot. Exercise the actual SQLite driver, not an assumed row-count rule.
+	for i := 0; i < 3; i++ {
+		request(viewer, http.MethodPatch, `{"layout":"classic","colors":{"wall":"dark","grove":"dark","console":"dark"}}`, 200)
+	}
 	for _, color := range got.Colors {
 		if color != "dark" {
 			t.Fatal("layout-only PATCH lost saved colors")

--- a/hub/design_prefs_test.go
+++ b/hub/design_prefs_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDesignPreferences(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	admin := loginAndGetToken(t, e)
+	s.seedTestUser(t, "design-viewer", "viewerpass123", "1234", RoleViewer, true, true)
+	viewer := loginAndGetTokenForCredentials(t, e, "design-viewer", "viewerpass123")
+	request := func(token, method, body string, want int) designPrefs {
+		t.Helper()
+		req := httptest.NewRequest(method, "/api/me/design", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		if rec.Code != want {
+			t.Fatalf("%s %s: got %d want %d: %s", method, body, rec.Code, want, rec.Body.String())
+		}
+		var prefs designPrefs
+		if want == http.StatusOK {
+			if err := json.Unmarshal(rec.Body.Bytes(), &prefs); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return prefs
+	}
+	request("", http.MethodGet, "", 401)
+	request("", http.MethodPatch, `{"layout":"wall"}`, 401)
+	initial := request(admin, http.MethodGet, "", 200)
+	if initial.Layout != "classic" || initial.Colors["grove"] != "original" {
+		t.Fatalf("bad migration defaults: %+v", initial)
+	}
+	for _, layout := range []string{"wall", "grove", "console"} {
+		for _, color := range []string{"original", "bright", "dark"} {
+			p := request(viewer, http.MethodPatch, `{"layout":"`+layout+`","colors":{"`+layout+`":"`+color+`"}}`, 200)
+			if p.Layout != layout || p.Colors[layout] != color {
+				t.Fatalf("not persisted: %+v", p)
+			}
+		}
+	}
+	got := request(viewer, http.MethodPatch, `{"layout":"classic"}`, 200)
+	for _, color := range got.Colors {
+		if color != "dark" {
+			t.Fatal("layout-only PATCH lost saved colors")
+		}
+	}
+	for _, body := range []string{`{}`, `null`, `{"layout":"invented"}`, `{"colors":{"wall":"system"}}`, `{"colors":{"classic":"bright"}}`, `{"colors":{"wall_color = 1":"dark"}}`, `{"user_id":"someone-else","layout":"wall"}`, `{"layout":"wall"} {}`, `{"layout":"wall","colors":{"grove":null}}`} {
+		request(viewer, http.MethodPatch, body, 400)
+	}
+	if p := request(viewer, http.MethodGet, "", 200); p.Layout != "classic" {
+		t.Fatal("invalid patch partially applied")
+	}
+	if p := request(admin, http.MethodGet, "", 200); p.Layout != "classic" || p.Colors["wall"] != "original" {
+		t.Fatal("viewer mutated admin preferences")
+	}
+	var name, mode string
+	if err := s.db.QueryRow(`SELECT theme_name, theme_mode FROM users WHERE username = 'design-viewer'`).Scan(&name, &mode); err != nil {
+		t.Fatal(err)
+	}
+	if name != "bloxos" || mode != "system" {
+		t.Fatal("new design changed legacy theme")
+	}
+	if _, err := s.db.Exec(`UPDATE users SET dashboard_layout = 'unknown', wall_color = 'unknown' WHERE username = 'design-viewer'`); err != nil {
+		t.Fatal(err)
+	}
+	if p := request(viewer, http.MethodGet, "", 200); p.Layout != "classic" || p.Colors["wall"] != "original" {
+		t.Fatal("invalid stored value did not fall back")
+	}
+	if err := runMigrations(s.db); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/hub/main.go
+++ b/hub/main.go
@@ -336,6 +336,8 @@ func (s *Server) registerRoutes(e *echo.Echo) {
 
 	// Phase 10 — per-user theme prefs and admin branding writes.
 	api.GET("/api/me/theme", s.handleGetMyThemePrefs)
+	api.GET("/api/me/design", s.handleGetMyDesign)
+	api.PATCH("/api/me/design", s.handlePatchMyDesign)
 	api.PATCH("/api/me/theme", s.handleUpdateMyThemePrefs)
 	api.PATCH("/api/branding", s.handleUpdateBrandingText)
 	api.POST("/api/branding/logo", s.handleUploadLogo)

--- a/hub/migrations.go
+++ b/hub/migrations.go
@@ -493,6 +493,22 @@ var migrations = []migration{
 			return err
 		},
 	},
+	{
+		description: "independent dashboard layout and per-layout colors",
+		apply: func(tx *sql.Tx) error {
+			for _, statement := range []string{
+				`ALTER TABLE users ADD COLUMN dashboard_layout TEXT NOT NULL DEFAULT 'classic'`,
+				`ALTER TABLE users ADD COLUMN wall_color TEXT NOT NULL DEFAULT 'original'`,
+				`ALTER TABLE users ADD COLUMN grove_color TEXT NOT NULL DEFAULT 'original'`,
+				`ALTER TABLE users ADD COLUMN console_color TEXT NOT NULL DEFAULT 'original'`,
+			} {
+				if _, err := tx.Exec(statement); err != nil && !isDuplicateColumnErr(err) {
+					return err
+				}
+			}
+			return nil
+		},
+	},
 }
 
 // isDuplicateColumnErr returns true when SQLite rejects an ALTER TABLE ADD

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -133,6 +133,8 @@ var routeScopeRequirements = map[string]string{
 	routeScopeKey(http.MethodPost, "/api/branding/favicon"): scopeBrandingAdmin,
 	routeScopeKey(http.MethodDelete, "/api/branding/:kind"): scopeBrandingAdmin,
 	routeScopeKey(http.MethodGet, "/api/me/theme"):          scopeAuthSelf,
+	routeScopeKey(http.MethodGet, "/api/me/design"):         scopeAuthSelf,
+	routeScopeKey(http.MethodPatch, "/api/me/design"):       scopeAuthSelf,
 	routeScopeKey(http.MethodPatch, "/api/me/theme"):        scopeAuthSelf,
 
 	// Phase 11 — per-user workflow personalization. All ten routes are


### PR DESCRIPTION
## Summary

Wire the three design studies into the live application: **Operations Wall**, **Grove Workspace**, and **Precision Console**. Each has **Original / Bright / Dark** colors. Classic and its existing palettes remain available.

- Account menu and Settings expose independent layout/color choices, persisted per user through `/api/me/design`; partial updates preserve other layout colors and legacy preferences.
- Shared shell navigation continues across inventory, versions, AI sessions, users, settings, and machine detail. Existing machine management, role-gated actions and command workflows are retained in one controller.
- Real fleet telemetry drives the compositions, including availability rings, per-GPU aggregation, stale exclusion and explicit missing/partial readings. GPU power is component telemetry, not whole-machine wall power.
- Account-scoped cache, serialized saves, captured credentials and visible sync failure feedback prevent silent save failures or cross-account leakage.
- Align React DOM with React 19.2.8 to fix the inherited runtime version mismatch.

## Validation

- Dashboard: **76 tests pass**, lint has zero errors (three pre-existing unused-directive warnings), production build passes.
- Hub: full tests and full race suite pass locally; new API/migration tests cover authorization, all nine combinations, partial updates, invalid input and user isolation.
- Production browser acceptance: **18/18** — all nine choices, reload/server persistence, Classic switch, 320/390px mobile, viewer/admin controls and no uncaught exceptions.
- **21 secondary-route combinations**, each checked at desktop and 320/390px, pass navigation and overflow checks.
- All nine palettes pass computed text/status contrast checks against raised surfaces.
- Browser failure injection passes: failed save/recovery, rapid serialized changes, cross-browser persistence, account switch with pending saves, failed bootstrap fallback.
- Follow-up regression checks pass: cached layout has no Classic flash during a delayed GET, editing stays enabled and wins over late reconciliation; failed saves survive reload until an explicit retry succeeds.
- **25/25 supplementary controls checks** pass across all three layouts and viewer/operator/admin (search/reset, list/grid, pins, role-gated palette, service/container/notes controls).
- Browser telemetry injection verifies authoritative SSE alert counts despite a failed alert-list fetch, partial power, real 50% rings, empty fleets and aging without SSE. Legacy zero-power readings are ambiguous and do not establish complete telemetry.
- Final review fixes: proper base64url/UTF-8 decoding across login/cache/bootstrap (actual-script unit and real-hub username browser regressions); connected counts explicitly expose stale telemetry rather than claiming all reporting.
- Claude completed an independent final source review with no blockers. Kimi contributed acceptance coverage; local DeepSeek/Qwen reviewed persistence (findings independently adjudicated).

Validation uses an isolated local hub and synthetic Linux/Windows agents. Production services and the real fleet are untouched. No agent/protocol release bump is needed.
