### PR TITLE
docs: update installation instructions for v1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ dashboard support **Linux amd64 and arm64**. Ports **80 and 443** must be availa
 ### 1. Download BloxOS
 
 ```sh
-git clone --branch v1.2.1 --depth 1 https://github.com/bokiko/bloxos.git
+git clone --branch v1.2.2 --depth 1 https://github.com/bokiko/bloxos.git
 cd bloxos/docker
 cp .env.example .env
 ```
@@ -111,7 +111,7 @@ hostname or IP—without `https://`, a path, or a port—and add the version:
 
 ```dotenv
 HUB_HOST=192.168.1.50
-BLOXOS_VERSION=1.2.1
+BLOXOS_VERSION=1.2.2
 ```
 
 Replace the example IP with your own address. Do not use `localhost` if other
@@ -165,7 +165,7 @@ second hub. A public one-line *hub* installer is not shipped.
 which preserves the database, secrets, signing identity and Caddy CA. Never
 use `docker compose down -v` to update.
 
-In your existing Compose directory, set `BLOXOS_VERSION=1.2.1` in your existing
+In your existing Compose directory, set `BLOXOS_VERSION=1.2.2` in your existing
 `.env`, then run these with the same project name and any existing overrides:
 
 ```sh
@@ -182,6 +182,13 @@ Since v1.2.0, new commands use `/api/join/`, so older proxies that already forwa
 or have expired.
 See the [Docker upgrade guide](docker/README.md#upgrades) for details.
 
+v1.2.2 adds Linux recovery for a saved CA from an older hub and stops fresh
+installs from receiving unnumbered agents whose enrollment compatibility cannot
+be verified. Generate a fresh command after updating. To keep pinned commands
+valid across routine Caddy renewal, also apply the bundled Caddyfile's key-reuse
+setting to your existing configuration; pulling images does not update that
+bind-mounted file. See [onboarding trust recovery](docs/configuration.md#tls-trust-for-onboarding).
+
 The hub serves agent updates too: eligible older agents can update and restart
 after a hub upgrade. Legacy agents may need update-key pinning; offline-signing
 installations have a separate procedure. Very old or customized deployments
@@ -191,7 +198,7 @@ On a native installation, replacing the hub executable does **not** replace
 separate agent files. Use the [native agent check-and-stage guide](docs/native-agent-upgrades.md)
 to prepare the published payloads without starting a fleet rollout.
 
-[Release notes](https://github.com/bokiko/bloxos/releases/tag/v1.2.1) ·
+[Release notes](https://github.com/bokiko/bloxos/releases/tag/v1.2.2) ·
 [Update signing](docs/offline-update-signing.md) ·
 [Agent recovery](docs/agent-update-recovery.md)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,13 +8,13 @@ they are not containerized.
 
 Use Docker Compose v2 on a Linux amd64 or arm64 host. Ports 80 and 443 must
 be free, and browsers and agents must be able to reach the host. From a
-clone of the released `v1.2.1` tag:
+clone of the released `v1.2.2` tag:
 
 ```bash
 cd docker
 cp .env.example .env
 # Edit .env: set HUB_HOST to this machine's reachable hostname or IP.
-# Add BLOXOS_VERSION=1.2.1 to use this release's images.
+# Add BLOXOS_VERSION=1.2.2 to use this release's images.
 docker compose pull
 docker compose up -d --no-build
 ```
@@ -89,6 +89,21 @@ docker compose up -d --no-build hub dashboard
 
 Source-build installations instead update to a chosen tested source revision
 and run `docker compose up -d --build`.
+
+For v1.2.2's stable onboarding pins, add `reuse_private_keys` inside your
+existing Caddy `tls internal` block, retaining `key_type rsa2048`. Compare the
+[bundled Caddyfile](Caddyfile); preserve custom routes, settings and CA data.
+Pulling hub/dashboard images does not update this bind-mounted configuration.
+Validate and reload the configuration after editing:
+
+```bash
+docker compose exec caddy caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+```
+
+Without that proxy change, generate a fresh command if renewal changes the key
+after you copied it. Never remove pinning to work around a mismatch. See
+[TLS trust for onboarding](../docs/configuration.md#tls-trust-for-onboarding).
 
 ### 2. Verify
 


### PR DESCRIPTION
Documentation only: update current install/version examples and release link to v1.2.2; explain that existing bind-mounted Caddy configuration needs its separate key-reuse change and validation/reload. Historical since-v1.2.0/v1.2.1 statements remain unchanged. Hold merge until the v1.2.2 release is public. No application, workflow, agent, or dependency changes. git diff --check passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only version and upgrade guidance; no runtime, workflow, or dependency changes.
> 
> **Overview**
> **Documentation-only release bump** from **v1.2.1** to **v1.2.2** across install examples (`git clone` tag, `BLOXOS_VERSION`, release notes link) in `README.md` and `docker/README.md`.
> 
> The upgrade sections now call out **v1.2.2 behavior**: Linux recovery for a saved CA from an older hub, stricter fresh-install agent numbering, and the need to **manually add `reuse_private_keys`** to an existing bind-mounted Caddy `tls internal` block (with validate/reload steps in `docker/README.md`) so pinned Add Machine commands stay valid across Caddy renewal—image pulls alone do not update the Caddyfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 068d35219bac2850e3f354008c6bf48c9abd6117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->