### PR TITLE
test: isolate bootstrap CA discovery from host Caddy roots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,11 @@ jobs:
   hub-race:
     name: Hub Tests (race)
     runs-on: ubuntu-latest
-    # The full suite can exceed 10m on hosted runners with race-instrumented
-    # bcrypt setup. Allow headroom without disabling the hang guard. Keep Go's
+    # The full suite can exceed 15m on hosted runners with race-instrumented
+    # bcrypt setup (PR208 reached the Windows tests before the old deadline).
+    # Allow headroom without disabling the hang guard. Keep Go's
     # deadline below the job limit so failures include goroutine stacks.
-    timeout-minutes: 20
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: hub
@@ -90,7 +91,7 @@ jobs:
           cache-dependency-path: hub/go.sum
 
       - name: Run hub tests with the race detector
-        run: go test -race -count=1 -timeout=15m ./...
+        run: go test -race -count=1 -timeout=20m ./...
 
   agent:
     name: Agent Tests

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -165,10 +165,10 @@ func (s *Server) handleCreateToken(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
-	caURL, caSHA256 := bootstrapCAFor(httpBase)
+	caURL, caSHA256 := s.bootstrapCAFor(httpBase)
 	joinPin := ""
 	if caSHA256 != "" {
-		joinPin, err = joinPinForPrivateCA(c.Request().Context(), publicURL)
+		joinPin, err = s.joinPinForPrivateCA(c.Request().Context(), publicURL)
 		if err != nil {
 			log.Printf("token_create: refusing to mint, cannot pin the hub's TLS key for the join command: %v", err)
 			return c.JSON(http.StatusServiceUnavailable, map[string]string{
@@ -267,7 +267,7 @@ func (s *Server) handleWindowsReenrollment(c echo.Context) error {
 	}
 
 	httpBase, wsBase := publicAndWebsocketBase()
-	caURL, caSHA256 := bootstrapCAFor(httpBase)
+	caURL, caSHA256 := s.bootstrapCAFor(httpBase)
 	return c.JSON(http.StatusOK, windowsReenrollmentResponse{
 		MachineID:      machineID,
 		Token:          token,
@@ -600,8 +600,20 @@ func bootstrapCACertCandidates() []string {
 	return candidates
 }
 
-func loadBootstrapCACert() ([]byte, string, error) {
-	for _, path := range bootstrapCACertCandidates() {
+// caCertCandidatePaths is the bootstrap-CA search path for this server. In
+// production s.caCertCandidates is nil and it returns the default host
+// candidates; tests inject an isolated list so the machine's real Caddy roots
+// never reach a test's classification. A nil receiver also falls back to the
+// default, so any caller that predates a *Server keeps the old behavior.
+func (s *Server) caCertCandidatePaths() []string {
+	if s != nil && s.caCertCandidates != nil {
+		return s.caCertCandidates()
+	}
+	return bootstrapCACertCandidates()
+}
+
+func (s *Server) loadBootstrapCACert() ([]byte, string, error) {
+	for _, path := range s.caCertCandidatePaths() {
 		if path == "" {
 			continue
 		}
@@ -617,9 +629,9 @@ func loadBootstrapCACert() ([]byte, string, error) {
 	return nil, "", os.ErrNotExist
 }
 
-func bootstrapCAFor(httpBase string) (caURL string, caSHA256 string) {
+func (s *Server) bootstrapCAFor(httpBase string) (caURL string, caSHA256 string) {
 	if strings.HasPrefix(httpBase, "https://") {
-		if caPEM, caPath, err := loadBootstrapCACert(); err == nil {
+		if caPEM, caPath, err := s.loadBootstrapCACert(); err == nil {
 			caURL = httpBase + "/download/ca.crt"
 			sum := sha256.Sum256(caPEM)
 			caSHA256 = hex.EncodeToString(sum[:])
@@ -678,8 +690,8 @@ func handleDownloadAgent(c echo.Context) error {
 	return c.File(state.Path)
 }
 
-func handleDownloadCACert(c echo.Context) error {
-	caPEM, _, err := loadBootstrapCACert()
+func (s *Server) handleDownloadCACert(c echo.Context) error {
+	caPEM, _, err := s.loadBootstrapCACert()
 	if err != nil {
 		if os.IsNotExist(err) {
 			return c.JSON(http.StatusNotFound, map[string]string{"error": "CA certificate not configured; set BLOXOS_CA_CERT"})

--- a/hub/ca_isolation_test.go
+++ b/hub/ca_isolation_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// isolatedCACandidates is the bootstrap-CA search path setupTestServer installs
+// on every test server. It honors an explicitly-set BLOXOS_CA_CERT — the many
+// private-CA tests depend on that env var to make a hub private — but drops the
+// ambient host paths (~/.local/share/caddy, /var/lib/caddy, /root) that the
+// production bootstrapCACertCandidates also reads. Those ambient paths are what
+// leaked a developer's or CI runner's real Caddy root into a public test hub's
+// classification, mis-classifying it private-CA and failing the public-hub
+// tests depending on where they ran. An *auto-discovered* ambient CA is now
+// exercised deliberately via injectAmbientCACandidate, never by accident.
+func isolatedCACandidates() []string {
+	if env := os.Getenv("BLOXOS_CA_CERT"); env != "" {
+		return []string{env}
+	}
+	return nil
+}
+
+// injectAmbientCACandidate makes s behave as if the host had an auto-discovered
+// Caddy root on disk (e.g. ~/.local/share/caddy/.../root.crt) — the exact
+// production condition that mis-classifies a public hub. It writes a temp cert
+// and points s.caCertCandidates at it *without* setting BLOXOS_CA_CERT, so the
+// candidate is ambient (auto-discovered), not operator-configured. The resolver
+// is stubbed in setupTestServer, so the cert bytes need not be a real chain.
+// Returns the candidate path.
+func injectAmbientCACandidate(t *testing.T, s *Server) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ambient-caddy-root.crt")
+	if err := os.WriteFile(path, []byte("ambient-host-caddy-root"), 0o600); err != nil {
+		t.Fatalf("write ambient CA: %v", err)
+	}
+	s.caCertCandidates = func() []string { return []string{path} }
+	return path
+}
+
+// TestAmbientCACandidateMisclassifiesPublicHub reproduces the reported failure
+// deterministically. A genuinely public HTTPS hub (HTTPS PUBLIC_URL, no
+// operator BLOXOS_CA_CERT) is classified public with the default isolation; the
+// only change that flips it to a private-CA mint is an ambient, auto-discovered
+// Caddy root leaking in from the host. This is the shared root cause of the
+// three reported failures:
+//   - TestPublicTrustedHTTPSAndHTTPCommandsDoNotFetchLocalCA (public mint gains
+//     CA material), which set BLOXOS_CA_CERT to a missing path but could not
+//     defeat the ambient host paths;
+//   - the "publicly trusted https is plain verified TLS" join case (the pin
+//     resolver runs and the command gains -k --pinnedpubkey); and
+//   - TestJoinRejectsMissingBinding, where the drift check finds the ambient
+//     CA so its empty-string ("empty-ca-ok") binding no longer matches and the
+//     code 404s instead of serving.
+// The seam also keeps other public-hub tests deterministic
+// (e.g. TestJoinRebuildByteEquivalenceAcrossTransports).
+//
+// The request Host ("evil.example") is identical for both mints; only the host
+// CA state differs. That pins the cause to ambient CA discovery, not the Host.
+func TestAmbientCACandidateMisclassifiesPublicHub(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "https://public.example")
+
+	// Baseline: isolated (as every test is by default) → public classification.
+	base := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
+	if base.CASHA256 != "" || base.JoinPin != "" || base.CAURL != "" {
+		t.Fatalf("isolated public hub already carries CA material: %+v", base)
+	}
+
+	// Simulate the host's auto-discovered Caddy root leaking into discovery.
+	injectAmbientCACandidate(t, s)
+	leaked := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
+	if leaked.CASHA256 == "" {
+		t.Fatal("ambient CA candidate did not change classification — seam not wired")
+	}
+	if !strings.Contains(leaked.Command, "--pinnedpubkey sha256//") {
+		t.Fatalf("private classification did not pin the leaf: %q", leaked.Command)
+	}
+}
+
+// TestPublicHubClassificationIsHostIndependent is the isolation proof: with the
+// default setupTestServer seam a public HTTPS hub is classified public — empty
+// CA, no pin, plain verified curl, join code served — regardless of the CA
+// roots on the machine running the suite. This is what makes the three reported
+// public-hub tests deterministic. The pin resolver must never run: reaching it
+// would mean the hub decided it was behind a private CA.
+func TestPublicHubClassificationIsHostIndependent(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "https://public.example")
+	withJoinPinResolver(t, func(context.Context, *url.URL, []byte) (string, error) {
+		t.Fatal("pin resolver ran for a public hub — classification leaked a CA")
+		return "", nil
+	})
+
+	got := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
+	if got.CASHA256 != "" || got.CAURL != "" || got.JoinPin != "" {
+		t.Fatalf("public hub carries CA material: %+v", got)
+	}
+	if strings.Contains(got.Command, " -k") || strings.Contains(got.Command, "--pinnedpubkey") {
+		t.Fatalf("public command has private-CA flags: %q", got.Command)
+	}
+	if strings.Contains(got.AdvancedCommand, "/download/ca.crt") {
+		t.Fatalf("public advanced command fetches local CA: %q", got.AdvancedCommand)
+	}
+	// The public (empty-CA) binding is a valid binding: the code serves.
+	if rec := getJoin(t, e, got.Token, ""); rec.Code != http.StatusOK {
+		t.Fatalf("empty-CA join: status=%d body=%q, want 200", rec.Code, rec.Body.String())
+	}
+}
+
+// TestJoinBindingStatesUnderIsolation locks the binding contract the isolation
+// must preserve: a real public mint stores an empty-string CA binding that is a
+// valid, served binding (200), while a never-recorded (NULL) binding is refused
+// with the same opaque 404 as any other unusable code.
+func TestJoinBindingStatesUnderIsolation(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "https://public.example")
+
+	// Real public mint → empty-string CA binding → usable (200).
+	got := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
+	var caBinding sql.NullString
+	if err := s.db.QueryRow(`SELECT mint_time_ca_sha256 FROM tokens WHERE token_hash = ?`, hashOf(got.Token)).Scan(&caBinding); err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if !caBinding.Valid || caBinding.String != "" {
+		t.Fatalf("public mint CA binding = %+v, want a valid empty string", caBinding)
+	}
+	if rec := getJoin(t, e, got.Token, ""); rec.Code != http.StatusOK {
+		t.Fatalf("empty-CA code: status=%d, want 200", rec.Code)
+	}
+
+	// A never-bound (NULL CA) row is refused, even though it is unexpired.
+	h := sha256.Sum256([]byte("never-bound-null-ca"))
+	if _, err := s.db.Exec(
+		`INSERT INTO tokens (token_hash, expires_at, mint_time_http_base, mint_time_ca_sha256) VALUES (?, ?, ?, ?)`,
+		hexOf(h[:]), time.Now().Add(time.Hour).Format("2006-01-02 15:04:05"), "https://public.example", nil); err != nil {
+		t.Fatalf("seed NULL-CA row: %v", err)
+	}
+	if rec := getJoin(t, e, "never-bound-null-ca", ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("NULL-CA code: status=%d, want 404", rec.Code)
+	}
+}

--- a/hub/install_enrollment_test.go
+++ b/hub/install_enrollment_test.go
@@ -33,7 +33,7 @@ func (s *Server) seedTokenValue(t *testing.T, raw string) string {
 	httpBase, _ := publicAndWebsocketBase()
 	var mintHTTPBase, mintCASHA256 interface{}
 	if httpBase != "" {
-		_, caSHA256 := bootstrapCAFor(httpBase)
+		_, caSHA256 := s.bootstrapCAFor(httpBase)
 		mintHTTPBase = httpBase
 		mintCASHA256 = caSHA256
 	}

--- a/hub/join.go
+++ b/hub/join.go
@@ -205,8 +205,8 @@ func parsePublicURL(raw string) (*url.URL, error) {
 // bootstrap CA and returns its SPKI pin. It is only called when the hub is
 // behind a private CA (bootstrapCAFor found one); a publicly trusted hub
 // needs no pin.
-func joinPinForPrivateCA(ctx context.Context, publicURL *url.URL) (string, error) {
-	caPEM, caPath, err := loadBootstrapCACert()
+func (s *Server) joinPinForPrivateCA(ctx context.Context, publicURL *url.URL) (string, error) {
+	caPEM, caPath, err := s.loadBootstrapCACert()
 	if err != nil {
 		return "", fmt.Errorf("load bootstrap CA: %w", err)
 	}
@@ -399,7 +399,7 @@ func (s *Server) handleJoinScript(c echo.Context) error {
 	// a pin for the mint-time cert and a URL for the mint-time hub, and serving
 	// a script with different values would either fail the pin check or redirect
 	// the agent to a different authority than what was authenticated at mint.
-	currentCAURL, currentCASHA256 := bootstrapCAFor(currentHTTPBase)
+	currentCAURL, currentCASHA256 := s.bootstrapCAFor(currentHTTPBase)
 	_ = currentCAURL // URL derivation is deterministic; SHA is the binding value
 
 	// Tokens minted before origin normalization may carry a trailing slash;

--- a/hub/main.go
+++ b/hub/main.go
@@ -272,7 +272,7 @@ func (s *Server) registerRoutes(e *echo.Echo) {
 	e.GET("/join/:code", s.handleJoinScript)
 	e.GET("/api/join/:code", s.handleJoinScript)
 	e.GET("/download/agent", handleDownloadAgent)
-	e.GET("/download/ca.crt", handleDownloadCACert)
+	e.GET("/download/ca.crt", s.handleDownloadCACert)
 	e.GET("/api/setup/status", s.handleSetupStatus)
 	e.POST("/api/setup", s.handleSetup)
 

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -154,6 +154,16 @@ func setupTestServer(t *testing.T) (*echo.Echo, *Server) {
 	}
 
 	s := newServer(db)
+	// Isolate bootstrap-CA discovery from the host's real Caddy roots. Without
+	// this, a developer or CI machine that happens to have a local Caddy CA at
+	// ~/.local/share/caddy (or /var/lib/caddy, /root) leaks that cert into the
+	// candidate list, so a public test hub is mis-classified private-CA and
+	// tests asserting public behavior fail depending on where they run. The
+	// isolated path still honors an explicitly-set BLOXOS_CA_CERT (the many
+	// private-CA tests rely on that) but never reads ambient host paths. Tests
+	// that need an auto-discovered ambient CA override s.caCertCandidates
+	// directly (see injectAmbientCACandidate in ca_isolation_test.go).
+	s.caCertCandidates = isolatedCACandidates
 	// Registered after the db.Close() cleanup above so it runs BEFORE it:
 	// t.Cleanup is LIFO, and background work must drain while the database
 	// it queries is still open.
@@ -207,6 +217,9 @@ func setupEmptyTestServer(t *testing.T) (*echo.Echo, *Server) {
 	setupTokenValue = "test-setup-token-abc123"
 
 	s := newServer(db)
+	// Isolate bootstrap-CA discovery from the host's real Caddy roots, exactly
+	// as setupTestServer does — see the rationale there.
+	s.caCertCandidates = isolatedCACandidates
 	// Registered after the db.Close() cleanup above so it runs BEFORE it:
 	// t.Cleanup is LIFO, and background work must drain while the database
 	// it queries is still open.

--- a/hub/server.go
+++ b/hub/server.go
@@ -36,6 +36,15 @@ type Server struct {
 	aiSessions    *aiSessionStore
 	aiSessionsCfg aiSessionsConfig
 
+	// caCertCandidates, when non-nil, replaces the default filesystem search
+	// path for the bootstrap CA certificate (see bootstrapCACertCandidates).
+	// Production leaves it nil and uses the default host candidates; tests set
+	// it so CA discovery is isolated from the machine's real Caddy roots
+	// (~/.local/share/caddy, /var/lib/caddy, /root) and a public test hub is
+	// never mis-classified private because the developer or CI runner happens
+	// to have a local Caddy CA on disk. See caCertCandidatePaths.
+	caCertCandidates func() []string
+
 	// Tracks background work this server spawned, so a caller can wait for
 	// it to finish before tearing the server down. See goTracked/Shutdown.
 	//


### PR DESCRIPTION
Phase 1 of the approved onboarding/native-upgrade remediation. Adds a per-Server CA-candidate seam; production retains the same candidate search and behavior, while both test-server factories exclude ambient host files. Deterministically reproduces the VM-reported public HTTPS failures using a temporary candidate. Verifies valid empty CA binding gives 200, absent NULL binding gives 404. No HOME changes, no host Caddy writes. Claude implemented, Codex reviewed. Validation: full hub race suite passed (549.938s), build/vet, affected join/bootstrap/setup regressions. Follow-up production CA selection is a separate PR. No VM deployment or agent rollout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production CA discovery is unchanged when the hook is nil; risk is limited to test determinism and slightly longer CI race job timeouts.
> 
> **Overview**
> **Isolates hub bootstrap-CA discovery in tests** so public HTTPS join/token behavior no longer depends on ambient Caddy roots on the developer or CI host.
> 
> Adds an optional per-`Server` `caCertCandidates` hook and moves CA loading (`loadBootstrapCACert`, `bootstrapCAFor`, `joinPinForPrivateCA`, `/download/ca.crt`) onto `*Server`. Production still uses the same default filesystem search when the hook is nil; test servers install `isolatedCACandidates`, which only respects `BLOXOS_CA_CERT` and skips `~/.local/share/caddy` and similar paths.
> 
> New tests in `ca_isolation_test.go` reproduce the misclassification when an ambient CA leaks in, assert public hubs stay public under isolation, and lock join binding rules (valid empty CA binding → 200, NULL → 404).
> 
> **CI:** the `hub-race` job and `go test -race` timeouts are raised (25m / 20m) after the full race suite began timing out before Windows tests finished.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 056e914561939e6c5d027955b0acc245f98c5639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->