### PR TITLE
docs: restore README dashboard image delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See what is running, understand your hardware, and manage your fleet from one da
 
 </div>
 
-![Operations Wall showing connected Linux and Windows demo machines, fleet resource usage, and machine controls](docs/screenshots/operations-wall.png)
+![Operations Wall showing connected Linux and Windows demo machines, fleet resource usage, and machine controls](https://cdn.jsdelivr.net/gh/bokiko/bloxos@bca13c456ecc1e5bd89282f96486a43b602bc4f9/docs/screenshots/operations-wall.png)
 
 *Actual v1.1.0 dashboard with synthetic demo machines. Missing GPU sensors display N/A; no private fleet data is shown.*
 
@@ -46,7 +46,7 @@ accounts keep Classic until they choose another design.
 
 | Grove Workspace · Original | Precision Console · Bright |
 | --- | --- |
-| [![Grove Workspace dashboard with synthetic demo machines](docs/screenshots/grove-workspace.png)](docs/screenshots/grove-workspace.png) | [![Precision Console dashboard with synthetic demo machines](docs/screenshots/precision-console.png)](docs/screenshots/precision-console.png) |
+| [![Grove Workspace dashboard with synthetic demo machines](https://cdn.jsdelivr.net/gh/bokiko/bloxos@bca13c456ecc1e5bd89282f96486a43b602bc4f9/docs/screenshots/grove-workspace.png)](https://cdn.jsdelivr.net/gh/bokiko/bloxos@bca13c456ecc1e5bd89282f96486a43b602bc4f9/docs/screenshots/grove-workspace.png) | [![Precision Console dashboard with synthetic demo machines](https://cdn.jsdelivr.net/gh/bokiko/bloxos@bca13c456ecc1e5bd89282f96486a43b602bc4f9/docs/screenshots/precision-console.png)](https://cdn.jsdelivr.net/gh/bokiko/bloxos@bca13c456ecc1e5bd89282f96486a43b602bc4f9/docs/screenshots/precision-console.png) |
 
 [See all three dashboards →](docs/screenshots/README.md) · [Design and color guide →](docs/themes/README.md)
 

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -14,26 +14,31 @@ are illustrative, not hardware benchmarks.
 
 An open overview with fleet health, resource bars and a machine register.
 
-![Operations Wall in its original blue palette, with summary panels and Linux and Windows demo machines](operations-wall.png)
+![Operations Wall in its original blue palette, with summary panels and Linux and Windows demo machines](https://cdn.jsdelivr.net/gh/bokiko/bloxos@bca13c456ecc1e5bd89282f96486a43b602bc4f9/docs/screenshots/operations-wall.png)
 
 ## Grove Workspace · Original
 
 A sidebar, central fleet analytics and a separate operational context column.
 
-![Grove Workspace in its original green palette, showing fleet analytics and a right-hand context column](grove-workspace.png)
+![Grove Workspace in its original green palette, showing fleet analytics and a right-hand context column](https://cdn.jsdelivr.net/gh/bokiko/bloxos@bca13c456ecc1e5bd89282f96486a43b602bc4f9/docs/screenshots/grove-workspace.png)
 
 ## Precision Console · Bright
 
 A compact navigation rail and table-first view with telemetry instruments.
 
-![Precision Console in its bright palette, showing a machine table and telemetry panels](precision-console.png)
+![Precision Console in its bright palette, showing a machine table and telemetry panels](https://cdn.jsdelivr.net/gh/bokiko/bloxos@bca13c456ecc1e5bd89282f96486a43b602bc4f9/docs/screenshots/precision-console.png)
 
 ## Asset notes
 
 - Captured from the release candidate whose source tree matches v1.1.0
   (`a46b39954616c8c1cb851412ee46fe05c816ab3e`).
-- Images are unmodified browser captures, 1440 pixels wide, stored locally so
-  the gallery does not depend on an external image host.
+- Images are unmodified browser captures, 1440 pixels wide. Originals remain
+  version-controlled beside this file.
+- Embedded images use commit-pinned jsDelivr copies of these public repository
+  files because GitHub raw-image delivery returned intermittent 503 errors.
+  When replacing captures, commit the new images
+  first, then update the image URLs in this gallery and the root README to that
+  commit. The URL pin identifies the stored files, not the app version captured.
 - Only synthetic fixture machines are visible. No enrollment links, passwords,
   tokens, real network addresses or private machine names are included.
 - The app's canonical [logo SVGs](../../dashboard/public/brand/) are reused by


### PR DESCRIPTION
GitHub raw-image URLs returned intermittent HTTP503, including commit-pinned raw URLs. README and gallery now use commit-pinned jsDelivr copies of the same public repository PNGs. Originals and v1.1.0 capture labels remain unchanged; future refresh instructions updated.

Validation: all three CDN images return HTTP200 image/png and SHA256 matches the repository originals. README and gallery use the same URLs. git diff --check passes. GitHub-rendered image delivery is also being checked.

Documentation-only; no application, deployment or release changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL and wording changes; no application, deployment, or runtime behavior is affected.
> 
> **Overview**
> **README** and **docs/screenshots/README.md** no longer embed dashboard screenshots via relative `docs/screenshots/*.png` paths. All three gallery images (Operations Wall, Grove Workspace, Precision Console) now point at **commit-pinned jsDelivr** URLs for the same PNGs in the public repo, so GitHub-rendered docs avoid intermittent **503** failures from raw/GitHub image delivery.
> 
> The gallery **asset notes** were updated to match: originals stay version-controlled locally, embedded views use jsDelivr, and refresh steps say to commit new captures first then update both README and gallery URLs to that commit pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4335d84a66d83dbd2a18d523bf5da1becb0429e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->