### PR TITLE
docs: point installation instructions at v1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ dashboard support **Linux amd64 and arm64**. Ports **80 and 443** must be availa
 ### 1. Download BloxOS
 
 ```sh
-git clone --branch v1.3.0 --depth 1 https://github.com/bokiko/bloxos.git
+git clone --branch v1.3.1 --depth 1 https://github.com/bokiko/bloxos.git
 cd bloxos/docker
 cp .env.example .env
 ```
@@ -186,7 +186,7 @@ systemd services, pulling containers does not update those services. If both
 exist, do not start another stack or switch the proxy: establish which existing
 installation serves your public URL. See [upgrade verification](docs/verified-upgrades.md).
 
-For an existing **Compose deployment**, set `BLOXOS_VERSION=1.3.0` in your existing
+For an existing **Compose deployment**, set `BLOXOS_VERSION=1.3.1` in your existing
 `.env`, then run these with the same project name and any existing overrides:
 
 ```sh
@@ -221,7 +221,7 @@ On a native installation, replacing the hub executable does **not** replace
 separate agent files. Use the [native agent check-and-stage guide](docs/native-agent-upgrades.md)
 to prepare the published payloads without starting a fleet rollout.
 
-[Release notes](https://github.com/bokiko/bloxos/releases/tag/v1.3.0) ·
+[Release notes](https://github.com/bokiko/bloxos/releases/tag/v1.3.1) ·
 [Update signing](docs/offline-update-signing.md) ·
 [Agent recovery](docs/agent-update-recovery.md)
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -6,4 +6,4 @@ HUB_HOST=hub.lan
 
 # Pin a published release for a predictable upgrade target; unset means
 # `latest`. See docker/README.md for the upgrade procedure.
-# BLOXOS_VERSION=1.3.0
+# BLOXOS_VERSION=1.3.1

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,13 +8,13 @@ they are not containerized.
 
 Use Docker Compose v2 on a Linux amd64 or arm64 host. Ports 80 and 443 must
 be free, and browsers and agents must be able to reach the host. From a
-clone of the released `v1.3.0` tag:
+clone of the released `v1.3.1` tag:
 
 ```bash
 cd docker
 cp .env.example .env
 # Edit .env: set HUB_HOST to this machine's reachable hostname or IP.
-# Add BLOXOS_VERSION=1.3.0 to use this release's images.
+# Add BLOXOS_VERSION=1.3.1 to use this release's images.
 docker compose pull
 docker compose up -d --no-build
 ```


### PR DESCRIPTION
Bumps the version-pinned installation instructions to `v1.3.1`, so a fresh
install gets the bare-IP public-edge fix (#219) rather than v1.3.0, which
cannot complete `init` on an IP-based (LAN) deployment.

Documentation only — no code, no workflow, no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only version string updates with no runtime, workflow, or deployment artifact changes.
> 
> **Overview**
> Updates installation and upgrade documentation to pin **v1.3.1** instead of **v1.3.0** everywhere users are told to clone, set `BLOXOS_VERSION`, or open release notes.
> 
> **README.md** changes the `git clone --branch` tag, the Compose manual-upgrade `.env` example, and the release-notes link. **docker/.env.example** updates the commented `BLOXOS_VERSION` default. **docker/README.md** updates the tagged-clone and `.env` comments in the quick-start flow.
> 
> No application code, Compose definitions, or CI changes—only docs so new and manual Compose upgrades target the release that includes the bare-IP / LAN `init` fix rather than v1.3.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77b63657c52268eb91f46fb5854e405c93805a5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->