### PR TITLE
fix: make operator rollout pause survive restarts and binary changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,11 @@ jobs:
   hub-race:
     name: Hub Tests (race)
     runs-on: ubuntu-latest
-    # The full suite can exceed 10m on hosted runners with race-instrumented
-    # bcrypt setup. Allow headroom without disabling the hang guard. Keep Go's
+    # The full suite can exceed 15m on hosted runners with race-instrumented
+    # bcrypt setup (PR208 reached the Windows tests before the old deadline).
+    # Allow headroom without disabling the hang guard. Keep Go's
     # deadline below the job limit so failures include goroutine stacks.
-    timeout-minutes: 20
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: hub
@@ -90,7 +91,7 @@ jobs:
           cache-dependency-path: hub/go.sum
 
       - name: Run hub tests with the race detector
-        run: go test -race -count=1 -timeout=15m ./...
+        run: go test -race -count=1 -timeout=20m ./...
 
   agent:
     name: Agent Tests

--- a/docs/offline-update-signing.md
+++ b/docs/offline-update-signing.md
@@ -1,22 +1,24 @@
 # Offline agent release signing
 
-This runbook builds and signs Linux and Windows agent releases on **FAT-LOLO**,
+This runbook prepares and signs Linux and Windows agent releases on an offline signing host,
 then installs the binary/signature pairs into root-owned serve directories on
 the hub. The private Ed25519 key stays on the offline build host.
 
 > **Scope boundary:** this document describes the later one-time keyless
-> cutover, but this PR does not perform it. Do not set
+> cutover, but reading or staging this runbook does not authorize it. Do not set
 > `BLOXOS_UPDATE_PUBKEY`, move or remove the hub's private key, restart the hub,
 > or deploy an agent release without a separate, environment-specific approval.
 
 ## Invariants
 
-- Build from a pinned, clean commit and record it with the artifact hashes.
+- Prefer the exact published native payloads; record their approved manifest
+  and hashes. A native hub rebuild does not replace separate served agent files.
+  If making a new agent build, use a pinned, clean commit and record it too.
 - For each new agent release, bump both the release number and matching marker
   in `agent/release.go` before building. A rebuild that changes the binary SHA
   also needs a new number; equal-number/different-SHA updates are refused by
   protocol-2 agents. Use the same number across the platform builds of a release.
-- The signing input and private key remain on FAT-LOLO. Never copy the private
+- The signing input and private key remain on the offline signing host. Never copy the private
   key to the hub or print it in a terminal transcript.
 - `bloxos-sign` and both agents use `updatesigning.Message`; the signed bytes
   are `bloxos-agent-update:v1:<os>:<sha256>` after trimming and lowercasing the
@@ -31,19 +33,39 @@ the hub. The private Ed25519 key stays on the offline build host.
 - The hub's configured Linux and Windows binary paths must be explicit and
   rooted in a `root:root` chain that is not group- or other-writable. Do not
   rely on relative paths or fallbacks.
-- Pause rollout before changing a served artifact. A served SHA change clears
-  the current in-memory pause, so verify and re-pause immediately after each
-  change before allowing agents to reconnect.
+- Pause rollout before changing a served artifact and confirm success.
+  On hubs with the durable operator-pause fix, a manual pause is saved in
+  `hub_settings` and survives both served-SHA changes and hub restarts. Only
+  an explicit Resume clears it. A database error must not be mistaken for a
+  successful pause/resume. The automatic failure breaker is separate and may
+  reset when a served binary changes.
+- **v1.2.0 and earlier do not have durable pause.** Upgrade the hub first, or
+  keep the hub stopped and agent connectivity controlled during activation.
+  Never rely on racing to re-pause after replacing an artifact.
+  Downgrading to an older hub also loses enforcement of the saved pause;
+  control agent connectivity before such a hub rollback.
+- Pause prevents new announcements, not an update already announced or in
+  flight. Before activation, inspect pending updates and confirm they have
+  settled. Resume is fleet-wide; this is not a per-machine canary mechanism.
 
-## 1. Build on FAT-LOLO
+## 1. Prepare exact payloads on the offline signing host
+
+For an existing official agent release, transfer the approved published
+payloads and manifest to the offline host and verify their hashes there.
+Do not rebuild the same release number with different bytes. Build only the
+`bloxos-sign` utility from the approved source when signing existing payloads;
+skip the agent build commands below.
+
+The following is the **alternative for a new agent release**, after the
+source-controlled number and marker have been bumped and approved.
 
 Use a fresh clone rather than a worktree so Go VCS stamping is unambiguous.
 Replace `<commit>` with the approved full commit SHA.
 
 ```sh
 set -euo pipefail
-SRC=/home/bokiko/bloxos-release-src
-ART=/home/bokiko/bloxos-release-artifacts
+SRC=/path/to/new-release-src
+ART=/path/to/new-release-artifacts
 COMMIT=<commit>
 
 [ ! -e "$SRC" ] && [ ! -e "$ART" ]
@@ -53,18 +75,21 @@ git -C "$SRC" checkout --detach "$COMMIT"
 mkdir -m 700 "$ART"
 
 ( cd "$SRC/hub" && go build -o "$ART/bloxos-sign" ./cmd/bloxos-sign )
-( cd "$SRC/agent" && go build -o "$ART/bloxos-agent-linux" . )
-( cd "$SRC/agent" && GOOS=windows GOARCH=amd64 go build -o "$ART/bloxos-agent-windows.exe" . )
+( cd "$SRC/agent" && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "$ART/bloxos-agent-linux-amd64" . )
+( cd "$SRC/agent" && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o "$ART/bloxos-agent-linux-arm64" . )
+( cd "$SRC/agent" && CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o "$ART/bloxos-agent-windows-amd64.exe" . )
 
-file "$ART/bloxos-sign" "$ART/bloxos-agent-linux" "$ART/bloxos-agent-windows.exe"
-go version -m "$ART/bloxos-agent-linux"
-go version -m "$ART/bloxos-agent-windows.exe"
+file "$ART/bloxos-sign" "$ART/bloxos-agent-linux-amd64" "$ART/bloxos-agent-linux-arm64" "$ART/bloxos-agent-windows-amd64.exe"
+go version -m "$ART/bloxos-agent-linux-amd64"
+go version -m "$ART/bloxos-agent-linux-arm64"
+go version -m "$ART/bloxos-agent-windows-amd64.exe"
 ```
 
-Gate: both agents report `vcs.revision=<commit>` and `vcs.modified=false`; the
-Windows artifact is PE32+ x86-64 and the Linux artifact is the expected ELF.
+Gate for new builds: all three report `vcs.revision=<commit>` and
+`vcs.modified=false`; Windows is PE32+ x86-64 and each Linux artifact is the
+correct ELF architecture. All carry the same newly approved release number.
 
-## 2. Sign on FAT-LOLO
+## 2. Sign the exact bytes offline
 
 `-key` takes precedence over `BLOXOS_UPDATE_SIGNING_KEY`; when neither is set,
 the tool uses `~/.bloxos/update-signing.key`. The tool prints only the target
@@ -73,15 +98,17 @@ OS, SHA-256, and signature path — never private key material.
 ```sh
 set -euo pipefail
 KEY=/secure/offline/bloxos-update-signing.key
-ART=/home/bokiko/bloxos-release-artifacts
+ART=/path/to/approved-release-artifacts
 
-"$ART/bloxos-sign" -key "$KEY" -os linux "$ART/bloxos-agent-linux"
-"$ART/bloxos-sign" -key "$KEY" -os windows "$ART/bloxos-agent-windows.exe"
+"$ART/bloxos-sign" -key "$KEY" -os linux "$ART/bloxos-agent-linux-amd64"
+"$ART/bloxos-sign" -key "$KEY" -os linux "$ART/bloxos-agent-linux-arm64"
+"$ART/bloxos-sign" -key "$KEY" -os windows "$ART/bloxos-agent-windows-amd64.exe"
 "$ART/bloxos-sign" -key "$KEY" -print-public-key > "$ART/update-signing.pub"
 
 sha256sum \
-  "$ART/bloxos-agent-linux" "$ART/bloxos-agent-linux.sig" \
-  "$ART/bloxos-agent-windows.exe" "$ART/bloxos-agent-windows.exe.sig" \
+  "$ART/bloxos-agent-linux-amd64" "$ART/bloxos-agent-linux-amd64.sig" \
+  "$ART/bloxos-agent-linux-arm64" "$ART/bloxos-agent-linux-arm64.sig" \
+  "$ART/bloxos-agent-windows-amd64.exe" "$ART/bloxos-agent-windows-amd64.exe.sig" \
   "$ART/bloxos-sign" > "$ART/SHA256SUMS"
 chmod 0444 "$ART"/*.sig "$ART/update-signing.pub" "$ART/SHA256SUMS"
 ```
@@ -95,6 +122,7 @@ The example paths assume the service is explicitly configured with:
 
 ```text
 BLOXOS_AGENT_BINARY=/usr/local/lib/bloxos/linux/bloxos-agent
+BLOXOS_AGENT_BINARY_ARM64=/usr/local/lib/bloxos/linux/arm64/bloxos-agent
 BLOXOS_AGENT_BINARY_WINDOWS=/usr/local/lib/bloxos/windows/bloxos-agent.exe
 ```
 
@@ -102,7 +130,8 @@ Transfer into a mode-`0700` user-owned transit directory, authenticate the
 manifest/hashes received through the trusted handoff, then use `sudo install`
 to copy into a root-owned staging directory. Delete only the named transit
 files after the root-owned hashes match. The transit directory is never a
-signing input.
+signing input. Keep staging outside all active serve directories. Merely
+preparing files there does not authorize activation or a fleet update.
 
 Before deployment, assert every ancestor of `/usr/local/lib/bloxos` is
 `root:root`, is traversable by the hub service user, and is not group- or
@@ -118,13 +147,13 @@ For each platform, install the **signature first**, then the binary, using
 temporary files in the same root-owned serve directory and atomic renames:
 
 ```sh
-# Example: Linux. Repeat with the Windows names and directory.
+# Example: Linux amd64. Repeat separately for Linux ARM64 and Windows amd64.
 set -euo pipefail
 STAGE=/usr/local/lib/bloxos/staging
 SERVE=/usr/local/lib/bloxos/linux/bloxos-agent
 
-sudo install -o root -g root -m 0644 "$STAGE/bloxos-agent-linux.sig" "$SERVE.sig.tmp"
-sudo install -o root -g root -m 0755 "$STAGE/bloxos-agent-linux" "$SERVE.tmp"
+sudo install -o root -g root -m 0644 "$STAGE/bloxos-agent-linux-amd64.sig" "$SERVE.sig.tmp"
+sudo install -o root -g root -m 0755 "$STAGE/bloxos-agent-linux-amd64" "$SERVE.tmp"
 # Verify both temp-file hashes against the approved manifest here.
 sudo mv -f "$SERVE.sig.tmp" "$SERVE.sig"
 sudo mv -f "$SERVE.tmp" "$SERVE"
@@ -134,16 +163,20 @@ Installing the signature first is fail-closed. While it belongs to the next
 binary, it cannot verify for the currently served SHA. In hub-held-key mode the
 hub can continue signing the current release; in offline mode it withholds an
 announcement during that brief mismatch instead of emitting an invalid one.
-After the binary rename, wait for `hub_sha`/`hub_windows_sha` to equal the
-approved SHA, then re-pause immediately because the SHA transition clears the
-in-memory pause. Resume only through the approved fleet rollout procedure.
+After the binary rename, check `agent_binaries_by_arch` in `/api/versions`
+for the approved SHA of **each** target and confirm `rollout_paused` remains
+true with the manual-pause reason. Verify detached signatures against the
+existing fleet public key and confirm the native hub is resolving the intended
+paths. Resume only through the approved fleet rollout procedure. Keep the old
+binary/signature pairs and a pre-change DB backup; do not delete protocol-2
+release-floor files to force an older agent rollback.
 
-## 5. One-time keyless cutover — not part of this PR
+## 5. One-time keyless cutover — separate operation
 
 Perform this only under a separate reviewed runbook and approval:
 
 1. While the hub still holds the existing private key, sign the **currently
-   served** Linux and Windows binaries offline with that same key.
+   served** Linux amd64/ARM64 and Windows binaries offline with that same key.
 2. Pre-place each matching `.sig` beside its unchanged binary. This is
    operationally a no-op: the hub prefers a detached signature only after it
    verifies for the exact current `(os, sha)`, and Ed25519 signing is
@@ -154,7 +187,7 @@ Perform this only under a separate reviewed runbook and approval:
 4. Set `BLOXOS_UPDATE_PUBKEY` to that public value and remove/unset
    `BLOXOS_UPDATE_SIGNING_KEY` in the hub service configuration. Restart the
    hub while rollout is controlled, and verify the log reports offline mode,
-   the hub holds no private key, both detached signatures verify, and no agent
+   the hub holds no private key, all detached signatures verify, and no agent
    sees a changed SHA.
 5. Only after those assertions pass, remove the private key from the hub host.
    Preserve independently verified offline backups; losing the sole signing

--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -299,8 +299,6 @@ func agentBinaryPathForArch(osName, arch string) string {
 // Linux agents get the SHA for the architecture the hub has recorded for
 // them (amd64 when none is known, matching the arch-less download).
 func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent) {
-	s.operatorRolloutMu.RLock()
-	defer s.operatorRolloutMu.RUnlock()
 	if paused, reason := s.operatorRolloutPause(); paused {
 		log.Printf("rollout: not announcing version to %s: %s", machineID, reason)
 		return
@@ -359,7 +357,20 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 	data, _ := json.Marshal(msg)
 
 	agent.WriteMu.Lock()
+	// Do not hold the operator gate while waiting behind unrelated socket
+	// writes. Recheck durable intent after acquiring the agent's write lock.
+	s.operatorRolloutMu.RLock()
+	if paused, _ := s.operatorRolloutPause(); paused || announcedSHAForArch(osName, v.Arch) != sha {
+		s.operatorRolloutMu.RUnlock()
+		agent.WriteMu.Unlock()
+		return
+	}
+	// Bound the only network I/O inside the pause barrier, matching the
+	// existing power-history ACK writer's deadline discipline.
+	_ = agent.Conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 	err := agent.Conn.WriteMessage(websocket.TextMessage, data)
+	_ = agent.Conn.SetWriteDeadline(time.Time{})
+	s.operatorRolloutMu.RUnlock()
 	agent.WriteMu.Unlock()
 	if err != nil {
 		log.Printf("rollout: failed to announce version to %s: %v", machineID, err)

--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -261,7 +261,8 @@ func recomputeBinaryForPlatform(platform agentPlatform) {
 	if previous.SHA != "" && previous.SHA != sha {
 		log.Printf("version: %s agent binary changed (%s -> %s), update will propagate",
 			platform, versionShortSHA(previous.SHA), versionShortSHA(sha))
-		// Reset circuit breaker — a fresh build deserves a fresh rollout.
+		// Reset only the automatic failure breaker. The operator's durable
+		// pause lives in hub_settings and must survive a served-SHA change.
 		rolloutFailuresMu.Lock()
 		rolloutFailures = nil
 		rolloutFailuresMu.Unlock()
@@ -298,6 +299,12 @@ func agentBinaryPathForArch(osName, arch string) string {
 // Linux agents get the SHA for the architecture the hub has recorded for
 // them (amd64 when none is known, matching the arch-less download).
 func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent) {
+	s.operatorRolloutMu.RLock()
+	defer s.operatorRolloutMu.RUnlock()
+	if paused, reason := s.operatorRolloutPause(); paused {
+		log.Printf("rollout: not announcing version to %s: %s", machineID, reason)
+		return
+	}
 	rolloutPausedMu.RLock()
 	paused := rolloutPaused
 	rolloutPausedMu.RUnlock()
@@ -826,6 +833,9 @@ func (s *Server) handleListVersions(c echo.Context) error {
 	paused := rolloutPaused
 	pauseReason := rolloutPauseReason
 	rolloutPausedMu.RUnlock()
+	if operatorPaused, reason := s.operatorRolloutPause(); operatorPaused {
+		paused, pauseReason = true, reason
+	}
 
 	signingEnabled, signingDisabledReason := updateSigningStatus()
 
@@ -861,16 +871,24 @@ func (s *Server) handleListVersions(c echo.Context) error {
 	})
 }
 
-func handlePauseRollout(c echo.Context) error {
-	rolloutPausedMu.Lock()
-	rolloutPaused = true
-	rolloutPauseReason = "manually paused by operator"
-	rolloutPausedMu.Unlock()
+func (s *Server) handlePauseRollout(c echo.Context) error {
+	s.operatorRolloutMu.Lock()
+	defer s.operatorRolloutMu.Unlock()
+	if err := s.setOperatorRolloutPause(true); err != nil {
+		log.Printf("rollout: could not persist operator pause: %v", err)
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "Could not save rollout pause. Do not replace served agent files; check hub database health and retry."})
+	}
 	log.Printf("rollout: PAUSED by operator")
 	return c.JSON(http.StatusOK, map[string]string{"status": "paused"})
 }
 
 func (s *Server) handleResumeRollout(c echo.Context) error {
+	s.operatorRolloutMu.Lock()
+	if err := s.setOperatorRolloutPause(false); err != nil {
+		s.operatorRolloutMu.Unlock()
+		log.Printf("rollout: could not persist operator resume: %v", err)
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "Could not save rollout resume. Rollout state was not changed; check hub database health and retry."})
+	}
 	rolloutPausedMu.Lock()
 	rolloutPaused = false
 	rolloutPauseReason = ""
@@ -879,6 +897,7 @@ func (s *Server) handleResumeRollout(c echo.Context) error {
 	rolloutFailuresMu.Lock()
 	rolloutFailures = nil
 	rolloutFailuresMu.Unlock()
+	s.operatorRolloutMu.Unlock()
 
 	log.Printf("rollout: RESUMED by operator")
 

--- a/hub/main.go
+++ b/hub/main.go
@@ -294,7 +294,7 @@ func (s *Server) registerRoutes(e *echo.Echo) {
 
 	// Phase 8 — agent version tracking and rollout control
 	api.GET("/api/versions", s.handleListVersions)
-	api.POST("/api/versions/pause", handlePauseRollout)
+	api.POST("/api/versions/pause", s.handlePauseRollout)
 	api.POST("/api/versions/resume", s.handleResumeRollout)
 	api.PUT("/api/machines/:id/tags", s.handleSetTags)
 	api.GET("/api/machines/:id/notes", s.handleGetMachineNotes)

--- a/hub/rollout_pause.go
+++ b/hub/rollout_pause.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"log"
+)
+
+const operatorRolloutPauseKey = "agent_rollout_operator_paused"
+
+// operatorRolloutPause reads the durable operator intent, separate from the
+// automatic per-build failure breaker. Missing means never paused. Unreadable
+// or corrupt state withholds announcements rather than silently resuming.
+func (s *Server) operatorRolloutPause() (bool, string) {
+	var value string
+	err := s.db.QueryRow(`SELECT value FROM hub_settings WHERE key = ?`, operatorRolloutPauseKey).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, ""
+	}
+	if err != nil {
+		log.Printf("rollout: operator pause state unreadable: %v", err)
+		return true, "operator pause state unreadable; check hub database health before resuming"
+	}
+	switch value {
+	case "0":
+		return false, ""
+	case "1":
+		return true, "manually paused by operator (saved across restarts)"
+	default:
+		return true, "operator pause state invalid; explicitly pause or resume after checking hub database health"
+	}
+}
+
+// Callers hold operatorRolloutMu exclusively through persistence and any
+// automatic-breaker reset. Announcements hold its read side through enqueue,
+// so a successful pause response is a barrier for new announcements. It cannot
+// cancel an update frame already queued or an agent update already in flight.
+func (s *Server) setOperatorRolloutPause(paused bool) error {
+	value := "0"
+	if paused {
+		value = "1"
+	}
+	_, err := s.db.Exec(`INSERT INTO hub_settings (key, value, updated_at)
+		VALUES (?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP`,
+		operatorRolloutPauseKey, value)
+	return err
+}

--- a/hub/rollout_pause.go
+++ b/hub/rollout_pause.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"log"
+	"time"
 )
 
 const operatorRolloutPauseKey = "agent_rollout_operator_paused"
@@ -13,7 +15,9 @@ const operatorRolloutPauseKey = "agent_rollout_operator_paused"
 // or corrupt state withholds announcements rather than silently resuming.
 func (s *Server) operatorRolloutPause() (bool, string) {
 	var value string
-	err := s.db.QueryRow(`SELECT value FROM hub_settings WHERE key = ?`, operatorRolloutPauseKey).Scan(&value)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := s.db.QueryRowContext(ctx, `SELECT value FROM hub_settings WHERE key = ?`, operatorRolloutPauseKey).Scan(&value)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, ""
 	}
@@ -40,7 +44,9 @@ func (s *Server) setOperatorRolloutPause(paused bool) error {
 	if paused {
 		value = "1"
 	}
-	_, err := s.db.Exec(`INSERT INTO hub_settings (key, value, updated_at)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := s.db.ExecContext(ctx, `INSERT INTO hub_settings (key, value, updated_at)
 		VALUES (?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP`,
 		operatorRolloutPauseKey, value)

--- a/hub/rollout_pause_test.go
+++ b/hub/rollout_pause_test.go
@@ -275,4 +275,41 @@ func TestOperatorPauseSurvivesSHAChangeAndSuppressesAnnouncements(t *testing.T) 
 	case <-time.After(time.Second):
 		t.Fatal("explicit resume did not allow announcement")
 	}
+
+	// A different socket writer must not hold Pause hostage. The announcement
+	// waiting behind it must recheck the pause before sending anything.
+	agent.WriteMu.Lock()
+	announceDone := make(chan struct{})
+	go func() { s.announceVersionToAgent("pause-regression", agent); close(announceDone) }()
+	time.Sleep(50 * time.Millisecond)
+	pauseDone := make(chan int, 1)
+	go func() {
+		r := httptest.NewRecorder()
+		c := echo.New().NewContext(httptest.NewRequest(http.MethodPost, "/", nil), r)
+		if err := s.handlePauseRollout(c); err != nil {
+			pauseDone <- 500
+			return
+		}
+		pauseDone <- r.Code
+	}()
+	select {
+	case status := <-pauseDone:
+		if status != 200 {
+			agent.WriteMu.Unlock()
+			t.Fatal(status)
+		}
+	case <-time.After(time.Second):
+		agent.WriteMu.Unlock()
+		t.Fatal("Pause waited behind an unrelated agent socket writer")
+	}
+	agent.WriteMu.Unlock()
+	select {
+	case <-announceDone:
+	case <-time.After(time.Second):
+		t.Fatal("queued announcement did not drain")
+	}
+	_ = client.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	if _, data, err := client.ReadMessage(); err == nil {
+		t.Fatalf("queued announcement escaped pause: %s", data)
+	}
 }

--- a/hub/rollout_pause_test.go
+++ b/hub/rollout_pause_test.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+)
+
+func openPauseTestServer(t *testing.T, path string) *Server {
+	t.Helper()
+	db, err := sql.Open("sqlite", databaseDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := runMigrations(db); err != nil {
+		t.Fatal(err)
+	}
+	return newServer(db)
+}
+
+func requestOperatorPause(t *testing.T, s *Server, pause bool) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRecorder()
+	c := echo.New().NewContext(httptest.NewRequest(http.MethodPost, "/", nil), r)
+	var err error
+	if pause {
+		err = s.handlePauseRollout(c)
+	} else {
+		err = s.handleResumeRollout(c)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func isolateAutomaticPause(t *testing.T) {
+	t.Helper()
+	rolloutPausedMu.Lock()
+	old, reason := rolloutPaused, rolloutPauseReason
+	rolloutPaused, rolloutPauseReason = false, ""
+	rolloutPausedMu.Unlock()
+	rolloutFailuresMu.Lock()
+	failures := append([]rolloutFailure(nil), rolloutFailures...)
+	rolloutFailures = nil
+	rolloutFailuresMu.Unlock()
+	t.Cleanup(func() {
+		rolloutPausedMu.Lock()
+		rolloutPaused, rolloutPauseReason = old, reason
+		rolloutPausedMu.Unlock()
+		rolloutFailuresMu.Lock()
+		rolloutFailures = failures
+		rolloutFailuresMu.Unlock()
+	})
+}
+
+func TestOperatorPauseSurvivesDatabaseReopen(t *testing.T) {
+	isolateAutomaticPause(t)
+	path := filepath.Join(t.TempDir(), "hub.db")
+	s := openPauseTestServer(t, path)
+	if paused, _ := s.operatorRolloutPause(); paused {
+		t.Fatal("new hub starts paused")
+	}
+	if r := requestOperatorPause(t, s, true); r.Code != 200 {
+		t.Fatal(r.Code, r.Body.String())
+	}
+	if err := s.db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	restarted := openPauseTestServer(t, path)
+	if paused, _ := restarted.operatorRolloutPause(); !paused {
+		t.Fatal("restart lost operator pause")
+	}
+	if r := requestOperatorPause(t, restarted, false); r.Code != 200 {
+		t.Fatal(r.Code, r.Body.String())
+	}
+	if err := restarted.db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	again := openPauseTestServer(t, path)
+	if paused, _ := again.operatorRolloutPause(); paused {
+		t.Fatal("explicit resume was not persisted")
+	}
+}
+
+func TestOperatorPauseWriteFailuresDoNotClaimSuccess(t *testing.T) {
+	isolateAutomaticPause(t)
+	s := openPauseTestServer(t, filepath.Join(t.TempDir(), "hub.db"))
+	if _, err := s.db.Exec(`CREATE TRIGGER reject_pause BEFORE INSERT ON hub_settings BEGIN SELECT RAISE(ABORT, 'disk failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if r := requestOperatorPause(t, s, true); r.Code != http.StatusServiceUnavailable {
+		t.Fatal(r.Code)
+	}
+	if _, err := s.db.Exec(`DROP TRIGGER reject_pause`); err != nil {
+		t.Fatal(err)
+	}
+	if r := requestOperatorPause(t, s, true); r.Code != 200 {
+		t.Fatal(r.Code)
+	}
+	if _, err := s.db.Exec(`CREATE TRIGGER reject_resume BEFORE UPDATE ON hub_settings BEGIN SELECT RAISE(ABORT, 'disk failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if r := requestOperatorPause(t, s, false); r.Code != http.StatusServiceUnavailable {
+		t.Fatal(r.Code)
+	}
+	if paused, _ := s.operatorRolloutPause(); !paused {
+		t.Fatal("failed resume cleared pause")
+	}
+}
+
+func TestOperatorPauseWaitsForAnnouncementGate(t *testing.T) {
+	s := openPauseTestServer(t, filepath.Join(t.TempDir(), "hub.db"))
+	// Model an announcement already inside the send gate. A successful pause
+	// must wait for it, then prevent subsequent readers from announcing.
+	s.operatorRolloutMu.RLock()
+	done := make(chan int, 1)
+	go func() {
+		r := httptest.NewRecorder()
+		c := echo.New().NewContext(httptest.NewRequest(http.MethodPost, "/", nil), r)
+		if err := s.handlePauseRollout(c); err != nil {
+			done <- 500
+			return
+		}
+		done <- r.Code
+	}()
+	select {
+	case <-done:
+		s.operatorRolloutMu.RUnlock()
+		t.Fatal("pause acknowledged before the active announcement gate drained")
+	case <-time.After(50 * time.Millisecond):
+	}
+	s.operatorRolloutMu.RUnlock()
+	select {
+	case status := <-done:
+		if status != 200 {
+			t.Fatal(status)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("pause did not complete after announcement gate drained")
+	}
+	if paused, _ := s.operatorRolloutPause(); !paused {
+		t.Fatal("pause was not saved before acknowledgment")
+	}
+}
+
+func TestOperatorPauseUnreadableAndCorruptFailClosed(t *testing.T) {
+	s := openPauseTestServer(t, filepath.Join(t.TempDir(), "hub.db"))
+	if _, err := s.db.Exec(`INSERT INTO hub_settings(key, value) VALUES (?, 'broken')`, operatorRolloutPauseKey); err != nil {
+		t.Fatal(err)
+	}
+	if paused, reason := s.operatorRolloutPause(); !paused || !strings.Contains(reason, "invalid") {
+		t.Fatal(paused, reason)
+	}
+	if err := s.db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if paused, reason := s.operatorRolloutPause(); !paused || !strings.Contains(reason, "unreadable") {
+		t.Fatal(paused, reason)
+	}
+	// This must return at the durable pause gate, before using an agent socket.
+	s.announceVersionToAgent("no-connection", nil)
+}
+
+func TestOperatorPauseSurvivesSHAChangeAndSuppressesAnnouncements(t *testing.T) {
+	isolateAutomaticPause(t)
+	_, s := setupTestServer(t)
+	t.Setenv("PUBLIC_URL", "https://hub.example.com")
+	s.seedTestMachine(t, "pause-regression")
+	agentRunningVersionsMu.Lock()
+	previous, existed := agentRunningVersions["pause-regression"]
+	agentRunningVersions["pause-regression"] = agentVersionInfo{MachineID: "pause-regression", OS: "linux", Arch: "amd64", RunningSHA: "older", UpdateProtocol: 1, UpdateKeyPinned: true, UpdateTransportOK: true}
+	agentRunningVersionsMu.Unlock()
+	t.Cleanup(func() {
+		agentRunningVersionsMu.Lock()
+		defer agentRunningVersionsMu.Unlock()
+		if existed {
+			agentRunningVersions["pause-regression"] = previous
+		} else {
+			delete(agentRunningVersions, "pause-regression")
+		}
+	})
+	if _, err := s.db.Exec(`UPDATE machines SET os = 'linux/amd64' WHERE id = 'pause-regression'`); err != nil {
+		t.Fatal(err)
+	}
+	binary := useGeneratedTestBinary(t, "linux")
+	recomputeBinaryFor("linux")
+	before := currentAgentBinaryState("linux").SHA
+	if r := requestOperatorPause(t, s, true); r.Code != 200 {
+		t.Fatal(r.Code)
+	}
+	rolloutPausedMu.Lock()
+	rolloutPaused, rolloutPauseReason = true, "automatic breaker"
+	rolloutPausedMu.Unlock()
+	if err := os.WriteFile(binary, []byte("changed binary fixture"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	recomputeBinaryFor("linux")
+	if currentAgentBinaryState("linux").SHA == before {
+		t.Fatal("test did not change served SHA")
+	}
+	rolloutPausedMu.RLock()
+	autoPaused := rolloutPaused
+	rolloutPausedMu.RUnlock()
+	if autoPaused {
+		t.Fatal("new build did not reset automatic breaker")
+	}
+	if paused, _ := s.operatorRolloutPause(); !paused {
+		t.Fatal("SHA change cleared operator pause")
+	}
+
+	connections := make(chan *websocket.Conn, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err == nil {
+			connections <- conn
+		}
+	}))
+	defer server.Close()
+	client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	conn := <-connections
+	defer conn.Close()
+	agent := &ConnectedAgent{Conn: conn}
+	frames := make(chan []byte, 1)
+	go func() {
+		_, data, err := client.ReadMessage()
+		if err == nil {
+			frames <- data
+		}
+	}()
+	s.announceVersionToAgent("pause-regression", agent)
+	select {
+	case data := <-frames:
+		t.Fatalf("paused hub announced: %s", data)
+	case <-time.After(50 * time.Millisecond):
+	}
+	r := httptest.NewRecorder()
+	if err := s.handleListVersions(echo.New().NewContext(httptest.NewRequest("GET", "/", nil), r)); err != nil {
+		t.Fatal(err)
+	}
+	var response struct {
+		Paused bool   `json:"rollout_paused"`
+		Reason string `json:"pause_reason"`
+	}
+	if err := json.Unmarshal(r.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if !response.Paused || !strings.Contains(response.Reason, "saved across restarts") {
+		t.Fatal(response)
+	}
+	if r := requestOperatorPause(t, s, false); r.Code != 200 {
+		t.Fatal(r.Code)
+	}
+	s.announceVersionToAgent("pause-regression", agent)
+	select {
+	case data := <-frames:
+		if !strings.Contains(string(data), "agent_version") {
+			t.Fatalf("unexpected frame: %s", data)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("explicit resume did not allow announcement")
+	}
+}

--- a/hub/server.go
+++ b/hub/server.go
@@ -20,6 +20,10 @@ type Server struct {
 	// Serializes agent authentication/registration with credential revocation.
 	agentAuthMu sync.RWMutex
 
+	// Serializes durable operator pause/resume with queuing update announcements.
+	// The persisted row is authoritative; there is no restart-sensitive cache.
+	operatorRolloutMu sync.RWMutex
+
 	// Alert evaluations are serialized; pending duration state is bounded by
 	// currently observable enabled rule/machine pairs and resets on restart.
 	alertEvalMu  sync.Mutex


### PR DESCRIPTION
Phase 4 of approved remediation. Store explicit operator pause in existing hub_settings, separate from automatic per-build failure breaker. Gate announcements with per-Server RW lock; persist before acknowledging pause/resume. Unreadable/corrupt state withholds updates. No schema migration or agent changes. Update offline-signing runbook for all three targets, exact published bytes, old-hub limitations, explicit fleet-wide activation, and no unsafe re-pause race. Validation: 5 targeted race tests (real DB reopen, write failures, corrupt/unreadable state, announcement barrier, real WebSocket suppression across SHA change and explicit resume); go vet clean; full race suite running. No live server, credentials, signing keys or fleet were touched. Claude cross-review pending; draft until reviewed and CI green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fleet-wide agent update announcement gating and rollout operator controls; mistakes could suppress or resume updates across connected agents, though behavior is fail-closed on DB errors and covered by targeted tests.
> 
> **Overview**
> **Operator rollout pause** is now stored in `hub_settings` and kept separate from the in-memory automatic failure breaker. Pause/resume APIs persist before returning success (503 if the DB write fails), `/api/versions` reflects the saved state, and unreadable or corrupt DB values **fail closed** (no version announcements). Changing the served agent binary SHA still clears only the automatic breaker—not an operator pause. Announcements consult the durable gate first, recheck under `operatorRolloutMu` after taking the agent write lock (so pause is not blocked by unrelated socket writers), and use a bounded WebSocket write deadline inside that barrier.
> 
> The **offline update signing runbook** is expanded for Linux amd64/ARM64 and Windows, preferring exact published payloads, documenting durable pause behavior (and pre–v1.2.0 limits), and warning against racing to re-pause after artifact swaps.
> 
> **CI** extends the hub race job and `go test -race` timeouts (20m test / 25m job) so the full suite can finish on hosted runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3044b8e47778d9d00df3f7ac8ba57f60bcfbf55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->