### PR TITLE
fix: distinguish public TLS from ambient bootstrap CAs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,8 +13,8 @@ the public URL and CA paths from its deployment configuration.
 | `HUB_LISTEN` | No | Hub listen address; defaults to `127.0.0.1:4000`. |
 | `BLOXOS_JWT_SECRET` | No | JWT secret, at least 32 bytes; otherwise generated and persisted. |
 | `BLOXOS_SETUP_TOKEN` | No | Fixed first-boot setup token; otherwise generated and persisted. |
-| `BLOXOS_CA_CERT` | No | Additional CA certificate used by installers and agents. |
-| `BLOXOS_PIN_DIAL_ADDR` | No | Internal TLS destination used to verify onboarding pins; Compose sets `caddy:443`. Does not change the verified public identity. |
+| `BLOXOS_CA_CERT` | No | Private-CA certificate the hub pins onboarding commands to. Leave **unset** for a publicly trusted (Let's Encrypt, etc.) hub. If set, it is authoritative: a missing, unreadable, or non-PEM file makes the hub refuse to mint install commands rather than fall back. See [TLS trust for onboarding](#tls-trust-for-onboarding). |
+| `BLOXOS_PIN_DIAL_ADDR` | No | Internal TLS destination used to verify onboarding pins; Compose sets `caddy:443`. Changes only the TCP target — SNI, hostname, and certificate verification still use `PUBLIC_URL`, so it can never downgrade trust. |
 | `BLOXOS_AI_SESSIONS` | Agent | Set to `0` to disable AI-tool metadata collection on that machine. |
 | `BLOXOS_AGENT_BINARY` | No | Absolute Linux **amd64** agent binary; blank uses the built-in defaults (`/usr/local/lib/bloxos/linux/amd64/bloxos-agent`, then the legacy `/usr/local/lib/bloxos/linux/bloxos-agent`, then a hub sibling). Served only for the architecture its ELF actually is. |
 | `BLOXOS_AGENT_BINARY_ARM64` | No | Absolute Linux arm64 agent binary; blank uses `/usr/local/lib/bloxos/linux/arm64/bloxos-agent`. ELF-verified like all Linux paths, so no request is served another CPU's binary. |
@@ -32,6 +32,31 @@ the public URL and CA paths from its deployment configuration.
 | `BLOXOS_TLS_INSECURE` | Development only | TLS bypass available only in an agent built with `-tags insecure`. |
 | `ProgramFiles` | Windows-provided | Used to discover NVIDIA tooling; normally never overridden. |
 | `NEXT_PUBLIC_HUB_URL` | Dashboard | Hub origin when dashboard and hub are not same-origin. |
+
+## TLS trust for onboarding
+
+When you generate an Add Machine (or Windows re-enrollment) command, the hub
+decides how that command should authenticate its download. Normal installations
+need no configuration here:
+
+- **Publicly trusted HTTPS** (Let's Encrypt and the like): leave `BLOXOS_CA_CERT`
+  unset. The command is plain verified TLS — no pinning, no `-k`.
+- **Private CA** (Caddy's internal CA in the Compose stack): the hub still
+  auto-discovers Caddy's local root on the usual paths, verifies the live
+  certificate against it, and pins the verified key in the command. This keeps
+  working with no extra steps.
+
+Only set `BLOXOS_CA_CERT` when you run your own private CA outside that
+auto-discovery. When set it is **authoritative**: if the file is missing,
+unreadable, or not a PEM certificate, or the hub's certificate does not verify
+against it, the hub refuses to mint a command (an actionable error) instead of
+emitting an unverifiable one — fix the path or the certificate and retry.
+
+An unrelated CA left on disk no longer turns a public hub "private": the hub
+checks its live certificate against your OS trust store and, if that verifies,
+treats the hub as public. If the hub cannot reach `PUBLIC_URL` over TLS at all,
+it refuses to mint rather than guess — this is a connectivity problem to fix,
+not a trust decision.
 
 For specialized power-history and update-floor settings, see
 [power history](power-history.md) and [agent recovery](agent-update-recovery.md).

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -165,18 +165,15 @@ func (s *Server) handleCreateToken(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
-	caURL, caSHA256 := s.bootstrapCAFor(httpBase)
-	joinPin := ""
-	if caSHA256 != "" {
-		joinPin, err = s.joinPinForPrivateCA(c.Request().Context(), publicURL)
-		if err != nil {
-			log.Printf("token_create: refusing to mint, cannot pin the hub's TLS key for the join command: %v", err)
-			return c.JSON(http.StatusServiceUnavailable, map[string]string{
-				"error": "cannot generate an install command: " + err.Error() +
-					". The hub must be able to reach PUBLIC_URL over TLS with a certificate issued by BLOXOS_CA_CERT.",
-			})
-		}
+	decision, err := s.classifyBootstrapCA(c.Request().Context(), httpBase, publicURL)
+	if err != nil {
+		log.Printf("token_create: refusing to mint, cannot classify PUBLIC_URL's TLS trust: %v", err)
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{
+			"error": "cannot generate an install command: " + err.Error() +
+				". The hub must reach PUBLIC_URL over TLS and present a certificate that verifies against BLOXOS_CA_CERT (private CA) or the system trust store (public).",
+		})
 	}
+	caURL, caSHA256, joinPin := decision.caURL, decision.caSHA256, decision.joinPin
 
 	token := uuid.New().String()
 	h := sha256.Sum256([]byte(token))
@@ -254,6 +251,24 @@ func (s *Server) handleWindowsReenrollment(c echo.Context) error {
 		})
 	}
 
+	// Resolve and validate the hub's TLS trust BEFORE staging any replacement
+	// enrollment state: a classification failure must return 503 without
+	// leaving an orphaned token row behind (same fail-closed ordering as
+	// handleCreateToken).
+	httpBase, wsBase := publicAndWebsocketBase()
+	publicURL, err := parsePublicURL(httpBase)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+	decision, err := s.classifyBootstrapCA(c.Request().Context(), httpBase, publicURL)
+	if err != nil {
+		log.Printf("windows_reenroll: refusing to mint, cannot classify PUBLIC_URL's TLS trust: %v", err)
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{
+			"error": "cannot generate a re-enrollment command: " + err.Error() +
+				". The hub must reach PUBLIC_URL over TLS and present a certificate that verifies against BLOXOS_CA_CERT (private CA) or the system trust store (public).",
+		})
+	}
+
 	token := uuid.New().String()
 	h := sha256.Sum256([]byte(token))
 	tokenHash := hex.EncodeToString(h[:])
@@ -266,14 +281,12 @@ func (s *Server) handleWindowsReenrollment(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 
-	httpBase, wsBase := publicAndWebsocketBase()
-	caURL, caSHA256 := s.bootstrapCAFor(httpBase)
 	return c.JSON(http.StatusOK, windowsReenrollmentResponse{
 		MachineID:      machineID,
 		Token:          token,
-		WindowsCommand: buildWindowsInstallCommand(httpBase, wsBase, token, caURL, caSHA256, true),
-		CAURL:          caURL,
-		CASHA256:       caSHA256,
+		WindowsCommand: buildWindowsInstallCommand(httpBase, wsBase, token, decision.caURL, decision.caSHA256, true),
+		CAURL:          decision.caURL,
+		CASHA256:       decision.caSHA256,
 		ExpiresAt:      expiresAt.Format(time.RFC3339),
 	})
 }
@@ -612,37 +625,6 @@ func (s *Server) caCertCandidatePaths() []string {
 	return bootstrapCACertCandidates()
 }
 
-func (s *Server) loadBootstrapCACert() ([]byte, string, error) {
-	for _, path := range s.caCertCandidatePaths() {
-		if path == "" {
-			continue
-		}
-		data, err := os.ReadFile(path)
-		if err == nil {
-			return data, path, nil
-		}
-		if os.IsNotExist(err) {
-			continue
-		}
-		return nil, "", fmt.Errorf("read CA cert %s: %w", path, err)
-	}
-	return nil, "", os.ErrNotExist
-}
-
-func (s *Server) bootstrapCAFor(httpBase string) (caURL string, caSHA256 string) {
-	if strings.HasPrefix(httpBase, "https://") {
-		if caPEM, caPath, err := s.loadBootstrapCACert(); err == nil {
-			caURL = httpBase + "/download/ca.crt"
-			sum := sha256.Sum256(caPEM)
-			caSHA256 = hex.EncodeToString(sum[:])
-			log.Printf("install bootstrap: using CA cert %s", caPath)
-		} else if !os.IsNotExist(err) {
-			log.Printf("WARNING: install bootstrap CA unavailable: %v", err)
-		}
-	}
-	return caURL, caSHA256
-}
-
 func handleDownloadAgent(c echo.Context) error {
 	// The target OS is detected from either the explicit ?os= query parameter
 	// or the User-Agent string. The architecture comes from ?arch= (GOARCH
@@ -691,12 +673,18 @@ func handleDownloadAgent(c echo.Context) error {
 }
 
 func (s *Server) handleDownloadCACert(c echo.Context) error {
-	caPEM, _, err := s.loadBootstrapCACert()
+	// Serve exactly the CA that classification selected and bound at mint time
+	// (same source-selection and explicit-authoritative rules), so a private
+	// join command's pinned CA_SHA256 always matches these bytes. Using the
+	// looser legacy loader here could serve a different first-readable file
+	// (e.g. a malformed ambient candidate that classification skipped).
+	caPEM, _, source, err := s.loadBootstrapCAClassified()
 	if err != nil {
-		if os.IsNotExist(err) {
-			return c.JSON(http.StatusNotFound, map[string]string{"error": "CA certificate not configured; set BLOXOS_CA_CERT"})
-		}
+		// An explicitly-configured CA that is unreadable/malformed.
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	if source == caSourceNone {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "CA certificate not configured; set BLOXOS_CA_CERT"})
 	}
 	return c.Blob(http.StatusOK, "application/x-pem-file", caPEM)
 }

--- a/hub/ca_isolation_test.go
+++ b/hub/ca_isolation_test.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"errors"
+	"fmt"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -12,6 +16,13 @@ import (
 	"testing"
 	"time"
 )
+
+// failingSystemTrustProbe is the default system-trust verifier setupTestServer
+// installs, so a test never silently dials the network during the
+// auto-discovered-CA fallback. Tests that exercise the fallback replace it.
+func failingSystemTrustProbe(context.Context, *url.URL) error {
+	return errors.New("system-trust probe not configured for this test")
+}
 
 // isolatedCACandidates is the bootstrap-CA search path setupTestServer installs
 // on every test server. It honors an explicitly-set BLOXOS_CA_CERT — the many
@@ -31,60 +42,124 @@ func isolatedCACandidates() []string {
 
 // injectAmbientCACandidate makes s behave as if the host had an auto-discovered
 // Caddy root on disk (e.g. ~/.local/share/caddy/.../root.crt) — the exact
-// production condition that mis-classifies a public hub. It writes a temp cert
-// and points s.caCertCandidates at it *without* setting BLOXOS_CA_CERT, so the
-// candidate is ambient (auto-discovered), not operator-configured. The resolver
-// is stubbed in setupTestServer, so the cert bytes need not be a real chain.
-// Returns the candidate path.
+// production condition that used to mis-classify a public hub. It writes a
+// real, parseable CA certificate and points s.caCertCandidates at it *without*
+// setting BLOXOS_CA_CERT, so the candidate is ambient (auto-discovered), not
+// operator-configured, and classification actually parses it. Returns the path.
 func injectAmbientCACandidate(t *testing.T, s *Server) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "ambient-caddy-root.crt")
-	if err := os.WriteFile(path, []byte("ambient-host-caddy-root"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(generateTestCertPEM(t)), 0o600); err != nil {
 		t.Fatalf("write ambient CA: %v", err)
 	}
 	s.caCertCandidates = func() []string { return []string{path} }
 	return path
 }
 
-// TestAmbientCACandidateMisclassifiesPublicHub reproduces the reported failure
-// deterministically. A genuinely public HTTPS hub (HTTPS PUBLIC_URL, no
-// operator BLOXOS_CA_CERT) is classified public with the default isolation; the
-// only change that flips it to a private-CA mint is an ambient, auto-discovered
-// Caddy root leaking in from the host. This is the shared root cause of the
-// three reported failures:
-//   - TestPublicTrustedHTTPSAndHTTPCommandsDoNotFetchLocalCA (public mint gains
-//     CA material), which set BLOXOS_CA_CERT to a missing path but could not
-//     defeat the ambient host paths;
-//   - the "publicly trusted https is plain verified TLS" join case (the pin
-//     resolver runs and the command gains -k --pinnedpubkey); and
-//   - TestJoinRejectsMissingBinding, where the drift check finds the ambient
-//     CA so its empty-string ("empty-ca-ok") binding no longer matches and the
-//     code 404s instead of serving.
-// The seam also keeps other public-hub tests deterministic
-// (e.g. TestJoinRebuildByteEquivalenceAcrossTransports).
+// TestAmbientCACandidateDoesNotMakeAPublicHubPrivate asserts the FIX. A
+// genuinely public HTTPS hub with an unrelated, auto-discovered Caddy root on
+// disk (the reported production condition) must still be classified public: the
+// leaf does not chain to that stray CA, but it verifies under the hub's OS
+// trust store, so the mint carries no CA material and no pin. This is the
+// shared root cause of the three reported failures
+// (TestPublicTrustedHTTPSAndHTTPCommandsDoNotFetchLocalCA, the "publicly
+// trusted https" join case, and TestJoinRejectsMissingBinding's empty-CA drift)
+// — all now host-independent.
 //
-// The request Host ("evil.example") is identical for both mints; only the host
-// CA state differs. That pins the cause to ambient CA discovery, not the Host.
-func TestAmbientCACandidateMisclassifiesPublicHub(t *testing.T) {
+// The request Host ("evil.example") never influences the decision; only the
+// host CA state and the endpoint's real chain do.
+func TestAmbientCACandidateDoesNotMakeAPublicHubPrivate(t *testing.T) {
 	e, s := setupTestServer(t)
 	s.markCredentialsRotated(t)
 	t.Setenv("PUBLIC_URL", "https://public.example")
 
-	// Baseline: isolated (as every test is by default) → public classification.
+	// Baseline: isolated, no candidate → public.
 	base := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
 	if base.CASHA256 != "" || base.JoinPin != "" || base.CAURL != "" {
 		t.Fatalf("isolated public hub already carries CA material: %+v", base)
 	}
 
-	// Simulate the host's auto-discovered Caddy root leaking into discovery.
+	// A real but unrelated ambient Caddy root leaks into discovery. The live
+	// leaf does not chain to it (resolver reports a chain mismatch)...
 	injectAmbientCACandidate(t, s)
-	leaked := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
-	if leaked.CASHA256 == "" {
-		t.Fatal("ambient CA candidate did not change classification — seam not wired")
+	withJoinPinResolver(t, func(context.Context, *url.URL, []byte) (string, error) {
+		return "", fmt.Errorf("leaf issued by a different authority: %w", errJoinCAChainMismatch)
+	})
+	// ...but the hub's OS trust store verifies it, so the hub is public.
+	s.systemTrustProbe = func(context.Context, *url.URL) error { return nil }
+
+	got := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
+	if got.CASHA256 != "" || got.JoinPin != "" || got.CAURL != "" {
+		t.Fatalf("ambient stray CA wrongly made a public hub private: %+v", got)
 	}
-	if !strings.Contains(leaked.Command, "--pinnedpubkey sha256//") {
-		t.Fatalf("private classification did not pin the leaf: %q", leaked.Command)
+	if strings.Contains(got.Command, "-k") || strings.Contains(got.Command, "--pinnedpubkey") {
+		t.Fatalf("public command gained private-CA flags: %q", got.Command)
 	}
+}
+
+// TestAmbientCACandidateNeitherVerifiesRefuses: when the live leaf verifies
+// against neither the auto-discovered CA nor the hub's OS trust store, the hub
+// refuses to mint (503) rather than emit an unverifiable command — and no token
+// is created.
+func TestAmbientCACandidateNeitherVerifiesRefuses(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "https://public.example")
+	injectAmbientCACandidate(t, s)
+	withJoinPinResolver(t, func(context.Context, *url.URL, []byte) (string, error) {
+		return "", fmt.Errorf("chain mismatch: %w", errJoinCAChainMismatch)
+	})
+	// systemTrustProbe stays the failing default installed by setupTestServer.
+
+	before := countTokens(t, s)
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
+	req.Header.Set("Authorization", "Bearer "+loginAndGetToken(t, e))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%q, want 503", rec.Code, rec.Body.String())
+	}
+	if after := countTokens(t, s); after != before {
+		t.Fatalf("a token was minted on refusal: before=%d after=%d", before, after)
+	}
+}
+
+// TestAmbientCACandidateNetworkFailureRefuses: a genuine chain mismatch tries
+// system trust, but an *unreachable* endpoint (the resolver reports a network
+// failure, not a mismatch) must be refused outright — never a silent downgrade
+// to system trust or a public command.
+func TestAmbientCACandidateNetworkFailureRefuses(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "https://public.example")
+	injectAmbientCACandidate(t, s)
+	withJoinPinResolver(t, func(context.Context, *url.URL, []byte) (string, error) {
+		return "", errors.New("dial tcp 10.0.0.1:443: connect: connection refused")
+	})
+	// If the network failure were wrongly treated as a mismatch, this passing
+	// probe would misclassify the hub public. It must never be consulted.
+	s.systemTrustProbe = func(context.Context, *url.URL) error {
+		t.Fatal("system trust must not be consulted on a network failure")
+		return nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
+	req.Header.Set("Authorization", "Bearer "+loginAndGetToken(t, e))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%q, want 503 on network failure", rec.Code, rec.Body.String())
+	}
+}
+
+// countTokens returns how many token rows exist, for no-orphan assertions.
+func countTokens(t *testing.T, s *Server) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM tokens`).Scan(&n); err != nil {
+		t.Fatalf("count tokens: %v", err)
+	}
+	return n
 }
 
 // TestPublicHubClassificationIsHostIndependent is the isolation proof: with the
@@ -149,5 +224,151 @@ func TestJoinBindingStatesUnderIsolation(t *testing.T) {
 	}
 	if rec := getJoin(t, e, "never-bound-null-ca", ""); rec.Code != http.StatusNotFound {
 		t.Fatalf("NULL-CA code: status=%d, want 404", rec.Code)
+	}
+}
+
+// TestClassifyBootstrapCALiveTLS exercises classifyBootstrapCA end-to-end
+// against real TLS listeners with the REAL pin resolver (not the stub), so the
+// network-failure-vs-chain-mismatch distinction is proven against actual
+// crypto/tls errors rather than injected sentinels.
+func TestClassifyBootstrapCALiveTLS(t *testing.T) {
+	// A real hub endpoint: a self-signed leaf for 127.0.0.1 and the CA to
+	// trust it with. PUBLIC_URL points straight at it, so the default dial
+	// target reaches it and SNI/verification use 127.0.0.1.
+	srv, caPEM := selfSignedServer(t, 24*time.Hour)
+	leaf := srv.Certificate()
+	httpBase := srv.URL // https://127.0.0.1:<port>
+	publicURL, err := url.Parse(httpBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newServerRealResolver := func(t *testing.T) *Server {
+		_, s := setupTestServer(t)
+		// Use the real TLS-dialling resolver for these cases.
+		withJoinPinResolver(t, pinPresentedLeafSPKI)
+		return s
+	}
+
+	t.Run("auto candidate that the leaf chains to is private", func(t *testing.T) {
+		s := newServerRealResolver(t)
+		s.caCertCandidates = func() []string { return []string{writeCAFile(t, caPEM)} }
+		dec, err := s.classifyBootstrapCA(context.Background(), httpBase, publicURL)
+		if err != nil {
+			t.Fatalf("classify: %v", err)
+		}
+		if dec.caSHA256 == "" || dec.joinPin != spkiPinOf(leaf) {
+			t.Fatalf("expected private with the leaf pinned, got %+v", dec)
+		}
+	})
+
+	t.Run("auto candidate mismatch but OS trust verifies is public", func(t *testing.T) {
+		s := newServerRealResolver(t)
+		_, otherCA := selfSignedServer(t, 24*time.Hour) // unrelated CA
+		s.caCertCandidates = func() []string { return []string{writeCAFile(t, otherCA)} }
+		s.systemTrustProbe = func(context.Context, *url.URL) error { return nil }
+		dec, err := s.classifyBootstrapCA(context.Background(), httpBase, publicURL)
+		if err != nil {
+			t.Fatalf("classify: %v", err)
+		}
+		if dec != (bootstrapCADecision{}) {
+			t.Fatalf("expected public (empty decision), got %+v", dec)
+		}
+	})
+
+	t.Run("auto candidate mismatch and OS trust also fails refuses", func(t *testing.T) {
+		s := newServerRealResolver(t)
+		_, otherCA := selfSignedServer(t, 24*time.Hour)
+		s.caCertCandidates = func() []string { return []string{writeCAFile(t, otherCA)} }
+		s.systemTrustProbe = func(context.Context, *url.URL) error {
+			return errors.New("not in the OS trust store")
+		}
+		if _, err := s.classifyBootstrapCA(context.Background(), httpBase, publicURL); err == nil {
+			t.Fatal("expected refusal when neither the CA nor OS trust verifies")
+		}
+	})
+
+	t.Run("network failure refuses without consulting OS trust", func(t *testing.T) {
+		s := newServerRealResolver(t)
+		s.caCertCandidates = func() []string { return []string{writeCAFile(t, caPEM)} }
+		s.systemTrustProbe = func(context.Context, *url.URL) error {
+			t.Fatal("OS trust must not be consulted on a network failure")
+			return nil
+		}
+		// A closed port: the handshake never completes, so this is a network
+		// failure, not a chain mismatch.
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		closedAddr := ln.Addr().String()
+		ln.Close()
+		deadURL, _ := url.Parse("https://" + closedAddr)
+		if _, err := s.classifyBootstrapCA(context.Background(), "https://"+closedAddr, deadURL); err == nil {
+			t.Fatal("expected refusal on an unreachable endpoint")
+		}
+	})
+
+	t.Run("explicit CA that the leaf does not chain to fails closed", func(t *testing.T) {
+		s := newServerRealResolver(t)
+		_, otherCA := selfSignedServer(t, 24*time.Hour)
+		t.Setenv("BLOXOS_CA_CERT", writeCAFile(t, otherCA))
+		s.systemTrustProbe = func(context.Context, *url.URL) error {
+			t.Fatal("an explicit CA is authoritative; OS trust must not be consulted")
+			return nil
+		}
+		if _, err := s.classifyBootstrapCA(context.Background(), httpBase, publicURL); err == nil {
+			t.Fatal("expected fail-closed for an explicit CA the leaf does not chain to")
+		}
+	})
+}
+
+// writeCAFile writes pem to a temp file and returns its path.
+func writeCAFile(t *testing.T, pem []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ca.crt")
+	if err := os.WriteFile(path, pem, 0o600); err != nil {
+		t.Fatalf("write CA: %v", err)
+	}
+	return path
+}
+
+// TestPrivateJoinGETDoesNotRePin is root's GET regression guard: a private join
+// link, once minted, must keep serving without re-running the pin resolver at
+// GET time. curl already authenticated the mint-time leaf via the pinned
+// command before the GET reaches the hub, so re-pinning here would wrongly
+// 404 a valid link when the leaf is near expiry or the hub endpoint has a
+// transient outage. GET recomputes the CA binding from the selected CA file
+// only, never a TLS probe.
+func TestPrivateJoinGETDoesNotRePin(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "https://hub.internal:8443")
+	t.Setenv("BLOXOS_CA_CERT", testCAFile(t))
+
+	// Mint a private link with a working resolver.
+	got := mintJoinToken(t, e, loginAndGetToken(t, e), "client.example")
+	if got.CASHA256 == "" || got.JoinPin == "" {
+		t.Fatalf("expected a private mint, got %+v", got)
+	}
+
+	// After mint, the resolver both fails AND would fail t.Fatal if called at
+	// GET time. The link must still serve.
+	withJoinPinResolver(t, func(context.Context, *url.URL, []byte) (string, error) {
+		t.Fatal("GET must not invoke the pin resolver for an already-minted private link")
+		return "", errJoinCAChainMismatch
+	})
+	// Any TLS probe at GET is likewise forbidden for a private binding.
+	s.systemTrustProbe = func(context.Context, *url.URL) error {
+		t.Fatal("GET must not probe system trust for a private binding")
+		return nil
+	}
+
+	rec := getJoin(t, e, got.Token, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("private GET status=%d body=%q, want 200 (no re-pin)", rec.Code, rec.Body.String())
+	}
+	if want := "#!/bin/bash\n" + got.AdvancedCommand + "\n"; rec.Body.String() != want {
+		t.Fatalf("served script is not the minted advanced command")
 	}
 }

--- a/hub/ca_selection_regression_test.go
+++ b/hub/ca_selection_regression_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestBootstrapExplicitCAFailuresNeverFallback(t *testing.T) {
+	valid := writeCAFile(t, []byte(generateTestCertPEM(t)))
+	bad := filepath.Join(t.TempDir(), "malformed.crt")
+	if err := os.WriteFile(bad, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	u, _ := url.Parse("https://hub.example")
+	for name, path := range map[string]string{"missing": filepath.Join(t.TempDir(), "missing.crt"), "malformed": bad, "directory": t.TempDir()} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("BLOXOS_CA_CERT", path)
+			s := &Server{caCertCandidates: func() []string { return []string{valid} }}
+			withJoinPinResolver(t, func(context.Context, *url.URL, []byte) (string, error) {
+				t.Fatal("invalid explicit CA reached pin resolver")
+				return "", nil
+			})
+			s.systemTrustProbe = func(context.Context, *url.URL) error {
+				t.Fatal("invalid explicit CA fell back to OS trust")
+				return nil
+			}
+			if _, err := s.classifyBootstrapCA(context.Background(), u.String(), u); err == nil || !strings.Contains(err.Error(), "BLOXOS_CA_CERT") {
+				t.Fatalf("expected actionable explicit-CA error, got %v", err)
+			}
+			r := httptest.NewRecorder()
+			if err := s.handleDownloadCACert(echo.New().NewContext(httptest.NewRequest("GET", "/download/ca.crt", nil), r)); err != nil {
+				t.Fatal(err)
+			}
+			if r.Code != http.StatusInternalServerError {
+				t.Fatalf("download fell back: %d %s", r.Code, r.Body.String())
+			}
+		})
+	}
+}
+
+func TestBootstrapSkippedCandidateDownloadMatchesBinding(t *testing.T) {
+	t.Setenv("BLOXOS_CA_CERT", "")
+	validPEM := []byte(generateTestCertPEM(t))
+	valid := writeCAFile(t, validPEM)
+	bad := filepath.Join(t.TempDir(), "stray.crt")
+	if err := os.WriteFile(bad, []byte("unrelated non-certificate file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{caCertCandidates: func() []string { return []string{bad, valid} }}
+	withJoinPinResolver(t, func(_ context.Context, _ *url.URL, pem []byte) (string, error) {
+		if string(pem) != string(validPEM) {
+			t.Fatal("mint did not select the valid candidate")
+		}
+		return testJoinPin, nil
+	})
+	u, _ := url.Parse("https://hub.internal")
+	decision, err := s.classifyBootstrapCA(context.Background(), u.String(), u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRecorder()
+	if err := s.handleDownloadCACert(echo.New().NewContext(httptest.NewRequest("GET", "/download/ca.crt", nil), r)); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(r.Body.Bytes())
+	if r.Code != 200 || hex.EncodeToString(sum[:]) != decision.caSHA256 {
+		t.Fatalf("download bytes differ from mint binding: %d", r.Code)
+	}
+}
+
+func TestBootstrapCAFailureLeavesBothMintEndpointsUnchanged(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	auth := loginAndGetToken(t, e)
+	t.Setenv("PUBLIC_URL", "https://hub.example")
+	t.Setenv("BLOXOS_CA_CERT", filepath.Join(t.TempDir(), "missing.crt"))
+	s.seedWindowsMachine(t, "win-ca-failure")
+	if _, err := s.db.Exec(`INSERT INTO agent_credentials(machine_id, secret_hash) VALUES ('win-ca-failure', 'existing-secret-hash')`); err != nil {
+		t.Fatal(err)
+	}
+	var before int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM tokens`).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{"/api/tokens", windowsReenrollmentPath("win-ca-failure")} {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		req.Header.Set("Authorization", "Bearer "+auth)
+		r := httptest.NewRecorder()
+		e.ServeHTTP(r, req)
+		if r.Code != 503 {
+			t.Fatalf("%s returned %d: %s", path, r.Code, r.Body.String())
+		}
+		var after int
+		if err := s.db.QueryRow(`SELECT COUNT(*) FROM tokens`).Scan(&after); err != nil {
+			t.Fatal(err)
+		}
+		if after != before {
+			t.Fatalf("%s left an orphan token", path)
+		}
+	}
+	var unchanged int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_credentials WHERE machine_id = 'win-ca-failure' AND secret_hash = 'existing-secret-hash' AND pending_secret_hash IS NULL`).Scan(&unchanged); err != nil {
+		t.Fatal(err)
+	}
+	if unchanged != 1 {
+		t.Fatal("failed mint changed the active or pending credential")
+	}
+}
+
+func TestBootstrapPinRefreshedPerMint(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	auth := loginAndGetToken(t, e)
+	t.Setenv("PUBLIC_URL", "https://hub.internal")
+	t.Setenv("BLOXOS_CA_CERT", "")
+	ca := testCAFile(t)
+	s.caCertCandidates = func() []string { return []string{ca} }
+	calls := 0
+	withJoinPinResolver(t, func(context.Context, *url.URL, []byte) (string, error) {
+		calls++
+		pin := make([]byte, 32)
+		pin[0] = byte(calls) // same CA/origin, newly presented leaf key
+		return base64.StdEncoding.EncodeToString(pin), nil
+	})
+	s.systemTrustProbe = func(context.Context, *url.URL) error {
+		t.Fatal("candidate that verifies must win even if OS store also trusts it")
+		return nil
+	}
+	first := mintJoinToken(t, e, auth, "client.example")
+	second := mintJoinToken(t, e, auth, "client.example")
+	if calls != 2 || first.JoinPin == second.JoinPin || first.CASHA256 != second.CASHA256 {
+		t.Fatalf("pin was cached across mints or probed twice within one mint: calls=%d", calls)
+	}
+}

--- a/hub/install_enrollment_test.go
+++ b/hub/install_enrollment_test.go
@@ -33,8 +33,17 @@ func (s *Server) seedTokenValue(t *testing.T, raw string) string {
 	httpBase, _ := publicAndWebsocketBase()
 	var mintHTTPBase, mintCASHA256 interface{}
 	if httpBase != "" {
-		_, caSHA256 := s.bootstrapCAFor(httpBase)
 		mintHTTPBase = httpBase
+		// Mirror production's stored binding without a live probe: the hash of
+		// the strictly-selected CA for an https hub with one, else the empty
+		// (public/http) binding. Same selection rules as classification.
+		caSHA256 := ""
+		if strings.HasPrefix(httpBase, "https://") {
+			if caPEM, _, source, err := s.loadBootstrapCAClassified(); err == nil && source != caSourceNone {
+				sum := sha256.Sum256(caPEM)
+				caSHA256 = hex.EncodeToString(sum[:])
+			}
+		}
 		mintCASHA256 = caSHA256
 	}
 	if _, err := s.db.Exec(`INSERT INTO tokens (token_hash, expires_at, used, mint_time_http_base, mint_time_ca_sha256) VALUES (?, ?, FALSE, ?, ?)`,

--- a/hub/installer_bootstrap_test.go
+++ b/hub/installer_bootstrap_test.go
@@ -48,10 +48,14 @@ func createInstallerToken(t *testing.T, publicURL, host, caPath string) installe
 	return got
 }
 
+// testCAFile writes a real, parseable CA certificate PEM and returns its path.
+// Bootstrap-CA classification now parses the candidate (not just hashes its
+// bytes), so a private-CA test needs a genuine certificate here; the stubbed
+// pin resolver still stands in for the live TLS handshake.
 func testCAFile(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "root.crt")
-	if err := os.WriteFile(path, []byte("test-private-ca"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(generateTestCertPEM(t)), 0o600); err != nil {
 		t.Fatalf("write CA: %v", err)
 	}
 	return path
@@ -120,7 +124,10 @@ func TestPublicTrustedHTTPSAndHTTPCommandsDoNotFetchLocalCA(t *testing.T) {
 		{name: "loopback HTTP", url: "http://127.0.0.1:4000"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := createInstallerToken(t, tc.url, "evil.example", filepath.Join(t.TempDir(), "missing.crt"))
+			// No CA configured (empty BLOXOS_CA_CERT) is how a public hub is
+			// expressed; an explicit-but-missing path is now a hard error, not
+			// a public fallback.
+			got := createInstallerToken(t, tc.url, "evil.example", "")
 			if got.CAURL != "" || got.CASHA256 != "" || got.JoinPin != "" || strings.Contains(got.AdvancedCommand, "/download/ca.crt") || strings.Contains(got.WindowsCommand, "/download/ca.crt") {
 				t.Fatalf("system-trust/direct-HTTP command unexpectedly bootstraps local CA: %+v", got)
 			}

--- a/hub/join.go
+++ b/hub/join.go
@@ -42,6 +42,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -201,20 +202,241 @@ func parsePublicURL(raw string) (*url.URL, error) {
 	return u, nil
 }
 
-// joinPinForPrivateCA verifies PUBLIC_URL's presented leaf against the
-// bootstrap CA and returns its SPKI pin. It is only called when the hub is
-// behind a private CA (bootstrapCAFor found one); a publicly trusted hub
-// needs no pin.
-func (s *Server) joinPinForPrivateCA(ctx context.Context, publicURL *url.URL) (string, error) {
-	caPEM, caPath, err := s.loadBootstrapCACert()
-	if err != nil {
-		return "", fmt.Errorf("load bootstrap CA: %w", err)
+// bootstrapCASource records where a bootstrap CA candidate came from, because
+// the two are held to different standards: an explicitly-configured CA is
+// authoritative (a mismatch or an unreadable/malformed file fails the mint
+// closed), while an auto-discovered one is a best-effort guess that may be
+// overruled by system trust.
+type bootstrapCASource int
+
+const (
+	caSourceNone     bootstrapCASource = iota // no candidate on this hub
+	caSourceExplicit                          // operator set BLOXOS_CA_CERT
+	caSourceAuto                              // discovered on a default host path
+)
+
+// loadBootstrapCAClassified selects the bootstrap CA and reports its source.
+// An explicit BLOXOS_CA_CERT is authoritative: it is never silently skipped for
+// an auto-discovered path, and if it is missing, unreadable, or not a PEM
+// certificate the mint fails closed rather than falling back. Auto-discovered
+// candidates on the default host paths are best-effort: a stray file that is
+// absent, unreadable, or not a certificate is skipped, so an unrelated file on
+// disk never turns a public hub private.
+func (s *Server) loadBootstrapCAClassified() ([]byte, string, bootstrapCASource, error) {
+	if env := strings.TrimSpace(os.Getenv("BLOXOS_CA_CERT")); env != "" {
+		data, err := os.ReadFile(env)
+		if err != nil {
+			return nil, env, caSourceExplicit, fmt.Errorf("BLOXOS_CA_CERT %s cannot be read: %w", env, err)
+		}
+		if !x509.NewCertPool().AppendCertsFromPEM(data) {
+			return nil, env, caSourceExplicit, fmt.Errorf("BLOXOS_CA_CERT %s holds no PEM certificate", env)
+		}
+		return data, env, caSourceExplicit, nil
 	}
-	pin, err := resolveJoinPin(ctx, publicURL, caPEM)
-	if err != nil {
-		return "", fmt.Errorf("%w (CA: %s)", err, caPath)
+	for _, path := range s.caCertCandidatePaths() {
+		if path == "" {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue // absent or unreadable stray file: not this hub's CA
+		}
+		if !x509.NewCertPool().AppendCertsFromPEM(data) {
+			continue // present but not a certificate: ignore it
+		}
+		return data, path, caSourceAuto, nil
 	}
-	return pin, nil
+	return nil, "", caSourceNone, nil
+}
+
+// bootstrapCADecision is how a join command will authenticate the fetch,
+// computed once per mint from a single classification of PUBLIC_URL's TLS
+// trust and reused for the whole response. It is never cached across requests,
+// so a re-keyed leaf is re-pinned on the next mint.
+type bootstrapCADecision struct {
+	caURL    string // "/download/ca.crt" URL when private; "" when public/http
+	caSHA256 string // sha256 of the bound CA PEM when private; "" otherwise
+	joinPin  string // leaf SPKI pin when private; "" otherwise
+}
+
+// errJoinCAChainMismatch marks a pin resolution that failed because the leaf
+// the endpoint presented does not chain to (or match the hostname of) the CA
+// it was verified against — a completed handshake with a mismatching cert — as
+// opposed to a network/handshake failure that never established what the
+// endpoint presents. Only a genuine mismatch against an auto-discovered CA
+// falls back to system trust; a network failure never does. Tests inject this
+// to exercise that fallback without a real endpoint.
+var errJoinCAChainMismatch = errors.New("presented certificate does not verify against the candidate CA")
+
+// isCAChainMismatch reports whether err is a certificate-verification failure
+// (the endpoint answered but its chain/hostname does not verify) rather than a
+// failure to reach or handshake with the endpoint at all.
+func isCAChainMismatch(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errJoinCAChainMismatch) {
+		return true
+	}
+	var cve *tls.CertificateVerificationError
+	if errors.As(err, &cve) {
+		return true
+	}
+	var ua x509.UnknownAuthorityError
+	var ci x509.CertificateInvalidError
+	var he x509.HostnameError
+	return errors.As(err, &ua) || errors.As(err, &ci) || errors.As(err, &he)
+}
+
+// joinSystemTrustVerifier verifies PUBLIC_URL's presented chain against the
+// hub's OS trust store (and the URL hostname) in one TLS handshake, returning
+// nil only if that store verifies it. Verifying there means the hub's own
+// operating system trusts the issuer — not proof the CA is globally public —
+// which is the right signal for whether this hub needs a bootstrap CA.
+type joinSystemTrustVerifier func(ctx context.Context, publicURL *url.URL) error
+
+// verifySystemTrust runs the per-server system-trust probe (tests inject one
+// via s.systemTrustProbe) or the default live handshake.
+func (s *Server) verifySystemTrust(ctx context.Context, publicURL *url.URL) error {
+	if s != nil && s.systemTrustProbe != nil {
+		return s.systemTrustProbe(ctx, publicURL)
+	}
+	return verifyEndpointSystemTrust(ctx, publicURL)
+}
+
+// verifyEndpointSystemTrust performs a single TLS handshake to PUBLIC_URL's
+// endpoint verified against the hub's OS trust store. Like the pin resolver it
+// makes no HTTP request and dials only PUBLIC_URL (or the operator-configured
+// BLOXOS_PIN_DIAL_ADDR), so nothing beyond the configured endpoint is
+// contacted, and a wrong dial target can only fail the handshake.
+func verifyEndpointSystemTrust(ctx context.Context, publicURL *url.URL) error {
+	if publicURL == nil || publicURL.Scheme != "https" {
+		return fmt.Errorf("PUBLIC_URL is not https")
+	}
+	host := publicURL.Hostname()
+	if host == "" {
+		return fmt.Errorf("PUBLIC_URL has no host")
+	}
+	dialAddr, err := pinDialAddress(publicURL)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, joinPinDialTimeout)
+	defer cancel()
+	dialer := &tls.Dialer{
+		NetDialer: &net.Dialer{Timeout: joinPinDialTimeout},
+		Config: &tls.Config{
+			ServerName: host, // RootCAs nil = system trust; full verification
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	conn, err := dialer.DialContext(ctx, "tcp", dialAddr)
+	if err != nil {
+		return fmt.Errorf("system-trust TLS handshake with %s (verifying SNI %q) failed: %w", dialAddr, host, err)
+	}
+	conn.Close()
+	return nil
+}
+
+// classifyBootstrapCA decides, once per request, how a join command for
+// PUBLIC_URL authenticates its fetch. The contract:
+//
+//   - http or no PUBLIC_URL: plain, no CA material, no probe.
+//   - https with no CA candidate: publicly trusted HTTPS, no probe added.
+//   - https with a CA candidate: verify the live leaf against it (one
+//     handshake).
+//   - verifies → private CA: bind its SHA-256 and pin the verified leaf.
+//   - explicit CA that does not verify (mismatch, unreachable, or invalid):
+//     fail closed — an operator-configured CA is authoritative and is never
+//     downgraded to system trust.
+//   - auto-discovered CA that the leaf does not chain to: consult the hub's
+//     OS trust store with the same endpoint. Verified there → classify public
+//     (plain verified TLS, no CA, no -k). Not verified there either → refuse.
+//   - auto-discovered CA but the endpoint is unreachable: refuse — we never
+//     learned what it presents, so we do not guess.
+//
+// A refusal returns an error the caller surfaces as an actionable 503 with no
+// token minted. The single verified handshake is reused within the request; no
+// SPKI is cached across requests.
+func (s *Server) classifyBootstrapCA(ctx context.Context, httpBase string, publicURL *url.URL) (bootstrapCADecision, error) {
+	if !strings.HasPrefix(httpBase, "https://") {
+		return bootstrapCADecision{}, nil
+	}
+	caPEM, caPath, source, err := s.loadBootstrapCAClassified()
+	if err != nil {
+		return bootstrapCADecision{}, err // explicit CA invalid: fail closed
+	}
+	if source == caSourceNone {
+		return bootstrapCADecision{}, nil // publicly trusted HTTPS, no probe
+	}
+
+	pin, perr := resolveJoinPin(ctx, publicURL, caPEM)
+	if perr == nil {
+		sum := sha256.Sum256(caPEM)
+		return bootstrapCADecision{
+			caURL:    httpBase + "/download/ca.crt",
+			caSHA256: hex.EncodeToString(sum[:]),
+			joinPin:  pin,
+		}, nil
+	}
+
+	if source == caSourceExplicit {
+		return bootstrapCADecision{}, fmt.Errorf(
+			"PUBLIC_URL's certificate does not verify against BLOXOS_CA_CERT (%s): %w", caPath, perr)
+	}
+
+	// Auto-discovered candidate. Only a completed-but-mismatching handshake is
+	// a reason to consult the hub's OS trust store; an unreachable endpoint is
+	// refused rather than guessed.
+	if !isCAChainMismatch(perr) {
+		return bootstrapCADecision{}, fmt.Errorf(
+			"cannot reach PUBLIC_URL over TLS to classify its certificate: %w", perr)
+	}
+	if verr := s.verifySystemTrust(ctx, publicURL); verr != nil {
+		return bootstrapCADecision{}, fmt.Errorf(
+			"PUBLIC_URL's certificate verifies against neither the discovered local CA (%s) nor the hub's OS trust store: %w", caPath, verr)
+	}
+	// The hub's OS trust store verifies the leaf, so the discovered local CA is
+	// unrelated to how this hub is actually served: plain verified TLS, no CA
+	// material.
+	return bootstrapCADecision{}, nil
+}
+
+// currentJoinCABinding recomputes the CA-binding value to compare against a
+// join token's mint-time binding, WITHOUT re-pinning the leaf. It returns the
+// current value and whether it could be established at all.
+//
+// The distinction matters at serve time: curl already authenticated the
+// mint-time leaf (via the pinned command for a private hub, or ordinary TLS
+// for a public one) before this GET runs, so re-probing/re-pinning here would
+// wrongly reject a still-valid link on a near-expiry leaf or a transient hub
+// outage. So:
+//
+//   - Private mint binding (non-empty): recompute the SELECTED CA's SHA-256
+//     using the same strict source rules as mint (explicit-authoritative,
+//     PEM-validated, malformed ambient skipped) — but no TLS probe and no
+//     leaf-lifetime guard. A removed or now-unreadable CA is genuine drift.
+//   - Public mint binding (empty): classify only to tell an unrelated ambient
+//     CA (still public → "") from a real private CA the leaf now chains to
+//     (drift). With no CA candidate this does no probe and returns "".
+func (s *Server) currentJoinCABinding(ctx context.Context, httpBase, mintTimeCASHA256 string) (string, bool) {
+	if mintTimeCASHA256 != "" {
+		caPEM, _, source, err := s.loadBootstrapCAClassified()
+		if err != nil || source == caSourceNone {
+			return "", false
+		}
+		sum := sha256.Sum256(caPEM)
+		return hex.EncodeToString(sum[:]), true
+	}
+	publicURL, err := parsePublicURL(httpBase)
+	if err != nil {
+		return "", false
+	}
+	decision, err := s.classifyBootstrapCA(ctx, httpBase, publicURL)
+	if err != nil {
+		return "", false
+	}
+	return decision.caSHA256, true
 }
 
 // joinURLFor is the link the short command fetches. The code is the install
@@ -354,8 +576,8 @@ func (s *Server) joinCodeUsable(code string) (bool, joinTokenInfo) {
 // rebuildLinuxJoinScript reconstructs the mint-time bootstrap script from the
 // stored config binding plus the token supplied in the join request. It never
 // reads a stored script, so the raw install token is not persisted; the
-// derivations mirror publicAndWebsocketBase and bootstrapCAFor exactly, so the
-// output is byte-identical to what was minted.
+// derivations mirror publicAndWebsocketBase and the mint-time CA classification
+// exactly, so the output is byte-identical to what was minted.
 func rebuildLinuxJoinScript(httpBase, caSHA256, token string) string {
 	wsBase := strings.Replace(httpBase, "https://", "wss://", 1)
 	wsBase = strings.Replace(wsBase, "http://", "ws://", 1)
@@ -399,19 +621,25 @@ func (s *Server) handleJoinScript(c echo.Context) error {
 	// a pin for the mint-time cert and a URL for the mint-time hub, and serving
 	// a script with different values would either fail the pin check or redirect
 	// the agent to a different authority than what was authenticated at mint.
-	currentCAURL, currentCASHA256 := s.bootstrapCAFor(currentHTTPBase)
-	_ = currentCAURL // URL derivation is deterministic; SHA is the binding value
 
-	// Tokens minted before origin normalization may carry a trailing slash;
-	// compare origins, not spellings.
+	// Origin drift first (cheap, no I/O).
 	if currentHTTPBase != strings.TrimRight(info.MintTimeHTTPBase, "/") {
 		// PUBLIC_URL has changed. The join command has the mint-time URL
 		// embedded, but if it somehow reaches this hub on the new URL, reject
 		// rather than serve a script that points to a different authority.
 		return c.String(http.StatusNotFound, joinUnavailableBody)
 	}
+
+	// CA drift. How we recompute the current binding depends on what was bound:
+	currentCASHA256, ok := s.currentJoinCABinding(c.Request().Context(), currentHTTPBase, info.MintTimeCASHA256)
+	if !ok {
+		// The hub cannot currently establish the binding (CA removed/unreadable,
+		// or — for a public binding with an ambient CA — PUBLIC_URL unreachable):
+		// treat the link as unavailable, like any other unusable code.
+		return c.String(http.StatusNotFound, joinUnavailableBody)
+	}
 	if currentCASHA256 != info.MintTimeCASHA256 {
-		// The bootstrap CA cert has changed. The join command has a pin for the
+		// The bootstrap CA has changed. The join command has a pin for the
 		// mint-time leaf, and a script with a different CA would fail bootstrap
 		// or redirect the agent to trust a different CA than was pinned.
 		return c.String(http.StatusNotFound, joinUnavailableBody)

--- a/hub/join_test.go
+++ b/hub/join_test.go
@@ -173,7 +173,12 @@ func TestJoinCommandShapes(t *testing.T) {
 		e, s := setupTestServer(t)
 		s.markCredentialsRotated(t)
 		t.Setenv("PUBLIC_URL", "https://hub.lan:8443")
-		t.Setenv("BLOXOS_CA_CERT", testCAFile(t))
+		caPath := testCAFile(t)
+		t.Setenv("BLOXOS_CA_CERT", caPath)
+		wantPEM, err := os.ReadFile(caPath)
+		if err != nil {
+			t.Fatalf("read configured CA: %v", err)
+		}
 		var sawURL string
 		var sawPEM []byte
 		withJoinPinResolver(t, func(_ context.Context, u *url.URL, caPEM []byte) (string, error) {
@@ -181,7 +186,7 @@ func TestJoinCommandShapes(t *testing.T) {
 			return testJoinPin, nil
 		})
 		got := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
-		if sawURL != "https://hub.lan:8443" || string(sawPEM) != "test-private-ca" {
+		if sawURL != "https://hub.lan:8443" || string(sawPEM) != string(wantPEM) {
 			t.Fatalf("resolver saw url=%q pem=%q; must be the explicit PUBLIC_URL and the configured CA", sawURL, sawPEM)
 		}
 		want := `bash -c 's=$(curl -fsSk --pinnedpubkey sha256//` + testJoinPin + ` https://hub.lan:8443/api/join/` + got.Token + `) && bash -c "$s"'`
@@ -203,7 +208,7 @@ func TestJoinCommandShapes(t *testing.T) {
 		e, s := setupTestServer(t)
 		s.markCredentialsRotated(t)
 		t.Setenv("PUBLIC_URL", "https://hub.example.com")
-		t.Setenv("BLOXOS_CA_CERT", filepath.Join(t.TempDir(), "missing.crt"))
+		t.Setenv("BLOXOS_CA_CERT", "")
 		withJoinPinResolver(t, func(context.Context, *url.URL, []byte) (string, error) {
 			t.Fatal("pin resolver must not run without a private CA")
 			return "", nil
@@ -222,7 +227,7 @@ func TestJoinCommandShapes(t *testing.T) {
 		e, s := setupTestServer(t)
 		s.markCredentialsRotated(t)
 		t.Setenv("PUBLIC_URL", "http://127.0.0.1:4000")
-		t.Setenv("BLOXOS_CA_CERT", filepath.Join(t.TempDir(), "missing.crt"))
+		t.Setenv("BLOXOS_CA_CERT", "")
 		got := mintJoinToken(t, e, loginAndGetToken(t, e), "evil.example")
 		want := `bash -c 's=$(curl -fsS http://127.0.0.1:4000/api/join/` + got.Token + `) && bash -c "$s"'`
 		if got.Command != want {
@@ -236,8 +241,8 @@ func TestJoinCommandShapes(t *testing.T) {
 	t.Run("no trust-all pipe in any command", func(t *testing.T) {
 		for _, tc := range []struct{ url, ca string }{
 			{"https://hub.lan", testCAFile(t)},
-			{"https://hub.example.com", filepath.Join(t.TempDir(), "missing.crt")},
-			{"http://127.0.0.1:4000", filepath.Join(t.TempDir(), "missing.crt")},
+			{"https://hub.example.com", ""},
+			{"http://127.0.0.1:4000", ""},
 		} {
 			e, s := setupTestServer(t)
 			s.markCredentialsRotated(t)
@@ -948,7 +953,7 @@ func TestJoinRebuildByteEquivalenceAcrossTransports(t *testing.T) {
 			if tc.setCA {
 				t.Setenv("BLOXOS_CA_CERT", testCAFile(t))
 			} else {
-				t.Setenv("BLOXOS_CA_CERT", filepath.Join(t.TempDir(), "absent.crt"))
+				t.Setenv("BLOXOS_CA_CERT", "")
 			}
 			got := mintJoinToken(t, e, loginAndGetToken(t, e), "client.example")
 			rec := getJoin(t, e, got.Token, "")
@@ -1075,9 +1080,11 @@ func TestJoinRejectsAfterCACertChange(t *testing.T) {
 		t.Fatal("mint-time script does not contain the mint-time CA SHA")
 	}
 
-	// Replace the CA file with different content (simulating cert rotation)
+	// Replace the CA file with a different, real certificate (simulating an
+	// operator swapping the bootstrap CA). Its SHA differs, so the classified
+	// binding no longer matches the mint-time one.
 	newCA := filepath.Join(t.TempDir(), "new-ca.crt")
-	if err := os.WriteFile(newCA, []byte("new-test-private-ca-cert"), 0644); err != nil {
+	if err := os.WriteFile(newCA, []byte(generateTestCertPEM(t)), 0644); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("BLOXOS_CA_CERT", newCA)

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -164,6 +164,9 @@ func setupTestServer(t *testing.T) (*echo.Echo, *Server) {
 	// that need an auto-discovered ambient CA override s.caCertCandidates
 	// directly (see injectAmbientCACandidate in ca_isolation_test.go).
 	s.caCertCandidates = isolatedCACandidates
+	// Fail the system-trust probe by default so no test silently dials the
+	// network; the auto-discovered-CA fallback tests inject a passing one.
+	s.systemTrustProbe = failingSystemTrustProbe
 	// Registered after the db.Close() cleanup above so it runs BEFORE it:
 	// t.Cleanup is LIFO, and background work must drain while the database
 	// it queries is still open.
@@ -220,6 +223,9 @@ func setupEmptyTestServer(t *testing.T) (*echo.Echo, *Server) {
 	// Isolate bootstrap-CA discovery from the host's real Caddy roots, exactly
 	// as setupTestServer does — see the rationale there.
 	s.caCertCandidates = isolatedCACandidates
+	// Fail the system-trust probe by default so no test silently dials the
+	// network; the auto-discovered-CA fallback tests inject a passing one.
+	s.systemTrustProbe = failingSystemTrustProbe
 	// Registered after the db.Close() cleanup above so it runs BEFORE it:
 	// t.Cleanup is LIFO, and background work must drain while the database
 	// it queries is still open.
@@ -841,7 +847,7 @@ func TestCreateTokenIncludesCABootstrapForHTTPS(t *testing.T) {
 
 	caDir := t.TempDir()
 	caPath := filepath.Join(caDir, "root.crt")
-	caPEM := []byte("-----BEGIN CERTIFICATE-----\nZmFrZS1ibG94b3MtY2E=\n-----END CERTIFICATE-----\n")
+	caPEM := []byte(generateTestCertPEM(t))
 	if err := os.WriteFile(caPath, caPEM, 0600); err != nil {
 		t.Fatalf("write CA cert: %v", err)
 	}
@@ -894,7 +900,7 @@ func TestDownloadCACert(t *testing.T) {
 
 	caDir := t.TempDir()
 	caPath := filepath.Join(caDir, "root.crt")
-	caPEM := []byte("-----BEGIN CERTIFICATE-----\nZmFrZS1ibG94b3MtY2E=\n-----END CERTIFICATE-----\n")
+	caPEM := []byte(generateTestCertPEM(t))
 	if err := os.WriteFile(caPath, caPEM, 0600); err != nil {
 		t.Fatalf("write CA cert: %v", err)
 	}

--- a/hub/server.go
+++ b/hub/server.go
@@ -45,6 +45,14 @@ type Server struct {
 	// to have a local Caddy CA on disk. See caCertCandidatePaths.
 	caCertCandidates func() []string
 
+	// systemTrustProbe, when non-nil, replaces the live TLS handshake that
+	// checks PUBLIC_URL's certificate against the hub's OS trust store during
+	// bootstrap-CA classification (the auto-discovered-CA fallback). Production
+	// leaves it nil and uses verifyEndpointSystemTrust; tests inject it so the
+	// fallback is exercised without a real endpoint. Per-server, like
+	// caCertCandidates, so parallel tests never race a package global.
+	systemTrustProbe joinSystemTrustVerifier
+
 	// Tracks background work this server spawned, so a caller can wait for
 	// it to finish before tearing the server down. See goTracked/Shutdown.
 	//


### PR DESCRIPTION
## Summary
- Isolate production trust selection from unrelated host CA files while preserving native Caddy auto-discovery.
- Explicit BLOXOS_CA_CERT remains authoritative; invalid configuration fails before either enrollment endpoint stages credentials.
- Public TLS uses ordinary verified HTTPS, while private TLS retains its CA binding and pinned key.
- Preserve mint-time origin/CA drift checks without re-pinning private join GETs.
- Use the same validated CA selection for downloads and command generation.

## Validation
- Focused real-TLS, join, ambient-CA and new failure/rotation regression race tests passed.
- Full hub race suite running; required CI and Compose smoke must pass before merge.
- Claude implementation, root review and additional regressions; Kimi independent review underway.

No deployment, real signing keys or fleet activation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how install and re-enrollment commands establish TLS trust and when minting fails closed; mistakes could block onboarding or weaken pinning, though behavior is heavily regression-tested.
> 
> **Overview**
> **Onboarding install/re-enroll commands** now go through **`classifyBootstrapCA`** instead of treating the first readable CA file as private TLS. Public Let's Encrypt hubs stay **plain verified HTTPS** (no CA download, pin, or `-k`) even when an unrelated Caddy root exists on the host; only when the live leaf verifies against a selected CA does the hub bind **`CA_SHA256`**, serve **`/download/ca.crt`**, and pin the leaf.
> 
> **`BLOXOS_CA_CERT`** is **authoritative**: missing, malformed, or non-matching certs cause **503 before any token row** on both **`/api/tokens`** and Windows re-enrollment (no orphan tokens). Auto-discovered candidates skip junk files, can fall back to an **OS trust probe** only after a real chain mismatch, and **refuse** on unreachable **`PUBLIC_URL`** rather than guessing public.
> 
> **Join link serving** recomputes CA drift via **`currentJoinCABinding`** without re-running TLS pin probes on GET; **`/download/ca.crt`** serves the same PEM classification chose at mint. Docs add a **TLS trust for onboarding** section describing when to leave **`BLOXOS_CA_CERT`** unset vs set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56b80f832d239f95573d85417ecb6404bc6d1e1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->