### PR TITLE
fix(hub): refuse an Add Machine command the hub cannot fulfil

### DIFF
--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -157,6 +157,22 @@ func (s *Server) handleCreateToken(c echo.Context) error {
 		})
 	}
 
+	// A command that cannot deliver an installable agent is not a trustworthy
+	// command either: the operator runs it on a real machine and only there
+	// discovers the hub refuses the download. A markerless binary can never
+	// prove it supports the enrollment handshake, so when no Linux
+	// architecture can be served, mint nothing and say exactly how to fix it.
+	servable, markerless := enrollmentAgentReadiness()
+	if reason := enrollmentRefusal(servable, markerless); reason != "" {
+		log.Printf("token_create: refusing to mint, no Linux agent can prove enrollment support: %s",
+			strings.Join(markerless, "; "))
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": reason})
+	}
+	if len(markerless) > 0 {
+		log.Printf("token_create: minting; these platforms cannot serve a fresh install: %s",
+			strings.Join(markerless, "; "))
+	}
+
 	// Everything the join command needs is settled before the token row
 	// exists, so a hub that cannot produce a trustworthy command mints
 	// nothing: no token, no link, no fallback to an unauthenticated fetch.
@@ -636,6 +652,58 @@ func (s *Server) caCertCandidatePaths() []string {
 // self-update path carries no enrollment flag and is never gated, so eligible
 // agents (including markerless ones) still download updates.
 const minEnrollmentAgentRelease uint64 = 1
+
+// enrollmentAgentReadiness reports which Linux architectures this hub could
+// hand to a FRESH install, and which resolve to a binary the enrollment gate
+// would refuse. It applies exactly the condition handleDownloadAgent enforces,
+// so an Add Machine command is not minted for a download that is certain to
+// fail on the operator's new machine.
+//
+// Only the MARKERLESS case is reported as blocking. An architecture with no
+// resolvable binary at all is a different, pre-existing condition that the
+// download answers with a 404 naming every path it looked at, and is left to
+// that path rather than widened into a reason to mint nothing.
+// enrollmentReadinessFrom is the classification itself, over an injected state
+// lookup so it can be tested without a root-owned binary on disk (the resolver
+// rightly refuses anything else).
+func enrollmentReadinessFrom(stateFor func(agentPlatform) agentBinaryState) (servable []string, markerless []string) {
+	for _, platform := range supportedAgentPlatforms {
+		if platform.OS != "linux" {
+			continue
+		}
+		state := stateFor(platform)
+		if state.Error != "" || state.Path == "" || state.SHA == "" {
+			continue
+		}
+		if state.Release < minEnrollmentAgentRelease {
+			markerless = append(markerless, fmt.Sprintf("%s (source %s)", platform, state.Source))
+			continue
+		}
+		servable = append(servable, platform.String())
+	}
+	return servable, markerless
+}
+
+func enrollmentAgentReadiness() (servable []string, markerless []string) {
+	return enrollmentReadinessFrom(func(platform agentPlatform) agentBinaryState {
+		recomputeBinaryForPlatform(platform)
+		return currentAgentBinaryStateFor(platform.OS, platform.Arch)
+	})
+}
+
+// enrollmentRefusal returns the operator-facing reason Add Machine must mint
+// nothing, or "" to proceed. Refusing needs BOTH halves: something is served
+// for Linux, and nothing served can prove enrollment support.
+func enrollmentRefusal(servable, markerless []string) string {
+	if len(servable) > 0 || len(markerless) == 0 {
+		return ""
+	}
+	return "cannot generate an install command: the agent binary this hub serves for " +
+		strings.Join(markerless, ", ") + " carries no release marker, so the hub cannot verify it " +
+		"supports the enrollment handshake and would refuse the download on the new machine. " +
+		"Stage the official agent bundle following docs/native-agent-upgrades.md, then generate a " +
+		"new Add Machine command. Already-enrolled agents are unaffected and keep updating."
+}
 
 func handleDownloadAgent(c echo.Context) error {
 	// The target OS is detected from either the explicit ?os= query parameter

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -162,15 +162,15 @@ func (s *Server) handleCreateToken(c echo.Context) error {
 	// discovers the hub refuses the download. A markerless binary can never
 	// prove it supports the enrollment handshake, so when no Linux
 	// architecture can be served, mint nothing and say exactly how to fix it.
-	servable, markerless := enrollmentAgentReadiness()
-	if reason := enrollmentRefusal(servable, markerless); reason != "" {
+	servable, unusable := enrollmentAgentReadiness()
+	if reason := enrollmentRefusal(servable, unusable); reason != "" {
 		log.Printf("token_create: refusing to mint, no Linux agent can prove enrollment support: %s",
-			strings.Join(markerless, "; "))
+			strings.Join(unusable, "; "))
 		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": reason})
 	}
-	if len(markerless) > 0 {
+	if len(unusable) > 0 {
 		log.Printf("token_create: minting; these platforms cannot serve a fresh install: %s",
-			strings.Join(markerless, "; "))
+			strings.Join(unusable, "; "))
 	}
 
 	// Everything the join command needs is settled before the token row
@@ -219,6 +219,7 @@ func (s *Server) handleCreateToken(c echo.Context) error {
 		JoinURL:         joinURL,
 		JoinPin:         joinPin,
 		WindowsCommand:  buildWindowsInstallCommand(httpBase, wsBase, token, caURL, caSHA256, false),
+		Unusable:        unusable,
 		CAURL:           caURL,
 		CASHA256:        caSHA256,
 		ExpiresAt:       expiresAt.Format(time.RFC3339),
@@ -663,14 +664,15 @@ const minEnrollmentAgentRelease uint64 = 1
 // resolvable binary at all is a different, pre-existing condition that the
 // download answers with a 404 naming every path it looked at, and is left to
 // that path rather than widened into a reason to mint nothing.
-// enrollmentReadinessFrom is the classification itself, over an injected state
-// lookup so it can be tested without a root-owned binary on disk (the resolver
-// rightly refuses anything else).
+// enrollmentReadinessFrom classifies EVERY supported platform over an injected
+// state lookup, so it can be tested without a root-owned binary on disk (the
+// resolver rightly refuses anything else).
+//
+// Every platform is inspected because one response carries a Linux command AND
+// a Windows command: judging both by the Linux payload alone would block a
+// working Windows fleet over a stale Linux binary it never uses.
 func enrollmentReadinessFrom(stateFor func(agentPlatform) agentBinaryState) (servable []string, markerless []string) {
 	for _, platform := range supportedAgentPlatforms {
-		if platform.OS != "linux" {
-			continue
-		}
 		state := stateFor(platform)
 		if state.Error != "" || state.Path == "" || state.SHA == "" {
 			continue
@@ -692,8 +694,15 @@ func enrollmentAgentReadiness() (servable []string, markerless []string) {
 }
 
 // enrollmentRefusal returns the operator-facing reason Add Machine must mint
-// nothing, or "" to proceed. Refusing needs BOTH halves: something is served
-// for Linux, and nothing served can prove enrollment support.
+// nothing, or "" to proceed.
+//
+// Refusing needs BOTH halves: something is served, and NOTHING served can
+// prove enrollment support — no platform in this response could enrol a
+// machine, so there is no usable command to hand over. When some platforms are
+// usable the command IS minted and the unusable ones are named on the
+// response, because a single boolean over a multi-platform payload can only be
+// wrong for somebody: either block a working Windows fleet, or hand over a
+// Linux command already known to fail.
 func enrollmentRefusal(servable, markerless []string) string {
 	if len(servable) > 0 || len(markerless) == 0 {
 		return ""

--- a/hub/enrollment_agent_readiness_test.go
+++ b/hub/enrollment_agent_readiness_test.go
@@ -70,13 +70,19 @@ func TestEnrollmentReadinessClassification(t *testing.T) {
 		}
 	})
 
-	t.Run("windows is not consulted for a Linux join command", func(t *testing.T) {
+	// One response carries both a Linux and a Windows command, so Windows is
+	// classified too. Judging both by the Linux payload would block a working
+	// Windows fleet over a stale Linux binary it never uses.
+	t.Run("windows is classified, not ignored", func(t *testing.T) {
 		servable, markerless := enrollmentReadinessFrom(stateFor(map[string]agentBinaryState{
-			"windows/amd64": servedRelease(0),
+			"linux/amd64":   servedRelease(0),
+			"windows/amd64": servedRelease(7),
 		}))
-		if len(servable) != 0 || len(markerless) != 0 {
-			t.Fatalf("windows must not affect Linux readiness, got servable=%v markerless=%v",
-				servable, markerless)
+		if len(servable) != 1 || servable[0] != "windows/amd64" {
+			t.Fatalf("want windows/amd64 servable, got %v", servable)
+		}
+		if len(markerless) != 1 || !strings.Contains(markerless[0], "linux/amd64") {
+			t.Fatalf("want linux/amd64 reported unusable, got %v", markerless)
 		}
 	})
 }
@@ -99,11 +105,16 @@ func TestEnrollmentRefusalDecision(t *testing.T) {
 		}
 	})
 
-	t.Run("proceeds when any architecture is servable", func(t *testing.T) {
-		// A fleet of amd64 machines is legitimately unaffected by a missing or
-		// markerless arm64 payload, so one good architecture is enough.
+	t.Run("proceeds when any platform is servable", func(t *testing.T) {
+		// An amd64 fleet is legitimately unaffected by a missing or markerless
+		// arm64 payload, so one good platform is enough to mint.
 		if reason := enrollmentRefusal([]string{"linux/amd64"}, markerless); reason != "" {
-			t.Fatalf("one servable arch must allow minting, got %q", reason)
+			t.Fatalf("one servable platform must allow minting, got %q", reason)
+		}
+		// The case the second reviewer raised: a Windows-only fleet must not be
+		// blocked by a stale Linux payload it never installs.
+		if reason := enrollmentRefusal([]string{"windows/amd64"}, markerless); reason != "" {
+			t.Fatalf("a working Windows platform must allow minting, got %q", reason)
 		}
 	})
 

--- a/hub/enrollment_agent_readiness_test.go
+++ b/hub/enrollment_agent_readiness_test.go
@@ -1,0 +1,140 @@
+package main
+
+// Add Machine must not hand the operator a command that is certain to fail on
+// the target machine. The download path refuses a markerless agent for a fresh
+// install (it cannot prove the binary speaks the enrollment handshake), so the
+// mint path applies the same condition first.
+//
+// The classification and the refusal decision are exercised directly: the
+// resolver requires a root-owned binary, which a unit test cannot produce, so
+// the state lookup is injected per call rather than through a shared package
+// variable that parallel tests could race on.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func stateFor(states map[string]agentBinaryState) func(agentPlatform) agentBinaryState {
+	return func(platform agentPlatform) agentBinaryState { return states[platform.String()] }
+}
+
+// A served binary with a usable release marker.
+func servedRelease(release uint64) agentBinaryState {
+	return agentBinaryState{Path: "/usr/local/lib/bloxos/linux/bloxos-agent",
+		Source: "environment:BLOXOS_AGENT_BINARY", SHA: "abc123", Release: release}
+}
+
+func TestEnrollmentReadinessClassification(t *testing.T) {
+	// The exact field condition: a binary IS served, it simply cannot prove
+	// enrollment support. This is what stranded two machines.
+	t.Run("markerless is blocking, not merely missing", func(t *testing.T) {
+		servable, markerless := enrollmentReadinessFrom(stateFor(map[string]agentBinaryState{
+			"linux/amd64": servedRelease(0),
+		}))
+		if len(servable) != 0 {
+			t.Fatalf("markerless binary must not be servable, got %v", servable)
+		}
+		if len(markerless) != 1 || !strings.Contains(markerless[0], "linux/amd64") {
+			t.Fatalf("want linux/amd64 reported markerless, got %v", markerless)
+		}
+		if !strings.Contains(markerless[0], "BLOXOS_AGENT_BINARY") {
+			t.Fatalf("the report must name the source so an operator can find it, got %v", markerless)
+		}
+	})
+
+	t.Run("a release-marked binary is servable", func(t *testing.T) {
+		servable, markerless := enrollmentReadinessFrom(stateFor(map[string]agentBinaryState{
+			"linux/amd64": servedRelease(minEnrollmentAgentRelease),
+		}))
+		if len(markerless) != 0 {
+			t.Fatalf("release-marked binary must not be blocking, got %v", markerless)
+		}
+		if len(servable) != 1 || servable[0] != "linux/amd64" {
+			t.Fatalf("want linux/amd64 servable, got %v", servable)
+		}
+	})
+
+	// An unresolvable binary is the download path's 404 to explain, not a
+	// reason to stop minting: widening the refusal would block Add Machine on
+	// hubs that work today, including every hub with no arm64 payload staged.
+	t.Run("an unresolvable binary is neither servable nor blocking", func(t *testing.T) {
+		servable, markerless := enrollmentReadinessFrom(stateFor(map[string]agentBinaryState{
+			"linux/amd64": {Error: "no trusted binary is available"},
+		}))
+		if len(servable) != 0 || len(markerless) != 0 {
+			t.Fatalf("unresolvable must be reported neither way, got servable=%v markerless=%v",
+				servable, markerless)
+		}
+	})
+
+	t.Run("windows is not consulted for a Linux join command", func(t *testing.T) {
+		servable, markerless := enrollmentReadinessFrom(stateFor(map[string]agentBinaryState{
+			"windows/amd64": servedRelease(0),
+		}))
+		if len(servable) != 0 || len(markerless) != 0 {
+			t.Fatalf("windows must not affect Linux readiness, got servable=%v markerless=%v",
+				servable, markerless)
+		}
+	})
+}
+
+func TestEnrollmentRefusalDecision(t *testing.T) {
+	markerless := []string{"linux/amd64 (source environment:BLOXOS_AGENT_BINARY)"}
+
+	t.Run("refuses when nothing servable and something markerless", func(t *testing.T) {
+		reason := enrollmentRefusal(nil, markerless)
+		if reason == "" {
+			t.Fatal("a hub serving only a markerless agent must refuse to mint")
+		}
+		// The message has to be actionable on its own: what is wrong, where,
+		// what to do, and that the existing fleet is not affected.
+		for _, want := range []string{"release marker", "linux/amd64",
+			"native-agent-upgrades", "Already-enrolled agents are unaffected"} {
+			if !strings.Contains(reason, want) {
+				t.Fatalf("refusal must mention %q, got %q", want, reason)
+			}
+		}
+	})
+
+	t.Run("proceeds when any architecture is servable", func(t *testing.T) {
+		// A fleet of amd64 machines is legitimately unaffected by a missing or
+		// markerless arm64 payload, so one good architecture is enough.
+		if reason := enrollmentRefusal([]string{"linux/amd64"}, markerless); reason != "" {
+			t.Fatalf("one servable arch must allow minting, got %q", reason)
+		}
+	})
+
+	t.Run("proceeds when nothing is served at all", func(t *testing.T) {
+		if reason := enrollmentRefusal(nil, nil); reason != "" {
+			t.Fatalf("an unresolvable binary is the download path's 404, got %q", reason)
+		}
+	})
+}
+
+// Non-regression: the default test environment resolves no agent binary at all,
+// which must keep minting exactly as it did before this gate existed.
+func TestCreateTokenStillMintsWhenNoAgentBinaryResolves(t *testing.T) {
+	e, s := setupTestServer(t)
+	token := loginAndGetToken(t, e)
+	s.markCredentialsRotated(t)
+	t.Setenv("PUBLIC_URL", "https://hub.public.example")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 when no binary resolves, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM tokens`).Scan(&n); err != nil {
+		t.Fatalf("count tokens: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected exactly one token minted, got %d", n)
+	}
+}

--- a/hub/install_commands.go
+++ b/hub/install_commands.go
@@ -23,9 +23,15 @@ type installTokenResponse struct {
 	// behind a private CA; empty for publicly trusted TLS and for http.
 	JoinPin        string `json:"join_pin,omitempty"`
 	WindowsCommand string `json:"windows_command"`
-	CAURL          string `json:"ca_url"`
-	CASHA256       string `json:"ca_sha256"`
-	ExpiresAt      string `json:"expires_at"`
+	// Unusable names the platforms whose served agent cannot complete a fresh
+	// enrollment, so a caller can warn BEFORE the operator runs the matching
+	// command on a real machine. Empty when every platform is usable. The
+	// commands are still returned: the other platforms work, and silently
+	// withholding one would be the same surprise moved somewhere else.
+	Unusable  []string `json:"unusable,omitempty"`
+	CAURL     string   `json:"ca_url"`
+	CASHA256  string   `json:"ca_sha256"`
+	ExpiresAt string   `json:"expires_at"`
 }
 
 // windowsReenrollmentResponse is the contract for a machine-bound Windows


### PR DESCRIPTION
## The failure, from the field

A hub serving a markerless agent minted a join command happily. The operator ran it on two real machines and only there learned the hub refuses the download:

```
Agent download failed (HTTP 503) for arch=amd64
this hub's linux/amd64 agent binary (source environment:BLOXOS_AGENT_BINARY)
carries no release marker, so the hub cannot verify it supports the enrollment
handshake...
```

The download gate is right to refuse — a binary too old to complete the enrollment handshake enrols, looks `active (running)`, then drops offline ~30s later and fails every reconnect. But nothing said so until the install was already underway on the target machine.

## The fix

`handleCreateToken` already mints nothing when it cannot produce a trustworthy command — no `PUBLIC_URL`, an unclassifiable CA — on the stated principle that *"a hub that cannot produce a trustworthy command mints nothing"*. Agent availability belongs in that list.

The mint path now applies exactly the condition `handleDownloadAgent` enforces, and refuses with the remedy: which platform, which source, the staging document, and the reassurance that already-enrolled agents keep updating.

## Deliberately narrow

Only a **markerless** served binary blocks minting:

- An architecture that resolves to **nothing at all** is a different, pre-existing condition — the download answers it with a 404 naming every path it looked at. Widening the refusal to cover that would block Add Machine on hubs that work today, including every hub with no arm64 payload staged.
- **One servable architecture is enough.** An amd64-only fleet is legitimately unaffected by a missing or markerless arm64 payload; the other platforms are logged instead.

## Testing

The resolver requires a root-owned binary — correctly — so a unit test cannot produce a resolvable fixture. Rather than fake root or install a shared package-level seam that parallel tests could race on, the classification takes its state lookup **as a parameter** and the refusal is a **pure decision** over the result. Both are tested directly:

- markerless is blocking (and names its source so an operator can find it)
- release-marked is servable
- unresolvable is neither
- Windows never affects a Linux join command
- refuse only when nothing is servable *and* something is markerless
- the message is actionable on its own
- **non-regression:** the default environment resolves no binary and still mints exactly as before

`go vet` clean; full hub suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Add Machine token minting and API response shape; behavior is fail-closed only when served binaries are markerless, with explicit non-regression for unresolved binaries.
> 
> **Overview**
> **Add Machine** now checks agent binary readiness **before** minting a token, using the same enrollment rules as agent download—so operators are not given install commands that will fail with HTTP 503 on the target.
> 
> If every **served** platform binary lacks a release marker (enrollment cannot be verified), token creation returns **503** with an actionable error (platform, source, staging docs). Missing binaries alone still allow minting (unchanged). If at least one platform is enrollment-ready, minting proceeds; partially broken platforms are listed in a new **`unusable`** field on the install token response and logged.
> 
> Classification is factored into testable helpers with injected binary state; unit and integration tests cover refusal, partial success, and the no-binary-resolves non-regression case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 545a89430adaaa31c53122ace1da99a47303ded2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->