### PR TITLE
feat(dashboard): add the Ledger layout

### DIFF
--- a/dashboard/src/app/design-layouts.css
+++ b/dashboard/src/app/design-layouts.css
@@ -415,6 +415,34 @@ html[data-layout="ledger"] {
 
 html[data-layout="ledger"] body { background: var(--ll-canvas); color: var(--ll-ink); }
 
+/* ---- Shell chrome ---------------------------------------------------- */
+/* One rule under a slim bar; no rail, no cards. AppShell mounts the page
+ * through this, so it must exist for the layout to render at all. */
+[data-layout="ledger"] .ll-shell { min-height: 100vh; background: var(--ll-canvas); color: var(--ll-ink); }
+[data-layout="ledger"] .ll-topbar {
+  display: flex; align-items: center; gap: 2rem; flex-wrap: wrap;
+  padding: 0.85rem 2rem; border-bottom: 1px solid var(--ll-rule-strong);
+}
+[data-layout="ledger"] .ll-brand {
+  display: inline-flex; align-items: center; gap: 0.55rem;
+  color: var(--ll-ink); text-decoration: none; font-weight: 600; font-size: 0.9rem;
+}
+[data-layout="ledger"] .ll-nav { display: flex; align-items: center; gap: 1.4rem; flex-wrap: wrap; }
+[data-layout="ledger"] .ll-nav a {
+  color: var(--ll-secondary); text-decoration: none; font-size: 0.82rem;
+  padding-bottom: 0.15rem; border-bottom: 1px solid transparent;
+}
+[data-layout="ledger"] .ll-nav a:hover { color: var(--ll-ink); }
+/* The active item is marked by a rule, not a filled pill: colour stays
+ * reserved for severity. */
+[data-layout="ledger"] .ll-nav a.is-active { color: var(--ll-ink); border-bottom-color: var(--ll-ink); }
+[data-layout="ledger"] .ll-actions { margin-left: auto; display: flex; align-items: center; gap: 0.5rem; }
+[data-layout="ledger"] .ll-content { display: block; }
+
+@media (max-width: 720px) {
+  [data-layout="ledger"] .ll-topbar { padding: 0.75rem 1rem; gap: 1rem; }
+}
+
 [data-layout="ledger"] .ll {
   max-width: 1400px;
   margin: 0 auto;

--- a/dashboard/src/app/design-layouts.css
+++ b/dashboard/src/app/design-layouts.css
@@ -382,3 +382,153 @@ html[data-layout="console"][data-design-color="bright"] {
   [data-layout="console"] .lc-lower .lc-instrument:first-child { grid-column: auto; }
   [data-layout="wall"] .lw-machine { grid-template-columns: 1fr 40px 40px 40px; gap: 8px; }
 }
+
+/* ============================================================================
+ * Ledger — still, type-led, evidence-forward.
+ *
+ * Three rules distinguish it from Wall/Grove/Console:
+ *   1. NOTHING ANIMATES. There is no transition, transform or keyframe below,
+ *      and no container changes size on update, so a value can be read while
+ *      it changes. This is the layout's whole reason to exist.
+ *   2. COLOUR IS SEVERITY. The palette is greyscale; the only chromatic ink is
+ *      the app's semantic --status-* tokens on a machine that is stale or
+ *      offline. A healthy fleet is legible entirely in grey, so anything
+ *      coloured is genuinely something to look at.
+ *   3. RULES AND SPACE, NOT BOXES. Sections are separated by hairlines and
+ *      whitespace rather than nested cards. Fewer containers is what lets the
+ *      density read as calm instead of cluttered.
+ *
+ * Ledger has ONE fixed palette and offers no colour variants, so it needs no
+ * per-layout colour column server-side (see hub/design_prefs.go).
+ * ========================================================================== */
+
+html[data-layout="ledger"] {
+  --ll-canvas: #0c0c0d;
+  --ll-ink: #ece9e4;
+  --ll-secondary: #a5a09a;
+  --ll-muted: #726d67;
+  --ll-rule: #ffffff14;
+  --ll-rule-strong: #ffffff26;
+  --ll-track: #ffffff12;
+  --ll-fill: #6f6a64;
+}
+
+html[data-layout="ledger"] body { background: var(--ll-canvas); color: var(--ll-ink); }
+
+[data-layout="ledger"] .ll {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem 2rem 4rem;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- Header --------------------------------------------------------- */
+[data-layout="ledger"] .ll-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 1.5rem; flex-wrap: wrap;
+  padding-bottom: 1.25rem; border-bottom: 1px solid var(--ll-rule-strong);
+}
+[data-layout="ledger"] .ll-head h1 {
+  font-size: 1.55rem; font-weight: 600; letter-spacing: -0.02em; margin: 0;
+}
+[data-layout="ledger"] .ll-head p { margin: 0.3rem 0 0; color: var(--ll-secondary); font-size: 0.875rem; }
+[data-layout="ledger"] .ll-head-meta {
+  color: var(--ll-muted); font-size: 0.7rem; letter-spacing: 0.14em; text-transform: uppercase;
+}
+
+/* ---- Bands ---------------------------------------------------------- */
+[data-layout="ledger"] .ll-band { padding: 2rem 0; border-bottom: 1px solid var(--ll-rule); }
+[data-layout="ledger"] .ll-band:last-child { border-bottom: 0; }
+[data-layout="ledger"] .ll-band-title {
+  margin: 0 0 1.1rem; font-size: 0.7rem; font-weight: 600;
+  letter-spacing: 0.16em; text-transform: uppercase; color: var(--ll-muted);
+}
+[data-layout="ledger"] .ll-quiet { margin: 0; color: var(--ll-secondary); font-size: 0.95rem; }
+[data-layout="ledger"] .ll-none { margin: 0.75rem 0 0; color: var(--ll-muted); font-size: 0.85rem; }
+
+/* ---- Band 1: attention ---------------------------------------------- */
+[data-layout="ledger"] .ll-issues { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.85rem; }
+[data-layout="ledger"] .ll-issues li { display: flex; align-items: baseline; gap: 0.9rem; }
+[data-layout="ledger"] .ll-issue-count {
+  min-width: 2.5rem; font-size: 1.5rem; font-weight: 600;
+  color: var(--status-warning, var(--ll-ink)); text-align: right;
+}
+[data-layout="ledger"] .ll-issue-text { display: flex; flex-direction: column; gap: 0.15rem; }
+[data-layout="ledger"] .ll-issue-text strong { font-size: 0.95rem; font-weight: 600; }
+[data-layout="ledger"] .ll-issue-text small { color: var(--ll-muted); font-size: 0.8rem; line-height: 1.45; }
+
+/* ---- Band 2: figures ------------------------------------------------ */
+[data-layout="ledger"] .ll-figures {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1.75rem 2rem; margin-bottom: 2rem;
+}
+[data-layout="ledger"] .ll-figure small {
+  display: block; font-size: 0.7rem; letter-spacing: 0.13em;
+  text-transform: uppercase; color: var(--ll-muted);
+}
+[data-layout="ledger"] .ll-figure strong {
+  display: block; margin: 0.4rem 0 0.35rem;
+  font-size: 1.9rem; font-weight: 500; letter-spacing: -0.02em; line-height: 1;
+}
+[data-layout="ledger"] .ll-unit {
+  margin-left: 0.2rem; font-size: 0.85rem; font-weight: 400; color: var(--ll-secondary);
+}
+[data-layout="ledger"] .ll-figure p {
+  margin: 0; font-size: 0.78rem; line-height: 1.45; color: var(--ll-muted);
+}
+
+/* ---- Band 2: table -------------------------------------------------- */
+[data-layout="ledger"] .ll-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+[data-layout="ledger"] .ll-table th,
+[data-layout="ledger"] .ll-table td {
+  text-align: left; padding: 0.7rem 0.9rem; border-bottom: 1px solid var(--ll-rule);
+}
+[data-layout="ledger"] .ll-table thead th {
+  font-size: 0.68rem; font-weight: 600; letter-spacing: 0.13em;
+  text-transform: uppercase; color: var(--ll-muted);
+  border-bottom: 1px solid var(--ll-rule-strong); white-space: nowrap;
+}
+[data-layout="ledger"] .ll-table tbody th { font-weight: 500; }
+[data-layout="ledger"] .ll-table tbody th a { color: var(--ll-ink); text-decoration: none; }
+[data-layout="ledger"] .ll-table tbody th a:hover { text-decoration: underline; }
+[data-layout="ledger"] .ll-table tbody th small {
+  display: block; margin-top: 0.15rem; font-weight: 400; font-size: 0.75rem; color: var(--ll-muted);
+}
+[data-layout="ledger"] .ll-table td { color: var(--ll-secondary); }
+[data-layout="ledger"] .ll-right { text-align: right; }
+[data-layout="ledger"] .ll-figures-num { font-variant-numeric: tabular-nums; color: var(--ll-ink); }
+
+/* A healthy machine's marker is neutral; only a degraded one takes semantic
+ * colour, so colour on this page always means "look here". */
+[data-layout="ledger"] .ll-dot {
+  display: inline-block; width: 0.4rem; height: 0.4rem; border-radius: 50%;
+  margin-right: 0.5rem; vertical-align: middle; background: var(--ll-fill);
+}
+[data-layout="ledger"] .ll-dot-alert { background: var(--dot, var(--status-warning)); }
+
+/* ---- Band 3: inventory ---------------------------------------------- */
+[data-layout="ledger"] .ll-inventory {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2.5rem;
+}
+[data-layout="ledger"] .ll-census h2 {
+  margin: 0; font-size: 0.95rem; font-weight: 600; letter-spacing: -0.01em;
+}
+[data-layout="ledger"] .ll-sub { margin: 0.25rem 0 1rem; font-size: 0.78rem; color: var(--ll-muted); }
+[data-layout="ledger"] .ll-census ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.6rem; }
+[data-layout="ledger"] .ll-census li {
+  display: grid; grid-template-columns: minmax(0, 1fr) 5.5rem 2.5rem;
+  align-items: center; gap: 0.9rem; font-size: 0.85rem;
+}
+[data-layout="ledger"] .ll-census-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+[data-layout="ledger"] .ll-census-track { height: 0.3rem; background: var(--ll-track); }
+[data-layout="ledger"] .ll-census-track i { display: block; height: 100%; background: var(--ll-fill); }
+[data-layout="ledger"] .ll-census-count { text-align: right; font-variant-numeric: tabular-nums; }
+
+[data-layout="ledger"] .ll-footnote {
+  margin: 2rem 0 0; max-width: 62ch; font-size: 0.78rem; line-height: 1.6; color: var(--ll-muted);
+}
+
+@media (max-width: 720px) {
+  [data-layout="ledger"] .ll { padding: 1.25rem 1rem 3rem; }
+  [data-layout="ledger"] .ll-table { display: block; overflow-x: auto; }
+}

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -72,7 +72,7 @@ const themeBootstrapScript = `
         user = JSON.parse(new TextDecoder().decode(Uint8Array.from(binary, function(c) { return c.charCodeAt(0); }))).user_id;
       }
       var saved = JSON.parse(localStorage.getItem('bloxos-design:' + (typeof user === 'string' ? user : 'guest')) || '{}');
-      if (['wall','grove','console'].indexOf(saved.layout) !== -1) {
+      if (['wall','grove','console','ledger'].indexOf(saved.layout) !== -1) {
         design = saved.layout;
         var color = saved.colors && saved.colors[design];
         if (['original','bright','dark'].indexOf(color) !== -1) designColor = color;

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -54,6 +54,7 @@ import { OPEN_ALERTS, OPEN_COMMAND, API_MACHINES_CHANGED } from "@/components/sh
 import { FleetWall } from "@/components/fleet/FleetWall";
 import { FleetGrove, FleetGroveRail } from "@/components/fleet/FleetGrove";
 import { FleetConsole } from "@/components/fleet/FleetConsole";
+import { FleetLedger } from "@/components/fleet/FleetLedger";
 
 type SortOption = "manual" | "name" | "status" | "cpu" | "gpu_temp";
 type StatusFilter = "all" | "live" | "warning" | "critical" | "offline" | "stale";
@@ -529,6 +530,7 @@ function DashboardContent() {
           {layout === "wall" && <FleetWall />}
           {layout === "grove" && <FleetGrove />}
           {layout === "console" && <FleetConsole />}
+          {layout === "ledger" && <FleetLedger />}
         </>
       )}
 

--- a/dashboard/src/components/DesignSettings.tsx
+++ b/dashboard/src/components/DesignSettings.tsx
@@ -9,11 +9,22 @@ const designs: { id: Layout; name: string; description: string }[] = [
   { id: "wall", name: "Operations Wall", description: "An open canvas of fleet health, resources and machines." },
   { id: "grove", name: "Grove Workspace", description: "Sidebar navigation, central analytics and a live context rail." },
   { id: "console", name: "Precision Console", description: "A compact, table-first workspace with telemetry instruments." },
+  { id: "ledger", name: "Ledger", description: "A still, type-led read of the fleet. Nothing animates and colour marks only what needs attention." },
 ];
 
 function DesignPreview({ layout }: { layout: Layout }) {
   return <svg viewBox="0 0 240 120" aria-hidden="true" className="w-full rounded-md mb-3 bg-blox-bg text-blox-blue border border-blox-border">
-    {layout === "grove" ? <>
+    {layout === "ledger" ? <>
+      {/* Rules and text, no cards: the layout's whole idea in one thumbnail. */}
+      <rect x="7" y="10" width="70" height="9" rx="2" fill="currentColor" opacity=".55" />
+      <rect x="7" y="27" width="226" height="1" fill="currentColor" opacity=".35" />
+      {[36,52,68].map((y, i) => <g key={y}>
+        <rect x="7" y={y} width={i === 0 ? 54 : 44} height="6" rx="2" fill="currentColor" opacity=".3" />
+        <rect x="96" y={y} width="137" height="6" rx="2" fill="currentColor" opacity=".16" />
+      </g>)}
+      <rect x="7" y="84" width="226" height="1" fill="currentColor" opacity=".35" />
+      {[93,104].map(y => <rect key={y} x="7" y={y} width="150" height="5" rx="2" fill="currentColor" opacity=".16" />)}
+    </> : layout === "grove" ? <>
       <rect x="7" y="7" width="37" height="106" rx="5" fill="currentColor" opacity=".25" />
       <rect x="51" y="7" width="128" height="43" rx="7" fill="currentColor" opacity=".45" />
       <rect x="186" y="7" width="47" height="106" rx="5" fill="currentColor" opacity=".2" />
@@ -46,7 +57,7 @@ export function DesignSettings({ compact = false }: { compact?: boolean }) {
         {!compact && <p className="text-xs text-blox-muted mt-1">{design.description}</p>}
       </button>)}
     </div>
-    {layout !== "classic" && <div role="group" aria-label="Design color" className="flex flex-wrap gap-2">
+    {layout !== "classic" && layout !== "ledger" && <div role="group" aria-label="Design color" className="flex flex-wrap gap-2">
       {DESIGN_COLORS.map(option => <button key={option} type="button" aria-pressed={color === option}
         aria-label={`Use ${option} design color`} onClick={() => setColor(option)} disabled={!ready}
         className={cn("px-3 py-2 text-xs rounded-md border capitalize", color === option ? "border-blox-blue text-blox-blue bg-blox-blue/10" : "border-blox-border text-blox-muted")}>{option}</button>)}

--- a/dashboard/src/components/fleet/FleetLedger.tsx
+++ b/dashboard/src/components/fleet/FleetLedger.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+// Ledger — a still, type-led read of the fleet. Three bands answer the three
+// questions an operator actually asks, in that order: does anything need me,
+// what is running right now, and what do I have?
+//
+// Deliberate departures from the other live layouts:
+//   * Nothing animates, and no container moves or resizes on update. Values are
+//     swapped in place so a number stays readable while it changes.
+//   * Colour is reserved for severity. A fleet with nothing wrong renders in
+//     greyscale; anything coloured is something to look at. The status dot is
+//     neutral for a healthy machine and only takes a semantic colour when the
+//     machine is stale or offline — the status word is always spelled out, so
+//     colour adds emphasis, never meaning on its own.
+//   * Every figure states what it excludes. Averages are fresh-only and GPU
+//     power says when it is a partial sum: the model already tracks this, so
+//     show it rather than implying a completeness we do not have.
+//
+// All values come from the shared fleet model over real SSE data. An
+// unavailable reading is "N/A" — never a fabricated zero (AGENTS.md).
+
+import Link from "next/link";
+import { useMemo, type CSSProperties } from "react";
+import { useFleetData } from "./useFleetData";
+import { pct, statusOf, statusVar, ramPct, diskPct, type Metric } from "./fleetModel";
+
+function num(value: Metric, unit = ""): string {
+  return value === null ? "N/A" : `${Math.round(value)}${unit}`;
+}
+
+/** Compact age since a machine last reported. Freshness is a first-class
+ * column here: the model already gates averages on it, so the operator should
+ * be able to see it rather than infer it from a status word. */
+function since(lastSeen: number | undefined, now: number): string {
+  if (!lastSeen) return "never";
+  const seconds = Math.max(0, Math.round((now - lastSeen) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
+function Figure({ label, value, unit, note }: { label: string; value: string; unit?: string; note: string }) {
+  return (
+    <div className="ll-figure">
+      <small>{label}</small>
+      <strong>
+        {value}
+        {unit && <span className="ll-unit">{unit}</span>}
+      </strong>
+      <p>{note}</p>
+    </div>
+  );
+}
+
+/** A counted inventory list — one row per distinct thing, biggest first. */
+function Census({ title, note, rows, empty }: {
+  title: string; note: string; rows: { name: string; count: number }[]; empty: string;
+}) {
+  const max = rows.reduce((m, r) => Math.max(m, r.count), 0);
+  return (
+    <section className="ll-census">
+      <h2>{title}</h2>
+      <p className="ll-sub">{note}</p>
+      {rows.length === 0 ? (
+        <p className="ll-none">{empty}</p>
+      ) : (
+        <ul>
+          {rows.map((r) => (
+            <li key={r.name}>
+              <span className="ll-census-name">{r.name}</span>
+              <span className="ll-census-track" aria-hidden="true">
+                <i style={{ width: `${max > 0 ? (r.count / max) * 100 : 0}%` }} />
+              </span>
+              <span className="ll-census-count">{r.count}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export function FleetLedger() {
+  const { machines, sorted, agg, sessionCount, sessionMachines, alertsCount, hasReceivedData, now } = useFleetData();
+  const offline = Math.max(0, agg.total - agg.online);
+
+  // Band 1 is triage: only genuine problems appear, so an empty band is a
+  // meaningful "nothing needs you" rather than a blank panel.
+  const issues = useMemo(() => {
+    const found: { key: string; count: number; label: string; note: string }[] = [];
+    if (offline > 0) {
+      found.push({ key: "offline", count: offline, label: "Offline",
+        note: "No report inside the offline window" });
+    }
+    if (agg.stale > 0) {
+      found.push({ key: "stale", count: agg.stale, label: "Stale telemetry",
+        note: "Connected, but readings aged out of the fresh window and are excluded from every average below" });
+    }
+    if (alertsCount > 0) {
+      found.push({ key: "alerts", count: alertsCount, label: "Active alerts",
+        note: "Raised by your alert rules" });
+    }
+    return found;
+  }, [offline, agg.stale, alertsCount]);
+
+  const accelerators = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const m of machines) {
+      for (const g of m.gpus ?? []) {
+        const name = (g.name || "").trim() || "Unnamed device";
+        counts.set(name, (counts.get(name) ?? 0) + 1);
+      }
+    }
+    return [...counts.entries()]
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+  }, [machines]);
+
+  const platforms = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const m of machines) {
+      const name = (m.os || "").trim() || "Unreported";
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+  }, [machines]);
+
+  return (
+    <div className="ll">
+      <header className="ll-head">
+        <div>
+          <h1>Fleet</h1>
+          <p>What needs you, what is running, what you have.</p>
+        </div>
+        <span className="ll-head-meta">
+          {agg.total} machine{agg.total === 1 ? "" : "s"} on record
+        </span>
+      </header>
+
+      {/* ---- Band 1 — does anything need me? --------------------------- */}
+      <section className="ll-band">
+        <h2 className="ll-band-title">Needs attention</h2>
+        {!hasReceivedData && agg.total === 0 ? (
+          <p className="ll-quiet">Waiting for the first telemetry report.</p>
+        ) : issues.length === 0 ? (
+          <p className="ll-quiet">Nothing needs attention.</p>
+        ) : (
+          <ul className="ll-issues">
+            {issues.map((issue) => (
+              <li key={issue.key}>
+                <span className="ll-issue-count">{issue.count}</span>
+                <span className="ll-issue-text">
+                  <strong>{issue.label}</strong>
+                  <small>{issue.note}</small>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* ---- Band 2 — what is running right now? ----------------------- */}
+      <section className="ll-band">
+        <h2 className="ll-band-title">Running now</h2>
+
+        <div className="ll-figures">
+          <Figure
+            label="Connected"
+            value={`${agg.online}`}
+            unit={`/${agg.total}`}
+            note={agg.total === 0 ? "No machines enrolled"
+              : agg.stale > 0 ? `${agg.stale} reporting stale`
+                : "All reporting fresh"}
+          />
+          <Figure label="CPU" value={num(agg.avgCpu)} unit={agg.avgCpu === null ? "" : "%"}
+            note="Mean across fresh machines" />
+          <Figure label="Memory" value={num(agg.avgRam)} unit={agg.avgRam === null ? "" : "%"}
+            note="Mean across fresh machines" />
+          <Figure label="GPU power" value={num(agg.gpuPowerTotal)} unit={agg.gpuPowerTotal === null ? "" : "W"}
+            note={agg.gpuPowerTotal === null ? "No device reported power"
+              : agg.gpuPowerComplete ? "Summed from every reporting device"
+                : "Partial sum — not every device reported"} />
+          <Figure label="Hottest GPU" value={num(agg.maxGpuTemp)} unit={agg.maxGpuTemp === null ? "" : "°C"}
+            note="Highest fresh device reading" />
+          <Figure label="AI sessions" value={sessionCount === null ? "N/A" : `${sessionCount}`}
+            note={sessionCount === null ? "Monitoring unavailable"
+              : `Across ${sessionMachines} machine${sessionMachines === 1 ? "" : "s"}`} />
+        </div>
+
+        <table className="ll-table">
+          <thead>
+            <tr>
+              <th scope="col">Machine</th>
+              <th scope="col">Status</th>
+              <th scope="col" className="ll-right">Last report</th>
+              <th scope="col" className="ll-right">CPU</th>
+              <th scope="col" className="ll-right">Memory</th>
+              <th scope="col" className="ll-right">Disk</th>
+              <th scope="col">Accelerator</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((m) => {
+              const status = statusOf(m);
+              const healthy = status === "live";
+              return (
+                <tr key={m.machine_id}>
+                  <th scope="row">
+                    <Link href={`/machine/${m.machine_id}`}>{m.hostname || m.machine_id}</Link>
+                    <small>{m.os || "platform unreported"}</small>
+                  </th>
+                  <td>
+                    <span
+                      className={healthy ? "ll-dot" : "ll-dot ll-dot-alert"}
+                      style={healthy ? undefined : ({ "--dot": statusVar(status) } as CSSProperties)}
+                      aria-hidden="true"
+                    />
+                    {status === "live" ? "Online" : status.charAt(0).toUpperCase() + status.slice(1)}
+                  </td>
+                  <td className="ll-right ll-figures-num">{since(m.last_seen, now)}</td>
+                  <td className="ll-right ll-figures-num">{pct(typeof m.cpu_percent === "number" ? m.cpu_percent : null)}</td>
+                  <td className="ll-right ll-figures-num">{pct(ramPct(m))}</td>
+                  <td className="ll-right ll-figures-num">{pct(diskPct(m))}</td>
+                  <td>{m.gpus && m.gpus.length > 0 ? m.gpus[0].name : "—"}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        {sorted.length === 0 && <p className="ll-none">No machines yet.</p>}
+      </section>
+
+      {/* ---- Band 3 — what do I have? ---------------------------------- */}
+      <section className="ll-band">
+        <h2 className="ll-band-title">Inventory</h2>
+        <div className="ll-inventory">
+          <Census
+            title="Accelerators"
+            note="One count per physical device reported by an agent"
+            rows={accelerators}
+            empty="No accelerators reported."
+          />
+          <Census
+            title="Platforms"
+            note="Machines by reported operating system"
+            rows={platforms}
+            empty="No machines enrolled."
+          />
+        </div>
+        <p className="ll-footnote">
+          Averages above use fresh machines only, so a stale or offline machine
+          never pulls a fleet figure toward a value nothing is actually
+          reporting. Counts here include every enrolled machine.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/dashboard/src/components/fleet/useFleetData.ts
+++ b/dashboard/src/components/fleet/useFleetData.ts
@@ -23,6 +23,10 @@ export interface FleetData {
   hasReceivedData: boolean;
   /** No machines are known yet (waiting for telemetry). */
   isEmpty: boolean;
+  /** The shared one-second clock already used to re-derive freshness.
+   * Exposed so a layout can render an age without calling Date.now()
+   * during render, which is impure and re-reads on every paint. */
+  now: number;
 }
 
 /** Single source of truth for the live layout bodies. Everything is real SSE
@@ -101,5 +105,6 @@ export function useFleetData(): FleetData {
     isDemo,
     hasReceivedData,
     isEmpty: machines.length === 0,
+    now,
   };
 }

--- a/dashboard/src/components/shell/AppShell.tsx
+++ b/dashboard/src/components/shell/AppShell.tsx
@@ -2,9 +2,11 @@
 
 // Shared authenticated navigation shell. Classic is a pure passthrough so the
 // existing pages (their own headers, modals and behavior) are untouched. The
-// three live layouts render persistent navigation chrome — Wall header, Grove
-// sidebar (+ optional context rail), Console icon rail + tabs — around the
-// page content, so navigation does not vanish on a machine click. The chrome's
+// live layouts render persistent navigation chrome — Wall header, Grove
+// sidebar (+ optional context rail), Console icon rail + tabs, Ledger top
+// rule — around the page content, so navigation does not vanish on a machine
+// click. EVERY non-classic layout must mount children through some chrome
+// here; a layout missing from the list below renders an empty shell. The chrome's
 // global actions and modals are owned by ShellActionsProvider and reachable on
 // every route, including mobile.
 
@@ -44,6 +46,7 @@ export function AppShell({ children, rail }: { children: ReactNode; rail?: React
       {layout === "wall" && <WallChrome>{children}</WallChrome>}
       {layout === "grove" && <GroveChrome rail={rail}>{children}</GroveChrome>}
       {layout === "console" && <ConsoleChrome>{children}</ConsoleChrome>}
+      {layout === "ledger" && <LedgerChrome>{children}</LedgerChrome>}
     </ShellActionsProvider>
   );
 }
@@ -203,6 +206,38 @@ function GroveChrome({ children, rail }: { children: ReactNode; rail?: ReactNode
 }
 
 /* ---- 03 Precision Console: icon rail + tabs ----------------------------- */
+function LedgerChrome({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const nav = useVisibleNav();
+  const { logoUrl, branding } = useBranding();
+  return (
+    <div className="ld-shell ll-shell">
+      <header className="ll-topbar">
+        <Link href="/" className="ll-brand" aria-label={branding.title || "Fleet"}>
+          {logoUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={logoUrl} alt={branding.title || "BloxOS"} className="ld-mark w-6 h-6 object-contain" />
+          ) : (
+            <BloxosMark className="ld-mark w-6 h-6" />
+          )}
+          <span>{branding.title || "BloxOS"}</span>
+        </Link>
+        <nav className="ll-nav" aria-label="Primary">
+          {nav.map(({ href, label }) => (
+            <Link key={href} href={href} className={isNavActive(pathname, href) ? "is-active" : ""}>
+              {label.replace(" overview", "")}
+            </Link>
+          ))}
+        </nav>
+        <div className="ll-actions">
+          <ShellActionCluster />
+        </div>
+      </header>
+      <main className="ll-content">{children}</main>
+    </div>
+  );
+}
+
 function ConsoleChrome({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const nav = useVisibleNav();

--- a/dashboard/src/contexts/DesignContext.tsx
+++ b/dashboard/src/contexts/DesignContext.tsx
@@ -31,7 +31,11 @@ export function DesignProvider({ children }: { children: ReactNode }) {
   const queue = useRef(Promise.resolve());
   const ready = state.ready && state.owner === userID;
   const prefs = ready ? state.prefs : normalizeDesign(null);
-  const color = prefs.layout === "classic" ? "original" : prefs.colors[prefs.layout];
+  // Ledger ships one fixed palette (colour is reserved for severity), so
+  // like Classic it exposes no colour choice and stores no colour column.
+  const color = prefs.layout === "classic" || prefs.layout === "ledger"
+    ? "original"
+    : prefs.colors[prefs.layout];
 
   // Bind both queued and in-flight requests to the login that initiated them.
   // Another tab may change storage at any time; never borrow its credentials.

--- a/dashboard/src/lib/design-layout-wiring.test.mjs
+++ b/dashboard/src/lib/design-layout-wiring.test.mjs
@@ -1,0 +1,55 @@
+// Every layout must be WIRED, not merely declared.
+//
+// A layout can typecheck, lint, build and pass every unit test while rendering
+// a completely blank page, because the two places that must know about it are
+// plain runtime string comparisons:
+//
+//   * AppShell dispatches children into per-layout chrome. A layout missing
+//     from that dispatch mounts no children at all — an empty shell.
+//   * The pre-hydration bootstrap in app/layout.tsx whitelists the layouts it
+//     will paint before React runs. A layout missing there flashes the wrong
+//     chrome and colour scheme on every load.
+//
+// Both were missed for Ledger and found in review, not by the build. These
+// assertions read the sources so adding a sixth layout cannot repeat it.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { DESIGN_LAYOUTS } from './design-prefs.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel) => readFileSync(join(here, rel), 'utf8');
+
+// Classic is a deliberate passthrough: AppShell returns children directly and
+// the bootstrap leaves the user's own theme alone.
+const LIVE_LAYOUTS = DESIGN_LAYOUTS.filter((layout) => layout !== 'classic');
+
+test('AppShell mounts children for every live layout', () => {
+  const source = read('../components/shell/AppShell.tsx');
+  assert.match(source, /layout === "classic"/,
+    'classic must stay an explicit passthrough');
+  for (const layout of LIVE_LAYOUTS) {
+    assert.ok(source.includes(`layout === "${layout}"`),
+      `AppShell has no chrome branch for "${layout}" — it would render an empty shell`);
+  }
+});
+
+test('the pre-hydration bootstrap paints every live layout', () => {
+  const source = read('../app/layout.tsx');
+  const match = source.match(/\[((?:'[a-z]+',?)+)\]\.indexOf\(saved\.layout\)/);
+  assert.ok(match, 'could not find the bootstrap layout whitelist in app/layout.tsx');
+  const whitelisted = match[1].split(',').map((name) => name.trim().replace(/'/g, ''));
+  assert.deepEqual(whitelisted.slice().sort(), LIVE_LAYOUTS.slice().sort(),
+    'the bootstrap whitelist and DESIGN_LAYOUTS disagree; a missing layout flashes the wrong chrome');
+});
+
+test('every live layout is offered in appearance settings', () => {
+  const source = read('../components/DesignSettings.tsx');
+  for (const layout of DESIGN_LAYOUTS) {
+    assert.ok(source.includes(`id: "${layout}"`),
+      `DesignSettings does not offer "${layout}", so it cannot be selected`);
+  }
+});

--- a/dashboard/src/lib/design-prefs.d.mts
+++ b/dashboard/src/lib/design-prefs.d.mts
@@ -1,6 +1,9 @@
-export type Layout = 'classic' | 'wall' | 'grove' | 'console';
+export type Layout = 'classic' | 'wall' | 'grove' | 'console' | 'ledger';
 export type DesignColor = 'original' | 'bright' | 'dark';
-export interface DesignPreferences { layout: Layout; colors: Record<Exclude<Layout, 'classic'>, DesignColor>; }
+/** Only the layouts with a colour column carry a colour. Classic and Ledger
+ * each ship one fixed palette, so neither stores nor offers a choice. */
+export type ColorfulLayout = Exclude<Layout, 'classic' | 'ledger'>;
+export interface DesignPreferences { layout: Layout; colors: Record<ColorfulLayout, DesignColor>; }
 export const DESIGN_LAYOUTS: readonly Layout[];
 export const DESIGN_COLORS: readonly DesignColor[];
 export function normalizeDesign(value: unknown): DesignPreferences;

--- a/dashboard/src/lib/design-prefs.mjs
+++ b/dashboard/src/lib/design-prefs.mjs
@@ -1,4 +1,4 @@
-export const DESIGN_LAYOUTS = ['classic', 'wall', 'grove', 'console'];
+export const DESIGN_LAYOUTS = ['classic', 'wall', 'grove', 'console', 'ledger'];
 export const DESIGN_COLORS = ['original', 'bright', 'dark'];
 export function normalizeDesign(value) {
   return {

--- a/dashboard/src/lib/design-prefs.test.mjs
+++ b/dashboard/src/lib/design-prefs.test.mjs
@@ -3,7 +3,16 @@ import assert from 'node:assert/strict';
 import { DESIGN_LAYOUTS, DESIGN_COLORS, normalizeDesign, readDesign, writeDesign, hasDesignCache, hasPendingDesign, markDesignSynced } from './design-prefs.mjs';
 
 test('designs and colors are independent and have exactly nine new combinations', () => {
-  assert.equal((DESIGN_LAYOUTS.length - 1) * DESIGN_COLORS.length, 9);
+  // Colour variants belong only to the layouts that carry a colour column.
+  // Classic and Ledger each ship ONE fixed palette and store no colour, so the
+  // nine combinations come from the three that do.
+  const withColors = Object.keys(normalizeDesign(null).colors);
+  assert.deepEqual(withColors, ['wall', 'grove', 'console']);
+  assert.equal(withColors.length * DESIGN_COLORS.length, 9);
+  for (const fixed of ['classic', 'ledger']) {
+    assert.ok(DESIGN_LAYOUTS.includes(fixed));
+    assert.equal(normalizeDesign({ layout: fixed }).colors[fixed], undefined);
+  }
   for (const layout of DESIGN_LAYOUTS) for (const color of DESIGN_COLORS) {
     const prefs = normalizeDesign({ layout, colors: { wall: color, grove: color, console: color } });
     assert.equal(prefs.layout, layout);

--- a/hub/design_prefs.go
+++ b/hub/design_prefs.go
@@ -12,7 +12,11 @@ import (
 
 var designColumns = map[string]string{"wall": "wall_color", "grove": "grove_color", "console": "console_color"}
 
-func validDesignLayout(v string) bool { return v == "classic" || designColumns[v] != "" }
+// Ledger, like classic, has a single fixed palette and therefore no colour
+// column: colour there is reserved for severity, so there is nothing to pick.
+func validDesignLayout(v string) bool {
+	return v == "classic" || v == "ledger" || designColumns[v] != ""
+}
 func validDesignColor(v string) bool  { return v == "original" || v == "bright" || v == "dark" }
 
 type designPrefs struct {


### PR DESCRIPTION
A fifth layout, added alongside the existing four rather than replacing them, for reading the fleet instead of watching it.

Three bands answer the three questions an operator actually asks, in order:

1. **Needs attention** — offline, stale telemetry, active alerts. When there is nothing, it says so plainly instead of showing an empty panel.
2. **Running now** — figures plus the machine table, with **freshness as a first-class column**.
3. **Inventory** — accelerators and platforms counted from reported data.

## Three rules that make it different

- **Nothing animates.** There is no transition, transform or keyframe in its stylesheet, and no container resizes on update, so a value stays readable *while* it changes. This is the layout's whole reason to exist.
- **Colour is severity.** The palette is greyscale; the only chromatic ink is the app's semantic `--status-*` tokens on a stale or offline machine. A healthy fleet reads entirely in grey, so anything coloured is worth looking at. The status word is always spelled out — colour never carries meaning on its own.
- **Rules and space, not boxes.** Sections are separated by hairlines rather than nested cards. Fewer containers is what lets the density read as calm rather than cluttered.

## Honesty made visible

The fleet model already gates averages on freshness and flags partial GPU-power sums; Ledger stops keeping that implicit. Every figure states what it excludes — "Mean across fresh machines", "Partial sum — not every device reported", "No device reported power" — and a closing note explains why a stale machine never pulls a fleet figure toward a value nothing is reporting.

## No migration

Ledger ships **one fixed palette** and offers no colour variants, so it needs no per-layout colour column. `validDesignLayout` accepts it the way it accepts `classic`, and `DesignPreferences.colors` is now typed `Record<ColorfulLayout, DesignColor>` to match what `normalizeDesign` has always built.

`useFleetData` now exposes the one-second clock it already maintains, so a layout can render an age without an impure `Date.now()` during render.

## Checks

Dashboard: 103 tests pass, lint clean (0 errors), `next build` succeeds. Hub: `go vet` clean, full suite passes.

Existing layouts are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI and design-preference validation; existing layouts and auth paths are unchanged aside from accepting a new layout value.
> 
> **Overview**
> Adds a fifth selectable dashboard layout, **Ledger**, aimed at a calm, non-animated fleet read rather than a live “wall” experience.
> 
> **Fleet view:** New `FleetLedger` renders three bands—**Needs attention** (offline, stale, alerts), **Running now** (fresh-only aggregates with explicit footnotes, machine table including **Last report**), and **Inventory** (accelerator/platform censuses). Metrics reuse `useFleetData`; **`now`** is exported from that hook so ages update without `Date.now()` during render.
> 
> **Chrome & styling:** Ledger gets a slim top-bar shell in `AppShell` (`LedgerChrome`) plus a large `data-layout="ledger"` stylesheet (fixed grey palette, semantic colour only for degraded status). Appearance settings list Ledger but hide colour variants, matching Classic.
> 
> **Preferences & hub:** `ledger` is added to `DESIGN_LAYOUTS`, pre-hydration bootstrap, and home layout switching. Types treat Ledger like Classic (no per-layout colour column); hub `validDesignLayout` accepts `ledger`. Source tests in `design-layout-wiring.test.mjs` guard AppShell, bootstrap whitelist, and DesignSettings stay in sync when layouts are added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84cd1aa906502f7d74e7be56aebdfa9e813d126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->