### PR TITLE
fix(dashboard): drop the Top VRAM usage ranking

### DIFF
--- a/dashboard/src/app/design-layouts.css
+++ b/dashboard/src/app/design-layouts.css
@@ -209,8 +209,7 @@ html[data-layout="console"][data-design-color="bright"] {
 [data-layout="wall"] .lw-resource-bars { display: grid; gap: 23px; margin-top: 27px; }
 [data-layout="wall"] .lw-resource-row { display: grid; grid-template-columns: 90px 1fr 45px; gap: 16px; align-items: center; font-size: 11px; color: var(--ld-secondary); }
 [data-layout="wall"] .lw-resource-row strong { text-align: right; font-size: 12px; font-weight: 500; color: var(--ld-ink); font-variant-numeric: tabular-nums; }
-[data-layout="wall"] .lw-ranks { grid-column: span 6; display: grid; grid-template-columns: 1fr 1fr; gap: 25px; }
-[data-layout="wall"] .lw-ranks > div + div { border-left: 1px solid var(--ld-edge); padding-left: 25px; }
+[data-layout="wall"] .lw-ranks { grid-column: span 6; display: grid; grid-template-columns: 1fr; gap: 25px; }
 [data-layout="wall"] .lw-ranks h2 { font-size: 12px; color: var(--ld-secondary); font-weight: 500; }
 [data-layout="wall"] .lw-foot-tile { grid-column: span 2; background: var(--ld-panel-alt); }
 [data-layout="wall"] .lw-foot-tile .lw-big { font-size: 39px; font-weight: 450; letter-spacing: -1.8px; margin-top: 40px; white-space: nowrap; color: var(--ld-ink); }
@@ -258,7 +257,7 @@ html[data-layout="console"][data-design-color="bright"] {
 [data-layout="grove"] .lg-health small { color: var(--ld-secondary); font-size: 10px; }
 [data-layout="grove"] .lg-health strong { display: block; font-size: 25px; font-weight: 400; margin: 12px 0; color: var(--ld-ink); }
 [data-layout="grove"] .lg-health .ld-bar { height: 4px; }
-[data-layout="grove"] .lg-ranks { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin: 28px 0; }
+[data-layout="grove"] .lg-ranks { display: grid; grid-template-columns: 1fr; gap: 24px; margin: 28px 0; }
 [data-layout="grove"] .lg-ranks h2 { font-size: 12px; color: var(--ld-ink); font-weight: 500; }
 [data-layout="grove"] .lg-fleet { border-top: 1px solid var(--ld-edge); padding-top: 24px; }
 [data-layout="grove"] .lg-fleet > h2 { font-size: 13px; color: var(--ld-ink); margin-bottom: 6px; }
@@ -314,7 +313,7 @@ html[data-layout="console"][data-design-color="bright"] {
 [data-layout="console"] .lc-table a:hover { color: var(--ld-accent); }
 [data-layout="console"] .lc-meter { width: 60px; margin-top: 8px; height: 3px; background: var(--ld-track); }
 [data-layout="console"] .lc-meter i { display: block; height: 100%; background: var(--ld-accent); }
-[data-layout="console"] .lc-lower { display: grid; grid-template-columns: 1.1fr 1fr 1fr; gap: 18px; margin-top: 22px; }
+[data-layout="console"] .lc-lower { display: grid; grid-template-columns: 1.1fr 1fr; gap: 18px; margin-top: 22px; }
 [data-layout="console"] .lc-instrument { border: 1px solid var(--ld-edge); border-radius: 6px; padding: 20px; background: var(--ld-panel); }
 [data-layout="console"] .lc-instrument h2 { color: var(--ld-secondary); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; }
 [data-layout="console"] .lc-instrument .ld-rank-item { font-family: var(--font-mono, monospace); }
@@ -344,7 +343,6 @@ html[data-layout="console"][data-design-color="bright"] {
   [data-layout="wall"] .lw-foot-tile { grid-column: span 3; }
   [data-layout="wall"] .lw-machines { grid-column: span 6; }
   [data-layout="console"] .lc-lower { grid-template-columns: 1fr 1fr; }
-  [data-layout="console"] .lc-lower .lc-instrument:first-child { grid-column: span 2; }
   [data-layout="grove"] .lg-health { grid-template-columns: repeat(2, 1fr); }
 }
 @media (max-width: 800px) {
@@ -358,7 +356,6 @@ html[data-layout="console"][data-design-color="bright"] {
 @media (max-width: 700px) {
   [data-layout="wall"] .lw { padding: 20px 14px; }
   [data-layout="wall"] .lw-ranks { grid-template-columns: 1fr; gap: 24px; }
-  [data-layout="wall"] .lw-ranks > div + div { border-left: 0; border-top: 1px solid var(--ld-edge); padding: 20px 0 0; }
   [data-layout="grove"] .lg { grid-template-columns: 1fr; min-height: auto; }
   [data-layout="grove"] .lg-sidebar { display: none; }
   /* The sidebar is hidden on mobile, so the compact top bar carries the full

--- a/dashboard/src/components/FleetOverview.tsx
+++ b/dashboard/src/components/FleetOverview.tsx
@@ -48,39 +48,6 @@ export function FleetOverview({ machines }: FleetOverviewProps) {
     return items;
   }, [activeMachines]);
 
-  const topVram = useMemo(() => {
-    const items: Array<{ id: string; label: string; value: number }> = [];
-
-    for (const m of activeMachines) {
-      if (m.gpus && m.gpus.length > 0) {
-        // For multi-GPU machines, use max VRAM utilization
-        const maxVram = Math.max(
-          ...m.gpus.map((g) =>
-            (g.mem_total_bytes ?? 0) > 0
-              ? ((g.mem_used_bytes ?? 0) / g.mem_total_bytes) * 100
-              : 0
-          )
-        );
-        if (maxVram > 0) {
-          items.push({
-            id: m.machine_id,
-            label: m.hostname || m.machine_id,
-            value: maxVram,
-          });
-        }
-      } else if ((m.gpu_vram_total_bytes ?? 0) > 0) {
-        const vramPct = ((m.gpu_vram_used_bytes ?? 0) / (m.gpu_vram_total_bytes ?? 1)) * 100;
-        items.push({
-          id: m.machine_id,
-          label: m.hostname || m.machine_id,
-          value: vramPct,
-        });
-      }
-    }
-
-    return items;
-  }, [activeMachines]);
-
   const gauges = useMemo(() => {
     const base = [
       {
@@ -164,20 +131,13 @@ export function FleetOverview({ machines }: FleetOverviewProps) {
       </div>
 
       {/* Resource attribution */}
-      {metrics.hasGpu && (topGpuUtil.length > 0 || topVram.length > 0) && (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      {metrics.hasGpu && topGpuUtil.length > 0 && (
+        <div className="grid grid-cols-1 gap-4">
           {topGpuUtil.length > 0 && (
             <RankedBar
               items={topGpuUtil}
               maxItems={5}
               title="Top GPU Utilization"
-            />
-          )}
-          {topVram.length > 0 && (
-            <RankedBar
-              items={topVram}
-              maxItems={5}
-              title="Top VRAM Usage"
             />
           )}
         </div>

--- a/dashboard/src/components/fleet/FleetConsole.tsx
+++ b/dashboard/src/components/fleet/FleetConsole.tsx
@@ -144,7 +144,6 @@ export function FleetConsole() {
           </div>
         </section>
         <Instrument title="Top GPU utilization" rows={agg.topGpu} />
-        <Instrument title="Top VRAM usage" rows={agg.topVram} />
       </div>
 
       <div className="lc-bottom">

--- a/dashboard/src/components/fleet/FleetGrove.tsx
+++ b/dashboard/src/components/fleet/FleetGrove.tsx
@@ -89,7 +89,6 @@ export function FleetGrove() {
 
       <div className="lg-ranks">
         <Ranks title="Top GPU utilization" rows={agg.topGpu} />
-        <Ranks title="Top VRAM usage" rows={agg.topVram} />
       </div>
 
       <section className="lg-fleet">

--- a/dashboard/src/components/fleet/FleetWall.tsx
+++ b/dashboard/src/components/fleet/FleetWall.tsx
@@ -123,7 +123,6 @@ export function FleetWall() {
 
         <article className="lw-tile lw-ranks">
           <Ranks title="Top GPU utilization" rows={agg.topGpu} />
-          <Ranks title="Top VRAM usage" rows={agg.topVram} />
         </article>
 
         <article className="lw-tile lw-foot-tile">

--- a/dashboard/src/components/fleet/fleetModel.ts
+++ b/dashboard/src/components/fleet/fleetModel.ts
@@ -45,7 +45,6 @@ export interface FleetAggregate {
    * total above is a partial sum and must not be labelled a complete total. */
   gpuPowerComplete: boolean;
   topGpu: RankRow[];
-  topVram: RankRow[];
 }
 
 function mean(nums: number[]): Metric {
@@ -85,25 +84,6 @@ export function machineGpuUtil(m: MachineMetrics): Metric {
     return m.gpu_util_percent as number;
   }
   return null;
-}
-
-/** VRAM usage % for one machine — summed across devices (used/total),
- * preferring gpus[]; null when no VRAM is reported. */
-export function machineVramPct(m: MachineMetrics): Metric {
-  if (m.gpus && m.gpus.length > 0) {
-    let used = 0;
-    let total = 0;
-    for (const g of m.gpus) {
-      if ((g.mem_total_bytes ?? 0) > 0) {
-        used += g.mem_used_bytes ?? 0;
-        total += g.mem_total_bytes;
-      }
-    }
-    return total > 0 ? finiteOrNull((used / total) * 100) : null;
-  }
-  const total = m.gpu_vram_total_bytes ?? 0;
-  if (!(total > 0)) return null;
-  return finiteOrNull(((m.gpu_vram_used_bytes ?? 0) / total) * 100);
 }
 
 /** Hottest GPU on one machine, preferring per-device temps; null if none. */
@@ -198,7 +178,6 @@ export function aggregate(machines: MachineMetrics[], now: number = Date.now()):
     gpuPowerTotal: powerDevices > 0 ? power : null,
     gpuPowerComplete: gpuDevices > 0 && powerDevices === gpuDevices,
     topGpu: rank(machineGpuUtil),
-    topVram: rank(machineVramPct),
   };
 }
 

--- a/dashboard/src/lib/design-fleet-model.test.mjs
+++ b/dashboard/src/lib/design-fleet-model.test.mjs
@@ -11,7 +11,7 @@ test('new layouts report unavailable GPU telemetry for CPU-only and empty fleets
  for(const machines of [[],[cpuOnly()]]){
   const result=aggregate(machines);
   for(const key of ['avgGpuUtil','avgVram','maxGpuTemp','gpuPowerTotal'])assert.equal(result[key],null,key);
-  assert.deepEqual(result.topGpu,[]);assert.deepEqual(result.topVram,[]);
+  assert.deepEqual(result.topGpu,[]);
  }
  assert.equal(aggregate([]).onlinePct,null);
 });
@@ -27,7 +27,6 @@ test('stale and offline machines cannot contribute to current resource or power 
  const result=aggregate([stale,offline]);
  for(const key of ['avgCpu','avgRam','avgGpuUtil','avgVram','maxGpuTemp','gpuPowerTotal'])assert.equal(result[key],null,key);
  assert.deepEqual(result.topGpu,[]);
- assert.deepEqual(result.topVram,[]);
 });
 test('fleet averages count GPUs, not machine averages, when device counts differ',()=>{
  const second={...gpuMachine(),machine_id:'single',gpus:[{name:'GPU0',util_percent:100,mem_used_bytes:8,mem_total_bytes:8,temp_c:70,power_watts:50}]};


### PR DESCRIPTION
Ranking machines by VRAM **percentage** across a mixed fleet carries no useful signal: 90% of an 8 GB card and 40% of a 48 GB card sort in an order that says nothing about where memory pressure actually matters.

Removes:
- the "Top VRAM usage" ranking from all four layouts (classic, console, grove, wall)
- the now-dead `topVram` field in `fleetModel`
- `machineVramPct`, whose only consumer was that ranking

Kept: the fleet-wide **Avg VRAM** stat and the **per-machine VRAM chart** — both have enough context to be readable.

Dashboard tests 103 passed; lint clean (3 pre-existing warnings in `PreferencesContext`, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and aggregation cleanup only; no auth, data pipeline, or security paths touched.
> 
> **Overview**
> Removes the **Top VRAM usage** machine ranking from the classic fleet overview and from the Wall, Grove, and Console design layouts, because VRAM **percentage** across mixed GPU sizes is misleading.
> 
> The shared `fleetModel` no longer exposes `topVram` or `machineVramPct`; layout CSS switches rank areas to a **single column** and tightens the Console lower grid now that one ranking panel is gone.
> 
> **Avg VRAM** fleet stats and other VRAM context (resource bars, gauges) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8418d8703aa3a70d11640700aafb8b83f7320c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->