### PR TITLE
feat: stable fleet arrangement and legacy-proxy onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,8 @@ Fleet management dashboard for AI machines. Go hub + agent, Next.js dashboard.
   only (no history) and re-sanitizes every frame. The admin switch defaults
   to on; disabling it stops agent-side scanning via the `ai_sessions_config`
   frame, and `BLOXOS_AI_SESSIONS=0` on an agent is a hard local opt-out.
-- **Join links** (`GET /join/<token>`, `hub/join.go`) reuse the 15-minute
+- **Join links** (`GET /api/join/<token>`, with legacy `/join/<token>` retained;
+  `hub/join.go`) reuse the 15-minute
   install token as the code and serve the verbose Linux bootstrap. They are
   never consumed by a GET — only `enrollment_committed` consumes the token —
   and every unusable code gets the same 404. Behind a private CA the short

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -4,6 +4,8 @@ import { useState, useMemo, useCallback, useEffect } from "react";
 import { useSSE } from "@/contexts/SSEContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { usePreferences } from "@/contexts/PreferencesContext";
+import { ArrangeMachinesDialog } from "@/components/ArrangeMachinesDialog";
+import { orderMachines } from "@/lib/machine-order.mjs";
 import { SaveFilterButton } from "@/components/SaveFilterButton";
 import { SavedFiltersDropdown } from "@/components/SavedFiltersDropdown";
 import { demoMachines, MachineMetrics, AlertData } from "@/lib/demo-data";
@@ -53,7 +55,7 @@ import { FleetWall } from "@/components/fleet/FleetWall";
 import { FleetGrove, FleetGroveRail } from "@/components/fleet/FleetGrove";
 import { FleetConsole } from "@/components/fleet/FleetConsole";
 
-type SortOption = "name" | "status" | "cpu" | "gpu_temp";
+type SortOption = "manual" | "name" | "status" | "cpu" | "gpu_temp";
 type StatusFilter = "all" | "live" | "warning" | "critical" | "offline" | "stale";
 type ViewMode = "grid" | "list";
 
@@ -80,6 +82,7 @@ function timeSince(ms: number): string {
 }
 
 const sortLabels: Record<SortOption, string> = {
+  manual: "My order",
   name: "Name (A-Z)",
   status: "Status",
   cpu: "CPU %",
@@ -89,7 +92,7 @@ const sortLabels: Record<SortOption, string> = {
 function DashboardContent() {
   const { addToast } = useToast();
   const { machines: liveMachines, connected, hasReceivedData, alerts, setAlerts, setAlertCount, refreshMachine, refreshFleet } = useSSE();
-  const { authFetch, hasScope } = useAuth();
+  const { authFetch, hasScope, token } = useAuth();
   // One shared controller serves every layout. Classic renders its own header
   // and the FleetPulse/overview summary; the live layouts render their summary
   // composition instead. The machine-management section below (search, filter,
@@ -104,7 +107,8 @@ function DashboardContent() {
   // Phase 11 — hydrate viewMode/sortBy from per-user preferences. The
   // PreferencesContext lazy-init reads from localStorage so the defaults
   // are correct on first paint after a reload (no flash).
-  const { preferences, updateScalar } = usePreferences();
+  const { preferences, updateScalar, saveMachineOrder, loading: preferencesLoading } = usePreferences();
+  const [arrangeOpen, setArrangeOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [sortBy, setSortBy] = useState<SortOption>(() => preferences.default_sort);
@@ -136,9 +140,9 @@ function DashboardContent() {
   const changeSort = useCallback(
     (next: SortOption) => {
       setSortBy(next);
-      void updateScalar({ default_sort: next });
+      void updateScalar({ default_sort: next }).catch(() => addToast("error", "Sort changed locally but could not be saved. Please retry."));
     },
-    [updateScalar],
+    [updateScalar, addToast],
   );
 
   const applySavedFilter = useCallback(
@@ -156,7 +160,7 @@ function DashboardContent() {
         setStatusFilter(f.statusFilter === "online" ? "live" : f.statusFilter);
       }
       setTagFilter(typeof f.tagFilter === "string" ? f.tagFilter : null);
-      if (f.sortBy === "name" || f.sortBy === "status" || f.sortBy === "cpu" || f.sortBy === "gpu_temp") {
+      if (f.sortBy === "manual" || f.sortBy === "name" || f.sortBy === "status" || f.sortBy === "cpu" || f.sortBy === "gpu_temp") {
         changeSort(f.sortBy);
       }
     },
@@ -278,43 +282,13 @@ function DashboardContent() {
       );
     }
 
-    const primaryCompare = (a: MachineMetrics, b: MachineMetrics) => {
-      switch (sortBy) {
-        case "name":
-          return (a.hostname ?? "").localeCompare(b.hostname ?? "");
-        case "status":
-          return STATUS_ORDER[getStatus(a)] - STATUS_ORDER[getStatus(b)];
-        case "cpu":
-          return (b.cpu_percent ?? 0) - (a.cpu_percent ?? 0);
-        case "gpu_temp":
-          return (b.gpu_temp || 0) - (a.gpu_temp || 0);
-        default:
-          return 0;
-      }
-    };
-
-    // Composite ordering — applied as a single comparator so each priority
-    // is strictly higher than the next:
-    //   1. status severity (critical → warning → offline → stale → live)
-    //   2. pinned before unpinned within the same status bucket
-    //   3. user's chosen sort key within the same status+pin bucket
-    //
-    // Done as one sort to avoid the bug from the prior two-phase impl,
-    // where a healthy-pinned machine could outrank a critical-unpinned
-    // one — directly contradicting the PR's "problem-first" promise.
-    const pinnedSet = new Set(preferences.pinned_machines);
-    result = [...result].sort((a, b) => {
-      const statusDiff = STATUS_ORDER[getStatus(a)] - STATUS_ORDER[getStatus(b)];
-      if (statusDiff !== 0) return statusDiff;
-
-      const pinDiff = Number(pinnedSet.has(b.machine_id)) - Number(pinnedSet.has(a.machine_id));
-      if (pinDiff !== 0) return pinDiff;
-
-      return primaryCompare(a, b);
+    return orderMachines(result, {
+      sort: sortBy,
+      order: preferences.machine_order,
+      pinned: preferences.pinned_machines,
+      status: m => STATUS_ORDER[getStatus(m)],
     });
-
-    return result;
-  }, [machines, search, statusFilter, sortBy, tagFilter, preferences.pinned_machines]);
+  }, [machines, search, statusFilter, sortBy, tagFilter, preferences.pinned_machines, preferences.machine_order]);
 
 
   const handleAcknowledge = useCallback(async (id: string) => {
@@ -772,6 +746,9 @@ function DashboardContent() {
             </button>
           </div>
 
+          <Button variant="outline" size="sm" onClick={() => setArrangeOpen(true)} disabled={preferencesLoading || !hasReceivedData || machines.length < 2}
+            className="text-xs border-blox-border text-blox-text">Arrange machines</Button>
+
           <span className="text-[10px] text-blox-muted font-mono tabular-nums">
             {filteredMachines.length} machine{filteredMachines.length !== 1 ? "s" : ""}
           </span>
@@ -990,6 +967,13 @@ function DashboardContent() {
       </section>
 
       {/* Delete confirmation dialog */}
+      {arrangeOpen && <ArrangeMachinesDialog key={token}
+        machines={orderMachines(machines.filter(m => m && typeof m.machine_id === "string"), {
+          sort: sortBy, order: preferences.machine_order, pinned: preferences.pinned_machines,
+          status: m => STATUS_ORDER[getStatus(m)],
+        })}
+        onClose={() => setArrangeOpen(false)} onSave={saveMachineOrder} />}
+
       <Dialog open={!!deleteTarget} onOpenChange={(o) => { if (!o) setDeleteTarget(null); }}>
         <DialogContent className="bg-blox-card border-blox-border text-blox-text ring-0 sm:max-w-md" showCloseButton={false}>
           <DialogHeader>

--- a/dashboard/src/components/ArrangeMachinesDialog.tsx
+++ b/dashboard/src/components/ArrangeMachinesDialog.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowUp, ArrowDown, GripVertical } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { moveMachine } from "@/lib/machine-order.mjs";
+import type { MachineMetrics } from "@/lib/demo-data";
+
+export function ArrangeMachinesDialog({ machines, onSave, onClose }: {
+  machines: MachineMetrics[];
+  onSave: (ids: string[]) => Promise<void>;
+  onClose: () => void;
+}) {
+  // Freeze the draft while the user works: live telemetry must not move it.
+  // Include all machines, even when the fleet behind the dialog is filtered.
+  const [draft, setDraft] = useState(() => machines.map(m => m.machine_id));
+  const [dragging, setDragging] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+  const names = new Map(machines.map(m => [m.machine_id, m.hostname || m.machine_id]));
+  const move = (from: string, to: string) => {
+    if (saving) return;
+    const next = moveMachine(draft, from, to);
+    setDraft(next);
+    setAnnouncement(`${names.get(from) || from} moved to position ${next.indexOf(from) + 1}.`);
+  };
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      // Remove deleted machines, append arrivals without disturbing the draft.
+      const ids = [...draft.filter(id => names.has(id)), ...machines.map(m => m.machine_id).filter(id => !draft.includes(id))];
+      await onSave(ids);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save. Your arrangement is still here; retry when connected.");
+    } finally {
+      setSaving(false);
+    }
+  };
+  return (
+    <Dialog open onOpenChange={open => { if (!open && !saving) onClose(); }}>
+      <DialogContent className="sm:max-w-lg bg-blox-card border-blox-border text-blox-text" showCloseButton={!saving}>
+        <DialogHeader>
+          <DialogTitle>Arrange machines</DialogTitle>
+          <DialogDescription>
+            Drag machines or use the arrows. This order is saved for your account in both grid and list views.
+            Status changes will not move them. All machines are included, regardless of filters.
+          </DialogDescription>
+        </DialogHeader>
+        <ol className="max-h-[50vh] overflow-y-auto space-y-2" aria-label="Machine order">
+          {draft.map((id, index) => (
+            <li key={id} className={`flex items-center gap-2 rounded-lg border border-blox-border p-2 ${dragging === id ? "opacity-50" : ""}`}
+              onDragOver={e => { if (dragging && !saving) { e.preventDefault(); e.dataTransfer.dropEffect = "move"; } }}
+              onDrop={e => { e.preventDefault(); if (dragging) move(dragging, id); setDragging(null); }}>
+              <span draggable={!saving} onDragStart={e => { setDragging(id); e.dataTransfer.effectAllowed = "move"; e.dataTransfer.setData("text/plain", id); }}
+                onDragEnd={() => setDragging(null)} title="Drag to reorder" aria-hidden="true" className="cursor-grab p-2 text-blox-muted">
+                <GripVertical className="h-4 w-4" />
+              </span>
+              <span className="min-w-0 flex-1 truncate text-sm">{names.get(id) || "Removed machine"}</span>
+              <Button variant="outline" size="sm" aria-label={`Move ${names.get(id) || id} up`} disabled={saving || index === 0}
+                onClick={() => move(id, draft[index - 1])}><ArrowUp className="h-4 w-4" /></Button>
+              <Button variant="outline" size="sm" aria-label={`Move ${names.get(id) || id} down`} disabled={saving || index === draft.length - 1}
+                onClick={() => move(id, draft[index + 1])}><ArrowDown className="h-4 w-4" /></Button>
+            </li>
+          ))}
+        </ol>
+        <p className="sr-only" aria-live="polite">{announcement}</p>
+        <p className="text-xs text-blox-muted">Manual order takes precedence over pins. New machines appear after the saved machines.</p>
+        {error && <p role="alert" className="text-sm text-red-400">{error}</p>}
+        <DialogFooter>
+          <Button variant="outline" disabled={saving} onClick={onClose}>Cancel</Button>
+          <Button disabled={saving} onClick={() => void save()}>{saving ? "Saving…" : "Save order"}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dashboard/src/components/fleet/useFleetData.ts
+++ b/dashboard/src/components/fleet/useFleetData.ts
@@ -6,11 +6,13 @@ import { useAISessions } from "@/contexts/AISessionsContext";
 import { DEMO_MODE } from "@/lib/session";
 import { demoMachines, type MachineMetrics } from "@/lib/demo-data";
 import { STATUS_ORDER } from "@/components/StatusBadge";
+import { usePreferences } from "@/contexts/PreferencesContext";
+import { orderMachines } from "@/lib/machine-order.mjs";
 import { aggregate, statusOf, type FleetAggregate, type Metric } from "./fleetModel";
 
 export interface FleetData {
   machines: MachineMetrics[];
-  /** Problem-first ordering (critical -> warning -> offline -> stale -> live). */
+  /** Same user-selected order as the machine-management grid/list. */
   sorted: MachineMetrics[];
   agg: FleetAggregate;
   /** Live AI session count, or null when monitoring is off/failed/not loaded. */
@@ -30,6 +32,7 @@ export interface FleetData {
 export function useFleetData(): FleetData {
   const { machines: live, hasReceivedData, alertCount } = useSSE();
   const ai = useAISessions();
+  const { preferences } = usePreferences();
 
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -51,15 +54,16 @@ export function useFleetData(): FleetData {
 
   const sorted = useMemo(
     () =>
-      [...machines].sort(
-        (a, b) =>
-          STATUS_ORDER[statusOf(a)] - STATUS_ORDER[statusOf(b)] ||
-          (a.hostname ?? "").localeCompare(b.hostname ?? ""),
-      ),
+      orderMachines(machines, {
+        sort: preferences.default_sort,
+        order: preferences.machine_order,
+        pinned: preferences.pinned_machines,
+        status: m => STATUS_ORDER[statusOf(m)],
+      }),
     // `now` re-sorts as machines age even when SSE is quiet; statusOf reads the
     // wall clock internally, so it is a deliberate extra dependency.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [machines, now],
+    [machines, now, preferences.default_sort, preferences.machine_order, preferences.pinned_machines],
   );
 
   const { sessionCount, sessionMachines } = useMemo(() => {

--- a/dashboard/src/components/settings/PreferencesSettings.tsx
+++ b/dashboard/src/components/settings/PreferencesSettings.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 const SORT_LABELS: Record<DefaultSort, string> = {
+  manual: "My order",
   name: "Name (A-Z)",
   status: "Status",
   cpu: "CPU %",

--- a/dashboard/src/contexts/PreferencesContext.tsx
+++ b/dashboard/src/contexts/PreferencesContext.tsx
@@ -26,6 +26,7 @@ import {
 import { HUB_URL, getStoredToken } from "@/lib/session";
 import { useAuth } from "@/contexts/AuthContext";
 import { userIDFromToken } from "@/lib/auth-session.mjs";
+import { normalizeMachineOrder, acceptedMachineOrder, createPreferenceWriter } from "@/lib/machine-order.mjs";
 import {
   purgeLegacyPreferencesCache,
   readPreferencesCache,
@@ -34,7 +35,7 @@ import {
 
 export type Density = "comfortable" | "compact";
 export type DefaultView = "grid" | "list";
-export type DefaultSort = "name" | "status" | "cpu" | "gpu_temp";
+export type DefaultSort = "manual" | "name" | "status" | "cpu" | "gpu_temp";
 
 export interface SavedFilter {
   id: string;
@@ -51,6 +52,7 @@ export interface Preferences {
   default_view: DefaultView;
   default_sort: DefaultSort;
   pinned_machines: string[];
+  machine_order: string[];
   saved_filters: SavedFilter[];
 }
 
@@ -62,12 +64,14 @@ const DEFAULT_PREFS: Preferences = {
   default_view: "grid",
   default_sort: "name",
   pinned_machines: [],
+  machine_order: [],
   saved_filters: [],
 };
 
 interface PreferencesContextValue {
   preferences: Preferences;
   loading: boolean;
+  saveMachineOrder: (ids: string[]) => Promise<void>;
   /** Optimistic scalar update — applies locally then PATCHes. */
   updateScalar: (
     patch: Partial<Pick<Preferences, "display_name" | "density" | "default_view" | "default_sort">>,
@@ -91,7 +95,7 @@ function normalizePreferences(raw: unknown): Preferences {
   const defaultView = r.default_view === "list" ? "list" : "grid";
   const sortRaw = typeof r.default_sort === "string" ? r.default_sort : "name";
   const defaultSort: DefaultSort =
-    sortRaw === "status" || sortRaw === "cpu" || sortRaw === "gpu_temp"
+    sortRaw === "manual" || sortRaw === "status" || sortRaw === "cpu" || sortRaw === "gpu_temp"
       ? sortRaw
       : "name";
   const pinned = Array.isArray(r.pinned_machines)
@@ -110,6 +114,7 @@ function normalizePreferences(raw: unknown): Preferences {
     default_view: defaultView,
     default_sort: defaultSort,
     pinned_machines: pinned,
+    machine_order: normalizeMachineOrder(r.machine_order),
     saved_filters: saved,
   };
 }
@@ -129,7 +134,7 @@ function normalizeSavedFilter(raw: unknown): SavedFilter | null {
 // userIDFromToken (lib/auth-session.mjs) is the single JWT user_id reader.
 
 export function PreferencesProvider({ children }: { children: ReactNode }) {
-  const { authFetch, token } = useAuth();
+  const { authFetch, token, logout } = useAuth();
   // Lazy initializer: read THIS user's cached prefs synchronously so the
   // first paint already has the right density/view/sort. Never reads the
   // legacy unscoped cache (cross-user leak).
@@ -141,15 +146,40 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
   // or same-tab user switch with the same boolean state must still re-key.
   const userID = useMemo<string | null>(() => userIDFromToken(token), [token]);
   const userIDRef = useRef<string | null>(userID);
+  const preferencesRef = useRef(preferences);
+  const writePreference = useMemo(() => createPreferenceWriter(), []);
+  const patchPreferences = useCallback((patch: unknown) => {
+    const capturedToken = token;
+    return writePreference(async () => {
+      if (!capturedToken || getStoredToken() !== capturedToken) throw new Error("Your session changed. Please retry.");
+      const res = await fetch(`${HUB_URL}/api/me/preferences`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${capturedToken}` },
+        body: JSON.stringify(patch),
+        signal: AbortSignal.timeout(15000),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.status === 401 && getStoredToken() === capturedToken) logout();
+      if (!res.ok) throw new Error(typeof data.error === "string" ? data.error : "Could not save preferences. Please retry.");
+      return data;
+    });
+  }, [token, logout, writePreference]);
 
   // Track in-flight refresh to avoid races between the post-login refresh
   // and any optimistic patch the user fires before it returns.
   const refreshSeqRef = useRef(0);
 
   const setAndCache = useCallback((p: Preferences) => {
+    preferencesRef.current = p;
     setPreferences(p);
     writePreferencesCache(userIDRef.current, p);
   }, []);
+
+  // Mutations only replace fields they own. A late pin/avatar/filter response
+  // must not overwrite a machine order that was saved while it was in flight.
+  const mergeAndCache = useCallback((patch: Partial<Preferences>) => {
+    setAndCache({ ...preferencesRef.current, ...patch });
+  }, [setAndCache]);
 
   const refresh = useCallback(async () => {
     const seq = ++refreshSeqRef.current;
@@ -183,6 +213,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
     purgeLegacyPreferencesCache();
     userIDRef.current = userID;
     if (!userID) {
+      preferencesRef.current = DEFAULT_PREFS;
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setPreferences(DEFAULT_PREFS);
       // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -190,11 +221,24 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       return;
     }
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setPreferences(readPreferencesCache(userID, normalizePreferences) ?? DEFAULT_PREFS);
+    setAndCache(readPreferencesCache(userID, normalizePreferences) ?? DEFAULT_PREFS);
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
     void refresh();
-  }, [userID, refresh]);
+  }, [userID, refresh, setAndCache]);
+
+  const saveMachineOrder = useCallback(async (ids: string[]) => {
+    const uid = userIDRef.current;
+    if (!uid || loading) throw new Error("Wait for your preferences to load, then retry.");
+    const order = normalizeMachineOrder(ids);
+    ++refreshSeqRef.current;
+    const data = await patchPreferences({ machine_order: order });
+    if (userIDRef.current !== uid || userIDFromToken(getStoredToken()) !== uid) {
+      throw new Error("Your session changed. Sign in and check your saved order.");
+    }
+    if (!acceptedMachineOrder(data, order)) throw new Error("The hub did not confirm this order. Update the hub and retry.");
+    mergeAndCache({ machine_order: order, default_sort: "manual" });
+  }, [patchPreferences, loading, mergeAndCache]);
 
   // Apply density-* class to <html> so CSS variables propagate to every
   // descendant. Plain DOM mutation, not setState — safe in an effect.
@@ -215,29 +259,26 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
     ) => {
       const uid = userIDRef.current;
       // Optimistic local update.
-      setAndCache({ ...preferences, ...patch });
+      mergeAndCache(patch);
       try {
-        const res = await authFetch(`${HUB_URL}/api/me/preferences`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(patch),
-        });
-        if (!res.ok) {
-          const err = await res.json().catch(() => ({}));
-          throw new Error(typeof err.error === "string" ? err.error : "Failed to save preferences");
-        }
-        const data = await res.json();
+        const data = await patchPreferences(patch);
         // Late response after a user switch must not write the old user's
         // preferences into the new session.
         if (userIDRef.current !== uid) return;
-        setAndCache(normalizePreferences(data));
+        const normalized = normalizePreferences(data);
+        const owned: Partial<Preferences> = {};
+        if (patch.display_name !== undefined) owned.display_name = normalized.display_name;
+        if (patch.density !== undefined) owned.density = normalized.density;
+        if (patch.default_view !== undefined) owned.default_view = normalized.default_view;
+        if (patch.default_sort !== undefined) owned.default_sort = normalized.default_sort;
+        mergeAndCache(owned);
       } catch (e) {
         // Don't revert: we keep the optimistic state so the user isn't
         // jolted. The next refresh on reload reconciles with the server.
         throw e;
       }
     },
-    [authFetch, preferences, setAndCache],
+    [patchPreferences, mergeAndCache],
   );
 
   const uploadAvatar = useCallback(
@@ -256,9 +297,10 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       const data = await res.json();
       // Late response after a user switch must not write the old user's state.
       if (userIDRef.current !== uid) return;
-      setAndCache(normalizePreferences(data));
+      const normalized = normalizePreferences(data);
+      mergeAndCache({ has_avatar: normalized.has_avatar, avatar_sha: normalized.avatar_sha });
     },
-    [authFetch, setAndCache],
+    [authFetch, mergeAndCache],
   );
 
   const removeAvatar = useCallback(async () => {
@@ -270,15 +312,16 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
     }
     const data = await res.json();
     if (userIDRef.current !== uid) return;
-    setAndCache(normalizePreferences(data));
-  }, [authFetch, setAndCache]);
+    const normalized = normalizePreferences(data);
+    mergeAndCache({ has_avatar: normalized.has_avatar, avatar_sha: normalized.avatar_sha });
+  }, [authFetch, mergeAndCache]);
 
   const pinMachine = useCallback(
     async (machineID: string) => {
       if (preferences.pinned_machines.includes(machineID)) return;
       const uid = userIDRef.current;
       const next = { ...preferences, pinned_machines: [machineID, ...preferences.pinned_machines] };
-      setAndCache(next);
+      mergeAndCache({ pinned_machines: next.pinned_machines });
       try {
         const res = await authFetch(`${HUB_URL}/api/me/pinned/${encodeURIComponent(machineID)}`, {
           method: "POST",
@@ -288,13 +331,12 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
         // Revert on failure — unless the user switched meanwhile; the new
         // user's session owns its own state.
         if (userIDRef.current !== uid) return;
-        setAndCache({
-          ...next,
-          pinned_machines: next.pinned_machines.filter((id) => id !== machineID),
+        mergeAndCache({
+          pinned_machines: preferencesRef.current.pinned_machines.filter((id) => id !== machineID),
         });
       }
     },
-    [authFetch, preferences, setAndCache],
+    [authFetch, preferences, mergeAndCache],
   );
 
   const unpinMachine = useCallback(
@@ -303,7 +345,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       const uid = userIDRef.current;
       const prev = preferences.pinned_machines;
       const next = { ...preferences, pinned_machines: prev.filter((id) => id !== machineID) };
-      setAndCache(next);
+      mergeAndCache({ pinned_machines: next.pinned_machines });
       try {
         const res = await authFetch(`${HUB_URL}/api/me/pinned/${encodeURIComponent(machineID)}`, {
           method: "DELETE",
@@ -311,10 +353,10 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
         if (!res.ok) throw new Error("unpin failed");
       } catch {
         if (userIDRef.current !== uid) return;
-        setAndCache({ ...next, pinned_machines: prev });
+        mergeAndCache({ pinned_machines: [...new Set([...preferencesRef.current.pinned_machines, machineID])] });
       }
     },
-    [authFetch, preferences, setAndCache],
+    [authFetch, preferences, mergeAndCache],
   );
 
   const isPinned = useCallback(
@@ -339,21 +381,19 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       if (!normalized) throw new Error("Invalid server response");
       // Late response after a user switch must not write the old user's state.
       if (userIDRef.current !== uid) return normalized;
-      setAndCache({
-        ...preferences,
-        saved_filters: [normalized, ...preferences.saved_filters],
+      mergeAndCache({
+        saved_filters: [normalized, ...preferencesRef.current.saved_filters],
       });
       return normalized;
     },
-    [authFetch, preferences, setAndCache],
+    [authFetch, mergeAndCache],
   );
 
   const deleteFilter = useCallback(
     async (id: string) => {
       const uid = userIDRef.current;
       const prev = preferences.saved_filters;
-      setAndCache({
-        ...preferences,
+      mergeAndCache({
         saved_filters: prev.filter((f) => f.id !== id),
       });
       try {
@@ -363,10 +403,10 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
         if (!res.ok && res.status !== 404) throw new Error("delete failed");
       } catch {
         if (userIDRef.current !== uid) return;
-        setAndCache({ ...preferences, saved_filters: prev });
+        mergeAndCache({ saved_filters: [...preferencesRef.current.saved_filters, ...prev.filter(f => f.id === id)] });
       }
     },
-    [authFetch, preferences, setAndCache],
+    [authFetch, preferences, mergeAndCache],
   );
 
   const myAvatarURL =
@@ -379,6 +419,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       value={{
         preferences,
         loading,
+        saveMachineOrder,
         updateScalar,
         uploadAvatar,
         removeAvatar,

--- a/dashboard/src/lib/machine-order.d.mts
+++ b/dashboard/src/lib/machine-order.d.mts
@@ -1,0 +1,5 @@
+export function normalizeMachineOrder(value: unknown): string[];
+export function orderMachines<T extends {machine_id: string; hostname?: string; cpu_percent?: number; gpu_temp?: number}>(machines: T[], options?: {sort?: string; order?: string[]; pinned?: string[]; status?: (machine: T) => number}): T[];
+export function moveMachine(order: string[], fromID: string, toID: string): string[];
+export function acceptedMachineOrder(response: unknown, expected: string[]): boolean;
+export function createPreferenceWriter(): <T>(write: () => Promise<T>) => Promise<T>;

--- a/dashboard/src/lib/machine-order.mjs
+++ b/dashboard/src/lib/machine-order.mjs
@@ -1,0 +1,51 @@
+// Connectivity never participates in stable/name or user-defined ordering.
+// Keep unknown/new IDs after the saved set; ignore IDs no longer in the fleet.
+export function normalizeMachineOrder(value) {
+  return Array.isArray(value) ? [...new Set(value.filter(id => typeof id === 'string' && id.length > 0))] : [];
+}
+
+export function orderMachines(machines, { sort = 'name', order = [], pinned = [], status = () => 0 } = {}) {
+  const rank = new Map(normalizeMachineOrder(order).map((id, i) => [id, i]));
+  const pins = new Set(pinned);
+  const byName = (a, b) => (a.hostname ?? '').localeCompare(b.hostname ?? '') || a.machine_id.localeCompare(b.machine_id);
+  return [...machines].sort((a, b) => {
+    if (sort === 'manual') {
+      const ar = rank.get(a.machine_id), br = rank.get(b.machine_id);
+      if (ar !== undefined || br !== undefined) return (ar ?? Infinity) - (br ?? Infinity);
+      return byName(a, b);
+    }
+    const pin = Number(pins.has(b.machine_id)) - Number(pins.has(a.machine_id));
+    if (pin) return pin;
+    let delta = 0;
+    if (sort === 'status') delta = status(a) - status(b);
+    if (sort === 'cpu') delta = (b.cpu_percent ?? 0) - (a.cpu_percent ?? 0);
+    if (sort === 'gpu_temp') delta = (b.gpu_temp ?? 0) - (a.gpu_temp ?? 0);
+    return delta || byName(a, b);
+  });
+}
+
+export function moveMachine(order, fromID, toID) {
+  const result = normalizeMachineOrder(order);
+  const from = result.indexOf(fromID), to = result.indexOf(toID);
+  if (from < 0 || to < 0 || from === to) return result;
+  result.splice(to, 0, result.splice(from, 1)[0]);
+  return result;
+}
+
+// Reject older hubs that silently ignore an unknown PATCH field.
+export function acceptedMachineOrder(response, expected) {
+  return response?.default_sort === 'manual' && Array.isArray(response.machine_order)
+    && response.machine_order.length === expected.length
+    && expected.every((id, i) => response.machine_order[i] === id);
+}
+
+// Ordered preference PATCHes keep an older sort request from committing after
+// a manual arrangement. Failed requests do not poison the next retry.
+export function createPreferenceWriter() {
+  let tail = Promise.resolve();
+  return write => {
+    const next = tail.then(write);
+    tail = next.catch(() => {});
+    return next;
+  };
+}

--- a/dashboard/src/lib/machine-order.test.mjs
+++ b/dashboard/src/lib/machine-order.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { orderMachines, moveMachine, normalizeMachineOrder, acceptedMachineOrder, createPreferenceWriter } from './machine-order.mjs';
+const fleet = [{machine_id:'b',hostname:'Beta',cpu_percent:1},{machine_id:'a',hostname:'Alpha',cpu_percent:99},{machine_id:'c',hostname:'Gamma',cpu_percent:20}];
+const ids = list => list.map(m => m.machine_id);
+test('name order does not move when status, connectivity or metrics change', () => {
+  const changed = fleet.map(m => ({...m,cpu_percent:100-(m.cpu_percent??0),last_seen:0})).reverse();
+  assert.deepEqual(ids(orderMachines(fleet)), ['a','b','c']);
+  assert.deepEqual(ids(orderMachines(changed,{status:()=>999})), ['a','b','c']);
+  assert.deepEqual(ids(fleet), ['b','a','c']);
+});
+test('manual order beats telemetry, names, pins and incoming SSE order', () => {
+  for(const list of [fleet,[...fleet].reverse(),fleet.map(m=>({...m,hostname:'renamed',cpu_percent:0}))])
+    assert.deepEqual(ids(orderMachines(list,{sort:'manual',order:['c','a','b'],pinned:['b'],status:()=>100})), ['c','a','b']);
+});
+test('new machines append, deleted IDs disappear, filtered machines retain positions', () => {
+  const options={sort:'manual',order:['gone','c','a']};
+  assert.deepEqual(ids(orderMachines(fleet,options)),['c','a','b']);
+  assert.deepEqual(ids(orderMachines(fleet.filter(m=>m.machine_id!=='a'),options)),['c','b']);
+});
+test('ties are deterministic and explicit live sort still works', () => {
+  assert.deepEqual(ids(orderMachines(fleet,{sort:'cpu'})),['a','c','b']);
+  assert.deepEqual(ids(orderMachines(fleet,{sort:'status',status:m=>m.machine_id==='b'?0:1})),['b','a','c']);
+  const same=fleet.map(m=>({...m,hostname:'same'}));
+  assert.deepEqual(ids(orderMachines(same.reverse())),['a','b','c']);
+});
+test('pins only reorder non-manual views after explicit pin action', () => {
+  assert.deepEqual(ids(orderMachines(fleet,{pinned:['c']})),['c','a','b']);
+});
+test('moves work in both directions without duplicates or mutation', () => {
+  const order=['a','b','c'];
+  assert.deepEqual(moveMachine(order,'a','c'),['b','c','a']);
+  assert.deepEqual(moveMachine(order,'c','a'),['c','a','b']);
+  assert.deepEqual(moveMachine(order,'missing','a'),order);
+  assert.deepEqual(moveMachine(order,'a','a'),order);
+  assert.deepEqual(order,['a','b','c']);
+});
+test('corrupt cached order cannot create phantom entries or duplicates', () => {
+  assert.deepEqual(normalizeMachineOrder(['a',null,'a','',3,'b']),['a','b']);
+  assert.deepEqual(normalizeMachineOrder({}),[]);
+});
+test('save only succeeds for an exact server acknowledgment, including empty order', () => {
+  assert.equal(acceptedMachineOrder({default_sort:'manual',machine_order:['b','a']},['b','a']),true);
+  assert.equal(acceptedMachineOrder({default_sort:'manual',machine_order:[]},[]),true);
+  for(const bad of [{},{default_sort:'name',machine_order:['b','a']},{default_sort:'manual',machine_order:['a','b']},null])
+    assert.equal(acceptedMachineOrder(bad,['b','a']),false);
+});
+test('preference writes serialize and a failure does not block retry', async () => {
+  const write = createPreferenceWriter();
+  const seen=[];
+  let release;
+  const gate=new Promise(resolve=>{release=resolve});
+  const first=write(async()=>{seen.push('first');await gate;throw new Error('offline')});
+  const rejected=assert.rejects(first,/offline/);
+  const second=write(async()=>{seen.push('second');return 'saved'});
+  await Promise.resolve();
+  assert.deepEqual(seen,['first']);
+  release();
+  await rejected;
+  assert.equal(await second,'saved');
+  assert.deepEqual(seen,['first','second']);
+});

--- a/docs/machine-order.md
+++ b/docs/machine-order.md
@@ -1,0 +1,25 @@
+# Arrange machines
+
+The fleet's default **Name (A–Z)** order no longer changes when a machine goes
+offline or its readings change. Alerts and status badges still show problems.
+
+To choose your own positions:
+
+1. On the fleet page, choose **Arrange machines**.
+2. Drag a machine by its handle, or use the up/down arrows.
+3. Choose **Save order**. The sort selector changes to **My order**.
+
+Your order is saved to your BloxOS account and applies to grid/list views and
+the Classic, Live Wall, Grove and Ops Console layouts. Each user has their own
+order, including viewers. Saving requires a successful hub acknowledgement;
+if the connection fails, the dialog keeps your draft so you can retry.
+
+The arrangement includes all machines, even if you have a search or filter
+active. Removed machines disappear, and newly added machines appear after the
+saved set. Pins do not override **My order**. You can still explicitly choose
+**Status**, **CPU %** or **GPU Temp** when you want a changing, live sort.
+
+Upgrade both hub and dashboard to v1.2.0 or newer to save an arrangement.
+The database migration adds an empty order without resetting existing users'
+preferences. Existing explicitly selected live sorts remain selected; choose
+**Name (A–Z)** or save **My order** for stable positions.

--- a/hub/join.go
+++ b/hub/join.go
@@ -220,8 +220,16 @@ func joinPinForPrivateCA(ctx context.Context, publicURL *url.URL) (string, error
 // joinURLFor is the link the short command fetches. The code is the install
 // token, placed in the path so the hub can look it up without the client
 // sending anything else.
+//
+// Newly minted links use the canonical /api/join/ path: old reverse proxies
+// already forward /api/* to the hub but may not forward a bare /join, so the
+// /api-prefixed path onboards through those deployments with no proxy change.
+// The legacy GET /join/:code route is retained for links minted earlier; both
+// routes share the same handler and public status. The code stays a path
+// segment (never a query parameter), so redactJoinCodes scrubs it from logs
+// and it never leaks in a query string.
 func joinURLFor(httpBase, code string) string {
-	return strings.TrimRight(httpBase, "/") + "/join/" + code
+	return strings.TrimRight(httpBase, "/") + "/api/join/" + code
 }
 
 // shellBareWord is what can sit inside the single-quoted wrapper of the

--- a/hub/join_api_route_test.go
+++ b/hub/join_api_route_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"crypto/sha256"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// getJoinAt performs GET on an arbitrary path (so tests can hit both the
+// canonical /api/join/<code> and the legacy /join/<code>).
+func getJoinAt(t *testing.T, e interface {
+	ServeHTTP(http.ResponseWriter, *http.Request)
+}, path, host string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if host != "" {
+		req.Host = host
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestJoinCanonicalAPIPathMatchesLegacy: /api/join/<code> and /join/<code>
+// share one handler, so a fresh token serves the same bootstrap on both, and
+// neither GET consumes the token — repeated fetches keep succeeding.
+func TestJoinCanonicalAPIPathMatchesLegacy(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "https://hub.public.example")
+	got := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
+
+	// The canonical path serves the bootstrap with no auth header (public).
+	api := getJoinAt(t, e, "/api/join/"+got.Token, "")
+	if api.Code != http.StatusOK {
+		t.Fatalf("/api/join: status=%d body=%q", api.Code, api.Body.String())
+	}
+	assertJoinResponseHeaders(t, api)
+
+	legacy := getJoinAt(t, e, "/join/"+got.Token, "")
+	if legacy.Code != http.StatusOK {
+		t.Fatalf("/join: status=%d body=%q", legacy.Code, legacy.Body.String())
+	}
+	if api.Body.String() != legacy.Body.String() {
+		t.Fatalf("canonical and legacy bodies differ")
+	}
+
+	// No-consume: a third fetch (canonical) still serves — only
+	// enrollment_committed consumes the token.
+	if again := getJoinAt(t, e, "/api/join/"+got.Token, ""); again.Code != http.StatusOK {
+		t.Fatalf("repeated /api/join GET status=%d (should not consume)", again.Code)
+	}
+
+	// The served script must carry the mint-time pin/origin and never the
+	// request Host, on the canonical path exactly as on the legacy one.
+	body := api.Body.String()
+	if !strings.Contains(body, "hub.public.example") {
+		t.Fatalf("served script missing PUBLIC_URL origin")
+	}
+	if strings.Contains(body, "evil.example") {
+		t.Fatalf("served script leaked request Host")
+	}
+}
+
+// TestJoinMintedURLIsCanonical: newly minted links point at /api/join/ (what
+// old proxies forward), never the bare /join.
+func TestJoinMintedURLIsCanonical(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "https://hub.public.example")
+	got := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
+
+	if got.JoinURL != "https://hub.public.example/api/join/"+got.Token {
+		t.Fatalf("join_url = %q, want canonical /api/join path", got.JoinURL)
+	}
+	if !strings.Contains(got.Command, got.JoinURL) {
+		t.Fatalf("short command missing canonical join URL: %q", got.Command)
+	}
+}
+
+// TestJoinCanonicalUnusableCodesOpaque: unknown/expired/consumed codes on the
+// canonical path get the same opaque 404 as the legacy path.
+func TestJoinCanonicalUnusableCodesOpaque(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "https://hub.example")
+
+	expired := "expired-code-api-3c0a4e7f"
+	h := sha256.Sum256([]byte(expired))
+	if _, err := s.db.Exec(`INSERT INTO tokens (token_hash, expires_at, used) VALUES (?, ?, FALSE)`,
+		hexOf(h[:]), time.Now().UTC().Add(-time.Minute).Format("2006-01-02 15:04:05")); err != nil {
+		t.Fatal(err)
+	}
+	used := s.seedTokenValue(t, "used-code-api-9b1d2e6a")
+	if _, err := s.db.Exec(`UPDATE tokens SET used = TRUE WHERE token_hash = ?`, hashOf(used)); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, code := range map[string]string{
+		"unknown": "never-minted-code-api",
+		"expired": expired,
+		"used":    used,
+	} {
+		rec := getJoinAt(t, e, "/api/join/"+code, "")
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("%s: status=%d, want 404", name, rec.Code)
+		}
+		assertJoinResponseHeaders(t, rec)
+		if rec.Body.String() != joinUnavailableBody {
+			t.Fatalf("%s: body=%q, want shared unavailable text", name, rec.Body.String())
+		}
+	}
+}
+
+// TestRedactJoinCodesCoversAPIPath: the log redactor scrubs the code on the
+// canonical /api/join/ path too, since it matches the "/join/" substring.
+func TestRedactJoinCodesCoversAPIPath(t *testing.T) {
+	cases := map[string]string{
+		"GET /api/join/0f9d2c1e-secret 200 1ms\n": "GET /api/join/[REDACTED] 200 1ms\n",
+		"GET /api/join/abc?x=1 404":               "GET /api/join/[REDACTED]?x=1 404",
+		"GET /api/join/ 404":                      "GET /api/join/ 404",
+	}
+	for in, want := range cases {
+		if got := redactJoinCodes(in); got != want {
+			t.Errorf("redactJoinCodes(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+const syntheticNext404 = "<!DOCTYPE html><html><head><title>404: This page could not be found</title></head><body>404 | This page could not be found.</body></html>"
+
+// TestJoinThroughLegacyProxy is the root-cause regression: a reverse proxy
+// that forwards ONLY /api/*, /install.sh and /download/* to the hub — and
+// answers a bare /join with a synthetic Next.js HTML 404, exactly like the old
+// deployment that broke — must still onboard through the canonical URL.
+//
+// PUBLIC_URL is the proxy origin, so the minted link is what a real operator
+// would paste. Fetching that link through the proxy reaches the hub and serves
+// the bootstrap; the legacy /join path for the same token hits the SPA 404;
+// and a repeated canonical fetch still succeeds (the token is not consumed).
+func TestJoinThroughLegacyProxy(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+
+	hub := httptest.NewServer(e)
+	defer hub.Close()
+	hubURL, err := url.Parse(hub.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rp := httputil.NewSingleHostReverseProxy(hubURL)
+
+	mux := http.NewServeMux()
+	forward := func(w http.ResponseWriter, r *http.Request) { rp.ServeHTTP(w, r) }
+	// Legacy proxy contract: only these prefixes reach the hub.
+	mux.HandleFunc("/api/", forward)
+	mux.HandleFunc("/install.sh", forward)
+	mux.HandleFunc("/download/", forward)
+	// A bare /join is NOT forwarded — the SPA serves an HTML 404, as the old
+	// deployment did.
+	mux.HandleFunc("/join/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+		io.WriteString(w, syntheticNext404)
+	})
+	proxy := httptest.NewServer(mux)
+	defer proxy.Close()
+
+	// Mint with the proxy as the public origin, so the link is canonical.
+	t.Setenv("PUBLIC_URL", proxy.URL)
+	got := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
+	if got.JoinURL != proxy.URL+"/api/join/"+got.Token {
+		t.Fatalf("join_url = %q, want %s/api/join/%s", got.JoinURL, proxy.URL, got.Token)
+	}
+	if !strings.Contains(got.Command, got.JoinURL) {
+		t.Fatalf("short command does not carry the canonical URL: %q", got.Command)
+	}
+
+	// The pasted link, through the proxy, reaches the hub and serves the
+	// exact advanced bootstrap.
+	wantBody := "#!/bin/bash\n" + got.AdvancedCommand + "\n"
+	for i := 0; i < 2; i++ { // repeat proves the GET does not consume the token
+		resp, err := http.Get(got.JoinURL)
+		if err != nil {
+			t.Fatalf("GET %s (attempt %d): %v", got.JoinURL, i+1, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("canonical via proxy (attempt %d): status=%d", i+1, resp.StatusCode)
+		}
+		if string(body) != wantBody {
+			t.Fatalf("canonical body via proxy (attempt %d) does not match the advanced bootstrap", i+1)
+		}
+	}
+
+	// The legacy path for the same token hits the SPA 404, never the hub.
+	legacyResp, err := http.Get(proxy.URL + "/join/" + got.Token)
+	if err != nil {
+		t.Fatalf("GET legacy via proxy: %v", err)
+	}
+	legacyBody, _ := io.ReadAll(legacyResp.Body)
+	legacyResp.Body.Close()
+	if legacyResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("legacy via proxy: status=%d, want 404", legacyResp.StatusCode)
+	}
+	if !strings.Contains(string(legacyBody), "could not be found") {
+		t.Fatalf("legacy via proxy should be the SPA HTML 404, got %q", legacyBody)
+	}
+}

--- a/hub/join_test.go
+++ b/hub/join_test.go
@@ -126,7 +126,7 @@ func TestJoinServesTheAdvancedCommandForAFreshToken(t *testing.T) {
 	t.Setenv("BLOXOS_CA_CERT", testCAFile(t))
 	got := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
 
-	if got.JoinURL != "https://hub.public.example/join/"+got.Token {
+	if got.JoinURL != "https://hub.public.example/api/join/"+got.Token {
 		t.Fatalf("join_url = %q", got.JoinURL)
 	}
 	rec := getJoin(t, e, got.Token, "attacker.evil.example")
@@ -184,7 +184,7 @@ func TestJoinCommandShapes(t *testing.T) {
 		if sawURL != "https://hub.lan:8443" || string(sawPEM) != "test-private-ca" {
 			t.Fatalf("resolver saw url=%q pem=%q; must be the explicit PUBLIC_URL and the configured CA", sawURL, sawPEM)
 		}
-		want := `bash -c 's=$(curl -fsSk --pinnedpubkey sha256//` + testJoinPin + ` https://hub.lan:8443/join/` + got.Token + `) && bash -c "$s"'`
+		want := `bash -c 's=$(curl -fsSk --pinnedpubkey sha256//` + testJoinPin + ` https://hub.lan:8443/api/join/` + got.Token + `) && bash -c "$s"'`
 		if got.Command != want {
 			t.Fatalf("command = %q\nwant      %q", got.Command, want)
 		}
@@ -209,7 +209,7 @@ func TestJoinCommandShapes(t *testing.T) {
 			return "", nil
 		})
 		got := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
-		want := `bash -c 's=$(curl -fsS https://hub.example.com/join/` + got.Token + `) && bash -c "$s"'`
+		want := `bash -c 's=$(curl -fsS https://hub.example.com/api/join/` + got.Token + `) && bash -c "$s"'`
 		if got.Command != want {
 			t.Fatalf("command = %q\nwant      %q", got.Command, want)
 		}
@@ -224,7 +224,7 @@ func TestJoinCommandShapes(t *testing.T) {
 		t.Setenv("PUBLIC_URL", "http://127.0.0.1:4000")
 		t.Setenv("BLOXOS_CA_CERT", filepath.Join(t.TempDir(), "missing.crt"))
 		got := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
-		want := `bash -c 's=$(curl -fsS http://127.0.0.1:4000/join/` + got.Token + `) && bash -c "$s"'`
+		want := `bash -c 's=$(curl -fsS http://127.0.0.1:4000/api/join/` + got.Token + `) && bash -c "$s"'`
 		if got.Command != want {
 			t.Fatalf("command = %q\nwant      %q", got.Command, want)
 		}
@@ -560,7 +560,7 @@ func TestJoinCommandQuotesUnsafeShellWords(t *testing.T) {
 		t.Fatalf("IPv6 join URL: %q", got)
 	}
 	// A pin is only meaningful over https.
-	if got := buildLinuxJoinCommand("http://127.0.0.1:4000/join/abc", "AbC="); got != `bash -c 's=$(curl -fsS http://127.0.0.1:4000/join/abc) && bash -c "$s"'` {
+	if got := buildLinuxJoinCommand("http://127.0.0.1:4000/api/join/abc", "AbC="); got != `bash -c 's=$(curl -fsS http://127.0.0.1:4000/api/join/abc) && bash -c "$s"'` {
 		t.Fatalf("http with a pin: %q", got)
 	}
 	for _, bad := range []string{"https://hub.example/a b", "https://hub.example/it's", "https://hub.example/$(x)", "https://hub.example/a\"b"} {

--- a/hub/main.go
+++ b/hub/main.go
@@ -263,8 +263,14 @@ func (s *Server) registerRoutes(e *echo.Echo) {
 	e.GET("/install.ps1", handleWindowsInstallScript)
 	// One-line onboarding: the Linux bootstrap for an unexpired, unconsumed
 	// install token. Public by design; see join.go for what it does and
-	// does not reveal.
+	// does not reveal. Registered on `e` (not the authenticated `api` group),
+	// exactly like the other public /api/* routes (login, setup, branding),
+	// so both paths are unauthenticated. The canonical /api/join/:code path is
+	// what newly minted links use — old proxies already forward /api/* to the
+	// hub; the bare /join/:code is retained for links minted earlier. Both use
+	// the same handler, so their behavior and opaque 404s are identical.
 	e.GET("/join/:code", s.handleJoinScript)
+	e.GET("/api/join/:code", s.handleJoinScript)
 	e.GET("/download/agent", handleDownloadAgent)
 	e.GET("/download/ca.crt", handleDownloadCACert)
 	e.GET("/api/setup/status", s.handleSetupStatus)

--- a/hub/migrations.go
+++ b/hub/migrations.go
@@ -509,6 +509,20 @@ var migrations = []migration{
 			return nil
 		},
 	},
+	{
+		description: "per-user persistent machine order",
+		apply: func(tx *sql.Tx) error {
+			// A JSON array of machine IDs in the user's chosen display order.
+			// Empty array = no manual order. Stored on the users row so it is
+			// written atomically alongside default_sort='manual'.
+			if _, err := tx.Exec(
+				`ALTER TABLE users ADD COLUMN machine_order TEXT NOT NULL DEFAULT '[]'`,
+			); err != nil && !isDuplicateColumnErr(err) {
+				return err
+			}
+			return nil
+		},
+	},
 }
 
 // isDuplicateColumnErr returns true when SQLite rejects an ALTER TABLE ADD

--- a/hub/preferences.go
+++ b/hub/preferences.go
@@ -32,11 +32,15 @@ import (
 )
 
 const (
-	maxAvatarBytes        = 200 * 1024
-	maxDisplayNameLen     = 60
-	maxSavedFilterNameLen = 60
+	maxAvatarBytes         = 200 * 1024
+	maxDisplayNameLen      = 60
+	maxSavedFilterNameLen  = 60
 	maxSavedFiltersPerUser = 20
-	maxWelcomeMessageLen  = 500
+	maxWelcomeMessageLen   = 500
+	// machine_order bounds. IDs are machine UUIDs (~36 chars); 128 is a
+	// generous per-ID cap; the count cap bounds the stored payload.
+	maxMachineOrderCount = 1000
+	maxMachineOrderIDLen = 128
 )
 
 // displayNameRegex permits Unicode letters/digits, plus a small set of
@@ -59,6 +63,8 @@ var validDefaultSorts = map[string]struct{}{
 	"status":   {},
 	"cpu":      {},
 	"gpu_temp": {},
+	// "manual" means the user's persistent machine_order is authoritative.
+	"manual": {},
 }
 
 // SavedFilter is the public shape of a saved-filter row. The `Filter`
@@ -73,14 +79,18 @@ type SavedFilter struct {
 
 // UserPreferences is the bundle returned by GET /api/me/preferences.
 type UserPreferences struct {
-	DisplayName    string         `json:"display_name"`
-	HasAvatar      bool           `json:"has_avatar"`
-	AvatarSHA      string         `json:"avatar_sha,omitempty"`
-	Density        string         `json:"density"`
-	DefaultView    string         `json:"default_view"`
-	DefaultSort    string         `json:"default_sort"`
-	PinnedMachines []string       `json:"pinned_machines"`
-	SavedFilters   []SavedFilter  `json:"saved_filters"`
+	DisplayName    string        `json:"display_name"`
+	HasAvatar      bool          `json:"has_avatar"`
+	AvatarSHA      string        `json:"avatar_sha,omitempty"`
+	Density        string        `json:"density"`
+	DefaultView    string        `json:"default_view"`
+	DefaultSort    string        `json:"default_sort"`
+	PinnedMachines []string      `json:"pinned_machines"`
+	SavedFilters   []SavedFilter `json:"saved_filters"`
+	// MachineOrder is the user's persistent machine display order. Empty when
+	// unset. May contain stale/deleted IDs — stored and returned harmlessly;
+	// the UI reconciles against the live fleet.
+	MachineOrder []string `json:"machine_order"`
 }
 
 // handleGetMyPreferences returns the entire prefs bundle in one round-trip.
@@ -93,15 +103,18 @@ func (s *Server) handleGetMyPreferences(c echo.Context) error {
 	prefs := UserPreferences{
 		PinnedMachines: []string{},
 		SavedFilters:   []SavedFilter{},
+		MachineOrder:   []string{},
 	}
 	var avatarSHA sql.NullString
 	var hasAvatar sql.NullInt64
+	var machineOrderJSON string
 	err := s.db.QueryRow(`
 		SELECT
 			COALESCE(display_name, ''),
 			COALESCE(density, 'comfortable'),
 			COALESCE(default_view, 'grid'),
 			COALESCE(default_sort, 'name'),
+			COALESCE(machine_order, '[]'),
 			avatar_sha,
 			CASE WHEN avatar_data IS NOT NULL AND length(avatar_data) > 0 THEN 1 ELSE 0 END
 		FROM users WHERE id = ?
@@ -110,6 +123,7 @@ func (s *Server) handleGetMyPreferences(c echo.Context) error {
 		&prefs.Density,
 		&prefs.DefaultView,
 		&prefs.DefaultSort,
+		&machineOrderJSON,
 		&avatarSHA,
 		&hasAvatar,
 	)
@@ -132,6 +146,16 @@ func (s *Server) handleGetMyPreferences(c echo.Context) error {
 	}
 	if _, ok := validDefaultSorts[prefs.DefaultSort]; !ok {
 		prefs.DefaultSort = "name"
+	}
+	// Persistent machine order. Corrupt/legacy JSON snaps to an empty order
+	// rather than failing the whole bundle. Elements that are not non-empty
+	// strings are dropped defensively.
+	if parsed := []string(nil); json.Unmarshal([]byte(machineOrderJSON), &parsed) == nil {
+		for _, id := range parsed {
+			if id != "" {
+				prefs.MachineOrder = append(prefs.MachineOrder, id)
+			}
+		}
 	}
 
 	// Pinned machines (most-recent first).
@@ -190,17 +214,22 @@ func (s *Server) handlePatchMyPreferences(c echo.Context) error {
 		Density     *string `json:"density,omitempty"`
 		DefaultView *string `json:"default_view,omitempty"`
 		DefaultSort *string `json:"default_sort,omitempty"`
+		// RawMessage so we can tell "omitted" (preserve) from an explicit
+		// null (reject) from an array. A type error surfaces on Unmarshal.
+		MachineOrder json.RawMessage `json:"machine_order,omitempty"`
 	}
 	if err := c.Bind(&body); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid body"})
 	}
 
-	if body.DisplayName == nil && body.Density == nil && body.DefaultView == nil && body.DefaultSort == nil {
+	orderSupplied := len(body.MachineOrder) > 0
+	if body.DisplayName == nil && body.Density == nil && body.DefaultView == nil && body.DefaultSort == nil && !orderSupplied {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "no fields to update"})
 	}
 
 	var sets []string
 	var args []any
+	defaultSortSet := false
 
 	if body.DisplayName != nil {
 		dn := strings.TrimSpace(*body.DisplayName)
@@ -235,6 +264,56 @@ func (s *Server) handlePatchMyPreferences(c echo.Context) error {
 		}
 		sets = append(sets, "default_sort = ?")
 		args = append(args, *body.DefaultSort)
+		defaultSortSet = true
+	}
+
+	if orderSupplied {
+		if string(bytes.TrimSpace(body.MachineOrder)) == "null" {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "machine_order cannot be null"})
+		}
+		var order []string
+		if err := json.Unmarshal(body.MachineOrder, &order); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "machine_order must be an array of strings"})
+		}
+		if len(order) > maxMachineOrderCount {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("machine_order accepts at most %d entries", maxMachineOrderCount)})
+		}
+		seen := make(map[string]struct{}, len(order))
+		for _, id := range order {
+			if id == "" {
+				return c.JSON(http.StatusBadRequest, map[string]string{"error": "machine_order entries must be non-empty"})
+			}
+			if len(id) > maxMachineOrderIDLen {
+				return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("machine_order entries must be %d characters or fewer", maxMachineOrderIDLen)})
+			}
+			if _, dup := seen[id]; dup {
+				return c.JSON(http.StatusBadRequest, map[string]string{"error": "machine_order contains duplicate entries"})
+			}
+			seen[id] = struct{}{}
+		}
+		// Manual order is authoritative. Setting a non-manual default_sort in
+		// the same request is a conflict; setting it to "manual" is redundant
+		// but allowed.
+		if body.DefaultSort != nil && *body.DefaultSort != "manual" {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "default_sort conflicts with machine_order; omit it or set it to \"manual\""})
+		}
+		// Stored IDs are not checked against the fleet — stale/deleted IDs are
+		// kept harmlessly. Re-marshal the validated slice so what is persisted
+		// is canonical (never a nil array).
+		if order == nil {
+			order = []string{}
+		}
+		normalized, err := json.Marshal(order)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "could not encode machine_order"})
+		}
+		sets = append(sets, "machine_order = ?")
+		args = append(args, string(normalized))
+		if !defaultSortSet {
+			sets = append(sets, "default_sort = ?")
+			args = append(args, "manual")
+			defaultSortSet = true
+		}
 	}
 
 	query := fmt.Sprintf(`UPDATE users SET %s WHERE id = ?`, strings.Join(sets, ", "))

--- a/hub/preferences_machine_order_test.go
+++ b/hub/preferences_machine_order_test.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Upgrade an actual pre-order schema with existing user preferences, rather
+// than only exercising the new column on a fresh installation.
+func TestMachineOrderMigrationPreservesExistingUser(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	const previousVersion = 23
+	for _, migration := range migrations[:previousVersion] {
+		tx, err := db.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := migration.apply(tx); err != nil {
+			_ = tx.Rollback()
+			t.Fatal(err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := db.Exec(`CREATE TABLE schema_version (version INTEGER NOT NULL);
+		INSERT INTO schema_version VALUES (23);
+		INSERT INTO users (id, username, password_hash, display_name, default_sort, dashboard_layout)
+		VALUES ('existing-user', 'existing', 'synthetic-hash', 'Existing User', 'cpu', 'console')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := runMigrations(db); err != nil {
+		t.Fatal(err)
+	}
+	var order, name, sort, layout, hash string
+	if err := db.QueryRow(`SELECT machine_order, display_name, default_sort, dashboard_layout, password_hash FROM users WHERE id = 'existing-user'`).Scan(&order, &name, &sort, &layout, &hash); err != nil {
+		t.Fatal(err)
+	}
+	if order != "[]" || name != "Existing User" || sort != "cpu" || layout != "console" || hash != "synthetic-hash" {
+		t.Fatalf("upgrade changed existing preferences: order=%q name=%q sort=%q layout=%q", order, name, sort, layout)
+	}
+	if _, err := db.Exec(`UPDATE users SET machine_order = '["saved-id"]', default_sort = 'manual' WHERE id = 'existing-user'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := runMigrations(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT machine_order FROM users WHERE id = 'existing-user'`).Scan(&order); err != nil {
+		t.Fatal(err)
+	}
+	if order != `["saved-id"]` {
+		t.Fatal("restart reset saved order")
+	}
+}
+
+// prefsBundle is the subset of GET /api/me/preferences these tests assert on.
+type prefsBundle struct {
+	DefaultSort  string   `json:"default_sort"`
+	MachineOrder []string `json:"machine_order"`
+	DisplayName  string   `json:"display_name"`
+}
+
+func getPrefs(t *testing.T, e interface {
+	ServeHTTP(http.ResponseWriter, *http.Request)
+}, token string) prefsBundle {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/me/preferences", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET preferences: status %d, body %s", rec.Code, rec.Body.String())
+	}
+	var p prefsBundle
+	if err := json.Unmarshal(rec.Body.Bytes(), &p); err != nil {
+		t.Fatalf("GET preferences: decode: %v (body %s)", err, rec.Body.String())
+	}
+	return p
+}
+
+func patchPrefs(t *testing.T, e interface {
+	ServeHTTP(http.ResponseWriter, *http.Request)
+}, token, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPatch, "/api/me/preferences", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestMachineOrderDefaultEmpty proves the migration added the column and a
+// fresh user's order is an empty array (not null / not missing).
+func TestMachineOrderDefaultEmpty(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	p := getPrefs(t, e, token)
+	if p.MachineOrder == nil {
+		t.Fatal("machine_order should be [] not null on a fresh user")
+	}
+	if len(p.MachineOrder) != 0 {
+		t.Fatalf("machine_order = %v, want empty", p.MachineOrder)
+	}
+}
+
+// TestMachineOrderPersistsAndSetsManual: supplying an order stores it and
+// makes default_sort='manual' atomically, and it survives a reload.
+func TestMachineOrderPersistsAndSetsManual(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+
+	rec := patchPrefs(t, e, token, `{"machine_order":["m1","m2","m3"]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH order: status %d, body %s", rec.Code, rec.Body.String())
+	}
+	var patched prefsBundle
+	json.Unmarshal(rec.Body.Bytes(), &patched)
+	if fmt.Sprint(patched.MachineOrder) != "[m1 m2 m3]" {
+		t.Fatalf("PATCH response order = %v", patched.MachineOrder)
+	}
+	if patched.DefaultSort != "manual" {
+		t.Fatalf("default_sort = %q, want manual", patched.DefaultSort)
+	}
+
+	got := getPrefs(t, e, token)
+	if fmt.Sprint(got.MachineOrder) != "[m1 m2 m3]" || got.DefaultSort != "manual" {
+		t.Fatalf("reload: order %v sort %q", got.MachineOrder, got.DefaultSort)
+	}
+}
+
+// TestMachineOrderOmissionPreserves: a PATCH that omits machine_order leaves
+// the stored order (and manual sort) untouched.
+func TestMachineOrderOmissionPreserves(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	patchPrefs(t, e, token, `{"machine_order":["a","b"]}`)
+
+	rec := patchPrefs(t, e, token, `{"display_name":"Ops"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH display_name: %d %s", rec.Code, rec.Body.String())
+	}
+	got := getPrefs(t, e, token)
+	if fmt.Sprint(got.MachineOrder) != "[a b]" {
+		t.Fatalf("order not preserved: %v", got.MachineOrder)
+	}
+	if got.DefaultSort != "manual" || got.DisplayName != "Ops" {
+		t.Fatalf("sort %q name %q", got.DefaultSort, got.DisplayName)
+	}
+}
+
+// TestMachineOrderEmptyClears: an explicit [] is accepted and clears the order.
+func TestMachineOrderEmptyClears(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	patchPrefs(t, e, token, `{"machine_order":["a","b"]}`)
+
+	rec := patchPrefs(t, e, token, `{"machine_order":[]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH empty order: %d %s", rec.Code, rec.Body.String())
+	}
+	got := getPrefs(t, e, token)
+	if len(got.MachineOrder) != 0 {
+		t.Fatalf("order not cleared: %v", got.MachineOrder)
+	}
+}
+
+// TestMachineOrderStaleIDsAllowed: unknown/stale machine IDs are stored and
+// returned without failure (the UI reconciles against the live fleet).
+func TestMachineOrderStaleIDsAllowed(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	rec := patchPrefs(t, e, token, `{"machine_order":["does-not-exist-1","deleted-2"]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stale IDs should be accepted: %d %s", rec.Code, rec.Body.String())
+	}
+	if fmt.Sprint(getPrefs(t, e, token).MachineOrder) != "[does-not-exist-1 deleted-2]" {
+		t.Fatal("stale IDs not returned")
+	}
+}
+
+// TestMachineOrderTwoUserIsolation: each user owns their own order, including
+// a non-admin (auth.self applies to all roles), and one cannot affect another.
+func TestMachineOrderTwoUserIsolation(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	admin := loginAndGetToken(t, e)
+	s.seedTestUser(t, "alice", "alicepass123", "1234", RoleOperator, true, true)
+	alice := loginAndGetTokenForCredentials(t, e, "alice", "alicepass123")
+
+	patchPrefs(t, e, admin, `{"machine_order":["admin-1","admin-2"]}`)
+	rec := patchPrefs(t, e, alice, `{"machine_order":["alice-1"]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("operator must be able to own order: %d %s", rec.Code, rec.Body.String())
+	}
+	if fmt.Sprint(getPrefs(t, e, alice).MachineOrder) != "[alice-1]" {
+		t.Fatal("alice order wrong")
+	}
+	if fmt.Sprint(getPrefs(t, e, admin).MachineOrder) != "[admin-1 admin-2]" {
+		t.Fatal("admin order was affected by alice")
+	}
+}
+
+// TestMachineOrderRejectsMalformed covers null, type errors, empty entries,
+// duplicates, and oversize.
+func TestMachineOrderRejectsMalformed(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+
+	var big strings.Builder
+	big.WriteString(`{"machine_order":[`)
+	for i := 0; i < maxMachineOrderCount+1; i++ {
+		if i > 0 {
+			big.WriteByte(',')
+		}
+		fmt.Fprintf(&big, `"m%d"`, i)
+	}
+	big.WriteString(`]}`)
+
+	longID := `{"machine_order":["` + strings.Repeat("x", maxMachineOrderIDLen+1) + `"]}`
+
+	cases := map[string]string{
+		"null":           `{"machine_order":null}`,
+		"string":         `{"machine_order":"nope"}`,
+		"number-elems":   `{"machine_order":[1,2,3]}`,
+		"object":         `{"machine_order":{"a":1}}`,
+		"empty-entry":    `{"machine_order":["a","",""]}`,
+		"duplicate":      `{"machine_order":["a","a"]}`,
+		"oversize-count": big.String(),
+		"oversize-id":    longID,
+		"conflict-sort":  `{"machine_order":["a"],"default_sort":"name"}`,
+	}
+	for name, body := range cases {
+		rec := patchPrefs(t, e, token, body)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: status %d, want 400 (body %s)", name, rec.Code, rec.Body.String())
+		}
+	}
+	// A rejected PATCH must not have persisted anything.
+	if len(getPrefs(t, e, token).MachineOrder) != 0 {
+		t.Fatal("a rejected machine_order was persisted")
+	}
+}
+
+// TestMachineOrderManualSortAloneAccepted: default_sort='manual' is now valid
+// on its own, and 'manual' alongside machine_order is allowed (not a conflict).
+func TestMachineOrderManualSortAloneAccepted(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+
+	if rec := patchPrefs(t, e, token, `{"default_sort":"manual"}`); rec.Code != http.StatusOK {
+		t.Fatalf("default_sort=manual alone: %d %s", rec.Code, rec.Body.String())
+	}
+	if getPrefs(t, e, token).DefaultSort != "manual" {
+		t.Fatal("manual sort not stored")
+	}
+	if rec := patchPrefs(t, e, token, `{"machine_order":["a"],"default_sort":"manual"}`); rec.Code != http.StatusOK {
+		t.Fatalf("order + manual should be allowed: %d %s", rec.Code, rec.Body.String())
+	}
+}

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -251,6 +251,11 @@ var publicAPIRoutes = map[string]struct{}{
 	routeScopeKey(http.MethodGet, "/api/branding"):         {},
 	routeScopeKey(http.MethodGet, "/api/branding/logo"):    {},
 	routeScopeKey(http.MethodGet, "/api/branding/favicon"): {},
+	// One-line onboarding: the canonical join path. Public by design, exactly
+	// like the legacy /join/:code route (which is not under /api/ and so is
+	// never seen by this audit). It serves only the bootstrap for an
+	// unexpired, unconsumed token and never consumes it; see join.go.
+	routeScopeKey(http.MethodGet, "/api/join/:code"): {},
 }
 
 // auditRBACRouteCoverage verifies every protected /api/* route registered on e has a


### PR DESCRIPTION
## Summary

- Stop implicit health/connectivity sorting under Name across all four fleet layouts. Add per-user **Arrange machines → My order**, with drag handles and keyboard/touch arrows, shared by grid/list and layout summaries.
- Persist order in the authenticated user's preferences (migration 24). Preserve existing preferences, reconcile missing/new machines, and keep drafts on failed saves. Verify exact hub acknowledgement; serialize preference PATCHes and merge only owned fields to prevent late responses reverting an arrangement.
- Fix one-line Linux onboarding behind older reverse proxies at the product level: mint `/api/join/<code>` through the existing `/api/*` forwarding contract. Retain `/join/<code>`. No user-server workaround, proxy rewrite, agent change or security bypass.

## Compatibility / security

Newly generated commands after the hub upgrade work behind legacy proxies that forward `/api/*`. Previously copied bare `/join/` commands may still require a fresh command; the application cannot rewrite an external proxy or an already-copied command. The same handler, 15-minute expiry, mint-time origin/CA/SPKI binding, opaque unavailable response, code redaction and enrollment-committed token consumption remain intact. The new public route is explicitly covered by the RBAC startup audit.

Manual order overrides pins. Name stays stable under telemetry; explicitly selected Status/CPU/GPU sorts remain live. Existing user preferences are not reset. Upgrade hub and dashboard together; an older hub cannot silently report a successful arrangement save.

## Validation

- Full local hub package: PASS (~97s); go vet passed during Claude's backend review.
- Focused migration/preferences/join/legacy reverse-proxy tests: PASS. Upgrade test starts from real schema v23 with existing user preferences and verifies preservation and restart idempotence.
- Dashboard: 85/85 tests, production build, lint (no errors; existing directive warnings).
- Isolated Playwright browser run against production build: all four layouts; reversed/changed telemetry, manual save/reload, grid/list (including Console summary), drag/cancel, failed save/retry, filtered full-fleet dialog, 390/320px keyboard controls, viewer and account isolation. Synthetic fixtures only; no user servers touched.
- Real HTTP reverse-proxy regression forwards only legacy `/api/*`, install and download routes: minted canonical link serves bootstrap twice, same token on bare `/join/` reproduces dashboard HTML 404.
- Claude independently reviewed backend and frontend and agreed to merge after exact-head CI, including race and Compose smoke, is green. Root reviewed his backend changes and strengthened the proxy regression.

Release target: v1.2.0 after CI/review and the documentation update. Agent release number and binary sources are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted per-user preferences and a new public join route, but behavior is heavily tested and join security properties are preserved; mixed hub/dashboard versions can block arrangement saves until both are upgraded.
> 
> **Overview**
> Adds **per-user machine arrangement** so fleet lists stop reshuffling when telemetry or connectivity changes. Users get **Arrange machines** (drag/arrows), a **My order** sort mode, and shared `orderMachines` logic across the main grid/list and live layout summaries. Order is stored in new `machine_order` user preferences (hub migration + PATCH validation); saving switches `default_sort` to `manual`, requires an exact hub echo (so older hubs cannot fake success), and preference PATCHes are serialized with field-scoped merges to avoid races.
> 
> **Name (A–Z)** and **My order** no longer use the previous status-severity–then-pin composite sort; pins still apply only for explicit live sorts (status/CPU/GPU). Docs describe upgrade expectations (hub + dashboard v1.2.0).
> 
> Separately, **newly minted Linux join links** use **`GET /api/join/<token>`** so onboarding works behind reverse proxies that forward `/api/*` but not bare `/join/`; legacy `/join/<token>` stays on the same handler. Minted commands, tests, RBAC public-route audit, and `AGENTS.md` are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d985dc6003bf0b0dd8f6827aba2ac7e8561dce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->