### PR TITLE
fix(dashboard): never report an alert count from a list that failed to load

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -120,6 +120,7 @@ function OverviewContent() {
     connected,
     hasReceivedData,
     alerts,
+    alertsStatus,
     setAlerts,
     setAlertCount,
     refreshMachine,
@@ -571,6 +572,7 @@ function OverviewContent() {
         ready={hasReceivedData || isDemo}
         counts={counts}
         alerts={alerts}
+        alertsStatus={alertsStatus}
         onOpenAlerts={openAlertPanel}
         onFilterStatus={applyStatusFilter}
         powerPeriod={powerPeriod}

--- a/dashboard/src/components/overview/NeedsAttentionMini.tsx
+++ b/dashboard/src/components/overview/NeedsAttentionMini.tsx
@@ -15,6 +15,12 @@
 // alerts" is three words that say which one this is. There is no control at
 // zero: a button opening an empty sheet lies about there being something
 // behind it.
+//
+// And when the list could not be READ at all, it says so instead of printing
+// a zero. The count on the shell's bell and this list come from two different
+// places — a stream event and GET /api/alerts — so one can fail while the
+// other works. "0" would then be a claim nothing verified, sitting next to a
+// bell saying 1.
 
 import { ArrowRight } from "lucide-react";
 import type { AlertData } from "@/lib/demo-data";
@@ -22,11 +28,35 @@ import { alertBreakdown } from "@/lib/overview-layout.mjs";
 
 export function NeedsAttentionMini({
   alerts,
+  status,
   onOpenAlerts,
 }: {
   alerts: AlertData[];
+  /** Whether the alert list could be read at all. */
+  status: "loading" | "ready" | "error";
   onOpenAlerts: () => void;
 }) {
+  if (status !== "ready") {
+    const unknown = status === "error";
+    return (
+      <section className="mf-overview-module" aria-label="Needs attention">
+        <div className="mf-overview-module-head">
+          <h3 className="mf-kicker">Needs attention</h3>
+        </div>
+        <p className="mt-2">
+          <span className="mf-metric text-[24px] font-medium leading-none text-text-disabled">—</span>
+        </p>
+        <p
+          className={`mt-2 text-[13px] ${unknown ? "text-status-warning" : "text-text-tertiary"}`}
+          role={unknown ? "status" : undefined}
+          title={unknown ? "The hub's alert list could not be read. The count on the alerts button may still be accurate." : undefined}
+        >
+          {unknown ? "Alert list unavailable" : "Loading alerts…"}
+        </p>
+      </section>
+    );
+  }
+
   const { total, critical, warning } = alertBreakdown(alerts) as {
     total: number;
     critical: number;

--- a/dashboard/src/components/overview/OverviewWorkspace.tsx
+++ b/dashboard/src/components/overview/OverviewWorkspace.tsx
@@ -43,6 +43,8 @@ export interface OverviewWorkspaceProps {
   ready: boolean;
   counts: AvailabilityCounts;
   alerts: AlertData[];
+  /** Whether the alert list could be read at all. */
+  alertsStatus: "loading" | "ready" | "error";
   /** Opens the alert sheet. Only ever wired to real alert data. */
   onOpenAlerts: () => void;
   /** Filters the machine table below and moves focus to it. */
@@ -58,6 +60,7 @@ export function OverviewWorkspace({
   ready,
   counts,
   alerts,
+  alertsStatus,
   onOpenAlerts,
   onFilterStatus,
   powerPeriod,
@@ -71,7 +74,7 @@ export function OverviewWorkspace({
       case "availability":
         return <FleetAvailabilityMini key={key} counts={counts} onFilterStatus={onFilterStatus} />;
       case "attention":
-        return <NeedsAttentionMini key={key} alerts={alerts} onOpenAlerts={onOpenAlerts} />;
+        return <NeedsAttentionMini key={key} alerts={alerts} status={alertsStatus} onOpenAlerts={onOpenAlerts} />;
       case "urgent_alert":
         return <UrgentAlertMini key={key} alerts={alerts} />;
       default:

--- a/dashboard/src/contexts/SSEContext.tsx
+++ b/dashboard/src/contexts/SSEContext.tsx
@@ -36,6 +36,16 @@ interface SSEContextType {
   hasReceivedData: boolean;
   alertCount: number;
   alerts: AlertData[];
+  /**
+   * Whether the ACTIVE ALERT LIST could actually be read.
+   *
+   * `alertCount` and `alerts` come from different places — the count arrives
+   * on the stream, the list from GET /api/alerts — so one can succeed while
+   * the other fails. A consumer that renders "0 alerts" off an empty list
+   * would then be asserting something it never learned. Anything showing a
+   * count must check this first: "error" means unknown, not none.
+   */
+  alertsStatus: "loading" | "ready" | "error";
   setAlerts: React.Dispatch<React.SetStateAction<AlertData[]>>;
   setAlertCount: React.Dispatch<React.SetStateAction<number>>;
   refreshMachine: (machineID: string) => Promise<void>;
@@ -75,6 +85,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
   const [hasReceivedData, setHasReceivedData] = useState(false);
   const [alertCount, setAlertCount] = useState(0);
   const [alerts, setAlerts] = useState<AlertData[]>([]);
+  const [alertsStatus, setAlertsStatus] = useState<"loading" | "ready" | "error">("loading");
   const esRef = useRef<EventSource | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const backoffRef = useRef(3000);
@@ -157,6 +168,47 @@ export function SSEProvider({ children }: { children: ReactNode }) {
     cacheCancelRef.current = cancel;
   }, []);
 
+  /**
+   * Read the active alert list.
+   *
+   * Separate from the stream on purpose — the stream carries a COUNT, this
+   * carries the alerts themselves — which is exactly why its failure has to
+   * be recorded rather than swallowed. It used to end in `.catch(() => {})`,
+   * so a 401, a blip or a proxy hiccup left the list empty and silent for the
+   * life of the page while the count on the bell kept saying otherwise. The
+   * two then disagreed in public with nothing to explain why.
+   *
+   * The token captured at dispatch is re-checked before applying: a logout or
+   * re-login in flight must not repopulate state it just cleared.
+   */
+  const loadAlerts = useCallback(async () => {
+    const token = getStoredToken();
+    if (!token) return;
+    try {
+      const res = await fetch(`${HUB_URL}/api/alerts`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error(`alerts: ${res.status}`);
+      const data = await res.json();
+      if (!Array.isArray(data)) throw new Error("alerts: not a list");
+      if (mountedRef.current && getStoredToken() === token) {
+        setAlerts(data as AlertData[]);
+        // The list IS the count when we have just read it, so the two cannot
+        // drift apart on a successful load.
+        setAlertCount(data.length);
+        setAlertsStatus("ready");
+      }
+    } catch {
+      // Leave `alertCount` alone: the stream's count is still the best thing
+      // known about how many there are. Only the LIST is unknown.
+      if (mountedRef.current && getStoredToken() === token) setAlertsStatus("error");
+    }
+  }, []);
+  const alertsStatusRef = useRef(alertsStatus);
+  alertsStatusRef.current = alertsStatus;
+  const loadAlertsRef = useRef(loadAlerts);
+  loadAlertsRef.current = loadAlerts;
+
   const disconnect = useCallback((clearData = false) => {
     esRef.current?.close();
     esRef.current = null;
@@ -168,6 +220,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
       setMachineMap(new Map());
       setAlerts([]);
       setAlertCount(0);
+      setAlertsStatus("loading");
     }
   }, []);
 
@@ -222,6 +275,10 @@ export function SSEProvider({ children }: { children: ReactNode }) {
       if (!mountedRef.current || esRef.current !== es) return;
       setConnected(true);
       backoffRef.current = 3000;
+      // A stream that just came up is a working connection: retry a list that
+      // previously failed, so a transient error heals instead of persisting
+      // for the whole session.
+      if (alertsStatusRef.current === "error") void loadAlertsRef.current();
 
       if (sseTokenRefreshTimer.current) clearTimeout(sseTokenRefreshTimer.current);
       sseTokenRefreshTimer.current = setTimeout(() => {
@@ -424,24 +481,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
 
     connectRef.current();
 
-    // Fetch active alerts on mount. The token captured at dispatch time is
-    // re-checked before applying: a logout (or re-login) while the request
-    // is in flight must not repopulate state it just cleared.
-    const token = getStoredToken();
-    if (token) {
-      fetch(`${HUB_URL}/api/alerts`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-        .then((r) => r.json())
-        .then((data) => {
-          if (!Array.isArray(data)) return;
-          if (mountedRef.current && getStoredToken() === token) {
-            setAlerts(data);
-            setAlertCount(data.length);
-          }
-        })
-        .catch(() => {});
-    }
+    loadAlertsRef.current();
 
     const onStorage = (e: StorageEvent) => {
       if (e.key === "bloxos_token") {
@@ -533,6 +573,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
         hasReceivedData,
         alertCount,
         alerts,
+        alertsStatus,
         setAlerts,
         setAlertCount,
         refreshMachine,

--- a/dashboard/src/contexts/SSEContext.tsx
+++ b/dashboard/src/contexts/SSEContext.tsx
@@ -181,33 +181,34 @@ export function SSEProvider({ children }: { children: ReactNode }) {
    * The token captured at dispatch is re-checked before applying: a logout or
    * re-login in flight must not repopulate state it just cleared.
    */
-  const loadAlerts = useCallback(async () => {
+  const loadAlerts = useCallback(() => {
     const token = getStoredToken();
     if (!token) return;
-    try {
-      const res = await fetch(`${HUB_URL}/api/alerts`, {
-        headers: { Authorization: `Bearer ${token}` },
+    // A promise chain rather than async/await: every setState below lands in a
+    // `.then`, so it is plainly deferred past this tick — an async function
+    // called from an effect reads to the linter (and to a reviewer skimming
+    // it) as a synchronous state write.
+    fetch(`${HUB_URL}/api/alerts`, { headers: { Authorization: `Bearer ${token}` } })
+      .then((res) => {
+        if (!res.ok) throw new Error(`alerts: ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (!Array.isArray(data)) throw new Error("alerts: not a list");
+        if (mountedRef.current && getStoredToken() === token) {
+          setAlerts(data as AlertData[]);
+          // The list IS the count when we have just read it, so the two
+          // cannot drift apart on a successful load.
+          setAlertCount(data.length);
+          setAlertsStatus("ready");
+        }
+      })
+      .catch(() => {
+        // Leave `alertCount` alone: the stream's count is still the best thing
+        // known about how many there are. Only the LIST is unknown.
+        if (mountedRef.current && getStoredToken() === token) setAlertsStatus("error");
       });
-      if (!res.ok) throw new Error(`alerts: ${res.status}`);
-      const data = await res.json();
-      if (!Array.isArray(data)) throw new Error("alerts: not a list");
-      if (mountedRef.current && getStoredToken() === token) {
-        setAlerts(data as AlertData[]);
-        // The list IS the count when we have just read it, so the two cannot
-        // drift apart on a successful load.
-        setAlertCount(data.length);
-        setAlertsStatus("ready");
-      }
-    } catch {
-      // Leave `alertCount` alone: the stream's count is still the best thing
-      // known about how many there are. Only the LIST is unknown.
-      if (mountedRef.current && getStoredToken() === token) setAlertsStatus("error");
-    }
   }, []);
-  const alertsStatusRef = useRef(alertsStatus);
-  alertsStatusRef.current = alertsStatus;
-  const loadAlertsRef = useRef(loadAlerts);
-  loadAlertsRef.current = loadAlerts;
 
   const disconnect = useCallback((clearData = false) => {
     esRef.current?.close();
@@ -275,10 +276,12 @@ export function SSEProvider({ children }: { children: ReactNode }) {
       if (!mountedRef.current || esRef.current !== es) return;
       setConnected(true);
       backoffRef.current = 3000;
-      // A stream that just came up is a working connection: retry a list that
-      // previously failed, so a transient error heals instead of persisting
-      // for the whole session.
-      if (alertsStatusRef.current === "error") void loadAlertsRef.current();
+      // A stream that just came up is a working connection, so re-read the
+      // alert list: a load that failed earlier heals instead of persisting for
+      // the session, and a list that went stale while the stream was down (its
+      // `alert` events missed entirely) is corrected. `loadAlerts` is stable,
+      // so this costs one small GET per connect, not a render loop.
+      loadAlerts();
 
       if (sseTokenRefreshTimer.current) clearTimeout(sseTokenRefreshTimer.current);
       sseTokenRefreshTimer.current = setTimeout(() => {
@@ -454,7 +457,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
       backoffRef.current = Math.min(backoffRef.current * 2, 30000);
       reconnectTimer.current = setTimeout(() => connectRef.current(), delay);
     };
-  }, [disconnect, attachSubscription]);
+  }, [disconnect, attachSubscription, loadAlerts]);
 
   useEffect(() => {
     connectRef.current = () => {
@@ -481,7 +484,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
 
     connectRef.current();
 
-    loadAlertsRef.current();
+    loadAlerts();
 
     const onStorage = (e: StorageEvent) => {
       if (e.key === "bloxos_token") {
@@ -527,7 +530,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
       cacheFlushRef.current?.();
       disconnect();
     };
-  }, [disconnect, updateUserID]);
+  }, [disconnect, updateUserID, loadAlerts]);
 
   const getMachine = useCallback(
     (id: string) => machineMap.get(id),

--- a/dashboard/src/lib/lifecycle.test.mjs
+++ b/dashboard/src/lib/lifecycle.test.mjs
@@ -226,3 +226,25 @@ test("metric charts keep one series per card, so no axis lies", () => {
     );
   }
 });
+
+test("an alert count is never asserted from a list that failed to load", () => {
+  // The bell's count and the Needs-attention list come from two different
+  // places — an SSE event and GET /api/alerts — so one can fail while the
+  // other works. Rendering "0" off an empty list would then be a claim
+  // nothing verified, contradicting the bell in public. Seen in production:
+  // bell 1, module 0, with one genuinely active alert in the database.
+  const sse = readFileSync(new URL("../contexts/SSEContext.tsx", import.meta.url), "utf8");
+  assert.match(sse, /alertsStatus/, "the load state of the alert list must be observable");
+  assert.match(sse, /setAlertsStatus\("error"\)/, "a failed load must be recorded, not swallowed");
+  assert.match(sse, /setAlertsStatus\("ready"\)/, "a successful load must be recorded");
+
+  const mini = readFileSync(
+    new URL("../components/overview/NeedsAttentionMini.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    mini,
+    /if \(status !== "ready"\)/,
+    "the module must refuse to show a count before the list is known",
+  );
+});


### PR DESCRIPTION
## The symptom, on the live fleet

The shell's alert bell showed **1**. The Overview's Needs-attention module showed **0**. The database had **one genuinely active alert** (`orangepi5-01`, CPU 100%, plus one acknowledged). Both are supposed to be the same hub alerts.

## Why

The count and the list come from two different places:

- **count** → the stream's `alert_count` event
- **list** → `GET /api/alerts`

…and the list's fetch ended in a bare `.catch(() => {})`. A 401, a blip or a proxy hiccup left `alerts` empty and silent for the life of the page while the count carried on being right. Rendering `0` off that empty list was a claim nothing had verified, printed next to a bell saying otherwise.

**This is pre-existing**, not new — the same swallow shipped long before the Overview redesign. What changed is that the count used to live only on the bell, so nothing was ever in a position to contradict it. Putting a number where people are already looking surfaced it immediately.

## The fix

`alertsStatus` is now `loading | ready | error`.

- A failed load marks `error` and **deliberately leaves `alertCount` alone** — the stream's count is still the best thing known about *how many*; only the LIST is unknown.
- A reconnecting stream retries a failed load, so a transient failure heals instead of persisting for the session.
- A successful load sets the count from the list it just read, so the two cannot drift apart.
- Needs-attention refuses to show a count until the list is known: an em dash and "Alert list unavailable" in the warning tone, tooltip noting the bell may still be accurate.

The token re-check keeps the exact `getStoredToken() === token` form the lifecycle guard asserts — that guard protects a real cross-user leak and wasn't worth rewording around.

## Verified both directions

Against a stub reproducing production exactly (stream sends `count: 1`, list returns 500):

| Condition | Result |
|---|---|
| List unreadable | module shows `—` / "Alert list unavailable", bell still reads 1 |
| List readable | module shows `1` with "1 warning"; the urgent-alert module appears, taking the grid from 2 modules to 3 |

```
dashboard: 179 tests pass (one new guard, proven to bite), lint 0 errors
           (3 pre-existing warnings), build compiles
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only alert fetch and display honesty; no auth or API contract changes beyond surfacing existing fetch failures.
> 
> **Overview**
> Fixes a production mismatch where the shell alert bell could show a count from SSE while the Overview **Needs attention** module showed **0** after a silent `GET /api/alerts` failure.
> 
> **SSE layer:** Introduces `alertsStatus` (`loading` | `ready` | `error`) alongside the existing stream-driven `alertCount` and REST-backed `alerts`. Alert loading moves into `loadAlerts()`, which sets `error` on failure instead of swallowing errors, keeps the stream count on list failure, aligns count with the list on success, and re-fetches on SSE reconnect and mount.
> 
> **UI:** `NeedsAttentionMini` no longer renders a numeric count until `alertsStatus` is `ready`; loading and error states show `—` with explicit copy (and a tooltip that the bell may still be right).
> 
> A lifecycle regression test locks in that contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1874907076b798a8171db1ac0e2763a824c1d71a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->