### PR TITLE
feat: publish exact native agent bundles with check-only staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,11 @@ jobs:
   hub-race:
     name: Hub Tests (race)
     runs-on: ubuntu-latest
-    # The full suite can exceed 10m on hosted runners with race-instrumented
-    # bcrypt setup. Allow headroom without disabling the hang guard. Keep Go's
+    # The full suite can exceed 15m on hosted runners with race-instrumented
+    # bcrypt setup (PR208 reached the Windows tests before the old deadline).
+    # Allow headroom without disabling the hang guard. Keep Go's
     # deadline below the job limit so failures include goroutine stacks.
-    timeout-minutes: 20
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: hub
@@ -95,7 +96,7 @@ jobs:
           cache-dependency-path: hub/go.sum
 
       - name: Run hub tests with the race detector
-        run: go test -race -count=1 -timeout=15m ./...
+        run: go test -race -count=1 -timeout=20m ./...
 
   agent:
     name: Agent Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
       - name: Test backup failure and restart handling
         run: python3 ../scripts/test_backup_compose.py
 
+      - name: Test native agent bundle validation and staging
+        run: |
+          python3 ../scripts/test_agent_bundle.py
+          bash -n ../scripts/export-agent-bundle.sh
+
   # A real gate as of issue #60: the hub's DB handle and agent registry now live
   # on a Server instance, so tests build isolated servers instead of reassigning
   # package globals under leaked agent-WS goroutines. Verified stable across four

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,9 @@ on:
       - "docker/**"
       - "scripts/smoke/**"
       - "scripts/backup-compose.sh"
+      - "scripts/agent_bundle.py"
+      - "scripts/export-agent-bundle.sh"
+      - "scripts/test_agent_bundle.py"
       - "hub/**"
       - "agent/**"
       - "proto/**"
@@ -81,6 +84,8 @@ jobs:
     needs: [smoke, verify-release]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    outputs:
+      hub_digest: ${{ steps.hub.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -127,3 +132,44 @@ jobs:
           version="${VERSION#v}"
           docker buildx imagetools create -t "$HUB_IMAGE:$version" -t "$HUB_IMAGE:latest" "$HUB_IMAGE@$HUB_DIGEST"
           docker buildx imagetools create -t "$DASHBOARD_IMAGE:$version" -t "$DASHBOARD_IMAGE:latest" "$DASHBOARD_IMAGE@$DASHBOARD_DIGEST"
+
+  native-bundle:
+    name: Package native agents
+    needs: [publish]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract and check the exact published agent bytes
+        env:
+          HUB_DIGEST: ${{ needs.publish.outputs.hub_digest }}
+          SOURCE_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: bash scripts/export-agent-bundle.sh "$HUB_IMAGE@$HUB_DIGEST" "$SOURCE_SHA" "$RELEASE_TAG" "$RUNNER_TEMP/native-agents"
+      - name: Attach native payloads to a draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" --json isDraft >/dev/null 2>&1; then
+            test "$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)" = true
+          else
+            gh release create "$RELEASE_TAG" --verify-tag --draft --title "BloxOS $RELEASE_TAG" \
+              --notes "Release verification passed. Native payloads are extracted from the published image; operator review and final release notes are pending. Fleet signatures are installation-specific and are not included."
+          fi
+          gh release upload "$RELEASE_TAG" \
+            "$RUNNER_TEMP/native-agents/agent-manifest.json" \
+            "$RUNNER_TEMP/native-agents/agent-manifest.sha256" \
+            "$RUNNER_TEMP/native-agents/bloxos-agent-linux-amd64" \
+            "$RUNNER_TEMP/native-agents/bloxos-agent-linux-arm64" \
+            "$RUNNER_TEMP/native-agents/bloxos-agent-windows-amd64.exe"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,6 +91,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
+      - name: Validate the release tag before publishing any images
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: python3 scripts/agent_bundle.py validate-tag --version "$RELEASE_TAG"
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
@@ -130,8 +134,14 @@ jobs:
         run: |
           set -euo pipefail
           version="${VERSION#v}"
-          docker buildx imagetools create -t "$HUB_IMAGE:$version" -t "$HUB_IMAGE:latest" "$HUB_IMAGE@$HUB_DIGEST"
-          docker buildx imagetools create -t "$DASHBOARD_IMAGE:$version" -t "$DASHBOARD_IMAGE:latest" "$DASHBOARD_IMAGE@$DASHBOARD_DIGEST"
+          hub_tags=(-t "$HUB_IMAGE:$version")
+          dashboard_tags=(-t "$DASHBOARD_IMAGE:$version")
+          if [[ "$VERSION" != *-* ]]; then
+            hub_tags+=(-t "$HUB_IMAGE:latest")
+            dashboard_tags+=(-t "$DASHBOARD_IMAGE:latest")
+          fi
+          docker buildx imagetools create "${hub_tags[@]}" "$HUB_IMAGE@$HUB_DIGEST"
+          docker buildx imagetools create "${dashboard_tags[@]}" "$DASHBOARD_IMAGE@$DASHBOARD_DIGEST"
 
   native-bundle:
     name: Package native agents
@@ -164,7 +174,9 @@ jobs:
           if gh release view "$RELEASE_TAG" --json isDraft >/dev/null 2>&1; then
             test "$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)" = true
           else
-            gh release create "$RELEASE_TAG" --verify-tag --draft --title "BloxOS $RELEASE_TAG" \
+            prerelease_flags=()
+            if [[ "$RELEASE_TAG" == *-* ]]; then prerelease_flags=(--prerelease); fi
+            gh release create "$RELEASE_TAG" --verify-tag --draft "${prerelease_flags[@]}" --title "BloxOS $RELEASE_TAG" \
               --notes "Release verification passed. Native payloads are extracted from the published image; operator review and final release notes are pending. Fleet signatures are installation-specific and are not included."
           fi
           gh release upload "$RELEASE_TAG" \

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ dashboard support **Linux amd64 and arm64**. Ports **80 and 443** must be availa
 ### 1. Download BloxOS
 
 ```sh
-git clone --branch v1.2.0 --depth 1 https://github.com/bokiko/bloxos.git
+git clone --branch v1.2.1 --depth 1 https://github.com/bokiko/bloxos.git
 cd bloxos/docker
 cp .env.example .env
 ```
@@ -97,7 +97,7 @@ hostname or IP—without `https://`, a path, or a port—and add the version:
 
 ```dotenv
 HUB_HOST=192.168.1.50
-BLOXOS_VERSION=1.2.0
+BLOXOS_VERSION=1.2.1
 ```
 
 Replace the example IP with your own address. Do not use `localhost` if other
@@ -145,7 +145,7 @@ second hub. A public one-line *hub* installer is not shipped.
 which preserves the database, secrets, signing identity and Caddy CA. Never
 use `docker compose down -v` to update.
 
-In your existing Compose directory, set `BLOXOS_VERSION=1.2.0` in your existing
+In your existing Compose directory, set `BLOXOS_VERSION=1.2.1` in your existing
 `.env`, then run these with the same project name and any existing overrides:
 
 ```sh
@@ -170,7 +170,7 @@ On a native installation, replacing the hub executable does **not** replace
 separate agent files. Use the [native agent check-and-stage guide](docs/native-agent-upgrades.md)
 to prepare the published payloads without starting a fleet rollout.
 
-[Release notes](https://github.com/bokiko/bloxos/releases/tag/v1.2.0) ·
+[Release notes](https://github.com/bokiko/bloxos/releases/tag/v1.2.1) ·
 [Update signing](docs/offline-update-signing.md) ·
 [Agent recovery](docs/agent-update-recovery.md)
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ after a hub upgrade. Legacy agents may need update-key pinning; offline-signing
 installations have a separate procedure. Very old or customized deployments
 should compare their Compose configuration before updating.
 
+On a native installation, replacing the hub executable does **not** replace
+separate agent files. Use the [native agent check-and-stage guide](docs/native-agent-upgrades.md)
+to prepare the published payloads without starting a fleet rollout.
+
 [Release notes](https://github.com/bokiko/bloxos/releases/tag/v1.2.0) ·
 [Update signing](docs/offline-update-signing.md) ·
 [Agent recovery](docs/agent-update-recovery.md)

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,21 +8,22 @@ they are not containerized.
 
 Use Docker Compose v2 on a Linux amd64 or arm64 host. Ports 80 and 443 must
 be free, and browsers and agents must be able to reach the host. From a
-clone of the released `v1.2.0` tag:
+clone of the released `v1.2.1` tag:
 
 ```bash
 cd docker
 cp .env.example .env
 # Edit .env: set HUB_HOST to this machine's reachable hostname or IP.
-# Add BLOXOS_VERSION=1.2.0 to use this release's images.
+# Add BLOXOS_VERSION=1.2.1 to use this release's images.
 docker compose pull
 docker compose up -d --no-build
 ```
 
-After full CI and the Compose smoke test pass, release tags publish
+After full CI and the Compose smoke test pass, stable release tags publish
 `ghcr.io/bokiko/bloxos-hub` and `ghcr.io/bokiko/bloxos-dashboard` for
 amd64 and arm64, tagged with the version (without `v`) and `latest`. Pin
-`BLOXOS_VERSION` in `.env` for a predictable upgrade target. A merge to `main`
+`BLOXOS_VERSION` in `.env` for a predictable upgrade target. Prerelease tags
+such as `1.2.1-rc.1` do not replace `latest`. A merge to `main`
 does not publish images. To build your chosen source revision instead, use
 `docker compose up -d --build` in place of the pull/start commands.
 

--- a/docs/native-agent-upgrades.md
+++ b/docs/native-agent-upgrades.md
@@ -97,6 +97,12 @@ compile new binaries. The tagged release workflow uploads these assets to a
 draft GitHub release after the image checks pass. Review that draft and its
 checksums before publishing; fleet-specific signatures are not included.
 
+Tags use `vX.Y.Z` or a Docker-compatible prerelease such as `vX.Y.Z-rc.1`.
+The shared tag validator runs before any images are published. Prereleases
+get versioned image tags and a prerelease draft, but do not replace `latest`.
+Build-metadata suffixes (`+...`) and arbitrary `v...` names are rejected before
+publication because they cannot be used as these release image tags.
+
 Uploads deliberately do not overwrite existing assets or modify a published
 release. A rerun encountering either condition stops for maintainer review.
 For a partial draft upload, compare the existing asset hashes first; do not

--- a/docs/native-agent-upgrades.md
+++ b/docs/native-agent-upgrades.md
@@ -1,0 +1,105 @@
+# Native hub: check and stage agent updates
+
+Updating the hub executable does **not** update separately installed agent
+files. A machine that matches the hub's offered SHA is up to date **with that
+offered file**, not necessarily with the latest BloxOS release.
+
+Docker hub images include the agent payloads. Native installations can use the
+three payloads attached to newer GitHub releases, extracted from those exact
+images without rebuilding:
+
+| Platform | Release asset |
+| --- | --- |
+| Linux x86-64 | `bloxos-agent-linux-amd64` |
+| Linux ARM64 | `bloxos-agent-linux-arm64` |
+| Windows x86-64 | `bloxos-agent-windows-amd64.exe` |
+
+## 1. Download and check — no rollout
+
+Get the three binaries, `agent-manifest.json` and `agent-manifest.sha256` from
+the same approved [GitHub release](https://github.com/bokiko/bloxos/releases).
+Use `scripts/agent_bundle.py` from that release's source checkout with Python
+3.9 or newer on Linux or macOS. Earlier releases may not have these assets.
+
+The manifest records the source commit, published image digest, agent release
+number, architecture, size and SHA-256 of every payload. Obtain its SHA-256
+through the trusted release handoff; downloading a checksum alongside a file
+detects corruption but does not independently authenticate the publisher.
+
+```sh
+python3 scripts/agent_bundle.py check \
+  --bundle /path/to/downloaded-assets \
+  --manifest-sha256 <trusted-64-character-manifest-sha256>
+```
+
+This reads files only. It checks all three targets, including ELF/PE
+architecture and matching, nonzero embedded release numbers. It rejects
+missing, modified or unnumbered binaries. It does not contact the hub, run a
+binary, sign anything, install anything or change the fleet.
+
+## 2. Stage — still no rollout
+
+Choose a private, dedicated staging directory **outside every active agent
+serve directory**. Do not run this helper as root. Do not place staging under
+a directory that the hub watches or configure the hub to serve staging files.
+
+```sh
+mkdir -m 700 /path/to/agent-staging
+python3 scripts/agent_bundle.py stage \
+  --bundle /path/to/downloaded-assets \
+  --manifest-sha256 <trusted-64-character-manifest-sha256> \
+  --staging-root /path/to/agent-staging
+```
+
+The helper creates a new `agent-release-N` directory with read-only files and
+checks the copied bytes again. It refuses to overwrite an existing release.
+Use `check` on that existing directory if already staged. Failed validation
+does not change active binaries.
+
+If the computer loses power during staging, an incomplete destination may
+remain. `check` will reject it. Keep it for inspection and use a new dedicated
+staging root; do not activate a partially staged release. Staging is not a
+backup or a power-loss durability guarantee.
+
+Known native serve directories and the binary-path overrides visible in the
+calling shell are rejected as staging roots. The helper cannot discover a
+service's hidden environment: **you must check the hub service configuration**
+for `BLOXOS_AGENT_BINARY`, `BLOXOS_AGENT_BINARY_ARM64` and
+`BLOXOS_AGENT_BINARY_WINDOWS` before choosing a staging location.
+
+## 3. Signing and activation are separate
+
+Checksums are not fleet update signatures. An offline-signing installation
+must have its existing offline key holder sign each exact payload for the
+appropriate OS, and verify the signatures against the fleet's pinned public
+key. Never upload the private key to the hub. See
+[offline update signing](offline-update-signing.md).
+
+Installing a staged payload into an **active** serve path, or changing the
+hub's configured serve path to it, is activation. It can announce a fleet-wide
+update — even when the official payload is still numbered release 7 and the
+old served file has no release marker. Keep signing and activation behind
+your explicit rollout procedure; staging alone is not approval to activate.
+
+Protocol-2 agents reject older releases and equal-number/different-SHA
+payloads. Reuse the exact published bytes. If you rebuild and the bytes change,
+the source-controlled agent release number must advance before publication.
+Do not rebuild release 7 differently and label it release 7. Old protocol-1
+agents do not enforce this rollback floor; a matching offered SHA does not
+prove that protection is present.
+
+## Release maintainers
+
+`scripts/export-agent-bundle.sh IMAGE@sha256:DIGEST SOURCE_SHA vX.Y.Z NEW_DIR`
+extracts files from a never-started, network-disabled Docker container,
+checks the image's source revision and generates the manifest. It does not
+compile new binaries. The tagged release workflow uploads these assets to a
+draft GitHub release after the image checks pass. Review that draft and its
+checksums before publishing; fleet-specific signatures are not included.
+
+Uploads deliberately do not overwrite existing assets or modify a published
+release. A rerun encountering either condition stops for maintainer review.
+For a partial draft upload, compare the existing asset hashes first; do not
+blindly clobber previously published agent bytes. A failed export may leave
+its new output directory for inspection, but its temporary Docker container
+is removed on a normal/error exit.

--- a/scripts/agent_bundle.py
+++ b/scripts/agent_bundle.py
@@ -25,11 +25,18 @@ MANIFEST = "agent-manifest.json"
 MAX_BINARY = 128 * 1024 * 1024
 HEX = re.compile(r"[0-9a-f]{64}\Z")
 MARKER = re.compile(rb"BLOXOS-AGENT-RELEASE:([0-9]{10}):")
+VERSION = re.compile(r"v\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\Z")
 
 
 def require(condition, message):
     if not condition:
         raise ValueError(message)
+
+
+def validate_tag(version):
+    require(isinstance(version, str) and VERSION.fullmatch(version) and len(version) <= 129,
+            "expected vX.Y.Z or vX.Y.Z-prerelease (Docker-compatible, no build metadata)")
+    return version
 
 
 def read_regular(path, limit):
@@ -79,7 +86,7 @@ def inspect_payloads(directory):
 
 def create_manifest(directory, source, version, image_digest):
     require(re.fullmatch(r"[0-9a-f]{40}", source), "expected full source commit SHA")
-    require(re.fullmatch(r"v\d+\.\d+\.\d+", version), "expected vX.Y.Z release tag")
+    validate_tag(version)
     require(re.fullmatch(r"sha256:[0-9a-f]{64}", image_digest), "expected image digest")
     release, artifacts = inspect_payloads(directory)
     manifest = {"schema": 1, "version": version, "source": source,
@@ -97,7 +104,7 @@ def check(directory, manifest_sha):
     require(hashlib.sha256(data).hexdigest() == manifest_sha, "manifest SHA256 mismatch")
     manifest = json.loads(data)
     require(isinstance(manifest, dict) and manifest.get("schema") == 1, "unsupported manifest")
-    require(re.fullmatch(r"v\d+\.\d+\.\d+", str(manifest.get("version", ""))), "invalid release tag")
+    validate_tag(manifest.get("version"))
     require(re.fullmatch(r"[0-9a-f]{40}", str(manifest.get("source", ""))), "invalid source SHA")
     require(re.fullmatch(r"sha256:[0-9a-f]{64}", str(manifest.get("image_digest", ""))), "invalid image digest")
     release, artifacts = inspect_payloads(directory)
@@ -160,6 +167,8 @@ def stage(directory, manifest_sha, root):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
+    p = commands.add_parser("validate-tag", help="release-builder preflight; no files or network")
+    p.add_argument("--version", required=True)
     for name in ("check", "stage", "manifest"):
         p = commands.add_parser(name)
         p.add_argument("--bundle", required=True, type=Path)
@@ -173,7 +182,9 @@ def main():
             p.add_argument("--staging-root", required=True, type=Path)
     args = parser.parse_args()
     try:
-        if args.command == "manifest":
+        if args.command == "validate-tag":
+            print(validate_tag(args.version))
+        elif args.command == "manifest":
             print(create_manifest(args.bundle, args.source, args.version, args.image_digest))
         elif args.command == "check":
             print(json.dumps(check(args.bundle, args.manifest_sha256), indent=2))

--- a/scripts/agent_bundle.py
+++ b/scripts/agent_bundle.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Inspect/stage native agent payloads. Never install, sign, execute or announce them.
+
+Use a manifest SHA obtained through the trusted release handoff. A matching
+checksum is integrity evidence, not a replacement for the fleet's update key.
+"""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import struct
+import tempfile
+
+
+FILES = {
+    "linux/amd64": "bloxos-agent-linux-amd64",
+    "linux/arm64": "bloxos-agent-linux-arm64",
+    "windows/amd64": "bloxos-agent-windows-amd64.exe",
+}
+MANIFEST = "agent-manifest.json"
+MAX_BINARY = 128 * 1024 * 1024
+HEX = re.compile(r"[0-9a-f]{64}\Z")
+MARKER = re.compile(rb"BLOXOS-AGENT-RELEASE:([0-9]{10}):")
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def read_regular(path, limit):
+    """No symlinks/FIFOs; read the descriptor we checked, not a second pathname."""
+    fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW)
+    with os.fdopen(fd, "rb") as stream:
+        info = os.fstat(stream.fileno())
+        require(stat.S_ISREG(info.st_mode), f"not a regular file: {path}")
+        require(0 < info.st_size <= limit, f"invalid file size: {path}")
+        data = stream.read(limit + 1)
+        require(len(data) == info.st_size, f"file changed while reading: {path}")
+        return data
+
+
+def identity(data, platform):
+    require(len(data) >= 64, f"truncated binary: {platform}")
+    if platform.startswith("linux/"):
+        require(data[:6] == b"\x7fELF\x02\x01", f"expected 64-bit little-endian ELF: {platform}")
+        machine = struct.unpack_from("<H", data, 18)[0]
+        require(machine == {"linux/amd64": 62, "linux/arm64": 183}[platform],
+                f"wrong ELF architecture: {platform}")
+    else:
+        require(data[:2] == b"MZ", "expected Windows PE executable")
+        offset = struct.unpack_from("<I", data, 60)[0]
+        require(offset + 26 <= len(data) and data[offset:offset + 4] == b"PE\0\0",
+                "invalid PE header")
+        require(struct.unpack_from("<H", data, offset + 4)[0] == 0x8664
+                and struct.unpack_from("<H", data, offset + 24)[0] == 0x20B,
+                "expected Windows amd64 PE32+")
+    releases = [int(m) for m in MARKER.findall(data)]
+    require(data.count(b"BLOXOS-AGENT-RELEASE:") == 1 and len(releases) == 1 and releases[0] > 0,
+            f"missing, zero or conflicting release markers: {platform}")
+    return releases[0]
+
+
+def inspect_payloads(directory):
+    artifacts = {}
+    releases = set()
+    for platform, name in FILES.items():
+        data = read_regular(directory / name, MAX_BINARY)
+        releases.add(identity(data, platform))
+        artifacts[platform] = {"file": name, "size": len(data),
+                               "sha256": hashlib.sha256(data).hexdigest()}
+    require(len(releases) == 1, "platforms carry different agent release numbers")
+    return next(iter(releases)), artifacts
+
+
+def create_manifest(directory, source, version, image_digest):
+    require(re.fullmatch(r"[0-9a-f]{40}", source), "expected full source commit SHA")
+    require(re.fullmatch(r"v\d+\.\d+\.\d+", version), "expected vX.Y.Z release tag")
+    require(re.fullmatch(r"sha256:[0-9a-f]{64}", image_digest), "expected image digest")
+    release, artifacts = inspect_payloads(directory)
+    manifest = {"schema": 1, "version": version, "source": source,
+                "image_digest": image_digest, "agent_release": release, "artifacts": artifacts}
+    data = (json.dumps(manifest, sort_keys=True, indent=2) + "\n").encode()
+    # The release builder refuses to overwrite a previous manifest.
+    with (directory / MANIFEST).open("xb") as stream:
+        stream.write(data)
+    return hashlib.sha256(data).hexdigest()
+
+
+def check(directory, manifest_sha):
+    require(HEX.fullmatch(manifest_sha), "supply the trusted 64-character manifest SHA256")
+    data = read_regular(directory / MANIFEST, 64 * 1024)
+    require(hashlib.sha256(data).hexdigest() == manifest_sha, "manifest SHA256 mismatch")
+    manifest = json.loads(data)
+    require(isinstance(manifest, dict) and manifest.get("schema") == 1, "unsupported manifest")
+    require(re.fullmatch(r"v\d+\.\d+\.\d+", str(manifest.get("version", ""))), "invalid release tag")
+    require(re.fullmatch(r"[0-9a-f]{40}", str(manifest.get("source", ""))), "invalid source SHA")
+    require(re.fullmatch(r"sha256:[0-9a-f]{64}", str(manifest.get("image_digest", ""))), "invalid image digest")
+    release, artifacts = inspect_payloads(directory)
+    require(type(manifest.get("agent_release")) is int and manifest["agent_release"] == release,
+            "manifest/binary release mismatch")
+    require(manifest.get("artifacts") == artifacts, "artifact SHA256, size, filename or architecture mismatch")
+    return manifest
+
+
+def safe_staging_root(root):
+    require(root.is_dir() and not root.is_symlink(), "staging root must be an existing real directory")
+    resolved = root.resolve()
+    info = resolved.stat()
+    require(info.st_uid == os.geteuid() and not info.st_mode & 0o022,
+            "staging root must be owned by the invoking user and not writable by group/others")
+    forbidden = [Path("/usr/local/lib/bloxos/linux"), Path("/usr/local/lib/bloxos/windows")]
+    for name in ("BLOXOS_AGENT_BINARY", "BLOXOS_AGENT_BINARY_ARM64", "BLOXOS_AGENT_BINARY_WINDOWS"):
+        if os.environ.get(name):
+            forbidden.append(Path(os.environ[name]).resolve().parent)
+    for directory in forbidden:
+        require(resolved != directory and directory not in resolved.parents,
+                "staging root is inside an active agent directory")
+    require(resolved not in (Path("/"), Path.home()), "choose a dedicated staging directory")
+    return resolved
+
+
+def stage(directory, manifest_sha, root):
+    manifest = check(directory, manifest_sha)
+    root = safe_staging_root(root)
+    destination = root / f"agent-release-{manifest['agent_release']}"
+    # Reuse of a release number cannot replace a different staged payload.
+    require(not destination.exists() and not destination.is_symlink(),
+            f"already staged: {destination}; use check, never overwrite a release")
+    temporary = Path(tempfile.mkdtemp(prefix=".agent-stage-", dir=root))
+    try:
+        for name in [MANIFEST, *FILES.values()]:
+            data = read_regular(directory / name, 64 * 1024 if name == MANIFEST else MAX_BINARY)
+            with (temporary / name).open("xb") as stream:
+                stream.write(data)
+            (temporary / name).chmod(0o444)
+        # Recheck the copied bytes, catching source changes between check/copy.
+        check(temporary, manifest_sha)
+        # Never replace even an empty directory created by another operator.
+        destination.mkdir(mode=0o700)
+        try:
+            for name in [MANIFEST, *FILES.values()]:
+                (temporary / name).rename(destination / name)
+            destination.chmod(0o555)
+        except Exception:
+            for name in [MANIFEST, *FILES.values()]:
+                (destination / name).unlink(missing_ok=True)
+            destination.rmdir()
+            raise
+    finally:
+        # Only our unique temporary directory, never an operator's existing tree.
+        shutil.rmtree(temporary)
+    return destination
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    for name in ("check", "stage", "manifest"):
+        p = commands.add_parser(name)
+        p.add_argument("--bundle", required=True, type=Path)
+        if name == "manifest":
+            p.add_argument("--source", required=True)
+            p.add_argument("--version", required=True)
+            p.add_argument("--image-digest", required=True)
+        else:
+            p.add_argument("--manifest-sha256", required=True)
+        if name == "stage":
+            p.add_argument("--staging-root", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        if args.command == "manifest":
+            print(create_manifest(args.bundle, args.source, args.version, args.image_digest))
+        elif args.command == "check":
+            print(json.dumps(check(args.bundle, args.manifest_sha256), indent=2))
+            print("Payloads match the supplied manifest. Fleet signatures must be verified separately. No changes made.")
+        else:
+            print(f"Staged at {stage(args.bundle, args.manifest_sha256, args.staging_root)}")
+            print("No active binary changed. Nothing signed, restarted or announced. Activation is separate.")
+    except (OSError, ValueError, TypeError) as error:
+        parser.exit(1, f"agent-bundle: {error}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/agent_bundle.py
+++ b/scripts/agent_bundle.py
@@ -25,7 +25,7 @@ MANIFEST = "agent-manifest.json"
 MAX_BINARY = 128 * 1024 * 1024
 HEX = re.compile(r"[0-9a-f]{64}\Z")
 MARKER = re.compile(rb"BLOXOS-AGENT-RELEASE:([0-9]{10}):")
-VERSION = re.compile(r"v\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\Z")
+VERSION = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\Z")
 
 
 def require(condition, message):

--- a/scripts/agent_bundle.py
+++ b/scripts/agent_bundle.py
@@ -122,8 +122,15 @@ def safe_staging_root(root):
             "staging root must be owned by the invoking user and not writable by group/others")
     forbidden = [Path("/usr/local/lib/bloxos/linux"), Path("/usr/local/lib/bloxos/windows")]
     for name in ("BLOXOS_AGENT_BINARY", "BLOXOS_AGENT_BINARY_ARM64", "BLOXOS_AGENT_BINARY_WINDOWS"):
-        if os.environ.get(name):
-            forbidden.append(Path(os.environ[name]).resolve().parent)
+        # Match Go strings.TrimSpace in the hub resolver (Unicode White_Space,
+        # unlike Python's extra U+001C..U+001F separators). Relative overrides
+        # are rejected by the hub; never interpret them against our own cwd.
+        value = os.environ.get(name, "").strip(
+            "\t\n\v\f\r \u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004"
+            "\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000")
+        if value:
+            require(Path(value).is_absolute(), f"{name} must be an absolute path")
+            forbidden.append(Path(value).resolve().parent)
     for directory in forbidden:
         directory = directory.resolve()
         require(resolved != directory and directory not in resolved.parents

--- a/scripts/agent_bundle.py
+++ b/scripts/agent_bundle.py
@@ -125,8 +125,10 @@ def safe_staging_root(root):
         if os.environ.get(name):
             forbidden.append(Path(os.environ[name]).resolve().parent)
     for directory in forbidden:
-        require(resolved != directory and directory not in resolved.parents,
-                "staging root is inside an active agent directory")
+        directory = directory.resolve()
+        require(resolved != directory and directory not in resolved.parents
+                and resolved not in directory.parents,
+                "staging root overlaps an active agent directory")
     require(resolved not in (Path("/"), Path.home()), "choose a dedicated staging directory")
     return resolved
 

--- a/scripts/export-agent-bundle.sh
+++ b/scripts/export-agent-bundle.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Release builder only. Extract canonical bytes; never rebuild or start a hub.
+set -euo pipefail
+if [[ $# != 4 ]]; then
+  echo "usage: export-agent-bundle.sh IMAGE@sha256:DIGEST SOURCE_SHA vX.Y.Z NEW_OUTPUT_DIR" >&2
+  exit 2
+fi
+image_ref=$1
+source_sha=$2
+release_tag=$3
+output_dir=$4
+[[ "$image_ref" =~ @sha256:[0-9a-f]{64}$ ]] || { echo "image must be digest-pinned" >&2; exit 2; }
+[[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "source must be full commit SHA" >&2; exit 2; }
+[[ "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "invalid release tag" >&2; exit 2; }
+[[ ! -e "$output_dir" && ! -L "$output_dir" ]] || { echo "output already exists; refusing overwrite" >&2; exit 2; }
+script_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+docker pull --platform linux/amd64 "$image_ref"
+actual_source=$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "$image_ref")
+[[ "$actual_source" == "$source_sha" ]] || { echo "image source revision mismatch" >&2; exit 1; }
+container_id=$(docker create --platform linux/amd64 --network none "$image_ref")
+[[ "$container_id" =~ ^[0-9a-f]{64}$ ]] || { echo "invalid export container ID" >&2; exit 1; }
+trap 'docker rm -v "$container_id" >/dev/null' EXIT
+mkdir -m 0700 -- "$output_dir"
+docker cp "$container_id:/usr/local/lib/bloxos/linux/amd64/bloxos-agent" "$output_dir/bloxos-agent-linux-amd64"
+docker cp "$container_id:/usr/local/lib/bloxos/linux/arm64/bloxos-agent" "$output_dir/bloxos-agent-linux-arm64"
+docker cp "$container_id:/usr/local/lib/bloxos/windows/bloxos-agent.exe" "$output_dir/bloxos-agent-windows-amd64.exe"
+manifest_sha=$(python3 "$script_dir/agent_bundle.py" manifest --bundle "$output_dir" \
+  --source "$source_sha" --version "$release_tag" --image-digest "${image_ref##*@}")
+printf '%s  agent-manifest.json\n' "$manifest_sha" > "$output_dir/agent-manifest.sha256"
+python3 "$script_dir/agent_bundle.py" check --bundle "$output_dir" --manifest-sha256 "$manifest_sha"

--- a/scripts/export-agent-bundle.sh
+++ b/scripts/export-agent-bundle.sh
@@ -11,9 +11,9 @@ release_tag=$3
 output_dir=$4
 [[ "$image_ref" =~ @sha256:[0-9a-f]{64}$ ]] || { echo "image must be digest-pinned" >&2; exit 2; }
 [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "source must be full commit SHA" >&2; exit 2; }
-[[ "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "invalid release tag" >&2; exit 2; }
 [[ ! -e "$output_dir" && ! -L "$output_dir" ]] || { echo "output already exists; refusing overwrite" >&2; exit 2; }
 script_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+python3 "$script_dir/agent_bundle.py" validate-tag --version "$release_tag" >/dev/null
 docker pull --platform linux/amd64 "$image_ref"
 actual_source=$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "$image_ref")
 [[ "$actual_source" == "$source_sha" ]] || { echo "image source revision mismatch" >&2; exit 1; }

--- a/scripts/test_agent_bundle.py
+++ b/scripts/test_agent_bundle.py
@@ -211,7 +211,7 @@ class BundleTests(unittest.TestCase):
     def test_release_tag_contract(self):
         for tag in ("v1.2.1", "v1.2.1-rc.1", "v2.0.0-preview-2"):
             self.assertEqual(bundle.validate_tag(tag), tag)
-        for tag in (None, "vnext", "v1.2", "v1.2.1+build.1", "v1.2.1-", "v1.2.1-rc..1", "v1.2.1-" + "x" * 130):
+        for tag in (None, "vnext", "v1.2", "v١.٢.٣", "v1.２.3", "v1.2.٣", "v1.2.1+build.1", "v1.2.1-", "v1.2.1-rc..1", "v1.2.1-" + "x" * 130):
             with self.subTest(tag=tag), self.assertRaises(ValueError):
                 bundle.validate_tag(tag)
 
@@ -258,6 +258,12 @@ esac
 
     def test_export_invalid_tag_stops_before_docker(self):
         result, output, log = self.run_export(release_tag="vnext")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(output.exists())
+        self.assertEqual(log, "")
+
+    def test_export_unicode_digits_stops_before_docker(self):
+        result, output, log = self.run_export(release_tag="v١.٢.٣")
         self.assertNotEqual(result.returncode, 0)
         self.assertFalse(output.exists())
         self.assertEqual(log, "")

--- a/scripts/test_agent_bundle.py
+++ b/scripts/test_agent_bundle.py
@@ -172,7 +172,14 @@ class BundleTests(unittest.TestCase):
         with self.assertRaises(FileExistsError):
             bundle.create_manifest(self.source, "a" * 40, "v1.2.1", "sha256:" + "b" * 64)
 
-    def run_export(self, failure=""):
+    def test_release_tag_contract(self):
+        for tag in ("v1.2.1", "v1.2.1-rc.1", "v2.0.0-preview-2"):
+            self.assertEqual(bundle.validate_tag(tag), tag)
+        for tag in (None, "vnext", "v1.2", "v1.2.1+build.1", "v1.2.1-", "v1.2.1-rc..1", "v1.2.1-" + "x" * 130):
+            with self.subTest(tag=tag), self.assertRaises(ValueError):
+                bundle.validate_tag(tag)
+
+    def run_export(self, failure="", release_tag="v1.2.1"):
         bin_dir = self.root / "bin"
         bin_dir.mkdir()
         docker = bin_dir / "docker"
@@ -201,11 +208,23 @@ esac
         log = self.root / "docker.log"
         result = subprocess.run([
             "bash", str(Path(__file__).with_name("export-agent-bundle.sh")),
-            "ghcr.io/example/hub@sha256:" + "b" * 64, "0" * 40, "v1.2.1", str(output),
+            "ghcr.io/example/hub@sha256:" + "b" * 64, "0" * 40, release_tag, str(output),
         ], env={**os.environ, "PATH": str(bin_dir) + os.pathsep + os.environ["PATH"],
                 "DOCKER_LOG": str(log), "FIXTURES": str(self.source), "FAIL_EXPORT": failure},
             capture_output=True, text=True)
-        return result, output, log.read_text()
+        return result, output, log.read_text() if log.exists() else ""
+
+    def test_export_prerelease_roundtrip(self):
+        result, output, _ = self.run_export(release_tag="v1.2.1-rc.1")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        sha = (output / "agent-manifest.sha256").read_text().split()[0]
+        self.assertEqual(bundle.check(output, sha)["version"], "v1.2.1-rc.1")
+
+    def test_export_invalid_tag_stops_before_docker(self):
+        result, output, log = self.run_export(release_tag="vnext")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(output.exists())
+        self.assertEqual(log, "")
 
     def test_export_extracts_all_targets_without_starting_container(self):
         result, output, log = self.run_export()

--- a/scripts/test_agent_bundle.py
+++ b/scripts/test_agent_bundle.py
@@ -1,0 +1,235 @@
+"""Offline fixtures only: no Docker, server, signing key, network or agent execution."""
+import hashlib
+import json
+import os
+from pathlib import Path
+import struct
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+import agent_bundle as bundle
+
+
+def fixture(platform, release=7):
+    data = bytearray(128)
+    if platform.startswith("linux/"):
+        data[:6] = b"\x7fELF\x02\x01"
+        struct.pack_into("<H", data, 18, 62 if platform == "linux/amd64" else 183)
+    else:
+        data[:2] = b"MZ"
+        struct.pack_into("<I", data, 60, 64)
+        data[64:68] = b"PE\0\0"
+        struct.pack_into("<H", data, 68, 0x8664)
+        struct.pack_into("<H", data, 88, 0x20B)
+    return data + f"BLOXOS-AGENT-RELEASE:{release:010d}:".encode()
+
+
+class BundleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.addCleanup(self.unlock)
+        self.source = self.root / "download"
+        self.source.mkdir()
+        self.staging = self.root / "staging"
+        self.staging.mkdir()
+        self.active = self.root / "active"
+        self.active.mkdir()
+        (self.active / "bloxos-agent").write_bytes(b"existing agent")
+        for platform, name in bundle.FILES.items():
+            (self.source / name).write_bytes(fixture(platform))
+        self.sha = bundle.create_manifest(self.source, "a" * 40, "v1.2.1", "sha256:" + "b" * 64)
+
+    def unlock(self):
+        for path in self.root.rglob("*"):
+            if path.is_dir() and not path.is_symlink():
+                path.chmod(0o700)
+
+    def test_check_is_read_only_and_reports_three_targets(self):
+        before = {p.name: p.read_bytes() for p in self.source.iterdir()}
+        got = bundle.check(self.source, self.sha)
+        self.assertEqual(got["agent_release"], 7)
+        self.assertEqual(set(got["artifacts"]), set(bundle.FILES))
+        self.assertEqual(before, {p.name: p.read_bytes() for p in self.source.iterdir()})
+        self.assertEqual(list(self.staging.iterdir()), [])
+
+    def test_stage_copies_only_to_new_versioned_directory(self):
+        dest = bundle.stage(self.source, self.sha, self.staging)
+        self.assertEqual(dest, self.staging.resolve() / "agent-release-7")
+        self.assertEqual(bundle.check(dest, self.sha), bundle.check(self.source, self.sha))
+        self.assertEqual((self.active / "bloxos-agent").read_bytes(), b"existing agent")
+        self.assertEqual(dest.stat().st_mode & 0o777, 0o555)
+        self.assertTrue(all(p.stat().st_mode & 0o777 == 0o444 for p in dest.iterdir()))
+
+    def test_repeated_stage_never_overwrites_existing_release(self):
+        dest = bundle.stage(self.source, self.sha, self.staging)
+        with self.assertRaisesRegex(ValueError, "already staged"):
+            bundle.stage(self.source, self.sha, self.staging)
+        self.assertEqual(bundle.check(dest, self.sha)["agent_release"], 7)
+
+    def test_empty_existing_directory_and_dangling_symlink_are_preserved(self):
+        dest = self.staging / "agent-release-7"
+        dest.mkdir()
+        with self.assertRaisesRegex(ValueError, "already staged"):
+            bundle.stage(self.source, self.sha, self.staging)
+        self.assertTrue(dest.is_dir())
+        dest.rmdir()
+        dest.symlink_to(self.root / "nonexistent")
+        with self.assertRaisesRegex(ValueError, "already staged"):
+            bundle.stage(self.source, self.sha, self.staging)
+        self.assertTrue(dest.is_symlink())
+
+    def test_shared_writable_staging_root_rejected(self):
+        self.staging.chmod(0o777)
+        with self.assertRaisesRegex(ValueError, "not writable by group/others"):
+            bundle.stage(self.source, self.sha, self.staging)
+        self.assertEqual(list(self.staging.iterdir()), [])
+
+    def test_wrong_manifest_hash_creates_nothing(self):
+        with self.assertRaisesRegex(ValueError, "manifest SHA256 mismatch"):
+            bundle.stage(self.source, "0" * 64, self.staging)
+        self.assertEqual(list(self.staging.iterdir()), [])
+
+    def test_modified_binary_is_rejected(self):
+        p = self.source / bundle.FILES["linux/amd64"]
+        p.write_bytes(p.read_bytes() + b"changed")
+        with self.assertRaisesRegex(ValueError, "artifact SHA256"):
+            bundle.stage(self.source, self.sha, self.staging)
+        self.assertEqual(list(self.staging.iterdir()), [])
+
+    def test_missing_arm64_rejected(self):
+        (self.source / bundle.FILES["linux/arm64"]).unlink()
+        with self.assertRaises(FileNotFoundError):
+            bundle.check(self.source, self.sha)
+
+    def test_architecture_and_marker_contract(self):
+        with self.assertRaisesRegex(ValueError, "wrong ELF"):
+            bundle.identity(fixture("linux/amd64"), "linux/arm64")
+        with self.assertRaisesRegex(ValueError, "PE"):
+            bundle.identity(fixture("linux/amd64"), "windows/amd64")
+        for suffix in (b"", b"BLOXOS-AGENT-RELEASE:0000000000:",
+                       b"BLOXOS-AGENT-RELEASE:broken:",
+                       b"BLOXOS-AGENT-RELEASE:0000000007:" * 2):
+            with self.subTest(suffix=suffix), self.assertRaisesRegex(ValueError, "release markers"):
+                bundle.identity(fixture("linux/amd64")[:128] + suffix, "linux/amd64")
+
+    def test_mixed_release_numbers_rejected(self):
+        (self.source / bundle.FILES["linux/arm64"]).write_bytes(fixture("linux/arm64", 8))
+        with self.assertRaisesRegex(ValueError, "different agent release"):
+            bundle.check(self.source, self.sha)
+
+    def test_manifest_release_and_extra_targets_cannot_lie(self):
+        original = json.loads((self.source / bundle.MANIFEST).read_bytes())
+        for change in ({"agent_release": 8}, {"artifacts": {"../escape": {}}}):
+            data = json.dumps({**original, **change}).encode()
+            (self.source / bundle.MANIFEST).write_bytes(data)
+            with self.assertRaises(ValueError):
+                bundle.check(self.source, hashlib.sha256(data).hexdigest())
+
+    def test_no_symlink_or_fifo_input(self):
+        p = self.source / bundle.FILES["linux/amd64"]
+        p.unlink()
+        p.symlink_to(self.active / "bloxos-agent")
+        with self.assertRaises(OSError):
+            bundle.check(self.source, self.sha)
+        p.unlink()
+        os.mkfifo(p)
+        with self.assertRaisesRegex(ValueError, "not a regular file"):
+            bundle.check(self.source, self.sha)
+
+    def test_active_environment_directory_rejected(self):
+        with mock.patch.dict(os.environ, {"BLOXOS_AGENT_BINARY": str(self.active / "bloxos-agent")}):
+            with self.assertRaisesRegex(ValueError, "active agent directory"):
+                bundle.stage(self.source, self.sha, self.active)
+        self.assertEqual((self.active / "bloxos-agent").read_bytes(), b"existing agent")
+
+    def test_source_change_during_copy_leaves_no_stage(self):
+        original = bundle.read_regular
+        counts = {}
+        def read(path, limit):
+            key = str(path)
+            counts[key] = counts.get(key, 0) + 1
+            data = original(path, limit)
+            if path.name == bundle.FILES["linux/amd64"] and path.parent == self.source and counts[key] == 2:
+                data += b"changed between validation and copying"
+            return data
+        with mock.patch.object(bundle, "read_regular", side_effect=read):
+            with self.assertRaisesRegex(ValueError, "artifact SHA256"):
+                bundle.stage(self.source, self.sha, self.staging)
+        self.assertEqual(list(self.staging.iterdir()), [])
+
+    def test_copy_failure_preserves_existing_files(self):
+        with mock.patch.object(Path, "rename", side_effect=OSError("disk failure")):
+            with self.assertRaisesRegex(OSError, "disk failure"):
+                bundle.stage(self.source, self.sha, self.staging)
+        self.assertEqual(list(self.staging.iterdir()), [])
+        self.assertEqual((self.active / "bloxos-agent").read_bytes(), b"existing agent")
+
+    def test_manifest_creation_never_overwrites(self):
+        with self.assertRaises(FileExistsError):
+            bundle.create_manifest(self.source, "a" * 40, "v1.2.1", "sha256:" + "b" * 64)
+
+    def run_export(self, failure=""):
+        bin_dir = self.root / "bin"
+        bin_dir.mkdir()
+        docker = bin_dir / "docker"
+        docker.write_text('''#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$DOCKER_LOG"
+case "$1" in
+  pull) test "$2" = --platform; test "$3" = linux/amd64 ;;
+  image) if [[ "$FAIL_EXPORT" == revision ]]; then printf 'wrong'; else printf '%040d' 0; fi ;;
+  create) test "$2" = --platform; test "$3" = linux/amd64
+          test "$4" = --network; test "$5" = none; printf '%064d' 0 ;;
+  cp) [[ "$FAIL_EXPORT" != copy ]] || exit 9
+      case "$2" in
+        *:/usr/local/lib/bloxos/linux/amd64/bloxos-agent) name=bloxos-agent-linux-amd64 ;;
+        *:/usr/local/lib/bloxos/linux/arm64/bloxos-agent) name=bloxos-agent-linux-arm64 ;;
+        *:/usr/local/lib/bloxos/windows/bloxos-agent.exe) name=bloxos-agent-windows-amd64.exe ;;
+        *) exit 10 ;;
+      esac
+      cp "$FIXTURES/$name" "$3" ;;
+  rm) test "$2" = -v; test ${#3} = 64 ;;
+  *) exit 11 ;;
+esac
+''')
+        docker.chmod(0o700)
+        output = self.root / "export"
+        log = self.root / "docker.log"
+        result = subprocess.run([
+            "bash", str(Path(__file__).with_name("export-agent-bundle.sh")),
+            "ghcr.io/example/hub@sha256:" + "b" * 64, "0" * 40, "v1.2.1", str(output),
+        ], env={**os.environ, "PATH": str(bin_dir) + os.pathsep + os.environ["PATH"],
+                "DOCKER_LOG": str(log), "FIXTURES": str(self.source), "FAIL_EXPORT": failure},
+            capture_output=True, text=True)
+        return result, output, log.read_text()
+
+    def test_export_extracts_all_targets_without_starting_container(self):
+        result, output, log = self.run_export()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        sha = (output / "agent-manifest.sha256").read_text().split()[0]
+        self.assertEqual(bundle.check(output, sha)["agent_release"], 7)
+        self.assertEqual(sum(line.startswith("cp ") for line in log.splitlines()), 3)
+        self.assertTrue(log.splitlines()[-1].startswith("rm -v "))
+        self.assertNotIn("start ", log)
+        self.assertNotIn("run ", log)
+
+    def test_export_revision_mismatch_never_creates_container_or_output(self):
+        result, output, log = self.run_export("revision")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(output.exists())
+        self.assertNotIn("create ", log)
+
+    def test_export_copy_failure_removes_only_created_container(self):
+        result, output, log = self.run_export("copy")
+        self.assertEqual(result.returncode, 9, result.stderr)
+        self.assertFalse((output / bundle.MANIFEST).exists())
+        self.assertTrue(log.splitlines()[-1].startswith("rm -v "))
+        self.assertEqual((self.active / "bloxos-agent").read_bytes(), b"existing agent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_agent_bundle.py
+++ b/scripts/test_agent_bundle.py
@@ -162,6 +162,26 @@ class BundleTests(unittest.TestCase):
         with mock.patch.dict(os.environ, {"BLOXOS_AGENT_BINARY": str(self.active / "bloxos-agent")}):
             self.assertTrue(bundle.stage(self.source, self.sha, self.staging).is_dir())
 
+    def test_whitespace_wrapped_future_override_cannot_activate(self):
+        for env in ("BLOXOS_AGENT_BINARY", "BLOXOS_AGENT_BINARY_ARM64", "BLOXOS_AGENT_BINARY_WINDOWS"):
+            for padding in (" ", "\t\n", "\u0085\u00a0\u2003\u3000"):
+                with self.subTest(env=env, padding=repr(padding)):
+                    target = self.staging / "agent-release-7" / "bloxos-agent-linux-amd64"
+                    with mock.patch.dict(os.environ, {env: padding + str(target) + padding}):
+                        with self.assertRaisesRegex(ValueError, "active agent directory"):
+                            bundle.stage(self.source, self.sha, self.staging)
+                    self.assertEqual(list(self.staging.iterdir()), [])
+
+    def test_relative_visible_override_is_rejected(self):
+        with mock.patch.dict(os.environ, {"BLOXOS_AGENT_BINARY": " ../active/bloxos-agent "}):
+            with self.assertRaisesRegex(ValueError, "absolute path"):
+                bundle.stage(self.source, self.sha, self.staging)
+        self.assertEqual(list(self.staging.iterdir()), [])
+
+    def test_whitespace_only_override_matches_hub_unset_behavior(self):
+        with mock.patch.dict(os.environ, {"BLOXOS_AGENT_BINARY": " \t\n\u00a0"}):
+            self.assertTrue(bundle.stage(self.source, self.sha, self.staging).is_dir())
+
     def test_source_change_during_copy_leaves_no_stage(self):
         original = bundle.read_regular
         counts = {}

--- a/scripts/test_agent_bundle.py
+++ b/scripts/test_agent_bundle.py
@@ -146,6 +146,22 @@ class BundleTests(unittest.TestCase):
                 bundle.stage(self.source, self.sha, self.active)
         self.assertEqual((self.active / "bloxos-agent").read_bytes(), b"existing agent")
 
+    def test_future_active_override_under_staging_root_rejected(self):
+        for env, filename in zip(
+                ("BLOXOS_AGENT_BINARY", "BLOXOS_AGENT_BINARY_ARM64", "BLOXOS_AGENT_BINARY_WINDOWS"),
+                bundle.FILES.values()):
+            with self.subTest(env=env):
+                target = self.staging / "agent-release-7" / filename
+                with mock.patch.dict(os.environ, {env: str(target)}):
+                    with self.assertRaisesRegex(ValueError, "active agent directory"):
+                        bundle.stage(self.source, self.sha, self.staging)
+                self.assertFalse(target.exists())
+                self.assertEqual(list(self.staging.iterdir()), [])
+
+    def test_sibling_of_active_directory_can_be_staged(self):
+        with mock.patch.dict(os.environ, {"BLOXOS_AGENT_BINARY": str(self.active / "bloxos-agent")}):
+            self.assertTrue(bundle.stage(self.source, self.sha, self.staging).is_dir())
+
     def test_source_change_during_copy_leaves_no_stage(self):
         original = bundle.read_regular
         counts = {}


### PR DESCRIPTION
Part 5 of the v1.2.1 remediation. Native hub upgrades do not replace separately served agent binaries. Extract canonical Linux amd64/arm64 and Windows amd64 bytes from the digest-pinned published image, attach manifest/checksum to a draft release, and provide a Python stdlib check/stage helper. No signing, activation, restart or fleet API calls. Reuse exact numbered bytes; no agent source changes. Validation: 19 offline unit/export-contract tests; shell syntax and YAML parse; actual v1.2.0 image export and non-active staging, all three known release-7 hashes matched. Existing files and published assets are never clobbered. Root review complete; Claude/Kimi final cross-review and CI pending. This PR does not deploy to any operator server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the tagged release workflow (image tagging, draft release uploads with contents:write) and introduces operator-facing bundle validation; staging is designed not to activate fleet updates, but mistakes in release promotion could still ship wrong assets.
> 
> **Overview**
> Adds a **native agent bundle pipeline** so operators on native hubs can verify and stage the same Linux/Windows agent bytes that ship inside the published hub image—without signing, serving, or triggering fleet rollouts.
> 
> **Release automation:** Tagged releases now run `agent_bundle.py validate-tag` before image publish, skip moving `latest` for prerelease tags (`vX.Y.Z-rc.*`), and add a `native-bundle` job that digest-pins the hub image, runs `export-agent-bundle.sh` to extract three binaries plus `agent-manifest.json`/`.sha256`, and uploads them to a **draft** GitHub release (creating a prerelease draft when the tag contains `-`).
> 
> **Operator tooling:** `agent_bundle.py` supports read-only `check` and cautious `stage` (versioned `agent-release-N` dirs, no overwrites, guards against staging under active serve paths / env overrides). New `docs/native-agent-upgrades.md` documents the workflow; README/docker docs bump examples to **v1.2.1** and note native hub vs agent file upgrades.
> 
> **CI:** Hub job runs `test_agent_bundle.py` and `bash -n` on the export script; hub-race timeouts increase (25m job / 20m `go test`) after prior deadline pressure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85020f724cd93bc02983aec44669b0e04909224b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->