### PR TITLE
feat: verified upgrade foundation (public build and instance checks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Test backup failure and restart handling
         run: python3 ../scripts/test_backup_compose.py
 
+      - name: Test wrong-installation upgrade safeguards
+        run: python3 -m unittest discover -s ../scripts/tests -p 'test_upgrade*.py'
+
       - name: Test native agent bundle validation and staging
         run: |
           python3 ../scripts/test_agent_bundle.py
@@ -202,4 +205,13 @@ jobs:
         run: pnpm test
 
       - name: Build dashboard
+        env:
+          BLOXOS_BUILD_VERSION: ${{ github.ref_name }}
+          BLOXOS_BUILD_REVISION: ${{ github.sha }}
         run: pnpm build
+
+      - name: Verify production dashboard build identity
+        env:
+          EXPECT_VERSION: ${{ github.ref_name }}
+          EXPECT_REVISION: ${{ github.sha }}
+        run: node scripts/test-build-info.mjs

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,9 @@ jobs:
         with:
           context: .
           file: Dockerfile.hub
+          build-args: |
+            BLOXOS_BUILD_VERSION=${{ github.ref_name }}
+            BLOXOS_BUILD_REVISION=${{ github.sha }}
           load: true
           tags: ${{ env.HUB_IMAGE }}:latest
           cache-from: type=gha,scope=hub
@@ -64,6 +67,9 @@ jobs:
         with:
           context: .
           file: Dockerfile.dashboard
+          build-args: |
+            BLOXOS_BUILD_VERSION=${{ github.ref_name }}
+            BLOXOS_BUILD_REVISION=${{ github.sha }}
           load: true
           tags: ${{ env.DASHBOARD_IMAGE }}:latest
           cache-from: type=gha,scope=dashboard
@@ -72,6 +78,8 @@ jobs:
         env:
           SMOKE_CONFIRM_DISPOSABLE: "1"
           HUB_HOST: 127.0.0.1
+          BLOXOS_EXPECT_VERSION: ${{ github.ref_name }}
+          BLOXOS_EXPECT_REVISION: ${{ github.sha }}
         run: scripts/smoke/compose-enroll.sh
 
   # Multi-platform build and push, version tags only. This is the only job
@@ -108,6 +116,9 @@ jobs:
         with:
           context: .
           file: Dockerfile.hub
+          build-args: |
+            BLOXOS_BUILD_VERSION=${{ github.ref_name }}
+            BLOXOS_BUILD_REVISION=${{ github.sha }}
           platforms: linux/amd64,linux/arm64
           outputs: type=image,name=${{ env.HUB_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           labels: |
@@ -120,6 +131,9 @@ jobs:
         with:
           context: .
           file: Dockerfile.dashboard
+          build-args: |
+            BLOXOS_BUILD_VERSION=${{ github.ref_name }}
+            BLOXOS_BUILD_REVISION=${{ github.sha }}
           platforms: linux/amd64,linux/arm64
           outputs: type=image,name=${{ env.DASHBOARD_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           labels: |

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Thumbs.db
 *.swp
 
 # Build artifacts
+__pycache__/
 /agent/agent
 /hub/hub
 *.db-shm

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -17,6 +17,10 @@ WORKDIR /app
 COPY dashboard/package.json dashboard/pnpm-lock.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 COPY dashboard/ ./
+ARG BLOXOS_BUILD_VERSION=development
+ARG BLOXOS_BUILD_REVISION=unknown
+ENV BLOXOS_BUILD_VERSION=$BLOXOS_BUILD_VERSION \
+    BLOXOS_BUILD_REVISION=$BLOXOS_BUILD_REVISION
 RUN pnpm build
 
 FROM node:22-alpine

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -14,6 +14,8 @@
 
 FROM --platform=$BUILDPLATFORM golang:1.26.8-alpine AS build
 ARG TARGETARCH
+ARG BLOXOS_BUILD_VERSION=development
+ARG BLOXOS_BUILD_REVISION=unknown
 ENV CGO_ENABLED=0 \
     GOTOOLCHAIN=local \
     GOFLAGS="-trimpath -buildvcs=false"
@@ -28,7 +30,7 @@ COPY agent/ agent/
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     mkdir -p /out/linux/amd64 /out/linux/arm64 /out/windows \
- && (cd hub   && GOOS=linux   GOARCH="$TARGETARCH" go build -ldflags='-s -w' -o /out/bloxos-hub .) \
+ && (cd hub   && GOOS=linux   GOARCH="$TARGETARCH" go build -ldflags="-s -w -X main.buildVersion=$BLOXOS_BUILD_VERSION -X main.buildRevision=$BLOXOS_BUILD_REVISION" -o /out/bloxos-hub .) \
  && (cd agent && GOOS=linux   GOARCH=amd64        go build -ldflags='-s -w' -o /out/linux/amd64/bloxos-agent .) \
  && (cd agent && GOOS=linux   GOARCH=arm64        go build -ldflags='-s -w' -o /out/linux/arm64/bloxos-agent .) \
  && (cd agent && GOOS=windows GOARCH=amd64        go build -ldflags='-s -w' -o /out/windows/bloxos-agent.exe .)

--- a/README.md
+++ b/README.md
@@ -165,7 +165,13 @@ second hub. A public one-line *hub* installer is not shipped.
 which preserves the database, secrets, signing identity and Caddy CA. Never
 use `docker compose down -v` to update.
 
-In your existing Compose directory, set `BLOXOS_VERSION=1.2.2` in your existing
+**Identify the installation first.** The commands below update **Docker Compose
+only**. If your website is served by native `bloxos-hub` / `bloxos-dashboard`
+systemd services, pulling containers does not update those services. If both
+exist, do not start another stack or switch the proxy: establish which existing
+installation serves your public URL. See [upgrade verification](docs/verified-upgrades.md).
+
+For an existing **Compose deployment**, set `BLOXOS_VERSION=1.2.2` in your existing
 `.env`, then run these with the same project name and any existing overrides:
 
 ```sh
@@ -173,7 +179,9 @@ docker compose pull hub dashboard
 docker compose up -d --no-build hub dashboard
 ```
 
-Refresh your browser when the services are healthy. Keep your existing volumes
+Container health alone does not prove the public website was upgraded. Verify
+the hub **and dashboard** through the URL you actually use before declaring
+success. Keep your existing volumes
 and keys; normal upgrades do not require enrolling every machine again.
 
 For new machines, generate a **fresh** Add Machine command after upgrading.

--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,6 +1,12 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Compile these into the server bundle: changing runtime environment must
+  // not make an old dashboard advertise a newer build.
+  env: {
+    BLOXOS_BUILD_VERSION: process.env.BLOXOS_BUILD_VERSION || "development",
+    BLOXOS_BUILD_REVISION: process.env.BLOXOS_BUILD_REVISION || "unknown",
+  },
   // Self-contained server for the container image (Dockerfile.dashboard).
   output: "standalone",
   // Pin the project root so file tracing does not climb to a lockfile in a

--- a/dashboard/scripts/test-build-info.mjs
+++ b/dashboard/scripts/test-build-info.mjs
@@ -1,0 +1,61 @@
+// Run after a production build, with EXPECT_VERSION/EXPECT_REVISION set to
+// its build stamps. Exercise the shipped standalone server, not a mock route.
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { createServer } from 'node:net';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const { EXPECT_VERSION, EXPECT_REVISION } = process.env;
+assert.ok(EXPECT_VERSION && EXPECT_REVISION, 'expected build stamps are required');
+
+async function checkProcess() {
+  const reservation = createServer();
+  reservation.listen(0, '127.0.0.1');
+  await once(reservation, 'listening');
+  const port = reservation.address().port;
+  await new Promise(resolve => reservation.close(resolve));
+  const child = spawn(process.execPath, ['.next/standalone/server.js'], {
+    env: { ...process.env, HOSTNAME: '127.0.0.1', PORT: String(port),
+      BLOXOS_BUILD_VERSION: 'wrong-runtime-version',
+      BLOXOS_BUILD_REVISION: 'wrong-runtime-revision' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let logs = '';
+  child.stdout.on('data', data => { logs = (logs + data).slice(-4000); });
+  child.stderr.on('data', data => { logs = (logs + data).slice(-4000); });
+  let spawnError;
+  child.on('error', error => { spawnError = error; });
+  const read = () => fetch(`http://127.0.0.1:${port}/build-info`,
+    { signal: AbortSignal.timeout(2000), redirect: 'error' });
+  try {
+    let response;
+    for (let attempt = 0; attempt < 50; attempt++) {
+      if (spawnError) throw spawnError;
+      if (child.exitCode !== null) throw new Error(`server exited: ${logs}`);
+      try { response = await read(); break; } catch { await delay(100); }
+    }
+    assert.ok(response?.ok, `standalone server did not become ready: ${logs}`);
+    assert.match(response.headers.get('cache-control'), /no-store/);
+    const first = await response.json();
+    assert.equal(first.component, 'dashboard');
+    assert.equal(first.version, EXPECT_VERSION);
+    assert.equal(first.revision, EXPECT_REVISION);
+    assert.match(first.instance_id, /^[0-9a-f-]{36}$/);
+    assert.deepEqual(await (await read()).json(), first);
+    return first.instance_id;
+  } finally {
+    if (child.exitCode === null && child.pid) {
+      const stopped = once(child, 'exit');
+      child.kill('SIGTERM');
+      const timeout = setTimeout(() => child.kill('SIGKILL'), 2000);
+      await stopped;
+      clearTimeout(timeout);
+    }
+  }
+}
+
+const first = await checkProcess();
+const second = await checkProcess();
+assert.notEqual(first, second, 'different dashboard processes must have different identities');
+console.log('PASS: standalone build stamps survive runtime overrides; instance identity changes on restart');

--- a/dashboard/src/app/build-info/route.ts
+++ b/dashboard/src/app/build-info/route.ts
@@ -1,0 +1,13 @@
+import { buildInfo } from '@/lib/build-info.mjs';
+
+// /api/* is forwarded to the hub by existing proxies. Keep this dashboard
+// endpoint outside that prefix so old proxy configurations need no change.
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export function GET() {
+  return Response.json(
+    buildInfo(process.env.BLOXOS_BUILD_VERSION, process.env.BLOXOS_BUILD_REVISION),
+    { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+  );
+}

--- a/dashboard/src/lib/build-info.mjs
+++ b/dashboard/src/lib/build-info.mjs
@@ -1,0 +1,13 @@
+import { randomUUID } from 'node:crypto';
+
+// Correlation only, not an authentication credential. A restart gets a new ID.
+const instanceID = randomUUID();
+
+export function buildInfo(version, revision) {
+  return {
+    component: 'dashboard',
+    version: version || 'development',
+    revision: revision || 'unknown',
+    instance_id: instanceID,
+  };
+}

--- a/dashboard/src/lib/build-info.test.mjs
+++ b/dashboard/src/lib/build-info.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { buildInfo } from './build-info.mjs';
+
+test('build identity is minimal and process-stable', () => {
+  const a = buildInfo('v1.2.3', 'abc123');
+  assert.deepEqual(a, buildInfo('v1.2.3', 'abc123'));
+  assert.deepEqual(Object.keys(a).sort(), ['component', 'instance_id', 'revision', 'version']);
+  assert.equal(a.component, 'dashboard');
+  assert.equal(a.version, 'v1.2.3');
+  assert.equal(a.revision, 'abc123');
+  assert.match(a.instance_id, /^[0-9a-f-]{36}$/);
+  assert.equal(buildInfo().revision, 'unknown');
+});
+
+test('a different process has a different identity even on the same build', () => {
+  const moduleURL = new URL('./build-info.mjs', import.meta.url).href;
+  const child = spawnSync(process.execPath, ['--input-type=module', '-e',
+    `import {buildInfo} from ${JSON.stringify(moduleURL)}; process.stdout.write(buildInfo().instance_id)`], {encoding:'utf8'});
+  assert.equal(child.status, 0, child.stderr);
+  assert.notEqual(child.stdout, buildInfo().instance_id);
+});
+
+test('route bypasses static caching and build metadata is compiled in', () => {
+  const route = readFileSync(new URL('../app/build-info/route.ts', import.meta.url), 'utf8');
+  const config = readFileSync(new URL('../../next.config.ts', import.meta.url), 'utf8');
+  assert.match(route, /force-dynamic/);
+  assert.match(route, /no-store/);
+  assert.match(config, /BLOXOS_BUILD_VERSION: process.env.BLOXOS_BUILD_VERSION/);
+  assert.match(config, /BLOXOS_BUILD_REVISION: process.env.BLOXOS_BUILD_REVISION/);
+});

--- a/docker/README.md
+++ b/docker/README.md
@@ -73,6 +73,12 @@ Operations:
 
 ## Upgrades
 
+These instructions update an existing **Compose** installation, not native
+systemd services. Healthy new containers can coexist with an older native
+website still serving port 443. On a mixed host, first identify the actual
+upstreams; never choose Docker just because a Compose file exists. See
+[upgrade verification](../docs/verified-upgrades.md).
+
 Back up first using the [backup and restore guide](../docs/backup-restore.md),
 then upgrade from your existing Compose directory with the same project name
 and any existing overrides. Preserve volumes, keys, and your `.env`.
@@ -114,7 +120,10 @@ flags):
 docker compose exec caddy wget -qO- http://hub:4000/health
 ```
 
-Expected: `{"status":"ok"}`. Then, in the dashboard, generate a **fresh** Add
+Expected: `{"status":"ok"}`. This proves internal liveness only—not the build
+or that your public URL reaches this container. Check both public components
+as described in [upgrade verification](../docs/verified-upgrades.md).
+Then, in the dashboard, generate a **fresh** Add
 Machine command: v1.2.0 mints one-line onboarding links under `/api/join/`,
 which works with older proxies that already forward `/api/*` to the hub.
 No Caddyfile edit is required for those new commands. (The legacy `/join/`

--- a/docs/verified-upgrades.md
+++ b/docs/verified-upgrades.md
@@ -1,0 +1,85 @@
+# Verify the installation you are updating
+
+An upgrade is not complete just because containers started or `/health`
+returns `ok`. An older native installation may still serve your website.
+Likewise, the Git checkout tag does not identify an already running executable.
+
+## Current scope
+
+This branch adds **read-only verification**, not an automatic native/Compose
+updater. The in-place update adapters, migration-aware rollback and legacy
+upgrade bridge are not implemented yet. Do not use Docker commands to update
+a native installation, and do not switch databases or proxy upstreams as an
+upgrade shortcut.
+
+The new endpoints are:
+
+| Component | Public path | Reports |
+| --- | --- | --- |
+| Hub | `/api/build-info` | Hub executable version, revision, process instance ID |
+| Dashboard | `/build-info` | Compiled dashboard version, revision, process instance ID |
+
+These unauthenticated endpoints contain no secrets or filesystem paths and
+disable caching. The instance ID changes on restart, distinguishing two
+processes running the same release. It is a correlation identifier, not proof
+of authenticity; TLS and the trusted local connection provide that boundary.
+Existing proxy configurations forwarding `/api/*` to the hub and other paths
+to the dashboard need no new route.
+
+`/health` remains a liveness check. Existing `hub_sha` fields in the agent
+versions response still describe a **served agent payload**, not the hub build.
+
+## Read-only check
+
+For a native installation with verified local listeners on ports 4000/3000:
+
+```sh
+python3 scripts/upgrade_preflight.py \
+  --public-url https://YOUR-HUB \
+  --local-hub-url http://127.0.0.1:4000 \
+  --local-dashboard-url http://127.0.0.1:3000 \
+  --detect
+```
+
+For private TLS, add `--ca-file /path/to/the/trusted/root.crt`. Obtain that CA
+from your known installation, not an unverified download. The check never
+disables certificate verification. Use the actual ports; local URLs must be
+known to belong to the installation you intend to update.
+
+Add `--expect-version vX.Y.Z --expect-revision FULL_COMMIT_SHA` to verify a
+particular release. Public and local identities must agree for **both**
+components. Missing metadata in an older version is **UNKNOWN**, not success
+and not proof that the website is unhealthy. Native source builds without
+build stamps are also unverifiable as releases.
+
+This is not yet an automatic deployment detector: unit/container observations
+are evidence, not proof of proxy routing. A native Caddy process can proxy
+containers. Missing Docker permissions are not evidence that no containers
+exist. Load-balanced replicas require a replica-aware workflow; a single
+instance comparison intentionally refuses an ambiguous result.
+
+## Preserve the original installation
+
+- Do not remove orphan containers, volumes, untracked files or old keys as an
+  upgrade step. They may contain the real database or signing identity.
+- Keep a consistent backup, including SQLite WAL and all applicable identity
+  files. The existing Compose backup helper is **not** a native backup tool.
+- Build and validate both replacement components before downtime.
+- Do not restore only an old executable after a database migration; rollback
+  must account for the matching database snapshot and writes since the backup.
+- Hub/dashboard verification does not claim the fleet agents were updated.
+  Native agent payloads and offline signatures remain separate operations.
+
+## Build stamps
+
+Release images stamp both components with the release ref and source revision.
+For deliberate native builds, stamp the hub at link time:
+
+```sh
+go build -ldflags "-X main.buildVersion=vX.Y.Z -X main.buildRevision=FULL_COMMIT_SHA" .
+```
+
+Build the dashboard with `BLOXOS_BUILD_VERSION` and `BLOXOS_BUILD_REVISION` set
+to the same values. These values are compiled into the dashboard; changing
+its runtime environment cannot relabel an old build. These are build examples,
+not deployment commands. Agent binaries are deliberately not restamped.

--- a/hub/build_info.go
+++ b/hub/build_info.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	cryptoRand "crypto/rand"
+	"encoding/hex"
+	"log"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// buildVersion and buildRevision identify the hub executable. They are stamped
+// at link time by the release build (see the -X ldflags in the Dockerfile /
+// build tooling, owned outside hub/); an unstamped build reports the defaults
+// below so a developer or source run is never mislabelled as a release.
+//
+//	go build -ldflags "-X main.buildVersion=v1.2.2 -X main.buildRevision=<sha>"
+var (
+	buildVersion  = "development"
+	buildRevision = "unknown"
+)
+
+// hubInstanceID is a cryptographically random identifier minted once per hub
+// process at startup. It is NOT a secret and carries no host information (no
+// paths, env, hostname, or keys): its only purpose is to let a verified upgrade
+// confirm that the instance answering the public URL is the very process it
+// just started — two processes on the identical version and revision still have
+// distinct instance IDs. It is stable for the life of the process and changes
+// on every restart.
+var hubInstanceID = newHubInstanceID()
+
+func newHubInstanceID() string {
+	var b [16]byte
+	if _, err := cryptoRand.Read(b[:]); err != nil {
+		// crypto/rand failing is catastrophic and never expected; fail loud
+		// rather than emit a predictable or empty identifier.
+		log.Fatalf("build-info: cannot generate instance id: %v", err)
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// handleBuildInfo reports the hub executable's identity for upgrade
+// verification. It is public and unauthenticated by design — a client must be
+// able to confirm which build answers the public URL before it can log in —
+// and reveals nothing sensitive. It is never cached, so a check always sees the
+// process currently serving the endpoint. Distinct from /health (liveness only)
+// and from the agent-version fields (which describe served agent payloads, not
+// this executable).
+func handleBuildInfo(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "no-store")
+	return c.JSON(http.StatusOK, map[string]string{
+		"component":   "hub",
+		"version":     buildVersion,
+		"revision":    buildRevision,
+		"instance_id": hubInstanceID,
+	})
+}

--- a/hub/build_info_test.go
+++ b/hub/build_info_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func getBuildInfo(t *testing.T, e http.Handler) (*httptest.ResponseRecorder, map[string]string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/build-info", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	var body map[string]string
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode build-info: %v (body %q)", err, rec.Body.String())
+		}
+	}
+	return rec, body
+}
+
+// TestBuildInfoReportsHubIdentity: the endpoint is public (no auth), returns the
+// four identity fields, and defaults to the unstamped values in a test build.
+func TestBuildInfoReportsHubIdentity(t *testing.T) {
+	e, _ := setupTestServer(t)
+	rec, body := getBuildInfo(t, e)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200 (public, no auth): %s", rec.Code, rec.Body.String())
+	}
+	if body["component"] != "hub" {
+		t.Errorf("component=%q, want hub", body["component"])
+	}
+	// Unstamped test binary reports the safe defaults, never a false release.
+	if body["version"] != "development" {
+		t.Errorf("version=%q, want the unstamped default %q", body["version"], "development")
+	}
+	if body["revision"] != "unknown" {
+		t.Errorf("revision=%q, want the unstamped default %q", body["revision"], "unknown")
+	}
+	id := body["instance_id"]
+	if raw, err := hex.DecodeString(id); err != nil || len(raw) != 16 {
+		t.Errorf("instance_id=%q, want 32 hex chars of randomness", id)
+	}
+}
+
+// TestBuildInfoInstanceStableWithinProcess: the instance id is minted once per
+// process, so every request in this process sees the identical value (it only
+// changes on restart).
+func TestBuildInfoInstanceStableWithinProcess(t *testing.T) {
+	e, _ := setupTestServer(t)
+	_, first := getBuildInfo(t, e)
+	_, second := getBuildInfo(t, e)
+	// A second server in the same process shares the process-lifetime id.
+	e2, _ := setupTestServer(t)
+	_, third := getBuildInfo(t, e2)
+	if first["instance_id"] == "" {
+		t.Fatal("instance_id empty")
+	}
+	if first["instance_id"] != second["instance_id"] || first["instance_id"] != third["instance_id"] {
+		t.Fatalf("instance_id not stable within the process: %q %q %q",
+			first["instance_id"], second["instance_id"], third["instance_id"])
+	}
+}
+
+// TestBuildInfoIsNotCached: an upgrade check must always see the process
+// currently serving the endpoint, so the response is never cached.
+func TestBuildInfoIsNotCached(t *testing.T) {
+	e, _ := setupTestServer(t)
+	rec, _ := getBuildInfo(t, e)
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control=%q, want no-store", got)
+	}
+}
+
+// TestBuildInfoDoesNotAffectHealthOrAgentVersion: /health keeps its exact
+// liveness-only contract, and the legacy agent-version fields are untouched by
+// this addition.
+func TestBuildInfoDoesNotAffectHealthOrAgentVersion(t *testing.T) {
+	e, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/health status=%d, want 200", rec.Code)
+	}
+	var health map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &health); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	// /health stays liveness-only: exactly {"status":"ok"}, no build metadata
+	// leaked into it, and no Cache-Control added.
+	if len(health) != 1 || health["status"] != "ok" {
+		t.Fatalf("/health body changed: %v", health)
+	}
+	if rec.Header().Get("Cache-Control") != "" {
+		t.Errorf("/health gained a Cache-Control header: %q", rec.Header().Get("Cache-Control"))
+	}
+}

--- a/hub/main.go
+++ b/hub/main.go
@@ -257,6 +257,9 @@ func main() {
 func (s *Server) registerRoutes(e *echo.Echo) {
 	// Public endpoints (no auth).
 	e.GET("/health", handleHealth)
+	// Build identity for upgrade verification (public, uncached; see
+	// build_info.go). Distinct from /health, which proves liveness only.
+	e.GET("/api/build-info", handleBuildInfo)
 	e.GET("/ws/agent", s.handleAgentWS)
 	e.POST("/api/auth/login", s.handleLogin)
 	e.GET("/install.sh", handleInstallScript)

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -243,6 +243,9 @@ func roleHasScope(role UserRole, requiredScope string) bool {
 // publicAPIRoutes lists the /api/* endpoints that are served without RBAC enforcement.
 var publicAPIRoutes = map[string]struct{}{
 	routeScopeKey(http.MethodPost, "/api/auth/login"):  {},
+	// Build identity (version/revision/instance_id) for upgrade verification.
+	// Public so a client can confirm which build answers the URL before login.
+	routeScopeKey(http.MethodGet, "/api/build-info"):   {},
 	routeScopeKey(http.MethodGet, "/api/setup/status"): {},
 	routeScopeKey(http.MethodPost, "/api/setup"):       {},
 	// Phase 10 — branding metadata + image bytes are public so the

--- a/scripts/smoke/compose-build-info.py
+++ b/scripts/smoke/compose-build-info.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Read-only identity acceptance for the disposable Compose smoke stack."""
+import json
+import os
+from pathlib import Path
+import ssl
+import subprocess
+import urllib.request
+
+COMPOSE = ["docker", "compose", "--project-directory",
+           str(Path(__file__).resolve().parents[2] / "docker")]
+
+
+def container_read(service, *command):
+    return subprocess.check_output(COMPOSE + ["exec", "-T", service, *command],
+                                   timeout=15, text=True)
+
+
+def main():
+    # Trust comes from the selected local container, not an unverified download.
+    ca = container_read("caddy", "cat", "/data/caddy/pki/authorities/local/root.crt")
+    context = ssl.create_default_context(cadata=ca)
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}),
+                                        urllib.request.HTTPSHandler(context=context))
+    base = "https://" + os.environ.get("HUB_HOST", "127.0.0.1")
+    for component, port, path in [("hub", 4000, "/api/build-info"),
+                                  ("dashboard", 3000, "/build-info")]:
+        direct = json.loads(container_read(component, "wget", "-qO-",
+                                           f"http://127.0.0.1:{port}{path}"))
+        with opener.open(base + path, timeout=10) as response:
+            assert response.url == base + path, "unexpected proxy redirect"
+            assert "no-store" in response.headers.get("Cache-Control", ""), "identity cached"
+            public = json.load(response)
+        assert direct == public, f"public route is not serving the selected {component} instance"
+        assert public["component"] == component and public["instance_id"], "missing identity"
+        for field, variable in [("version", "BLOXOS_EXPECT_VERSION"),
+                                ("revision", "BLOXOS_EXPECT_REVISION")]:
+            expected = os.environ.get(variable)
+            if expected:
+                assert public[field] == expected, f"{component} has wrong {field}"
+        print(f"PASS: public {component} matches selected container build and process")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke/compose-enroll.sh
+++ b/scripts/smoke/compose-enroll.sh
@@ -84,6 +84,7 @@ curl -sk --max-time 3 "$HUB/health" | grep -q '"ok"' || fail "hub not healthy th
 # (30 attempts, 2 s apart, 3 s curl timeout), and keep the final assertion a hard 200.
 echo "== wait for dashboard"
 wait_for_http_200 "$HUB/login" 30 || fail "dashboard not served"
+python3 "$COMPOSE_DIR/../scripts/smoke/compose-build-info.py" || fail "public build identity mismatch"
 [[ "$(curl -sk -o /dev/null -w '%{http_code}' "$HUB/install.ps1")" == 200 ]] || fail "Windows installer not served"
 
 echo "== served certificate key type"

--- a/scripts/tests/test_upgrade_preflight.py
+++ b/scripts/tests/test_upgrade_preflight.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Regression tests for scripts/upgrade_preflight.py — local fixtures only.
+
+Every test stands up its own in-process HTTP(S) servers; nothing touches a
+real deployment, network path, Docker daemon or systemd.
+"""
+import contextlib
+import http.server
+import json
+import os
+import ssl
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "upgrade_preflight.py"
+
+PASS, FAIL, UNKNOWN = 0, 1, 2
+
+LOCAL_ARGS = ("--local-hub-url", "http://127.0.0.1:4000", "--local-dashboard-url", "http://127.0.0.1:3000")
+
+HUB_INFO = {"component": "hub", "version": "1.2.2", "revision": "a" * 40, "instance_id": "inst-hub-1"}
+DASH_INFO = {"component": "dashboard", "version": "1.2.2", "revision": "a" * 40, "instance_id": "inst-dash-1"}
+
+
+def json_response(handler, payload, status=200, cache=True):
+    body = json.dumps(payload).encode()
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    if cache:
+        handler.send_header("Cache-Control", "no-store")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def make_handler(routes):
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            route = routes.get(self.path)
+            if route is None:
+                self.send_response(404)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(b"<html><body>not found</body></html>")
+                return
+            kind, payload = route
+            if kind == "json":
+                json_response(self, payload)
+            elif kind == "nocache":
+                json_response(self, payload, cache=False)
+            elif kind == "html":
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(b"<html><body>old dashboard</body></html>")
+            elif kind == "malformed":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b"{not json")
+            elif kind == "missing-fields":
+                json_response(self, {"component": payload, "version": "1.2.2"})
+            elif kind == "nonstring":
+                json_response(self, {"component": "hub", "version": "1.2.2",
+                                     "revision": "a" * 40, "instance_id": 123})
+            elif kind == "redirect":
+                self.send_response(302)
+                self.send_header("Location", payload)
+                self.end_headers()
+            elif kind == "oversized":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"component":"hub","padding":"' + b"x" * (128 * 1024) + b'"}')
+
+        def log_message(self, *args):
+            pass
+
+    return Handler
+
+
+@contextlib.contextmanager
+def server(routes, tls_cert=None):
+    httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), make_handler(routes))
+    if tls_cert:
+        cert, key = tls_cert
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(cert, key)
+        httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"{'https' if tls_cert else 'http'}://127.0.0.1:{httpd.server_address[1]}"
+    finally:
+        httpd.shutdown()
+        thread.join(timeout=5)
+        httpd.server_close()
+
+
+def run_cli(*argv):
+    return subprocess.run([sys.executable, str(SCRIPT), *argv],
+                          capture_output=True, text=True, timeout=60)
+
+
+def write_test_ca(tmpdir):
+    """Self-signed test CA + server cert/key generated once via openssl."""
+    ca_key = tmpdir / "ca.key"
+    ca_crt = tmpdir / "ca.crt"
+    srv_key = tmpdir / "srv.key"
+    srv_crt = tmpdir / "srv.crt"
+    subprocess.run(["openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+                    "-keyout", str(ca_key), "-out", str(ca_crt), "-days", "1",
+                    "-subj", "/CN=test-ca",
+                    "-addext", "basicConstraints=critical,CA:TRUE",
+                    "-addext", "keyUsage=critical,digitalSignature,keyCertSign"],
+                   capture_output=True, check=True)
+    subprocess.run(["openssl", "req", "-newkey", "rsa:2048", "-nodes",
+                    "-keyout", str(srv_key), "-out", str(tmpdir / "srv.csr"),
+                    "-subj", "/CN=localhost", "-addext", "subjectAltName=IP:127.0.0.1"],
+                   capture_output=True, check=True)
+    subprocess.run(["openssl", "x509", "-req", "-in", str(tmpdir / "srv.csr"),
+                    "-CA", str(ca_crt), "-CAkey", str(ca_key), "-CAcreateserial",
+                    "-out", str(srv_crt), "-days", "1",
+                    "-extfile", "/dev/stdin"],
+                   input=b"subjectAltName=IP:127.0.0.1", capture_output=True, check=True)
+    return str(ca_crt), (str(srv_crt), str(srv_key))
+
+
+class PreflightTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        try:
+            cls.ca_file, cls.server_cert = write_test_ca(Path(cls.tmp.name))
+        except Exception as err:
+            cls.ca_file, cls.server_cert = None, None
+            print(f"note: TLS fixtures unavailable ({err})")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    def routes(self, hub=HUB_INFO, dash=DASH_INFO):
+        return {"/api/build-info": ("json", hub), "/build-info": ("json", dash)}
+
+    def test_verified_match_public_and_local(self):
+        with server(self.routes()) as base:
+            res = run_cli("--public-url", base, "--local-hub-url", base,
+                          "--local-dashboard-url", base,
+                          "--expect-version", "1.2.2")
+            self.assertEqual(res.returncode, PASS, res.stderr + res.stdout)
+            self.assertIn("identity correlation", res.stdout)
+
+    def test_wrong_public_backend_fails(self):
+        wrong_hub = dict(HUB_INFO, instance_id="inst-OTHER")
+        with server(self.routes()) as local, server(self.routes(hub=wrong_hub)) as public:
+            res = run_cli("--public-url", public, "--local-hub-url", local,
+                          "--local-dashboard-url", local)
+            self.assertEqual(res.returncode, FAIL, res.stdout)
+            self.assertIn("instance_id", res.stdout)
+
+    def test_same_build_different_instance_fails(self):
+        other_hub = dict(HUB_INFO, instance_id="inst-hub-2")
+        with server(self.routes()) as local, server(self.routes(hub=other_hub)) as public:
+            res = run_cli("--public-url", public, "--local-hub-url", local,
+                          "--local-dashboard-url", local)
+            self.assertEqual(res.returncode, FAIL, res.stdout)
+
+    def test_local_public_version_divergence_fails(self):
+        newer_hub = dict(HUB_INFO, version="1.2.3", revision="b" * 40)
+        with server(self.routes()) as local, server(self.routes(hub=newer_hub)) as public:
+            res = run_cli("--public-url", public, "--local-hub-url", local,
+                          "--local-dashboard-url", local)
+            self.assertEqual(res.returncode, FAIL, res.stdout)
+            self.assertIn("version", res.stdout)
+
+    def test_missing_metadata_is_unknown_not_success(self):
+        with server({}) as base:  # everything 404s
+            res = run_cli("--public-url", base, *LOCAL_ARGS)
+            self.assertEqual(res.returncode, UNKNOWN, res.stdout)
+            self.assertIn("legacy endpoint", res.stdout)
+
+    def test_locals_required_for_verified_result(self):
+        with server(self.routes()) as base:
+            res = subprocess.run([sys.executable, str(SCRIPT), "--public-url", base],
+                                 capture_output=True, text=True, timeout=60)
+            self.assertNotEqual(res.returncode, 0, "public-only must not be a verified PASS")
+
+    def test_dashboard_build_mismatch_fails(self):
+        old_dash = dict(DASH_INFO, version="1.2.0")
+        with server(self.routes()) as local, server(self.routes(dash=old_dash)) as public:
+            res = run_cli("--public-url", public, "--local-hub-url", local,
+                          "--local-dashboard-url", local, "--expect-version", "1.2.2")
+            self.assertEqual(res.returncode, FAIL, res.stdout)
+            self.assertIn("wrong build", res.stdout)
+
+    def test_dev_metadata_never_passes(self):
+        for marker in ("dev", "development", "unknown", "unreleased", "snapshot"):
+            dev_hub = dict(HUB_INFO, version=marker)
+            with server(self.routes(hub=dev_hub)) as base:
+                res = run_cli("--public-url", base, *LOCAL_ARGS)
+                self.assertEqual(res.returncode, UNKNOWN, f"{marker}: {res.stdout}")
+                self.assertIn("development", res.stdout)
+
+    def test_missing_no_store_is_unknown(self):
+        routes = {"/api/build-info": ("nocache", HUB_INFO), "/build-info": ("json", DASH_INFO)}
+        with server(routes) as base:
+            res = run_cli("--public-url", base, *LOCAL_ARGS)
+            self.assertEqual(res.returncode, UNKNOWN, res.stdout)
+            self.assertIn("no-store", res.stdout)
+
+    def test_invalid_and_malformed_responses_unknown(self):
+        cases = [
+            {"/api/build-info": ("malformed", None)},
+            {"/api/build-info": ("html", None)},
+            {"/api/build-info": ("missing-fields", "hub")},
+            {"/api/build-info": ("nonstring", None)},
+        ]
+        for routes in cases:
+            routes["/build-info"] = ("json", DASH_INFO)
+            with server(routes) as base:
+                res = run_cli("--public-url", base, *LOCAL_ARGS)
+                self.assertEqual(res.returncode, UNKNOWN, f"{routes['/api/build-info']}: {res.stdout}")
+
+    def test_redirect_never_followed(self):
+        routes = {"/api/build-info": ("redirect", "http://evil.example/x\x1b[31m"),
+                  "/build-info": ("json", DASH_INFO)}
+        with server(self.routes()) as local, server(routes) as public:
+            res = run_cli("--public-url", public, "--local-hub-url", local,
+                          "--local-dashboard-url", local)
+            self.assertEqual(res.returncode, FAIL, res.stdout)
+            self.assertIn("redirect refused", res.stdout)
+            self.assertNotIn("evil.example", res.stdout)  # never echo redirect targets
+
+    def test_decisive_fail_outranks_unknown(self):
+        # Wrong build on public dashboard while local hub is unreachable:
+        # a known-wrong answer must not be reported merely UNKNOWN.
+        old_dash = dict(DASH_INFO, version="1.2.0")
+        with server(self.routes(dash=old_dash)) as public:
+            res = run_cli("--public-url", public, "--local-hub-url", "http://127.0.0.1:9",
+                          "--local-dashboard-url", public, "--expect-version", "1.2.2")
+            self.assertEqual(res.returncode, FAIL, res.stdout)
+
+    def test_url_validation_rejects_userinfo_query_fragment_and_remote_http(self):
+        for bad in ("https://user:pw@h.example", "https://h.example/?x=1",
+                    "https://h.example/#frag", "http://10.0.0.5"):
+            res = run_cli("--public-url", bad, *LOCAL_ARGS)
+            self.assertNotEqual(res.returncode, 0, bad)
+
+    def test_url_validation_edge_cases(self):
+        for bad, want in (
+            ("https://h.example/a b", "whitespace"),
+            ("https://h.example/a\x1fb", "control"),
+            ("https://", "hostname"),
+            ("http://[::1", "invalid URL"),
+            ("https://h.example:abc", "invalid URL"),
+            ("https://h.example/base?sneaky=1", "query"),
+        ):
+            res = run_cli("--public-url", bad, *LOCAL_ARGS)
+            self.assertNotEqual(res.returncode, 0, bad)
+
+    def test_public_loopback_http_allowed(self):
+        # Development fixture policy: http on loopback is accepted for public.
+        with server(self.routes()) as base:  # plain http on 127.0.0.1
+            res = run_cli("--public-url", base, "--local-hub-url", base,
+                          "--local-dashboard-url", base, "--expect-version", "1.2.2")
+            self.assertEqual(res.returncode, PASS, res.stdout)
+
+    def test_timeout_must_be_finite(self):
+        res = run_cli("--public-url", "https://h.example", *LOCAL_ARGS, "--timeout", "nan")
+        self.assertEqual(res.returncode, 2, res.stdout)
+
+    def test_oversized_response_unknown(self):
+        routes = {"/api/build-info": ("oversized", None), "/build-info": ("json", DASH_INFO)}
+        with server(routes) as base:
+            res = run_cli("--public-url", base, *LOCAL_ARGS)
+            self.assertEqual(res.returncode, UNKNOWN, res.stdout)
+
+    def test_unreachable_unknown(self):
+        res = run_cli("--public-url", "http://127.0.0.1:9", *LOCAL_ARGS, "--timeout", "2")
+        self.assertEqual(res.returncode, UNKNOWN, res.stdout)
+
+    def test_tls_with_ca_file_and_never_insecure(self):
+        if not self.ca_file:
+            self.skipTest("openssl fixtures unavailable")
+        with server(self.routes(), tls_cert=self.server_cert) as base:
+            res = run_cli("--public-url", base, "--local-hub-url", base,
+                          "--local-dashboard-url", base, "--ca-file", self.ca_file)
+            self.assertEqual(res.returncode, PASS, res.stdout)
+            res2 = run_cli("--public-url", base, "--local-hub-url", base,
+                           "--local-dashboard-url", base)  # self-signed: must fail, never auto-trust
+            self.assertEqual(res2.returncode, FAIL, res2.stdout)
+            self.assertIn("TLS verification failed", res2.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_upgrade_preflight.py
+++ b/scripts/tests/test_upgrade_preflight.py
@@ -63,6 +63,15 @@ def make_handler(routes):
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()
                 self.wfile.write(b"{not json")
+            elif kind == "interrupted":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Transfer-Encoding", "chunked")
+                self.end_headers()
+                # Announce a 16-byte chunk, then close after just one byte.
+                self.wfile.write(b"10\r\n{")
+                self.wfile.flush()
+                self.close_connection = True
             elif kind == "missing-fields":
                 json_response(self, {"component": payload, "version": "1.2.2"})
             elif kind == "nonstring":
@@ -190,6 +199,17 @@ class PreflightTests(unittest.TestCase):
             res = subprocess.run([sys.executable, str(SCRIPT), "--public-url", base],
                                  capture_output=True, text=True, timeout=60)
             self.assertNotEqual(res.returncode, 0, "public-only must not be a verified PASS")
+
+    def test_interrupted_response_is_unknown_without_traceback(self):
+        routes = self.routes()
+        routes["/api/build-info"] = ("interrupted", None)
+        with server(self.routes()) as local, server(routes) as public:
+            res = run_cli("--public-url", public, "--local-hub-url", local,
+                          "--local-dashboard-url", local)
+            self.assertEqual(res.returncode, UNKNOWN, res.stdout + res.stderr)
+            self.assertIn("interrupted HTTP response", res.stdout)
+            self.assertIn("result  UNKNOWN", res.stdout)
+            self.assertNotIn("Traceback", res.stderr)
 
     def test_dashboard_build_mismatch_fails(self):
         old_dash = dict(DASH_INFO, version="1.2.0")

--- a/scripts/tests/test_upgrade_tls.py
+++ b/scripts/tests/test_upgrade_tls.py
@@ -1,0 +1,94 @@
+"""Exercise the verifier with real HTTPS, not just mocked request handlers."""
+import json
+import os
+from pathlib import Path
+import shutil
+import ssl
+import subprocess
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+SCRIPT = Path(__file__).resolve().parents[1] / "upgrade_preflight.py"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        component = "hub" if self.path == "/api/build-info" else "dashboard"
+        body = json.dumps({"component": component, "version": "v1.2.3",
+                           "revision": "a" * 40,
+                           "instance_id": component + "-" + self.server.identity}).encode()
+        self.send_response(200)
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):
+        pass
+
+
+@unittest.skipUnless(shutil.which("openssl"), "openssl required for isolated TLS fixture")
+class RealTLS(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temp = tempfile.TemporaryDirectory(prefix="bloxos-upgrade-tls-")
+        cls.cert = Path(cls.temp.name) / "cert.pem"
+        key = Path(cls.temp.name) / "key.pem"
+        subprocess.run(["openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+                        "-keyout", str(key), "-out", str(cls.cert), "-days", "1",
+                        "-subj", "/CN=localhost", "-addext", "subjectAltName=DNS:localhost"],
+                       check=True, capture_output=True, timeout=20)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(cls.cert, key)
+        cls.servers = []
+        cls.threads = []
+        for identity in ["selected", "wrong"]:
+            server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+            server.identity = identity
+            server.socket = context.wrap_socket(server.socket, server_side=True)
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            cls.servers.append(server)
+            cls.threads.append(thread)
+
+    @classmethod
+    def tearDownClass(cls):
+        for server, thread in zip(cls.servers, cls.threads):
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+        cls.temp.cleanup()
+
+    def run_check(self, *, trusted=True, wrong=False, env=None):
+        selected = f"https://localhost:{self.servers[0].server_port}"
+        public = f"https://localhost:{self.servers[int(wrong)].server_port}"
+        args = [os.sys.executable, str(SCRIPT), "--public-url", public,
+                "--local-hub-url", selected, "--local-dashboard-url", selected,
+                "--expect-version", "v1.2.3", "--expect-revision", "a" * 40]
+        if trusted:
+            args += ["--ca-file", str(self.cert)]
+        return subprocess.run(args, capture_output=True, text=True, timeout=15, env=env)
+
+    def test_private_ca_is_actually_used(self):
+        result = self.run_check()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_untrusted_tls_never_passes(self):
+        self.assertNotEqual(self.run_check(trusted=False).returncode, 0)
+
+    def test_same_build_wrong_instance_rejected(self):
+        self.assertNotEqual(self.run_check(wrong=True).returncode, 0)
+
+    def test_environment_proxy_cannot_redirect_local_comparison(self):
+        env = dict(os.environ, HTTPS_PROXY="http://127.0.0.1:1", https_proxy="http://127.0.0.1:1",
+                   HTTP_PROXY="http://127.0.0.1:1", http_proxy="http://127.0.0.1:1",
+                   NO_PROXY="", no_proxy="")
+        result = self.run_check(env=env)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/upgrade_preflight.py
+++ b/scripts/upgrade_preflight.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Read-only upgrade preflight: verify the public route serves the intended build.
+
+Compares build identity reported by the PUBLIC endpoint against the build the
+operator expects AND against the instance identity of the locally-running
+hub/dashboard (via their direct URLs). Nothing here installs, stops, restarts
+or mutates anything; every answer is PASS, FAIL, or UNKNOWN with evidence.
+
+Build-info contract (both endpoints): JSON object with string fields
+component, version, revision, instance_id, served with Cache-Control:
+no-store. Hub: GET {base}/api/build-info. Dashboard: GET {base}/build-info.
+An endpoint without this metadata is a legacy install — UNKNOWN, never PASS.
+
+A verified PASS requires ALL of: valid metadata on hub and dashboard, the
+expected build on both, matching identity fields between each public and
+local endpoint, and TLS that verifies (system trust or --ca-file; never
+insecure). Anything short of that is FAIL or UNKNOWN, never a green result
+for an older or unverifiable deployment.
+
+Exit codes: 0 verified PASS, 1 FAIL (wrong build/instance/untrusted), 2 UNKNOWN
+(missing metadata, unreachable, invalid response, tooling/permission error).
+"""
+import argparse
+import json
+import math
+import os
+import shutil
+import socket
+import ssl
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+MAX_BODY = 64 * 1024
+COMPONENTS = {"hub": "api/build-info", "dashboard": "build-info"}
+FIELDS = ("component", "version", "revision", "instance_id")
+LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+DEV_MARKERS = {"", "dev", "development", "unknown", "unreleased", "snapshot"}
+
+PASS, FAIL, UNKNOWN = 0, 1, 2
+results = []
+
+
+def record(status, name, detail=""):
+    tag = {PASS: "PASS", FAIL: "FAIL", UNKNOWN: "UNKNOWN"}[status]
+    results.append(status)
+    print(f"{tag}  {name}" + (f" — {detail}" if detail else ""))
+
+
+def safe(text):
+    """Strip terminal control characters from anything printed."""
+    return "".join(c for c in str(text) if c.isprintable() and c != "\x7f")
+
+
+class PreflightError(Exception):
+    def __init__(self, status, message):
+        super().__init__(message)
+        self.status = status
+
+
+def valid_url(raw, allow_http_loopback):
+    """Validate the raw base URL BEFORE any path is appended: a base carrying
+    userinfo/query/fragment or control characters must not smuggle an
+    appended build-info path. https anywhere; http on loopback only (the
+    supported development fixture policy)."""
+    if any(c.isspace() or not c.isprintable() for c in raw):
+        raise PreflightError(UNKNOWN, "URL contains whitespace or control characters")
+    try:
+        parts = urllib.parse.urlsplit(raw)
+        host = parts.hostname  # None when absent
+        _ = parts.port  # raises ValueError on an invalid port
+    except ValueError as err:
+        raise PreflightError(UNKNOWN, f"invalid URL: {type(err).__name__}")
+    if not host:
+        raise PreflightError(UNKNOWN, "URL has no hostname")
+    if parts.username or parts.password or parts.query or parts.fragment:
+        raise PreflightError(UNKNOWN, "URL must not contain userinfo, query or fragment")
+    if parts.scheme == "https":
+        return True
+    if parts.scheme == "http" and allow_http_loopback and host in LOOPBACK_HOSTS:
+        return True
+    raise PreflightError(UNKNOWN, "URL must be https, or http on loopback only")
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None  # treat every redirect as a terminal response
+
+
+def fetch_json(url, timeout, opener):
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with opener.open(req, timeout=timeout) as resp:
+            status = getattr(resp, "status", 200)
+            headers = resp.headers
+            body = resp.read(MAX_BODY + 1)
+    except urllib.error.HTTPError as err:
+        if err.code in (301, 302, 303, 307, 308):
+            raise PreflightError(FAIL, f"redirect refused (HTTP {err.code}; locations are never followed)")
+        raise PreflightError(UNKNOWN, f"HTTP {err.code} — legacy endpoint without build metadata is not verifiable")
+    except urllib.error.URLError as err:
+        reason = getattr(err, "reason", None)
+        if isinstance(reason, ssl.SSLError):
+            raise PreflightError(FAIL, "TLS verification failed (certificate not trusted; supply --ca-file or fix trust)")
+        raise PreflightError(UNKNOWN, f"unreachable: {type(err).__name__}")
+    except ssl.SSLError:
+        raise PreflightError(FAIL, "TLS verification failed (certificate not trusted; supply --ca-file or fix trust)")
+    except (socket.timeout, TimeoutError, OSError) as err:
+        raise PreflightError(UNKNOWN, f"unreachable: {type(err).__name__}")
+    if status in (301, 302, 303, 307, 308):
+        raise PreflightError(FAIL, "redirect refused (no redirect following to untrusted destinations)")
+    if len(body) > MAX_BODY:
+        raise PreflightError(UNKNOWN, f"response larger than {MAX_BODY} bytes")
+    try:
+        data = json.loads(body.decode("utf-8", "strict"))
+    except (UnicodeDecodeError, ValueError):
+        raise PreflightError(UNKNOWN, "non-JSON response — legacy endpoint without build metadata")
+    if not isinstance(data, dict):
+        raise PreflightError(UNKNOWN, "build-info is not a JSON object")
+    for field in FIELDS:
+        value = data.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise PreflightError(UNKNOWN, f"build-info missing or invalid field {field!r} — legacy endpoint")
+    return data, headers
+
+
+def check_endpoint(name, base_url, want_component, args, opener):
+    valid_url(base_url, allow_http_loopback=True)
+    info, headers = fetch_json(base_url.rstrip("/") + "/" + COMPONENTS[want_component],
+                               args.timeout, opener)
+    if info["component"] != want_component:
+        raise PreflightError(FAIL, f"wrong backend: component is {safe(info['component'])!r}, expected {want_component!r}")
+    if info["version"].strip().lower() in DEV_MARKERS or info["revision"].strip().lower() in DEV_MARKERS:
+        raise PreflightError(UNKNOWN, "endpoint reports development/unknown build metadata — not verifiable")
+    problems = []
+    if args.expect_version and info["version"] != args.expect_version:
+        problems.append(f"version {safe(info['version'])} != expected")
+    if args.expect_revision and info["revision"] != args.expect_revision:
+        problems.append("revision does not match the expected full commit SHA")
+    if problems:
+        raise PreflightError(FAIL, "wrong build: " + "; ".join(problems))
+    if "no-store" not in headers.get("Cache-Control", ""):
+        record(UNKNOWN, f"{name} cache header", "build-info served without Cache-Control: no-store")
+        raise PreflightError(UNKNOWN, "build-info lacks the no-store contract")
+    record(PASS, f"{name} build identity",
+           f"version {safe(info['version'])} revision {safe(info['revision'][:12])} instance {safe(info['instance_id'][:12])}")
+    return info
+
+
+def compare_identity(label, public, local, worst):
+    mismatches = [f for f in ("version", "revision", "instance_id") if public[f] != local[f]]
+    if mismatches:
+        record(FAIL, f"{label} identity correlation",
+               f"public and local differ on: {', '.join(mismatches)} — public route does not reach the intended instance")
+        return max(worst, FAIL)
+    record(PASS, f"{label} identity correlation", "public route reaches the intended instance (build + instance match)")
+    return worst
+
+
+def detect_evidence():
+    """Read-only deployment evidence. Tooling or permission failures are
+    UNKNOWN, never 'absent'. Evidence is informational only and is never used
+    to infer the public route — that is decided by identity comparison."""
+    lines = []
+    try:
+        units = sorted(u for u in os.listdir("/etc/systemd/system") if u.startswith("bloxos"))
+        lines.append(f"systemd units found: {', '.join(units) if units else 'none'}")
+    except OSError as err:
+        lines.append(f"systemd units: UNKNOWN ({type(err).__name__})")
+    if shutil.which("docker"):
+        try:
+            proc = subprocess.run(
+                ["docker", "ps", "--format", "{{.Names}} {{.Image}}"],
+                capture_output=True, text=True, timeout=10)
+            if proc.returncode == 0:
+                rows = [r for r in proc.stdout.splitlines() if "bloxos" in r]
+                lines.append("docker containers mentioning 'bloxos' (NOT proof of a Compose project): "
+                             + ("; ".join(rows) if rows else "none"))
+            else:
+                lines.append(f"docker containers: UNKNOWN (docker ps exit {proc.returncode})")
+        except (OSError, subprocess.TimeoutExpired) as err:
+            lines.append(f"docker containers: UNKNOWN ({type(err).__name__})")
+    else:
+        lines.append("docker containers: UNKNOWN (docker CLI not installed — not evidence of absence)")
+    return lines
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--public-url", required=True, help="public base URL of the deployment, e.g. https://hub.lan")
+    parser.add_argument("--local-hub-url", required=True, help="direct local hub URL, e.g. http://127.0.0.1:4000")
+    parser.add_argument("--local-dashboard-url", required=True, help="direct local dashboard URL, e.g. http://127.0.0.1:3000")
+    parser.add_argument("--ca-file", help="CA bundle for TLS verification (system trust otherwise; verification is never disabled)")
+    parser.add_argument("--expect-version", help="required exact version field, e.g. 1.2.2")
+    parser.add_argument("--expect-revision", help="required exact full commit SHA")
+    parser.add_argument("--timeout", type=float, default=5.0, help="per-request timeout seconds (default 5, max 60)")
+    parser.add_argument("--detect", action="store_true", help="also print read-only deployment evidence")
+    args = parser.parse_args()
+    if not math.isfinite(args.timeout) or args.timeout <= 0 or args.timeout > 60:
+        parser.exit(2, "upgrade-preflight: --timeout must be a finite number within (0, 60]\n")
+
+    context = ssl.create_default_context()
+    if args.ca_file:
+        try:
+            context.load_verify_locations(args.ca_file)
+        except (OSError, ssl.SSLError) as err:
+            parser.exit(2, f"upgrade-preflight: cannot load --ca-file: {type(err).__name__}\n")
+    # Direct connections only: no environment proxies, no redirect following,
+    # and the TLS context is explicitly handed to HTTPS requests.
+    opener = urllib.request.build_opener(
+        NoRedirect,
+        urllib.request.HTTPSHandler(context=context),
+        urllib.request.ProxyHandler({}),
+    )
+
+    worst = PASS
+    saw_fail = False
+    saw_unknown = False
+
+    def note(status):
+        nonlocal saw_fail, saw_unknown
+        if status == FAIL:
+            saw_fail = True
+        elif status == UNKNOWN:
+            saw_unknown = True
+
+    def run(status_fn):
+        nonlocal worst
+        try:
+            return status_fn()
+        except PreflightError as err:
+            record(err.status, "check", safe(err))
+            note(err.status)
+            return None
+
+    public_hub = run(lambda: check_endpoint("public hub", args.public_url, "hub", args, opener))
+    public_dash = run(lambda: check_endpoint("public dashboard", args.public_url, "dashboard", args, opener))
+    local_hub = run(lambda: check_endpoint("local hub", args.local_hub_url, "hub", args, opener))
+    local_dash = run(lambda: check_endpoint("local dashboard", args.local_dashboard_url, "dashboard", args, opener))
+
+    for label, public, local in (("hub", public_hub, local_hub), ("dashboard", public_dash, local_dash)):
+        if public is not None and local is not None:
+            worst = compare_identity(label, public, local, worst)
+            note(worst)
+
+    if args.detect:
+        for line in detect_evidence():
+            print(f"evidence  {safe(line)}")
+
+    # Precedence is explicit, not numeric: a decisive FAIL (wrong build, wrong
+    # backend, untrusted TLS, refused redirect) always outranks UNKNOWN; a
+    # merely unverifiable answer must never mask it.
+    print(f"result  {'FAIL' if saw_fail else 'UNKNOWN' if saw_unknown else 'PASS'}")
+    return FAIL if saw_fail else UNKNOWN if saw_unknown else PASS
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/upgrade_preflight.py
+++ b/scripts/upgrade_preflight.py
@@ -21,6 +21,7 @@ Exit codes: 0 verified PASS, 1 FAIL (wrong build/instance/untrusted), 2 UNKNOWN
 (missing metadata, unreachable, invalid response, tooling/permission error).
 """
 import argparse
+import http.client
 import json
 import math
 import os
@@ -107,6 +108,8 @@ def fetch_json(url, timeout, opener):
         raise PreflightError(UNKNOWN, f"unreachable: {type(err).__name__}")
     except ssl.SSLError:
         raise PreflightError(FAIL, "TLS verification failed (certificate not trusted; supply --ca-file or fix trust)")
+    except http.client.HTTPException:
+        raise PreflightError(UNKNOWN, "interrupted HTTP response; retry verification")
     except (socket.timeout, TimeoutError, OSError) as err:
         raise PreflightError(UNKNOWN, f"unreachable: {type(err).__name__}")
     if status in (301, 302, 303, 307, 308):


### PR DESCRIPTION
## Phase 1: identify the installation actually serving the website

Phase-1 foundation for the agreed verified-upgrade workflow. **Not a complete native/Compose updater; merging this does not mean legacy upgrades are solved.**

### Problem

Updating Compose images can succeed while native hub/dashboard services continue serving the public URL. Container health and checkout tags do not establish which build the browser reaches. Existing `hub_sha` fields describe agent payloads, not the hub executable.

### Changes

- Public, uncached hub `/api/build-info` and dashboard `/build-info`: component, build version/revision, process instance ID.
- Build stamps wired into release images without changing agent compilation flags; dashboard stamps compiled in rather than read from runtime environment.
- Read-only public/direct identity verifier, verified TLS and private-CA support, no redirect/proxy ambiguity, unknown legacy metadata never passes.
- Regression fixtures for wrong backend, same build/different instance, malformed metadata, CA verification and failure precedence.
- Production standalone dashboard test covers runtime override and restart identity; Compose release smoke compares public identities to selected containers.
- README explicitly distinguishes Compose updates from native installations and no longer equates healthy containers with a verified website upgrade.

### Local validation

- Dashboard: 97 unit tests pass; production build passes; lint has no errors (three existing unused-disable warnings).
- Standalone runtime test passes, including deliberately misleading runtime version/revision and different instance IDs after restart.
- Hub `go vet ./...` passes; focused `TestBuildInfo` tests pass under the race detector.
- Real HTTPS integration checks pass using isolated local servers.
- All 24 upgrade verifier tests pass (20 regression tests plus 4 real HTTPS tests). The added real truncated chunked-response test reproduced the crash before the fix and passes after it.
- Workflow YAML parses, shell syntax and diff whitespace checks pass.
- All seven test/build checks passed on the final interrupted-response fix, including full hub race and disposable Linux Compose smoke.

### Collaboration

Claude implemented/reviewed hub identity and reviewed dashboard/release/docs changes. Kimi implemented the verifier and regression fixtures; Codex reviewed and required corrections for ignored CA context, public-only false success, unknown metadata, URL validation and failure precedence. Existing visible Herdr sessions were reused. No production host was changed.

Both reviewers approved the final interrupted-response handling and real regression test after their full review. User authorized merge once we agree and checks pass. Native/Compose update adapters remain separate follow-up work.

### Still required before the full upgrade workflow can ship

- Supported native/Compose target discovery and ownership evidence, including the first hop from releases without identity endpoints.
- Separate in-place update adapters behind a simple entry point; staging both components before downtime.
- Correct native/Compose backup boundaries and migration-aware rollback/interruption testing.
- Mixed-host end-to-end update regression (not just metadata fixtures), agent payload/signing status reporting, complete release validation.

No automatic migration, proxy repointing, orphan cleanup, key deletion or fleet rollout is included.
