### PR TITLE
fix(dashboard): let Ledger's absent readings read as absent

### DIFF
--- a/dashboard/src/app/design-layouts.css
+++ b/dashboard/src/app/design-layouts.css
@@ -501,6 +501,19 @@ html[data-layout="ledger"] body { background: var(--ll-canvas); color: var(--ll-
 [data-layout="ledger"] .ll-unit {
   margin-left: 0.2rem; font-size: 0.85rem; font-weight: 400; color: var(--ll-secondary);
 }
+/* An unavailable reading keeps its place in the row but not its weight, so
+ * the eye passes over absence and stops on measurements. */
+[data-layout="ledger"] .ll-figure strong.ll-absent {
+  font-size: 1.05rem; color: var(--ll-muted); letter-spacing: 0;
+  line-height: 1.75; /* hold the baseline of a full-size figure */
+}
+/* Averages exclude stale machines, so when nothing is fresh every figure is
+ * N/A while the table below still shows per-machine numbers. Correct, but it
+ * reads as broken without a reason given in place. */
+[data-layout="ledger"] .ll-stale-note {
+  margin: 0 0 1.5rem; max-width: 68ch; font-size: 0.82rem; line-height: 1.55;
+  color: var(--ll-secondary); border-left: 2px solid var(--ll-rule-strong); padding-left: 0.85rem;
+}
 [data-layout="ledger"] .ll-figure p {
   margin: 0; font-size: 0.78rem; line-height: 1.45; color: var(--ll-muted);
 }

--- a/dashboard/src/components/fleet/FleetLedger.tsx
+++ b/dashboard/src/components/fleet/FleetLedger.tsx
@@ -43,10 +43,14 @@ function since(lastSeen: number | undefined, now: number): string {
 }
 
 function Figure({ label, value, unit, note }: { label: string; value: string; unit?: string; note: string }) {
+  // An unavailable reading is real information, but it is not a measurement:
+  // rendered at full size it gives dead fields the same weight as live data
+  // and the eye stops on nothing. Set smaller and muted so it reads as absent.
+  const unavailable = value === "N/A";
   return (
     <div className="ll-figure">
       <small>{label}</small>
-      <strong>
+      <strong className={unavailable ? "ll-absent" : undefined}>
         {value}
         {unit && <span className="ll-unit">{unit}</span>}
       </strong>
@@ -167,6 +171,14 @@ export function FleetLedger() {
       {/* ---- Band 2 — what is running right now? ----------------------- */}
       <section className="ll-band">
         <h2 className="ll-band-title">Running now</h2>
+
+        {agg.total > 0 && agg.online - agg.stale <= 0 && (
+          <p className="ll-stale-note">
+            No machine has reported inside the fresh window, so no fleet average
+            can be computed. The per-machine readings below are the last values
+            received, not current ones.
+          </p>
+        )}
 
         <div className="ll-figures">
           <Figure


### PR DESCRIPTION
Two problems that were only visible once the layout was actually rendered in a browser.

**1. `N/A` carried the weight of a measurement.** An unavailable reading set at the full 1.9rem figure size, so two dead fields (GPU power, AI sessions) competed with live data and the eye stopped on nothing. It now sets smaller and muted, holding its place in the row without pretending to be a number.

**2. A fully stale fleet looked broken.** Averages exclude stale machines by design, so when nothing is fresh every figure reads `N/A` while the table below still lists per-machine values. That is correct and it looks like a bug. The band now explains itself in place:

> No machine has reported inside the fresh window, so no fleet average can be computed. The per-machine readings below are the last values received, not current ones.

The closing footnote already stated the rule; this states the moment.

Verified in a browser against demo data in both states — fresh (figures live, N/A recedes) and fully stale (note present, statuses `Stale`, every average `N/A`) — rather than trusting a green build. Dashboard 106 tests, lint clean, `next build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Ledger-only presentation and copy changes; no aggregation logic or API behavior is modified.
> 
> **Overview**
> Improves how the **Ledger** fleet layout communicates missing data so operators are not misled by correct but confusing UI.
> 
> **N/A** fleet figures (CPU averages, GPU power, etc.) now get the `ll-absent` treatment—smaller, muted type—so unavailable readings keep their slot in the row without competing visually with live measurements. The shared `Figure` helper applies that class when `value === "N/A"`.
> 
> When every enrolled machine is stale (nothing inside the fresh window), a **`ll-stale-note`** appears above the "Running now" figures explaining that fleet averages cannot be computed and that the table still shows last-received per-machine values. Styling for both behaviors is scoped under `[data-layout="ledger"]` in `design-layouts.css`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 121b8338ecc385e0e4d33b07581c63fd3d8d6187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->