### PR TITLE
fix: prove a bare-IP public edge by address ownership

### DIFF
--- a/scripts/tests/test_updater_native.py
+++ b/scripts/tests/test_updater_native.py
@@ -439,6 +439,60 @@ class DiscoverTests(unittest.TestCase):
         self.assertFalse(valid)
         self.assertNotEqual(native._norm_hostport("[::1]:4000"), native._norm_hostport("127.0.0.1:4000"))
 
+    # --- bare-IP public edge (LAN installs) --------------------------------
+    # SNI may not carry an IP literal (RFC 6066), so Python sends NO SNI for one
+    # and a Caddy site keyed by an IP kills the handshake. A bare-IP edge must
+    # therefore be proven by local address ownership, never by a TLS probe.
+    LOOPBACK_UPSTREAMS = {"upstreams": [{"dial": "127.0.0.1:4000"}, {"dial": "127.0.0.1:3000"}]}
+
+    def _route_ip(self, public_url, is_local):
+        probed = []
+
+        def leaf_cert(*args):
+            probed.append(args)
+            raise AssertionError("a bare-IP edge must never be probed over TLS")
+
+        valid, reason = native._verify_routing(
+            public_url, "http://127.0.0.1:4000", "http://127.0.0.1:3000", None,
+            lambda: self.LOOPBACK_UPSTREAMS, leaf_cert, lambda host: is_local)
+        self.assertEqual(probed, [])
+        return valid, reason
+
+    def test_bare_ip_edge_is_proven_by_local_address_not_tls(self):
+        for url in ("https://192.168.16.113", "https://192.168.16.113:8443", "https://[fd00::1]"):
+            with self.subTest(url=url):
+                valid, reason = self._route_ip(url, True)
+                self.assertTrue(valid, reason)
+                self.assertIn("bound to this host", reason)
+
+    def test_bare_ip_edge_not_on_this_host_is_refused(self):
+        valid, reason = self._route_ip("https://192.168.16.113", False)
+        self.assertFalse(valid)
+        self.assertIn("not configured on this host", reason)
+
+    def test_dns_edge_still_compared_by_certificate(self):
+        probed = []
+
+        def leaf_cert(host, port, server_name, ca_file):
+            probed.append((host, server_name))
+            return b"same verified certificate"
+
+        valid, _ = native._verify_routing(
+            "https://hub.example", "http://127.0.0.1:4000", "http://127.0.0.1:3000", None,
+            lambda: self.LOOPBACK_UPSTREAMS, leaf_cert,
+            lambda host: self.fail("a DNS edge must be proven by certificate"))
+        self.assertTrue(valid)
+        self.assertEqual(probed, [("127.0.0.1", "hub.example"), ("hub.example", "hub.example")])
+
+    def test_ip_literal_detection_and_real_local_address_check(self):
+        for host in ("192.168.16.113", "127.0.0.1", "fd00::1", "[fd00::1]", "::1"):
+            self.assertTrue(native._is_ip_literal(host), host)
+        for host in ("hub.example", "localhost", ""):
+            self.assertFalse(native._is_ip_literal(host), host)
+        # Loopback is always assigned here; TEST-NET-1 (RFC 5737) never is.
+        self.assertTrue(native._address_is_local("127.0.0.1"))
+        self.assertFalse(native._address_is_local("192.0.2.1"))
+
     def _seams(self, *, caddy_ok=True, cert_match=True,
                dash_owner="bloxos-dashboard.service", caddy443_owner="caddy.service",
                hub_env=None):

--- a/scripts/updater/native.py
+++ b/scripts/updater/native.py
@@ -472,6 +472,7 @@ def _fsync_dir(path):
 
 def discover_native(repo_dir=None, *, show=None, read_proc=None, listeners=None,
                     caddy_config=None, leaf_cert=None, read_cgroup=None,
+                    address_is_local=None,
                     proxy_candidates=("caddy.service", "bloxos-caddy.service")) -> dict:
     """Read-only evidence for a one-time `init`, grounded in the ACTUAL running
     services and the ACTIVE proxy config — never unit-file text, /home guesses,
@@ -497,6 +498,7 @@ def discover_native(repo_dir=None, *, show=None, read_proc=None, listeners=None,
     caddy_config = caddy_config or _caddy_config
     leaf_cert = leaf_cert or _leaf_cert
     read_cgroup = read_cgroup or _read_cgroup
+    address_is_local = address_is_local or _address_is_local
 
     hub = show("bloxos-hub.service")
     dash = show("bloxos-dashboard.service")
@@ -568,7 +570,7 @@ def discover_native(repo_dir=None, *, show=None, read_proc=None, listeners=None,
     hub_url = listener_url(hub_listener)
     dash_url = listener_url(dash_listener)
     routing_verified, reason = _verify_routing(public_url, hub_url, dash_url, ca_file,
-                                               caddy_config, leaf_cert)
+                                               caddy_config, leaf_cert, address_is_local)
 
     return {
         "mode": "native",
@@ -584,10 +586,12 @@ def discover_native(repo_dir=None, *, show=None, read_proc=None, listeners=None,
     }
 
 
-def _verify_routing(public_url, hub_url, dash_url, ca_file, caddy_config, leaf_cert):
+def _verify_routing(public_url, hub_url, dash_url, ca_file, caddy_config, leaf_cert,
+                    address_is_local=None):
     """Proof, not confirmation: (1) the active Caddy config routes to the owned
-    loopback hub/dashboard; (2) the local :443 leaf equals the public :443 leaf,
-    verified under BLOXOS_CA_CERT (private) or system trust (public)."""
+    loopback hub/dashboard; (2) the public edge is proven to be THIS host —
+    by certificate for a DNS name, by local address ownership for a bare IP."""
+    address_is_local = address_is_local or _address_is_local
     try:
         cfg = caddy_config()
     except engine.UpdaterError as err:
@@ -601,6 +605,24 @@ def _verify_routing(public_url, hub_url, dash_url, ca_file, caddy_config, leaf_c
         return False, "public URL is not https; cannot prove the edge by certificate"
     host = pub.hostname
     port = pub.port or 443
+    if _is_ip_literal(host):
+        # A bare-IP deployment CANNOT be proven by comparing TLS leaves. SNI may
+        # not carry an IP literal (RFC 6066), so Python sends no SNI at all for
+        # one; with no SNI the proxy selects its certificate by the LOCAL address
+        # the connection landed on. Dialling the public IP therefore serves fine,
+        # but the loopback leg of the comparison finds no certificate for
+        # 127.0.0.1 and the handshake dies — the local-vs-public comparison is
+        # simply not expressible for an IP edge. Prove it structurally: the public address
+        # must be assigned to THIS host. Together with the already-proven facts —
+        # the verified-owned Caddy holds :443 and its active config routes to our
+        # owned loopback backends — an IP that is bound here cannot be served
+        # anywhere else, which is a STRONGER claim than certificate equality
+        # (two hosts can share a certificate; one LAN address binds in one place).
+        if not address_is_local(host):
+            return False, ("the public address %s is not configured on this host; "
+                           "re-run init on the machine that serves it" % host)
+        return True, ("proxy routes owned loopback backends and the public address "
+                      "is bound to this host")
     try:
         local = leaf_cert("127.0.0.1", 443, host, ca_file)
         remote = leaf_cert(host, port, host, ca_file)
@@ -681,6 +703,38 @@ def _caddy_config(admin="http://127.0.0.1:2019/config/"):
         return _json.loads(body)
     except ValueError:
         raise engine.UpdaterError("caddy admin config is not JSON")
+
+
+def _is_ip_literal(host):
+    """True when the public host is a bare IP address rather than a DNS name."""
+    try:
+        ipaddress.ip_address((host or "").strip("[]"))
+        return True
+    except ValueError:
+        return False
+
+
+def _address_is_local(host):
+    """True iff `host` is an IP assigned to one of THIS host's interfaces.
+
+    Binding an ephemeral socket to an address succeeds only when the kernel has
+    that address on a local interface; otherwise it fails with EADDRNOTAVAIL.
+    That makes this a definitive ownership check with no extra dependency and
+    no parsing of `ip addr` output. Port 0 is ephemeral and the socket is closed
+    immediately, so nothing is disturbed."""
+    import socket
+    try:
+        infos = socket.getaddrinfo(host, 0, type=socket.SOCK_STREAM)
+    except OSError:
+        return False
+    for family, socktype, proto, _canon, sockaddr in infos:
+        try:
+            with socket.socket(family, socktype, proto) as probe:
+                probe.bind(sockaddr)
+                return True
+        except OSError:
+            continue
+    return False
 
 
 def _leaf_cert(host, port, server_name, ca_file):


### PR DESCRIPTION
## The failure

Any install whose `PUBLIC_URL` is a bare IP — the common LAN case — could not complete `init`, and every preflight failed:

```
BloxOS updater: cannot prove the public edge still routes to this host's hub:
could not compare local and public certificates: TLS probe of 192.168.16.113 failed: SSLError
```

Reported from a real v1.3.0 upgrade on an IP-based deployment.

## Root cause

SNI may not carry an IP literal (RFC 6066), so CPython sends **no SNI at all** for one. Verified empirically:

```
server_hostname='127.0.0.1'  -> SNI received by server: None
server_hostname='localhost'  -> SNI received by server: 'localhost'
```

With no SNI, the proxy selects its certificate by the **local address the connection landed on**. Three observations from the affected host pin this down exactly:

| connection | SNI | result |
|---|---|---|
| `curl` → `192.168.16.113:443` | none | 200 |
| `openssl` → `127.0.0.1:443`, `-servername 192.168.16.113` | IP | established |
| `openssl` → `127.0.0.1:443`, `-noservername` | none | internal error |

So dialling the public IP serves correctly, but the **loopback leg** of the local-vs-public comparison finds no certificate for `127.0.0.1` and the handshake is refused:

```python
local  = leaf_cert("127.0.0.1", 443, host, ca_file)   # dies for an IP edge
remote = leaf_cert(host, port, host, ca_file)          # would have succeeded
```

The comparison is simply **not expressible** for an IP edge.

## The fix

For a bare-IP public URL, prove the edge **structurally** rather than by certificate — a *stronger* claim than certificate equality:

- the public address must be assigned to this host (an ephemeral `bind()` succeeds only for a locally configured address — no `ip addr` parsing, no new dependency);
- combined with the already-proven facts (the verified-owned proxy holds `:443`, and its **active** config routes to our owned loopback backends), an IP bound here cannot be served anywhere else.

Two hosts can share a certificate; one LAN address binds in one place.

DNS hostnames are **unaffected** and keep the certificate comparison, where SNI works and the check genuinely detects a name pointing at another machine. A public IP that is *not* local is refused with an actionable message instead of an opaque `SSLError`.

## Tests

5 new cases: IPv4/IPv6/non-default-port IP edges verify without ever attempting a TLS probe; a non-local public IP is refused; a DNS edge still performs both certificate probes; plus `_is_ip_literal` and the real `_address_is_local` (loopback true, RFC 5737 TEST-NET-1 false).

Full updater suite: **138 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes init/preflight public-edge proof logic on the security-sensitive updater path, though DNS verification is unchanged and the new IP path replaces a previously broken check.
> 
> **Overview**
> Fixes **init and preflight** for LAN installs where `PUBLIC_URL` is a bare IP (IPv4/IPv6), which previously failed with opaque TLS errors because the local-vs-public certificate check cannot work when Python sends no SNI for IP literals.
> 
> **`_verify_routing`** now branches on **`_is_ip_literal`**: for DNS hostnames, behavior is unchanged (compare local `:443` and public leaf certs). For a bare IP, it **skips TLS probes** and instead requires **`_address_is_local`**—an ephemeral `bind()` that succeeds only if the address is configured on this host—together with the existing Caddy upstream checks.
> 
> **`discover_native`** exposes an injectable **`address_is_local`** seam (default **`_address_is_local`**) for tests. New unit tests cover IP edges (with/without custom port, IPv6), refusal when the IP is not local, unchanged DNS cert probing, and helper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b53c540c70155ca6ba46c06cf8b36b91ee80b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->