### PR TITLE
fix: show honest per-platform agent version status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,11 @@ jobs:
   hub-race:
     name: Hub Tests (race)
     runs-on: ubuntu-latest
-    # The full suite can exceed 10m on hosted runners with race-instrumented
-    # bcrypt setup. Allow headroom without disabling the hang guard. Keep Go's
+    # The full suite can exceed 15m on hosted runners with race-instrumented
+    # bcrypt setup (PR208 reached the Windows tests before the old deadline).
+    # Allow headroom without disabling the hang guard. Keep Go's
     # deadline below the job limit so failures include goroutine stacks.
-    timeout-minutes: 20
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: hub
@@ -90,7 +91,7 @@ jobs:
           cache-dependency-path: hub/go.sum
 
       - name: Run hub tests with the race detector
-        run: go test -race -count=1 -timeout=15m ./...
+        run: go test -race -count=1 -timeout=20m ./...
 
   agent:
     name: Agent Tests

--- a/dashboard/src/app/versions/page.tsx
+++ b/dashboard/src/app/versions/page.tsx
@@ -103,7 +103,7 @@ function AgentBinaryCard({
               {shortSHA(binary.sha)}
             </code>
             <span className="text-[11px] text-blox-muted">
-              checked {timeSince(binary.mtime)}
+              file modified {timeSince(binary.mtime)}
             </span>
           </div>
           <dl className="mt-3 grid gap-2 text-[11px]">

--- a/dashboard/src/app/versions/page.tsx
+++ b/dashboard/src/app/versions/page.tsx
@@ -405,7 +405,7 @@ function VersionsContent() {
                                 className="border-red-500/30 bg-red-500/10 text-red-400 text-[10px]"
                               >
                                 <AlertTriangle className="w-2.5 h-2.5 mr-1" />
-                                {agentStatusLabel(agent).label}
+                                {agentStatusLabel(agent, data).label}
                               </Badge>
                             ) : agent.update_pending ? (
                               <Badge
@@ -413,22 +413,22 @@ function VersionsContent() {
                                 className="border-amber-500/30 bg-amber-500/10 text-amber-400 text-[10px]"
                               >
                                 <Clock className="w-2.5 h-2.5 mr-1" />
-                                {agentStatusLabel(agent).label}
+                                {agentStatusLabel(agent, data).label}
                               </Badge>
                             ) : (
                               <Badge
                                 variant="outline"
                                 className={
-                                  agentStatusLabel(agent).kind === "current"
+                                  agentStatusLabel(agent, data).kind === "current"
                                     ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-[10px]"
                                     : "border-blox-border text-blox-muted text-[10px]"
                                 }
                               >
                                 {/* current-hub contract: not pending and not
                                     blocked already means running == offered;
-                                    we only refuse the green label when the
-                                    running SHA is missing (older/malformed) */}
-                                {agentStatusLabel(agent).label}
+                                    older hubs lack this guarantee, so show
+                                    unknown rather than infer a match. */}
+                                {agentStatusLabel(agent, data).label}
                               </Badge>
                             )}
                           </TableCell>

--- a/dashboard/src/app/versions/page.tsx
+++ b/dashboard/src/app/versions/page.tsx
@@ -17,6 +17,13 @@ import {
   ShieldCheck,
 } from "lucide-react";
 import { AgentBinaryInfo, useVersions } from "@/contexts/VersionsContext";
+import {
+  agentProtocolNote,
+  agentStatusLabel,
+  binaryReleaseLabel,
+  binaryStateLabel,
+  buildBinaryCards,
+} from "@/lib/versions-honesty.mjs";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import {
@@ -57,7 +64,12 @@ function AgentBinaryCard({
   testId: string;
   binary: AgentBinaryInfo;
 }) {
-  const available = Boolean(binary.sha) && !binary.error;
+  // Available means only that the hub resolved bytes on a validated path.
+  // Signing is a separate, hub-wide property shown by the signing banner;
+  // a resolved path alone never earns a "trusted" label.
+  const state = binaryStateLabel(binary);
+  const available = state.available;
+  const releaseLabel = binaryReleaseLabel(binary, Boolean(binary && "release" in binary));
 
   return (
     <div
@@ -81,7 +93,7 @@ function AgentBinaryCard({
               : "border-red-500/30 bg-red-500/10 text-red-400 text-[10px]"
           }
         >
-          {available ? "Trusted" : "Unavailable"}
+          {state.label}
         </Badge>
       </div>
       {available ? (
@@ -96,6 +108,10 @@ function AgentBinaryCard({
           </div>
           <dl className="mt-3 grid gap-2 text-[11px]">
             <div>
+              <dt className="text-blox-muted">Release</dt>
+              <dd className="text-blox-text">{releaseLabel}</dd>
+            </div>
+            <div>
               <dt className="text-blox-muted">Source</dt>
               <dd className="text-blox-text font-mono break-all">{binary.source}</dd>
             </div>
@@ -107,7 +123,7 @@ function AgentBinaryCard({
         </>
       ) : (
         <p className="text-xs text-red-300 mt-3 break-words">
-          {binary.error || "No trusted binary resolved for this platform."}
+          {state.detail}
         </p>
       )}
     </div>
@@ -122,51 +138,13 @@ function VersionsContent() {
   const { data, loading, error, refresh, pauseRollout, resumeRollout } = useVersions();
   const { hasScope } = useAuth();
   const canManageRollout = hasScope("fleet.admin");
-  const binaries = data
-    ? data.agent_binaries ?? {
-        linux: {
-          path: "",
-          source: "legacy API",
-          sha: data.hub_sha,
-          mtime: data.hub_mtime,
-          error: "Resolver details require an updated hub.",
-        },
-        windows: {
-          path: "",
-          source: "legacy API",
-          sha: data.hub_windows_sha,
-          mtime: data.hub_windows_mtime,
-          error: "Resolver details require an updated hub.",
-        },
-      }
-    : null;
 
   // Per-architecture cards from a per-arch hub (clear CPU labels); legacy
   // two-card fallback for older hubs, whose "Linux" binary is whatever the
   // hub serves without an arch key — its CPU is not reported, so the card
   // stays unlabeled. A platform the hub has no binary for still renders a
   // card — its error names the missing build.
-  const binaryCards: { key: string; label: string; binary: AgentBinaryInfo }[] = [];
-  if (data) {
-    if (data.agent_binaries_by_arch) {
-      const byArch = data.agent_binaries_by_arch;
-      const linuxArches: [string, string][] = [
-        ["amd64", "Linux · x86-64"],
-        ["arm64", "Linux · ARM64"],
-      ];
-      for (const [arch, label] of linuxArches) {
-        const binary = byArch.linux?.[arch];
-        if (binary) binaryCards.push({ key: `linux-${arch}`, label, binary });
-      }
-      const windows = byArch.windows?.amd64;
-      if (windows) binaryCards.push({ key: "windows-amd64", label: "Windows · x86-64", binary: windows });
-    } else if (binaries) {
-      binaryCards.push(
-        { key: "linux", label: "Linux", binary: binaries.linux },
-        { key: "windows", label: "Windows", binary: binaries.windows }
-      );
-    }
-  }
+  const binaryCards = buildBinaryCards(data);
 
   useEffect(() => {
     refresh();
@@ -222,7 +200,8 @@ function VersionsContent() {
           <p className="text-[12px] text-blox-muted mt-1.5">
             Auto-update status and version visibility across the fleet.
             Protocol-v1 agents verify signed updates against their pinned key.
-            Windows revalidates the staged binary&apos;s SHA and signature on service restart, but still requires manual rollback.
+            Protocol-v2 agents also enforce a signed release floor against downgrades;
+            protocol-v1 agents do not. Windows revalidates the staged binary&apos;s SHA and signature on service restart, but still requires manual rollback.
           </p>
         </div>
       </section>
@@ -426,7 +405,7 @@ function VersionsContent() {
                                 className="border-red-500/30 bg-red-500/10 text-red-400 text-[10px]"
                               >
                                 <AlertTriangle className="w-2.5 h-2.5 mr-1" />
-                                {agent.update_pending ? "Withheld" : "Unavailable"}
+                                {agentStatusLabel(agent).label}
                               </Badge>
                             ) : agent.update_pending ? (
                               <Badge
@@ -434,15 +413,22 @@ function VersionsContent() {
                                 className="border-amber-500/30 bg-amber-500/10 text-amber-400 text-[10px]"
                               >
                                 <Clock className="w-2.5 h-2.5 mr-1" />
-                                Update pending
+                                {agentStatusLabel(agent).label}
                               </Badge>
                             ) : (
                               <Badge
                                 variant="outline"
-                                className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-[10px]"
+                                className={
+                                  agentStatusLabel(agent).kind === "current"
+                                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-[10px]"
+                                    : "border-blox-border text-blox-muted text-[10px]"
+                                }
                               >
-                                <CheckCircle2 className="w-2.5 h-2.5 mr-1" />
-                                Up to date
+                                {/* current-hub contract: not pending and not
+                                    blocked already means running == offered;
+                                    we only refuse the green label when the
+                                    running SHA is missing (older/malformed) */}
+                                {agentStatusLabel(agent).label}
                               </Badge>
                             )}
                           </TableCell>
@@ -470,6 +456,11 @@ function VersionsContent() {
                                 <AlertTriangle className="w-2.5 h-2.5 mr-1" />
                                 Missing
                               </Badge>
+                            )}
+                            {agentProtocolNote(agent) && (
+                              <div className="text-[10px] text-blox-muted mt-1">
+                                {agentProtocolNote(agent)}
+                              </div>
                             )}
                           </TableCell>
                           <TableCell

--- a/dashboard/src/contexts/VersionsContext.tsx
+++ b/dashboard/src/contexts/VersionsContext.tsx
@@ -35,6 +35,10 @@ export interface AgentBinaryInfo {
   sha: string;
   mtime: string;
   error: string;
+  /** Release number embedded in the binary's marker; 0 = legacy/unnumbered.
+   *  Older hubs omit the field entirely (unknown — not legacy). Presence of
+   *  the marker is not proof the bytes are signed or verified. */
+  release?: number;
 }
 
 export interface VersionsResponse {

--- a/dashboard/src/lib/versions-honesty.mjs
+++ b/dashboard/src/lib/versions-honesty.mjs
@@ -63,14 +63,16 @@ export function buildBinaryCards(data) {
 // agentStatusLabel: with a current hub, no-blocker + no-pending already
 // implies running SHA == offered SHA (handleListVersions computes
 // update_pending = expected != "" && running_sha != expected). The label only
-// refuses a green match when running_sha is absent (older/malformed
-// response). Never a claim about the newest release anywhere.
-export function agentStatusLabel(agent) {
+// refuses a green match when running_sha is absent or the hub predates
+// per-architecture availability/blocker reporting. Older hubs can report
+// no pending update even when no build is offered. Never infer a match then.
+export function agentStatusLabel(agent, data) {
   if (agent.update_blocked_reason) {
     return { kind: "blocked", label: agent.update_pending ? "Withheld" : "Unavailable" };
   }
   if (agent.update_pending) return { kind: "pending", label: "Update pending" };
   if (!agent.running_sha) return { kind: "unknown", label: "Version unknown" };
+  if (!data?.agent_binaries_by_arch) return { kind: "unknown", label: "Status unknown (older hub)" };
   return { kind: "current", label: "Matches offered build" };
 }
 

--- a/dashboard/src/lib/versions-honesty.mjs
+++ b/dashboard/src/lib/versions-honesty.mjs
@@ -1,0 +1,85 @@
+// Versions page honesty helpers. Everything here is a pure mapping from the
+// hub's existing /api/versions fields to truthful labels. Availability is not
+// trust: a resolved binary only proves the hub found bytes on a validated
+// path; signing is a separate, global property shown by its own banner.
+
+// binaryReleaseLabel: release > 0 is a numbered release; an explicit 0 from
+// the hub means legacy/unnumbered bytes; a missing field (older hub) is
+// unknown — never guess "legacy" for it.
+export function binaryReleaseLabel(binary, releaseFieldPresent) {
+  if (!releaseFieldPresent) return "Release unknown (older hub)";
+  if (!binary || binary.release == null) return "Release unknown (older hub)";
+  if (binary.release > 0) return `Release ${binary.release}`;
+  return "Legacy (unnumbered)";
+}
+
+// binaryStateLabel: availability only — never "trusted". Safe on a missing
+// platform entry (undefined binary from an absent legacy platform).
+export function binaryStateLabel(binary) {
+  const available = Boolean(binary && binary.sha) && !binary?.error;
+  return {
+    available,
+    label: available ? "Available" : "Unavailable",
+    detail: available ? null : binary?.error || "No binary resolved for this platform.",
+  };
+}
+
+// buildBinaryCards returns one card per platform the hub tracks. A platform
+// the hub has no binary for still gets a card that says so — a missing
+// Linux ARM64 build must be visible, not silently absent. Older hubs without
+// agent_binaries_by_arch fall back to the two unlabeled legacy states.
+export function buildBinaryCards(data) {
+  if (!data) return [];
+  if (data.agent_binaries_by_arch) {
+    const byArch = data.agent_binaries_by_arch;
+    const cards = [];
+    for (const [arch, label] of [["amd64", "Linux · x86-64"], ["arm64", "Linux · ARM64"]]) {
+      const binary = byArch.linux?.[arch] ?? { path: "", source: "", sha: "", mtime: "", error: `No ${arch} agent binary is served by this hub.` };
+      cards.push({ key: `linux-${arch}`, label, binary });
+    }
+    const win = byArch.windows?.amd64 ?? { path: "", source: "", sha: "", mtime: "", error: "No Windows amd64 agent binary is served by this hub." };
+    cards.push({ key: "windows-amd64", label: "Windows · x86-64", binary: win });
+    return cards;
+  }
+  if (!data.agent_binaries) {
+    // Oldest hubs expose only the legacy hub_sha/hub_windows_sha fields;
+    // surface those as unlabeled cards instead of an empty grid.
+    if (!data.hub_sha && !data.hub_windows_sha) return [];
+    const legacyNote = "Resolver details require an updated hub.";
+    return [
+      { key: "linux", label: "Linux", binary: { path: "", source: "legacy API", sha: data.hub_sha ?? "", mtime: data.hub_mtime ?? "", error: legacyNote } },
+      { key: "windows", label: "Windows", binary: { path: "", source: "legacy API", sha: data.hub_windows_sha ?? "", mtime: data.hub_windows_mtime ?? "", error: legacyNote } },
+    ];
+  }
+  // A platform absent from the legacy map still gets a placeholder card —
+  // downstream labels never dereference an undefined binary.
+  const missing = (platform) => ({ path: "", source: "", sha: "", mtime: "", error: `No ${platform} binary is served by this hub.` });
+  return [
+    { key: "linux", label: "Linux", binary: data.agent_binaries.linux ?? missing("Linux") },
+    { key: "windows", label: "Windows", binary: data.agent_binaries.windows ?? missing("Windows") },
+  ];
+}
+
+// agentStatusLabel: with a current hub, no-blocker + no-pending already
+// implies running SHA == offered SHA (handleListVersions computes
+// update_pending = expected != "" && running_sha != expected). The label only
+// refuses a green match when running_sha is absent (older/malformed
+// response). Never a claim about the newest release anywhere.
+export function agentStatusLabel(agent) {
+  if (agent.update_blocked_reason) {
+    return { kind: "blocked", label: agent.update_pending ? "Withheld" : "Unavailable" };
+  }
+  if (agent.update_pending) return { kind: "pending", label: "Update pending" };
+  if (!agent.running_sha) return { kind: "unknown", label: "Version unknown" };
+  return { kind: "current", label: "Matches offered build" };
+}
+
+// agentProtocolNote: protocol-1 agents verify signatures but do not enforce
+// the protocol-2 release floor, so a signed older build is not rejected by
+// them. An absent field (older hub) is unknown, not protocol 0.
+export function agentProtocolNote(agent) {
+  if (agent.update_protocol == null) return "Protocol unknown (older hub)";
+  if (agent.update_protocol >= 2) return null;
+  if (agent.update_protocol === 1) return "No rollback floor (protocol 1)";
+  return "Pre-signature agent (no update verification)";
+}

--- a/dashboard/src/lib/versions-honesty.test.mjs
+++ b/dashboard/src/lib/versions-honesty.test.mjs
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  binaryReleaseLabel,
+  binaryStateLabel,
+  buildBinaryCards,
+  agentStatusLabel,
+  agentProtocolNote,
+} from "./versions-honesty.mjs";
+
+test("release labels: numbered, explicit-legacy, and unknown are distinct", () => {
+  assert.equal(binaryReleaseLabel({ release: 5, sha: "abc" }, true), "Release 5");
+  assert.equal(binaryReleaseLabel({ release: 0, sha: "abc" }, true), "Legacy (unnumbered)");
+  // Older hubs omit the field entirely: unknown, not legacy.
+  assert.equal(binaryReleaseLabel({ sha: "abc" }, false), "Release unknown (older hub)");
+  assert.equal(binaryReleaseLabel({ sha: "abc" }, true), "Release unknown (older hub)");
+});
+
+test("availability never claims trust", () => {
+  const ok = binaryStateLabel({ sha: "abc", error: "" });
+  assert.equal(ok.available, true);
+  assert.equal(ok.label, "Available");
+  assert.doesNotMatch(ok.label, /trusted/i);
+  const bad = binaryStateLabel({ sha: "", error: "no binary for arch" });
+  assert.equal(bad.available, false);
+  assert.equal(bad.label, "Unavailable");
+  assert.equal(bad.detail, "no binary for arch");
+});
+
+test("per-arch cards always include Linux ARM64, even when unserved", () => {
+  const data = {
+    agent_binaries_by_arch: {
+      linux: { amd64: { sha: "aaa", mtime: "2026-09-08T00:00:00Z", release: 5 } },
+      windows: { amd64: { sha: "bbb", mtime: "2026-09-08T00:00:00Z", release: 5 } },
+    },
+  };
+  const cards = buildBinaryCards(data);
+  assert.equal(cards.length, 3);
+  const arm = cards.find((c) => c.key === "linux-arm64");
+  assert.equal(arm.label, "Linux · ARM64");
+  assert.equal(binaryStateLabel(arm.binary).available, false);
+  assert.match(arm.binary.error, /arm64/);
+});
+
+test("legacy hubs keep the two unlabeled cards", () => {
+  const data = { agent_binaries: { linux: { sha: "aaa" }, windows: { sha: "bbb" } } };
+  const cards = buildBinaryCards(data);
+  assert.deepEqual(cards.map((c) => c.key), ["linux", "windows"]);
+});
+
+test("oldest hubs with only hub_sha fields still render legacy cards", () => {
+  const cards = buildBinaryCards({ hub_sha: "aaa", hub_windows_sha: "bbb" });
+  assert.deepEqual(cards.map((c) => c.key), ["linux", "windows"]);
+  assert.equal(cards[0].binary.source, "legacy API");
+  assert.equal(buildBinaryCards({}).length, 0);
+});
+
+test("agent status is offered-build truth, not 'latest'", () => {
+  assert.equal(agentStatusLabel({ update_pending: true }).label, "Update pending");
+  assert.equal(agentStatusLabel({ update_pending: true, update_blocked_reason: "x" }).label, "Withheld");
+  assert.equal(agentStatusLabel({ update_pending: false, update_blocked_reason: "x" }).label, "Unavailable");
+  // Current-hub contract: not pending and not blocked implies the match.
+  assert.equal(agentStatusLabel({ update_pending: false, running_sha: "aaa" }).label, "Matches offered build");
+  // Older/malformed responses without a running SHA must not go green.
+  assert.equal(agentStatusLabel({ update_pending: false, running_sha: "" }).label, "Version unknown");
+  assert.equal(agentStatusLabel({ update_pending: false }).label, "Version unknown");
+});
+
+test("missing platform entries never throw", () => {
+  assert.equal(binaryStateLabel(undefined).available, false);
+  assert.equal(binaryStateLabel(null).label, "Unavailable");
+  const cards = buildBinaryCards({ agent_binaries: { linux: { sha: "aaa" } } });
+  assert.equal(cards.length, 2);
+  assert.equal(binaryStateLabel(cards[1].binary).available, false); // windows absent
+});
+
+test("protocol notes flag the rollback-floor limitation honestly", () => {
+  assert.equal(agentProtocolNote({ update_protocol: 2 }), null);
+  assert.equal(agentProtocolNote({ update_protocol: 1 }), "No rollback floor (protocol 1)");
+  assert.equal(agentProtocolNote({ update_protocol: 0 }), "Pre-signature agent (no update verification)");
+  // Field absent on older hubs: unknown, not protocol 0.
+  assert.equal(agentProtocolNote({}), "Protocol unknown (older hub)");
+});

--- a/dashboard/src/lib/versions-honesty.test.mjs
+++ b/dashboard/src/lib/versions-honesty.test.mjs
@@ -60,10 +60,18 @@ test("agent status is offered-build truth, not 'latest'", () => {
   assert.equal(agentStatusLabel({ update_pending: true, update_blocked_reason: "x" }).label, "Withheld");
   assert.equal(agentStatusLabel({ update_pending: false, update_blocked_reason: "x" }).label, "Unavailable");
   // Current-hub contract: not pending and not blocked implies the match.
-  assert.equal(agentStatusLabel({ update_pending: false, running_sha: "aaa" }).label, "Matches offered build");
+  assert.equal(agentStatusLabel({ update_pending: false, running_sha: "aaa" }, { agent_binaries_by_arch: { linux: { amd64: { sha: "aaa" } } } }).label, "Matches offered build");
   // Older/malformed responses without a running SHA must not go green.
   assert.equal(agentStatusLabel({ update_pending: false, running_sha: "" }).label, "Version unknown");
   assert.equal(agentStatusLabel({ update_pending: false }).label, "Version unknown");
+});
+
+test("older hubs never infer a match from no pending update", () => {
+  const agent = { os: "linux", running_sha: "aaa", update_pending: false };
+  for (const data of [undefined, {}, { hub_sha: "" }, { agent_binaries: { linux: { sha: "" } } }, { hub_sha: "aaa" }]) {
+    assert.equal(agentStatusLabel(agent, data).kind, "unknown");
+    assert.equal(agentStatusLabel(agent, data).label, "Status unknown (older hub)");
+  }
 });
 
 test("missing platform entries never throw", () => {

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Start with the [project overview](../README.md) or choose the task you need.
 | Back up or restore your hub and its identity | [Backup and restore](backup-restore.md) |
 | Configure the hub and agents | [Configuration reference](configuration.md) and [environment template](../.env.example) |
 | Diagnose a refused agent update or recover an agent | [Agent update recovery](agent-update-recovery.md) |
+| Read the Versions page labels (served builds, rollout states) | [Agent versions and rollout](versions.md) |
 | Operate without a hub-held signing key | [Offline update signing](offline-update-signing.md) |
 
 ## Explore the app

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -19,6 +19,8 @@ legacy SHAs).
   older hub that does not report the field is shown as unknown, not legacy.
 - A platform with no binary (e.g. no Linux ARM64 build) still renders a card
   naming the gap instead of disappearing silently.
+- **File modified** is the served file's modification time, not a build date
+  or the time the hub last checked it.
 
 ## Per-agent status
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,0 +1,46 @@
+# Agent versions and rollout
+
+The Versions page (`/versions`) reports what the hub serves and what agents
+report. Labels are deliberately literal; this is what each one means.
+
+## Served agent binaries
+
+One card per platform the hub tracks (Linux x86-64, Linux ARM64, Windows
+x86-64; older hubs show two unlabeled cards, and the oldest show only the
+legacy SHAs).
+
+- **Available / Unavailable** — the hub resolved bytes on a validated path.
+  Available is not a trust claim: whether updates are *signed* is a separate,
+  hub-wide property shown in the "Update signing" banner above the cards.
+- **Release N / Legacy (unnumbered) / Release unknown (older hub)** — the
+  release number marker embedded in the served binary (a marker's presence is
+  not proof the bytes are signed or verified — that is what the signing banner
+  and the agent's own verification cover). `0` means pre-numbering bytes; an
+  older hub that does not report the field is shown as unknown, not legacy.
+- A platform with no binary (e.g. no Linux ARM64 build) still renders a card
+  naming the gap instead of disappearing silently.
+
+## Per-agent status
+
+- **Matches offered build** — the agent's reported SHA equals what the hub
+  currently offers for its platform. It does not mean the newest release in
+  existence is running; only the hub's current offer is the reference.
+- **Version unknown** — the hub has no reported running SHA for this agent
+  (older hub response or no report yet), so no match is claimed.
+- **Update pending** — the offered SHA differs and nothing blocks the update.
+- **Withheld / Unavailable** — the hub refuses to announce (see the blocked
+  reason: missing pinned key, unreadable release floor, transport policy,
+  or no binary for the platform).
+- **Key pinned** — the agent reported a usable pinned update key.
+  Protocol-2 agents additionally enforce a signed release floor against
+  downgrades; the note **"No rollback floor (protocol 1)"** marks agents that
+  verify signatures but do not enforce the floor, and pre-signature agents
+  (protocol 0) verify nothing.
+
+## Rollout control
+
+Pause halts update announcements fleet-wide; the automatic circuit breaker
+can also pause after repeated rollout failures. See
+[update recovery](agent-update-recovery.md) for the failure/rollback paths and
+[offline update signing](offline-update-signing.md) for detached-signature
+operation.


### PR DESCRIPTION
Phase 3 of approved remediation. Use existing per-architecture release metadata; show Release N, Legacy (unnumbered), or unknown for older hubs. Missing ARM64/legacy platform entries stay visible without crashing. Available is not claimed as trusted. Matches offered build replaces Up to date; unknown running SHA stays unknown; protocol-1 rollback-floor limitation is visible. File timestamp is accurately labeled modification time. No new backend inventory or dependencies. Kimi implemented; Codex reviewed and corrected edge cases. Validation: 93/93 dashboard tests, lint zero errors (3 pre-existing warnings), production build/typecheck; isolated Playwright desktop/mobile fixtures for numbered+legacy, old hub missing platform, withheld update, pause/resume/reload and viewer controls, no runtime errors or page-wide overflow. No real hub APIs were used. No deployment or fleet changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard copy and pure mapping helpers only—no hub API or rollout behavior changes. CI change only adds runner headroom for race tests.
> 
> **Overview**
> The **Versions** page stops overstating what the hub knows: served binaries use **Available** (not **Trusted**), show **Release** metadata when present, and always render per-platform cards—including explicit **Unavailable** placeholders when a build (e.g. Linux ARM64) is not served. Fleet agent status drops **Up to date** for **Matches offered build** only when the hub contract supports it; missing `running_sha` or older hubs get **unknown** labels instead of a green match. Protocol-1 agents get an inline note that they lack the protocol-2 rollback floor.
> 
> Label logic moves into shared `versions-honesty.mjs` with node tests; `AgentBinaryInfo` documents optional `release`. **docs/versions.md** explains the vocabulary and is linked from the docs index.
> 
> **CI** extends the hub race job: job timeout **20→25** minutes and `go test -race` **15m→20m** so the full suite can finish after recent growth (e.g. Windows tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd891e21059440ee000fe3173f8bbd93eff2e83e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->