### PR TITLE
docs: point installation instructions at v1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ dashboard support **Linux amd64 and arm64**. Ports **80 and 443** must be availa
 ### 1. Download BloxOS
 
 ```sh
-git clone --branch v1.3.1 --depth 1 https://github.com/bokiko/bloxos.git
+git clone --branch v1.3.2 --depth 1 https://github.com/bokiko/bloxos.git
 cd bloxos/docker
 cp .env.example .env
 ```
@@ -186,7 +186,7 @@ systemd services, pulling containers does not update those services. If both
 exist, do not start another stack or switch the proxy: establish which existing
 installation serves your public URL. See [upgrade verification](docs/verified-upgrades.md).
 
-For an existing **Compose deployment**, set `BLOXOS_VERSION=1.3.1` in your existing
+For an existing **Compose deployment**, set `BLOXOS_VERSION=1.3.2` in your existing
 `.env`, then run these with the same project name and any existing overrides:
 
 ```sh
@@ -221,7 +221,7 @@ On a native installation, replacing the hub executable does **not** replace
 separate agent files. Use the [native agent check-and-stage guide](docs/native-agent-upgrades.md)
 to prepare the published payloads without starting a fleet rollout.
 
-[Release notes](https://github.com/bokiko/bloxos/releases/tag/v1.3.1) ·
+[Release notes](https://github.com/bokiko/bloxos/releases/tag/v1.3.2) ·
 [Update signing](docs/offline-update-signing.md) ·
 [Agent recovery](docs/agent-update-recovery.md)
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -6,4 +6,4 @@ HUB_HOST=hub.lan
 
 # Pin a published release for a predictable upgrade target; unset means
 # `latest`. See docker/README.md for the upgrade procedure.
-# BLOXOS_VERSION=1.3.1
+# BLOXOS_VERSION=1.3.2

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,13 +8,13 @@ they are not containerized.
 
 Use Docker Compose v2 on a Linux amd64 or arm64 host. Ports 80 and 443 must
 be free, and browsers and agents must be able to reach the host. From a
-clone of the released `v1.3.1` tag:
+clone of the released `v1.3.2` tag:
 
 ```bash
 cd docker
 cp .env.example .env
 # Edit .env: set HUB_HOST to this machine's reachable hostname or IP.
-# Add BLOXOS_VERSION=1.3.1 to use this release's images.
+# Add BLOXOS_VERSION=1.3.2 to use this release's images.
 docker compose pull
 docker compose up -d --no-build
 ```


### PR DESCRIPTION
Bumps the version-pinned installation instructions to `v1.3.2` so a fresh install lands on the current release.

Documentation only — no code, no workflow, no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only version string updates with no runtime, build, or deployment logic changes.
> 
> **Overview**
> Updates **documentation and examples** so new installs and manual Compose upgrades target **v1.3.2** instead of v1.3.1.
> 
> The `git clone` branch in the root **README**, **`BLOXOS_VERSION`** in the manual upgrade section, the release-notes link, the commented pin in **`docker/.env.example`**, and the clone/pin notes in **`docker/README.md`** all now reference **1.3.2** / **`v1.3.2`**. No application code, images, or CI behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49dbd4fd0edc456ff41162edb9bb5c5fa3eff9e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->