### PR TITLE
docs: complete v1.2.1 README guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ Unavailable readings stay unavailable, and incomplete totals are labelled.
 **Component power is not wall power.** CPU and GPU readings do not include every
 part of a machine or power-supply losses. [How power history works →](docs/power-history.md)
 
+### Know what your agents are running
+
+The **Versions** page shows the agent builds your hub offers for Linux x86-64,
+Linux ARM64 and Windows x86-64, including missing platform binaries. It
+distinguishes numbered releases, legacy unnumbered builds and unknown versions.
+**Matches offered build** means a machine matches its hub's offered file—not
+necessarily the newest BloxOS release. Older hubs without enough information
+show an unknown status instead of guessing. [Version labels explained →](docs/versions.md)
+
+An operator's **Pause rollout** is saved across hub restarts and changes to
+served agent files in v1.2.1 and later. It stops new update announcements; it
+cannot cancel updates already announced. Downgrading to an older hub loses
+enforcement of that saved pause. [Rollout control →](docs/versions.md#rollout-control)
+
 ## Get started
 
 You need a Docker host with **Docker Compose v2**, Git, and a hostname or IP
@@ -118,6 +132,12 @@ The default stack uses a private certificate authority. Your browser will need
 to trust its root certificate; follow the [browser trust instructions](docker/README.md#browser-trust).
 The generated agent command already includes the required verification.
 
+Using a publicly trusted certificate, such as Let's Encrypt, instead of the
+default private CA? Leave `BLOXOS_CA_CERT` unset in the hub configuration.
+An invalid explicit CA setting stops install-command generation with an error;
+private-CA installations should keep their correct CA configuration.
+[TLS configuration guidance →](docs/configuration.md#tls-trust-for-onboarding)
+
 [Full installation guide and troubleshooting →](docker/README.md)
 
 ## Add your first machine
@@ -157,8 +177,9 @@ Refresh your browser when the services are healthy. Keep your existing volumes
 and keys; normal upgrades do not require enrolling every machine again.
 
 For new machines, generate a **fresh** Add Machine command after upgrading.
-v1.2.0 uses `/api/join/`, so older proxies that already forward `/api/*` need
-no route edit. Previously copied `/join/` commands may still fail or have expired.
+Since v1.2.0, new commands use `/api/join/`, so older proxies that already forward
+`/api/*` need no route edit. Previously copied `/join/` commands may still fail
+or have expired.
 See the [Docker upgrade guide](docker/README.md#upgrades) for details.
 
 The hub serves agent updates too: eligible older agents can update and restart

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -29,6 +29,9 @@ legacy SHAs).
   existence is running; only the hub's current offer is the reference.
 - **Version unknown** — the hub has no reported running SHA for this agent
   (older hub response or no report yet), so no match is claimed.
+- **Status unknown (older hub)** — the hub predates per-architecture availability
+  reporting. Even if it reports no pending update, the dashboard does not infer
+  that the agent matches an available build.
 - **Update pending** — the offered SHA differs and nothing blocks the update.
 - **Withheld / Unavailable** — the hub refuses to announce (see the blocked
   reason: missing pinned key, unreadable release floor, transport policy,
@@ -41,8 +44,15 @@ legacy SHAs).
 
 ## Rollout control
 
-Pause halts update announcements fleet-wide; the automatic circuit breaker
-can also pause after repeated rollout failures. See
+In v1.2.1 and later, an operator's **Pause rollout** is saved in the hub database
+and survives hub restarts and changes to served agent files. A successful pause
+stops new update announcements fleet-wide; it cannot cancel an update already
+announced or in progress. Failed pause/resume writes return an error instead of
+claiming success, and unreadable saved state withholds announcements.
+
+The automatic circuit breaker can also pause after repeated rollout failures;
+it is separate from the saved operator pause. v1.2.0 and earlier do not enforce
+the durable pause, including after a downgrade. See
 [update recovery](agent-update-recovery.md) for the failure/rollback paths and
 [offline update signing](offline-update-signing.md) for detached-signature
 operation.


### PR DESCRIPTION
## Summary
- Explain offered-build, legacy/unknown and missing-platform status.
- Document durable pause, already-announced updates and downgrade limitations.
- Link public HTTPS CA guidance and clarify the since-v1.2.0 join route.
- Align the Versions guide with shipped labels and behavior.
- Preserve accurately labelled v1.1.0 screenshots.

## Validation
- All 34 relative documentation links and heading anchors checked.
- git diff --check passed.
- Documentation only: no app, workflow, deployment or release changes.
- Independent Claude factual review underway.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application, deployment, or release artifact updates.
> 
> **Overview**
> **Documentation-only** update for v1.2.1: the README gains a **Know what your agents are running** section (Versions page semantics, offered vs newest release, durable **Pause rollout** behavior and downgrade limits) and **public TLS** onboarding notes (`BLOXOS_CA_CERT` unset for Let's Encrypt, invalid CA blocks install commands). The upgrade blurb now frames `/api/join/` as the path **since v1.2.0**.
> 
> `docs/versions.md` adds **Status unknown (older hub)** for pre–per-arch availability reporting and expands **Rollout control** to match v1.2.1: pause persisted in the hub DB, cannot revoke in-flight announcements, error handling for pause/resume, and separation from the automatic circuit breaker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0a678edcd8860e4e778018e2cb75acea51a31f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->