### PR TITLE
fix: recover onboarding trust and prevent incompatible agent installs

### DIFF
--- a/dashboard/src/components/AddMachineModal.tsx
+++ b/dashboard/src/components/AddMachineModal.tsx
@@ -591,7 +591,8 @@ function CommandDisplay({
                 TLS key (<code className="font-mono text-[10px] break-all">{resp.join_pin}</code>), so a different
                 server can&apos;t answer in its place. Hub certificates renew periodically; if the machine prints{" "}
                 <code className="font-mono text-[10px]">curl: (90) SSL: public key does not match pinned public key</code>
-                , the key changed since this command was made. Come back here and generate a new one.
+                , the endpoint no longer matches this command. Generate a new one. If a fresh command also fails,
+                ask the hub administrator to check the proxy certificate and pin-dial address. Do not remove the pin.
               </p>
             )}
             <p>

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -13,6 +13,9 @@ https://{$HUB_HOST} {
 	# accept Caddy's default ECDSA keys (see AGENTS.md).
 	tls internal {
 		key_type rsa2048
+		# Join commands pin the leaf key for 15 minutes. Keep that key
+		# across routine renewals so a renewal cannot invalidate a fresh command.
+		reuse_private_keys
 	}
 
 	# Hub API, agent and terminal WebSockets, installers and downloads.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,43 @@ treats the hub as public. If the hub cannot reach `PUBLIC_URL` over TLS at all,
 it refuses to mint rather than guess — this is a connectivity problem to fix,
 not a trust decision.
 
+### A copied command reports a TLS key mismatch
+
+`curl: (90)` means the endpoint's key does not match the key authenticated when
+the command was generated. Nothing from that command has run. Generate a fresh
+command in **Add Machine**; never remove `--pinnedpubkey`. If a fresh command
+also fails, check that `PUBLIC_URL` and `BLOXOS_PIN_DIAL_ADDR` reach the same TLS
+terminator and certificate seen by clients. Multiple proxies must present a
+consistent key, not merely certificates signed by the same CA.
+
+The bundled native and Compose Caddyfiles reuse the leaf key across routine
+renewals, keeping a fresh, 15-minute onboarding command valid during renewal.
+Certificates still renew and expire normally. This trades per-renewal key
+rotation for short-command stability; deliberate key rotation still requires
+fresh commands. Caddy currently documents `reuse_private_keys` as a temporary
+option: review its support when upgrading Caddy. See the
+[Caddy TLS policy documentation](https://caddyserver.com/docs/modules/tls).
+Existing deployments must apply the Caddyfile change separately from updating
+the hub; replacing the hub executable does not reload the proxy configuration.
+
+Keep Caddy's data volume or native data directory when upgrading. Recreating
+its private CA invalidates the trust saved by existing agents; leaf renewal
+alone does not require replacing their CA.
+
+### A Linux machine still has an older hub CA
+
+A fresh authenticated Add Machine command verifies the new CA against the
+fingerprint embedded in that command. If `/etc/bloxos/ca.crt` belongs to an older
+hub, the bootstrap keeps it and installs the verified replacement separately at
+`/etc/bloxos/certs/<sha256>.crt`. The installer configures the agent service to
+use that path. It does not delete secrets, update keys or rollback floors, and
+it refuses to overwrite a corrupt file at the fingerprint-specific path.
+
+This happens only when you run a new onboarding command; running agents do not
+silently accept a changed CA. An old copied script still has its original
+behavior, so generate a fresh command after updating the hub. Windows still
+refuses a mismatching saved CA and requires operator-managed trust recovery.
+
 For specialized power-history and update-floor settings, see
 [power history](power-history.md) and [agent recovery](agent-update-recovery.md).
 Do not commit filled environment files or include tokens/private keys in issue reports.

--- a/docs/native-agent-upgrades.md
+++ b/docs/native-agent-upgrades.md
@@ -4,6 +4,28 @@ Updating the hub executable does **not** update separately installed agent
 files. A machine that matches the hub's offered SHA is up to date **with that
 offered file**, not necessarily with the latest BloxOS release.
 
+### Agent is running, but drops offline after enrollment
+
+Very old agents save the issued secret without sending the enrollment
+confirmation required by newer hubs. The symptom is a successful first
+connection followed by a disconnect about 30 seconds later and repeated
+WebSocket handshake failures. `systemctl` can still report `active (running)`:
+that describes the process, not its connection to BloxOS. Hub logs are needed
+to distinguish this from proxy, network or other authentication failures.
+
+Use the current official agent payloads, not a rebuild of an old source tree.
+The onboarding download rejects unnumbered payloads because their enrollment
+compatibility cannot be established. Normal signed-update downloads remain
+available for existing agents; this check is specific to new installations.
+
+For a stranded machine, stage and activate compatible payloads using the steps
+below, then generate a fresh **Add Machine** command and run it again. A secret
+issued by the old incomplete handshake was never committed by the hub; merely
+restarting that old agent does not repair it. Do not delete the machine's CA,
+update key or rollback floor. If the hub already has an active credential for
+that machine, use explicit credential recovery instead of attempting to replace
+it with a generic install token.
+
 Docker hub images include the agent payloads. Native installations can use the
 three payloads attached to newer GitHub releases, extracted from those exact
 images without rebuilding:

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -377,7 +377,7 @@ fi
 # install here, with the hub's own explanation, rather than after a
 # service has been written.
 echo "Downloading agent binary..."
-DOWNLOAD_URL="${HUB_HTTP}/download/agent?os=linux&arch=${ARCH}"
+DOWNLOAD_URL="${HUB_HTTP}/download/agent?os=linux&arch=${ARCH}&enrollment=1"
 HTTP_STATUS=$(curl_fetch_status "$DOWNLOAD_URL" "${CA_CURL_ARGS[@]}" -o /tmp/bloxos-agent) || HTTP_STATUS="000"
 if [[ "$HTTP_STATUS" != "200" ]]; then
   echo "Agent download failed (HTTP ${HTTP_STATUS}) for arch=${ARCH}: ${DOWNLOAD_URL}" >&2
@@ -625,6 +625,18 @@ func (s *Server) caCertCandidatePaths() []string {
 	return bootstrapCACertCandidates()
 }
 
+// minEnrollmentAgentRelease is the lowest agent release marker a FRESH install
+// may receive. The agent's enrollment_committed handshake shipped first (agent
+// #169) and the source-controlled release marker was introduced later (#180),
+// so ANY release-marked binary (>= 1) is guaranteed to speak that handshake. A
+// markerless binary (release 0) MAY still support it — builds between those two
+// changes are markerless yet compatible — so the hub cannot VERIFY a markerless
+// binary's enrollment compatibility and refuses it for a fresh install rather
+// than risk stranding the machine, not because it is known incompatible. The
+// self-update path carries no enrollment flag and is never gated, so eligible
+// agents (including markerless ones) still download updates.
+const minEnrollmentAgentRelease uint64 = 1
+
 func handleDownloadAgent(c echo.Context) error {
 	// The target OS is detected from either the explicit ?os= query parameter
 	// or the User-Agent string. The architecture comes from ?arch= (GOARCH
@@ -661,6 +673,25 @@ func handleDownloadAgent(c echo.Context) error {
 		// through the resolver error, every path the hub looked at.
 		return c.JSON(http.StatusNotFound, map[string]string{
 			"error":  fmt.Sprintf("no %s agent binary is available for arch=%s: %s", platform.OS, platform.Arch, reason),
+			"os":     platform.OS,
+			"arch":   platform.Arch,
+			"source": state.Source,
+		})
+	}
+
+	// Enrollment compatibility gate. A fresh install (the installer requests
+	// ?enrollment=1) must not receive an agent that predates the mandatory
+	// enrollment_committed handshake: such a build saves a secret locally,
+	// then the hub drops it at the auth window with no credential stored, and
+	// every subsequent secret reconnect fails. The release marker is the
+	// reliable signal (see minEnrollmentAgentRelease). The flagless self-update
+	// path is unaffected, so already-enrolled agents keep updating.
+	if c.QueryParam("enrollment") == "1" && state.Release < minEnrollmentAgentRelease {
+		log.Printf("refusing enrollment download: %s/%s binary (source %s) carries no release marker; enrollment compatibility cannot be verified",
+			platform.OS, platform.Arch, state.Source)
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{
+			"error": fmt.Sprintf("this hub's %s/%s agent binary (source %s) carries no release marker, so the hub cannot verify it supports the enrollment handshake; installing it risks a machine that enrolls but never completes and then fails every reconnect. Stage the official current agent bundle following docs/native-agent-upgrades.md, then generate a fresh Add Machine command. Already-enrolled agents continue to update normally.",
+				platform.OS, platform.Arch, state.Source),
 			"os":     platform.OS,
 			"arch":   platform.Arch,
 			"source": state.Source,
@@ -955,7 +986,20 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 	for {
 		_, msg, err := ws.ReadMessage()
 		if err != nil {
-			log.Printf("agent disconnected: %v", err)
+			if authPending && freshPendingTokenHash != "" {
+				// Fact: a secret was issued ("enrolled") but the socket closed
+				// — typically at the fixed auth window — before any
+				// "enrollment_committed" arrived, so no credential was stored
+				// and the token was not consumed. The cause is not certain from
+				// here: an agent that predates the enrollment commit handshake
+				// never sends it, but a modern agent that could not durably
+				// save its secret (disk/network/interrupted) also, correctly,
+				// withholds it. Name the fact and the next steps, not a
+				// presumed cause.
+				log.Printf("enrollment did not complete for %s: no enrollment_committed received before the socket closed (%v); no credential was stored and every secret reconnect will fail. Possible causes: an outdated agent that cannot send the commit, or an interrupted enrollment (disk/network). Check the agent's logs; to recover, install a current release-numbered agent (see docs/native-agent-upgrades.md) and generate a fresh Add Machine command.", machineID, err)
+			} else {
+				log.Printf("agent disconnected: %v", err)
+			}
 			return nil
 		}
 		// A frame arrived — extend the deadline to the idle timeout, but only

--- a/hub/enrollment_compat_test.go
+++ b/hub/enrollment_compat_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
+)
+
+// The enrollment compatibility gate refuses to serve a fresh install
+// (?enrollment=1) an agent binary whose enrollment-handshake support cannot be
+// verified — a markerless (release 0) binary — while leaving the flagless
+// self-update download completely unchanged. These tests pin that contract.
+
+// writeMarkedAgentBinary writes a fake binary carrying release marker `release`
+// and returns its path. A marked binary is, by construction, built after the
+// enrollment_committed handshake shipped, so the gate must accept it.
+func writeMarkedAgentBinary(t *testing.T, release uint64) string {
+	t.Helper()
+	marker, err := updatesigning.ReleaseMarker(release)
+	if err != nil {
+		t.Fatalf("build release marker: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "bloxos-agent")
+	body := []byte("marked agent prefix\x00" + marker + "\x00marked agent suffix")
+	if err := os.WriteFile(path, body, 0o755); err != nil {
+		t.Fatalf("write marked binary: %v", err)
+	}
+	return path
+}
+
+func downloadAgent(t *testing.T, e http.Handler, query string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/download/agent"+query, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec.Code, rec.Body.String()
+}
+
+// TestEnrollmentDownloadRejectsMarkerlessBinary: a fresh install must not
+// receive a markerless binary — the hub cannot verify it speaks the enrollment
+// handshake — so the request is refused with an actionable 503 and the binary
+// bytes are never served.
+func TestEnrollmentDownloadRejectsMarkerlessBinary(t *testing.T) {
+	e, _ := setupTestServer(t)
+	withAgentBinaryState(t)
+	// useGeneratedTestBinaryForArch writes plain bytes: no release marker.
+	markerless := useGeneratedTestBinaryForArch(t, "linux", "amd64")
+	recomputeAgentBinarySHA()
+
+	code, body := downloadAgent(t, e, "?os=linux&arch=amd64&enrollment=1")
+	if code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%q, want 503 for a markerless enrollment download", code, body)
+	}
+	// Actionable, honest body: unverifiable (not "predates"), points at the
+	// staging procedure, and reassures the update path is unaffected.
+	for _, want := range []string{"release marker", "cannot verify", "docs/native-agent-upgrades.md", "update normally"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("503 body missing %q: %q", want, body)
+		}
+	}
+	// The refusal must be a JSON error, never the binary bytes.
+	if raw, _ := os.ReadFile(markerless); strings.Contains(body, string(raw)) {
+		t.Fatal("markerless binary bytes were served despite the gate")
+	}
+}
+
+// TestUpdateDownloadServesMarkerlessBinaryUnchanged: the same markerless binary
+// on the flagless self-update path still downloads with 200 — the gate never
+// touches updates, so no-marker fixtures and the migration hop are preserved.
+func TestUpdateDownloadServesMarkerlessBinaryUnchanged(t *testing.T) {
+	e, _ := setupTestServer(t)
+	withAgentBinaryState(t)
+	path := useGeneratedTestBinaryForArch(t, "linux", "amd64")
+	recomputeAgentBinarySHA()
+
+	code, body := downloadAgent(t, e, "?os=linux&arch=amd64")
+	if code != http.StatusOK {
+		t.Fatalf("status=%d body=%q, want 200 on the flagless update path", code, body)
+	}
+	want, _ := os.ReadFile(path)
+	if body != string(want) {
+		t.Fatal("update download did not serve the exact binary bytes")
+	}
+}
+
+// TestEnrollmentDownloadAcceptsReleasedBinaryAllArch: a release-marked binary is
+// accepted for enrollment on every platform the installer targets.
+func TestEnrollmentDownloadAcceptsReleasedBinaryAllArch(t *testing.T) {
+	e, _ := setupTestServer(t)
+	withAgentBinaryState(t)
+	for _, tc := range []struct{ os, arch, query string }{
+		{"linux", "amd64", "?os=linux&arch=amd64&enrollment=1"},
+		{"linux", "arm64", "?os=linux&arch=arm64&enrollment=1"},
+		{"windows", "amd64", "?os=windows&enrollment=1"},
+	} {
+		path := writeMarkedAgentBinary(t, 7)
+		useTestResolvedBinaryForArch(t, tc.os, tc.arch, path)
+		recomputeAgentBinarySHA()
+
+		code, body := downloadAgent(t, e, tc.query)
+		if code != http.StatusOK {
+			t.Fatalf("%s/%s: status=%d body=%q, want 200 for a release-marked enrollment download", tc.os, tc.arch, code, body)
+		}
+		want, _ := os.ReadFile(path)
+		if body != string(want) {
+			t.Fatalf("%s/%s: enrollment download did not serve the exact binary bytes", tc.os, tc.arch)
+		}
+	}
+}
+
+// TestEnrollmentDownloadMissingBinaryUnchanged: an architecture the hub has no
+// binary for stays a 404 (its own honest message), with or without the flag —
+// the gate is not confused with the absent-binary case.
+func TestEnrollmentDownloadMissingBinaryUnchanged(t *testing.T) {
+	e, _ := setupTestServer(t)
+	withAgentBinaryState(t)
+	// Serve only linux/amd64; arm64 has no binary.
+	useTestResolvedBinaryForArch(t, "linux", "amd64", writeMarkedAgentBinary(t, 7))
+	recomputeAgentBinarySHA()
+
+	for _, q := range []string{"?os=linux&arch=arm64", "?os=linux&arch=arm64&enrollment=1"} {
+		code, body := downloadAgent(t, e, q)
+		if code != http.StatusNotFound {
+			t.Fatalf("query %q: status=%d body=%q, want 404 for an absent binary (not the enrollment 503)", q, code, body)
+		}
+	}
+}
+
+// TestEnrollmentDownloadDefaultArchGated: no ?arch means amd64, and the
+// enrollment flag still gates that default the installer's one-liner uses.
+func TestEnrollmentDownloadDefaultArchGated(t *testing.T) {
+	e, _ := setupTestServer(t)
+	withAgentBinaryState(t)
+	useGeneratedTestBinaryForArch(t, "linux", "amd64") // markerless default
+	recomputeAgentBinarySHA()
+
+	if code, body := downloadAgent(t, e, "?os=linux&enrollment=1"); code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%q, want 503 for the default-arch markerless enrollment download", code, body)
+	}
+}

--- a/hub/install_ca_recovery_test.go
+++ b/hub/install_ca_recovery_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLinuxBootstrapPreservesOldCA(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash unavailable")
+	}
+	ca := "new authenticated hub CA\n"
+	digest := sha256.Sum256([]byte(ca))
+	wantSHA := hex.EncodeToString(digest[:])
+	for _, tc := range []struct {
+		name, legacy, cached, download string
+		wantOK, wantFetch              bool
+	}{
+		{"new install", "", "", ca, true, true},
+		{"matching legacy", ca, "", "wrong", true, false},
+		{"rotated CA", "old CA\n", "", ca, true, true},
+		{"cached rotated CA", "old CA\n", ca, "wrong", true, false},
+		{"wrong download", "old CA\n", "", "wrong", false, true},
+		{"corrupt cached CA", "old CA\n", "corrupt", ca, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cred := filepath.Join(dir, "bloxos")
+			bin := filepath.Join(dir, "bin")
+			for _, path := range []string{cred, bin, filepath.Join(cred, "certs")} {
+				if err := os.MkdirAll(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			write := func(path, value string, mode os.FileMode) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte(value), mode); err != nil {
+					t.Fatal(err)
+				}
+			}
+			legacy := filepath.Join(cred, "ca.crt")
+			cached := filepath.Join(cred, "certs", wantSHA+".crt")
+			if tc.legacy != "" {
+				write(legacy, tc.legacy, 0o644)
+			}
+			if tc.cached != "" {
+				write(cached, tc.cached, 0o644)
+			}
+			// Trust changes must not delete credentials or rollback floors.
+			for _, name := range []string{"agent-secret", "agent-update.pub", "agent-update-floor"} {
+				write(filepath.Join(cred, name), "preserve-me", 0o600)
+			}
+			write(filepath.Join(dir, "download-ca"), tc.download, 0o644)
+			write(filepath.Join(bin, "curl"), `#!/bin/bash
+set -eu
+out=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    https://*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+case "$url" in
+  */ca.crt) touch "$TEST_ROOT/fetched"; cp "$TEST_ROOT/download-ca" "$out" ;;
+  */install.sh) printf 'printf "%%s" "$BLOXOS_CA_CERT" > "$TEST_ROOT/installed"\n' > "$out" ;;
+  *) exit 99 ;;
+esac
+`, 0o755)
+			if _, err := exec.LookPath("sha256sum"); err != nil {
+				if _, err := exec.LookPath("shasum"); err != nil {
+					t.Skip("no SHA-256 utility")
+				}
+				write(filepath.Join(bin, "sha256sum"), "#!/bin/sh\nexec shasum -a 256 \"$@\"\n", 0o755)
+			}
+			script := buildLinuxInstallCommand("https://hub.test", "wss://hub.test", "test-token", "https://hub.test/download/ca.crt", wantSHA)
+			// Sandbox privileged I/O only; execute the generated CA selection,
+			// hashing, failure paths and installer environment without root.
+			script = strings.NewReplacer(
+				"/etc/bloxos", cred,
+				`if [[ $(id -u) -eq 0 ]]; then SUDO=""; else SUDO=sudo; fi`, `SUDO=""`,
+				"install -d -o root -g root -m 0755", "mkdir -p",
+				"install -o root -g root -m 0644", "cp",
+			).Replace(script)
+			cmd := exec.Command("bash", "-c", script)
+			cmd.Env = append(os.Environ(), "PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"), "TEST_ROOT="+dir)
+			out, err := cmd.CombinedOutput()
+			if (err == nil) != tc.wantOK {
+				t.Fatalf("success=%v want=%v: %s", err == nil, tc.wantOK, out)
+			}
+			_, fetchedErr := os.Stat(filepath.Join(dir, "fetched"))
+			if (fetchedErr == nil) != tc.wantFetch {
+				t.Errorf("CA fetch=%v want=%v", fetchedErr == nil, tc.wantFetch)
+			}
+			installed, installErr := os.ReadFile(filepath.Join(dir, "installed"))
+			if tc.wantOK {
+				wantPath := legacy
+				if tc.legacy != "" && tc.legacy != ca {
+					wantPath = cached
+				}
+				if installErr != nil || string(installed) != wantPath {
+					t.Fatalf("installer CA path=%q, want=%q, err=%v", installed, wantPath, installErr)
+				}
+				got, err := os.ReadFile(wantPath)
+				if err != nil || string(got) != ca {
+					t.Fatal("installed CA does not match authenticated bytes")
+				}
+			} else if installErr == nil {
+				t.Fatal("installer ran despite unverified CA")
+			}
+			if tc.legacy != "" {
+				got, _ := os.ReadFile(legacy)
+				if string(got) != tc.legacy {
+					t.Fatal("legacy CA overwritten")
+				}
+			}
+			if tc.cached != "" {
+				got, _ := os.ReadFile(cached)
+				if string(got) != tc.cached {
+					t.Fatal("cached CA overwritten")
+				}
+			} else if !tc.wantOK {
+				if _, err := os.Stat(cached); !os.IsNotExist(err) {
+					t.Fatal("unverified CA persisted")
+				}
+			}
+			for _, name := range []string{"agent-secret", "agent-update.pub", "agent-update-floor"} {
+				got, _ := os.ReadFile(filepath.Join(cred, name))
+				if string(got) != "preserve-me" {
+					t.Errorf("%s changed", name)
+				}
+			}
+		})
+	}
+}

--- a/hub/install_commands.go
+++ b/hub/install_commands.go
@@ -63,6 +63,18 @@ CA_ARGS=()
 CA_ENV=()
 if [[ -n "$CA_SHA256" ]]; then
   CA_PATH=/etc/bloxos/ca.crt
+  CA_DIR=/etc/bloxos
+  if $SUDO test -f "$CA_PATH"; then
+    ACTUAL_CA_SHA=$($SUDO sha256sum "$CA_PATH" | awk '{print $1}')
+    if [[ "$ACTUAL_CA_SHA" != "$CA_SHA256" ]]; then
+      # A fresh authenticated command can belong to a rebuilt or different
+      # hub. Preserve the existing CA for the running agent and rollback;
+      # provision the newly verified CA separately for this installation.
+      echo "Keeping existing CA; provisioning this hub CA separately."
+      CA_DIR=/etc/bloxos/certs
+      CA_PATH="$CA_DIR/$CA_SHA256.crt"
+    fi
+  fi
   if $SUDO test -f "$CA_PATH"; then
     ACTUAL_CA_SHA=$($SUDO sha256sum "$CA_PATH" | awk '{print $1}')
     if [[ "$ACTUAL_CA_SHA" != "$CA_SHA256" ]]; then
@@ -78,7 +90,7 @@ if [[ -n "$CA_SHA256" ]]; then
       echo "CA fingerprint mismatch; expected $CA_SHA256, got $ACTUAL_CA_SHA" >&2
       exit 1
     fi
-    $SUDO install -d -o root -g root -m 0755 /etc/bloxos
+    $SUDO install -d -o root -g root -m 0755 "$CA_DIR"
     $SUDO install -o root -g root -m 0644 "$TMP_CA" "$CA_PATH"
   fi
   CA_ARGS=(--cacert "$CA_PATH")

--- a/hub/installer_bootstrap_test.go
+++ b/hub/installer_bootstrap_test.go
@@ -211,6 +211,23 @@ func TestCaddyRoutesBothInstallerPaths(t *testing.T) {
 	}
 }
 
+func TestBundledCaddyPreservesOnboardingPins(t *testing.T) {
+	for _, path := range []string{
+		filepath.Join("..", "scripts", "caddy", "Caddyfile"),
+		filepath.Join("..", "docker", "Caddyfile"),
+	} {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, directive := range []string{"default_sni {$HUB_HOST}", "key_type rsa2048", "reuse_private_keys"} {
+			if !strings.Contains(string(body), directive) {
+				t.Errorf("%s missing %s", path, directive)
+			}
+		}
+	}
+}
+
 func TestDashboardRendersOnlyServerGeneratedCommands(t *testing.T) {
 	body, err := os.ReadFile(filepath.Join("..", "dashboard", "src", "components", "AddMachineModal.tsx"))
 	if err != nil {
@@ -285,7 +302,7 @@ func TestLinuxInstallerConsumesPasteBlockCAContract(t *testing.T) {
 		`CA fingerprint mismatch at $CA_PATH`,
 		`CA_CURL_ARGS+=(--cacert "$CA_PATH")`,
 		`AGENT_CA_ENV="Environment=\"BLOXOS_CA_CERT=$CA_PATH\""`,
-		`DOWNLOAD_URL="${HUB_HTTP}/download/agent?os=linux&arch=${ARCH}"`,
+		`DOWNLOAD_URL="${HUB_HTTP}/download/agent?os=linux&arch=${ARCH}&enrollment=1"`,
 		`curl_fetch_status "$DOWNLOAD_URL" "${CA_CURL_ARGS[@]}" -o /tmp/bloxos-agent`,
 		"[Service]",
 		"${AGENT_CA_ENV}",
@@ -331,7 +348,7 @@ func TestLinuxInstallerRequestsArchAndVerifiesELF(t *testing.T) {
 	assertOrdered(t, script,
 		`x86_64)  ARCH="amd64"; ELF_MACHINE_WANT="3e00" ;;`,
 		`aarch64) ARCH="arm64"; ELF_MACHINE_WANT="b700" ;;`,
-		`DOWNLOAD_URL="${HUB_HTTP}/download/agent?os=linux&arch=${ARCH}"`,
+		`DOWNLOAD_URL="${HUB_HTTP}/download/agent?os=linux&arch=${ARCH}&enrollment=1"`,
 		`HTTP_STATUS=$(curl_fetch_status "$DOWNLOAD_URL"`,
 		`if [[ "$HTTP_STATUS" != "200" ]]; then`,
 		`echo "Hub response: $(cat /tmp/bloxos-agent)" >&2`,

--- a/hub/join_renewal_test.go
+++ b/hub/join_renewal_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Exercise the real copied command across renewal, not just a config string.
+// Renewing the certificate with the same key must work; changing the key must
+// still fail closed, even when the response contains an executable script.
+func TestJoinCommandAcrossCertificateRenewal(t *testing.T) {
+	for _, tool := range []string{"bash", "curl"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s unavailable", tool)
+		}
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate := func(serial int64, key *ecdsa.PrivateKey) *tls.Certificate {
+		t.Helper()
+		template := &x509.Certificate{
+			SerialNumber: big.NewInt(serial), NotBefore: time.Now().Add(-time.Minute),
+			NotAfter: time.Now().Add(time.Hour), KeyUsage: x509.KeyUsageDigitalSignature,
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+	}
+	var current atomic.Pointer[tls.Certificate]
+	initial := certificate(1, key)
+	current.Store(initial)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("echo bloxos-renewal-script-ran\n"))
+	}))
+	srv.TLS = &tls.Config{GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+		return &tls.Config{Certificates: []tls.Certificate{*current.Load()}}, nil
+	}}
+	srv.StartTLS()
+	defer srv.Close()
+	leaf, err := x509.ParseCertificate(initial.Certificate[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := buildLinuxJoinCommand(srv.URL+"/api/join/test", spkiPinOf(leaf))
+	for _, serial := range []int64{1, 2} {
+		current.Store(certificate(serial, key))
+		out, err := exec.Command("bash", "-c", command).CombinedOutput()
+		if err != nil || !strings.Contains(string(out), "bloxos-renewal-script-ran") {
+			t.Fatalf("certificate %d: %v, %s", serial, err, out)
+		}
+	}
+	newKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Store(certificate(3, newKey))
+	out, err := exec.Command("bash", "-c", command).CombinedOutput()
+	if err == nil || strings.Contains(string(out), "bloxos-renewal-script-ran") {
+		t.Fatalf("key rotation bypassed pin: %v, %s", err, out)
+	}
+}

--- a/hub/windows_installer.go
+++ b/hub/windows_installer.go
@@ -101,7 +101,7 @@ function Invoke-CurlDownload([string]$Url, [string]$OutputPath) {
     if ($LASTEXITCODE -ne 0) { throw "Download failed for $Url (curl exit $LASTEXITCODE)" }
 }
 
-$DownloadUrl = "$HubHttp/download/agent?os=windows"
+$DownloadUrl = "$HubHttp/download/agent?os=windows&enrollment=1"
 $StagingExe = "$AgentExe.installing"
 Remove-Item -LiteralPath $StagingExe -Force -ErrorAction SilentlyContinue
 Invoke-CurlDownload $DownloadUrl $StagingExe

--- a/scripts/caddy/Caddyfile
+++ b/scripts/caddy/Caddyfile
@@ -1,5 +1,7 @@
 {
 	# Use Caddy's internal CA for self-signed TLS on LAN
+	# IP-address clients send no SNI (including the hub's pin probe).
+	default_sni {$HUB_HOST}
 }
 
 https://{$HUB_HOST} {
@@ -7,6 +9,8 @@ https://{$HUB_HOST} {
 	# accept Caddy's default ECDSA keys (see AGENTS.md).
 	tls internal {
 		key_type rsa2048
+		# Keep short-lived onboarding pins valid across certificate renewal.
+		reuse_private_keys
 	}
 
 	# Hub API routes


### PR DESCRIPTION
## Summary

Fix the product paths behind two onboarding failures without deleting machine trust or weakening enrollment authentication.

- Linux bootstrap preserves a mismatching legacy CA and installs the newly fingerprint-verified CA at a separate content-addressed path. The installer persists that path in the service; secrets, update keys, and rollback floors stay intact.
- Native/Compose Caddyfiles retain RSA leaf keys across ordinary renewal, so an otherwise fresh 15-minute pinned command does not break at renewal. Native IP clients also receive the configured default SNI certificate. Explicit key rotation still fails closed and needs a fresh command.
- Both installers request `enrollment=1` when downloading the agent. The hub refuses an unnumbered binary on that path because it cannot establish enrollment-handshake compatibility. The existing flagless signed-update/migration download stays unchanged.
- Hub logs distinguish incomplete enrollment from ordinary disconnection, with possible causes and recovery instructions. Dashboard/docs explain stale pins, inconsistent TLS endpoints, retained CAs and native payload activation.

## Why

Older deployed agents save an issued secret but never send `enrollment_committed`. A newer hub correctly refuses to commit that enrollment, then closes at its 30-second authentication deadline. The agent keeps running but cannot authenticate subsequent reconnects. Serving that old payload again repeats the problem. This change prevents the incompatible installation rather than undoing the durable enrollment handshake.

Not every unnumbered build is incompatible; this is a conservative compatibility check. Numbered official builds postdate the commit handshake. It is not an authentication or signing substitute.

## Validation

- Exact-commit CI: hub tests, full hub race tests, both agent platforms, shared protocol, dashboard and Compose onboarding all passed.
- Executed generated Bash recovery tests: new CA, matching legacy CA, rotated CA, cached replacement, bad download, corrupt cached target, and preservation of credential/floor files.
- Real curl test: renewed certificate with the same key works; changed key cannot execute the script.
- Final focused race run passed (14.9s), covering compatibility gates, both changed URL expectations, CA recovery, pin renewal and bundled Caddy configuration.
- An earlier local full race run started during edits and failed only the two old installer-URL expectations. The committed expectations are corrected; no race warning was reported. Full race CI passed on the exact committed snapshot.
- Dashboard: 94 tests, TypeScript, component ESLint and production build passed.
- Both Caddyfiles adapted with verified official Caddy 2.11.4; generated policies retain RSA2048 and `reuse_private_keys`.
- Unchanged agent source cross-builds for Linux/Windows; native macOS agent tests are unsupported. Linux CI covers the agent runtime tests.

## Deployment / limits

- No live machine, CA, credential, service, update floor or fleet signing key was changed.
- Existing native hubs must activate compatible official agent payloads through their normal staging/signing procedure; updating only the hub executable does not replace those files.
- Already-stranded machines need a fresh Add Machine command after payload activation. The patch cannot recover a secret the old handshake never committed.
- Apply/reload the Caddyfile separately on existing deployments. Preserve Caddy's CA data. `reuse_private_keys` trades per-renewal leaf-key rotation for onboarding stability and is documented by Caddy as temporary; review it when upgrading Caddy.
- Windows CA rotation remains operator-managed; the automatic retained-CA recovery here is Linux-only.
