### PR TITLE
fix(power): stop presenting sampled power as measured energy and current draw

### DIFF
--- a/dashboard/src/components/overview/FleetPowerPane.tsx
+++ b/dashboard/src/components/overview/FleetPowerPane.tsx
@@ -295,9 +295,10 @@ export function FleetPowerPane({ period, onPeriodChange }: FleetPowerPaneProps) 
 
   // Series come from BOTH sources: a capped or empty history must not hide a
   // domain that is reporting right now.
+  const current = state.current;
   const series = useMemo(
-    () => (combinedSeries(data, state.current, selected) as Series[]) ?? [],
-    [data, state.current, selected],
+    () => (combinedSeries(data, current, selected) as Series[]) ?? [],
+    [data, current, selected],
   );
   const rows = useMemo(() => fleetPowerChartRows(data, series), [data, series]);
   const warnings = useMemo(() => (fleetPowerWarnings(data) as string[]) ?? [], [data]);

--- a/dashboard/src/components/overview/FleetPowerPane.tsx
+++ b/dashboard/src/components/overview/FleetPowerPane.tsx
@@ -40,28 +40,30 @@
  * green/amber/red appear here only for a real warning, with words.
  * ========================================================================== */
 
-import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { ChartTooltip } from "@/components/charts/ChartTooltip";
 import { Zap } from "lucide-react";
 
 import { DEMO_MODE, HUB_URL, getStoredToken } from "@/lib/session";
+import { freshnessNote } from "@/lib/power-freshness.mjs";
 import {
   PERIOD_LABELS,
   POWER_PERIODS,
   coverageSentence,
   domainLabel,
-  domainOf,
   fleetPowerChartRows,
-  fleetPowerCost,
-  fleetPowerMode,
-  fleetPowerSeries,
+  fleetPowerEnergyAvailability,
   fleetPowerWarnings,
-  formatKWh,
-  formatMoney,
   formatWatts,
-  latestReading,
+  currentReading,
+  currentDomainOf,
+  domainOf,
+  domainSeries,
+  resolveDomainChoice,
+  availableDomains,
+  POWER_DOMAINS,
+  normalizeFleetPowerCurrent,
   normalizeFleetPower,
   shortfallSentence,
 } from "@/lib/fleet-power.mjs";
@@ -97,6 +99,18 @@ interface Series {
   label: string;
 }
 
+/**
+ * The current snapshot, from GET /api/fleet/power/current. Kept distinct from
+ * the history type so nothing can pass one where the other belongs — that
+ * substitution is what let a charted bucket be presented as a current reading.
+ */
+interface FleetPowerCurrent {
+  generatedUnixMS: number | null;
+  machinesTotal: number;
+  machinesReporting: number;
+  domains: Map<string, unknown>;
+}
+
 interface FleetPowerHistory {
   period: PowerPeriod;
   coverage: {
@@ -116,11 +130,47 @@ export interface FleetPowerPaneProps {
   /** Read-only here. The control that sets it lives in Settings → Preferences
    * (components/settings/PowerRateSettings.tsx); a tariff is typed once and
    * read on every visit, so it does not belong on the pane. */
-  rate: PowerRate;
+  /**
+   * Retained so the Overview's props do not churn while energy accounting is
+   * withheld. The pane prices nothing today; see CostRow.
+   */
+  rate?: PowerRate;
 }
 
-export function FleetPowerPane({ period, onPeriodChange, rate }: FleetPowerPaneProps) {
-  const [state, setState] = useState<{ period: string; data?: FleetPowerHistory; error?: string }>({
+/**
+ * The reader's chosen domain, per browser.
+ *
+ * Deliberately localStorage rather than an account preference: this is a view
+ * choice, and adding an account field would mean a schema change this work does
+ * not otherwise need. Every access is guarded — a cookie-blocked browser throws
+ * on access, and a throw during render would take the page down.
+ */
+const DOMAIN_STORAGE_KEY = "bloxos.fleetPower.domain";
+
+function readStoredDomain(): string | null {
+  try {
+    const raw = window.localStorage.getItem(DOMAIN_STORAGE_KEY);
+    return raw && (POWER_DOMAINS as string[]).includes(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredDomain(domain: string): void {
+  try {
+    window.localStorage.setItem(DOMAIN_STORAGE_KEY, domain);
+  } catch {
+    // A reader who cannot persist the choice still gets it for this session.
+  }
+}
+
+export function FleetPowerPane({ period, onPeriodChange }: FleetPowerPaneProps) {
+  const [state, setState] = useState<{
+    period: string;
+    data?: FleetPowerHistory;
+    current?: FleetPowerCurrent;
+    error?: string;
+  }>({
     period,
   });
 
@@ -151,7 +201,25 @@ export function FleetPowerPane({ period, onPeriodChange, rate }: FleetPowerPaneP
           );
         }
         const data = normalizeFleetPower(await res.json()) as FleetPowerHistory;
-        if (!stopped) setState({ period, data });
+
+        // The CURRENT reading is a separate request, deliberately. Reading it
+        // off the charted buckets made it depend on the selected period and let
+        // it reach hours backwards for the last non-null value. If this request
+        // fails the readouts say unavailable — they must never fall back to the
+        // history aggregate wearing a "current" label.
+        let current: FleetPowerCurrent | undefined;
+        try {
+          const curRes = await fetch(`${HUB_URL}/api/fleet/power/current`, {
+            headers: token ? { Authorization: `Bearer ${token}` } : {},
+            signal: controller.signal,
+          });
+          if (curRes.ok) {
+            current = normalizeFleetPowerCurrent(await curRes.json()) as FleetPowerCurrent;
+          }
+        } catch {
+          // Leave it undefined: unavailable is the honest state.
+        }
+        if (!stopped) setState({ period, data, current });
       } catch (error) {
         if (!stopped) {
           setState((previous) => ({
@@ -182,25 +250,111 @@ export function FleetPowerPane({ period, onPeriodChange, rate }: FleetPowerPaneP
   const data = state.period === period ? state.data : undefined;
   const error = state.period === period ? state.error : undefined;
 
-  const mode = fleetPowerMode(data) as "system" | "component" | "none";
-  const series = useMemo(() => (fleetPowerSeries(data) as Series[]) ?? [], [data]);
+  // DOMAIN CHOICE IS EXPLICIT AND LATCHED.
+  //
+  // It used to be automatic: any machine reporting system power took the whole
+  // chart, hiding every other domain. That was survivable while only measured
+  // counters existed and became actively harmful once a MODELLED system reading
+  // could appear — one estimating board joining the fleet would evict the
+  // measured CPU and GPU history of every other machine.
+  //
+  // So the reader chooses, the choice persists, and the initial default is
+  // computed ONCE. Recomputing it per poll would let an arriving domain move
+  // the view out from under someone mid-read.
+  // SSR-SAFE: storage is read AFTER mount, never in the initialiser.
+  //
+  // Reading localStorage while computing initial state produces different
+  // markup on the server (no window, so null) and in the browser (a stored
+  // "dram", say), and React then reports a hydration mismatch and discards the
+  // server render. So the first render is always the neutral default, and the
+  // stored choice is applied in an effect on the client.
+  const [domain, setDomain] = useState<string | null>(null);
+  const latched = useRef(false);
+
+  useEffect(() => {
+    if (latched.current) return;
+    const stored = readStoredDomain();
+    if (stored) {
+      latched.current = true;
+      setDomain(stored);
+      return;
+    }
+    // No stored choice: latch the computed default ONCE, so a domain arriving
+    // on a later poll cannot move the view out from under the reader.
+    if (!data) return;
+    latched.current = true;
+    setDomain(resolveDomainChoice(data, null) as string);
+  }, [data]);
+
+  const selected = domain ?? (resolveDomainChoice(data, null) as string);
+  const chooseDomain = (next: string) => {
+    latched.current = true;
+    setDomain(next);
+    writeStoredDomain(next);
+  };
+
+  const series = useMemo(
+    () => (domainSeries(data, selected) as Series[]) ?? [],
+    [data, selected],
+  );
   const rows = useMemo(() => fleetPowerChartRows(data, series), [data, series]);
   const warnings = useMemo(() => (fleetPowerWarnings(data) as string[]) ?? [], [data]);
   const coverage = data?.coverage;
 
-  // The costed domain is whatever the pane is leading with. In component mode
-  // that is CPU package power, which is a real cost of a real component — not
-  // the machine's wall draw, and the copy under it says so.
-  const costDomain = mode === "component" ? "cpu" : "system";
-  const cost = fleetPowerCost(data, costDomain, rate, period);
+  // The domain the energy row names. Energy itself is withheld (see CostRow),
+  // but the row still names which domain it would have costed.
+  const costDomain = selected;
 
+  // Readouts come from the CURRENT snapshot, never from the charted history.
+  // Each carries its own freshness, judged from its oldest contributor, so a
+  // mostly-dark fleet cannot be made to read as current by one live machine.
   const readouts = series.map((s) => ({
     ...s,
-    latest: latestReading(data, s.domain, s.kind) as
-      | { watts: number; machines: number; timestamp: number }
+    latest: currentReading(state.current, s.domain, s.kind) as
+      | {
+          watts: number;
+          machines: number;
+          sources: string[];
+          freshness: { state: string; ageMS: number | null };
+        }
       | null,
   }));
 
+
+  // The selector only offers domains that have data, but the SELECTED domain is
+  // always offered even when it goes quiet — a reader watching DRAM must not
+  // have the control vanish underneath them the moment it stops reporting.
+  // Offered domains come from BOTH sources. Deriving them from history alone
+  // would let a truncated or empty history response hide a domain that is
+  // reporting right now — the record cap drops the oldest rows, and a fleet
+  // that only just started reporting has little history to show.
+  const currentDomains = state.current
+    ? (POWER_DOMAINS as string[]).filter((d) => {
+        const c = currentDomainOf(state.current, d);
+        return c.measured.machines > 0 || c.estimated.machines > 0;
+      })
+    : [];
+  const offered = Array.from(
+    new Set([...(availableDomains(data) as string[]), ...currentDomains, selected]),
+  ).filter((d) => (POWER_DOMAINS as string[]).includes(d));
+
+  const domainSwitch = (
+    <div className="mf-segment" role="group" aria-label="Power domain">
+      {(POWER_DOMAINS as string[])
+        .filter((d) => offered.includes(d))
+        .map((d) => (
+          <button
+            key={d}
+            type="button"
+            aria-pressed={d === selected}
+            onClick={() => chooseDomain(d)}
+            title={`Chart ${domainLabel(d)} power`}
+          >
+            {domainLabel(d)}
+          </button>
+        ))}
+    </div>
+  );
 
   const periodSwitch = (
     <div className="mf-segment" role="group" aria-label="Power window">
@@ -222,6 +376,7 @@ export function FleetPowerPane({ period, onPeriodChange, rate }: FleetPowerPaneP
     <section className="mf-panel mf-power-anchor min-w-0 overflow-hidden" aria-label="Fleet power">
       <div className={MF_PANEL_HEAD}>
         <h2 className={MF_PANEL_TITLE}>Fleet power</h2>
+        {domainSwitch}
         {periodSwitch}
       </div>
       <div className="mf-power-anchor-body">
@@ -230,7 +385,7 @@ export function FleetPowerPane({ period, onPeriodChange, rate }: FleetPowerPaneP
             title="Not in the demo data."
             tip="Power comes from real counters on real machines — RAPL, a battery, a BMC — so there is nothing here to simulate. Connect a hub to see it."
           />
-        ) : mode === "none" ? (
+        ) : series.length === 0 && !data ? (
           <EmptyState
             // The error IS the title. It used to be the body under a
             // "Fleet power unavailable." heading, which said the same thing
@@ -253,15 +408,39 @@ export function FleetPowerPane({ period, onPeriodChange, rate }: FleetPowerPaneP
           />
         ) : (
           <>
-            {/* The one caveat the numbers cannot carry themselves: two
-                component lines are not a machine's wall draw, and must not be
-                added into one. Whole-machine mode needs no such warning — its
-                readout is already labelled "whole-machine" — and the window is
-                on the segmented control in the header, so neither is repeated
-                here. */}
-            {mode === "component" && (
+            {/* The caveat the numbers cannot carry themselves. A component
+                domain is not a machine's wall draw, and domains are never added
+                across: CPU plus GPU omits everything else in the box. The
+                whole-machine domain needs no such warning, so it does not get
+                one. The window is on the segmented control in the header. */}
+            {selected !== "system" && (
               <p className="mf-table-meta mt-3">Component power — not wall power</p>
             )}
+
+            {/* WHAT IS MISSING FROM THIS DOMAIN, and why. A shrinking
+                contributor count with no explanation reads as a bug; these
+                counts say which machines were excluded and on what grounds.
+                Unknown provenance is shown because it is deliberately excluded
+                from both series — silence there would hide the exclusion. */}
+            {(() => {
+              const diag = state.current ? currentDomainOf(state.current, selected) : null;
+              if (!diag) return null;
+              const notes = [
+                diag.staleMachines > 0 ? `${diag.staleMachines} stale` : null,
+                diag.skewedMachines > 0 ? `${diag.skewedMachines} clock-skewed` : null,
+                diag.unknownMachines > 0 ? `${diag.unknownMachines} unrecognised backend` : null,
+                diag.unreadableMachines > 0 ? `${diag.unreadableMachines} unreadable` : null,
+              ].filter(Boolean);
+              if (notes.length === 0) return null;
+              return (
+                <p
+                  className="mf-table-meta mt-1"
+                  title="These machines reported this domain but were excluded from the current figure. Their last values are not carried forward."
+                >
+                  Excluded: {notes.join(" · ")}
+                </p>
+              );
+            })()}
 
             {/* THE READOUTS, which are also the chart's legend: each number
                 carries the swatch of the line it came from, that line's name,
@@ -284,12 +463,32 @@ export function FleetPowerPane({ period, onPeriodChange, rate }: FleetPowerPaneP
                         the only thing carrying the series colour. */}
                     <span className="text-text-secondary">{r.label}</span>
                     {r.kind === "estimated" ? <span>— modelled, not measured</span> : null}
+                    {/* What the number IS. Each contributor reports its own 30s
+                        mean and those windows are not synchronised across
+                        machines, so this is a sum of per-machine sample means —
+                        not a measurement of the fleet at one instant. */}
+                    <span title="Each machine reports a mean over its own 30-second window. Those windows are not synchronised across machines, so this is the sum of their sample means, not a simultaneous fleet measurement.">
+                      — sum of sample means
+                    </span>
                     <span>
                       ·{" "}
+                      {/* The denominator is the CURRENT fleet size, not the
+                          history window's. Mixing them would compare live
+                          contributors against a count drawn from a different
+                          span. */}
                       {r.latest
-                        ? `${r.latest.machines} / ${coverage?.machinesTotal ?? 0} reporting`
+                        ? `${r.latest.machines} / ${state.current?.machinesTotal ?? coverage?.machinesTotal ?? 0} reporting`
                         : "no reading"}
                     </span>
+                    {/* A value that is not current NEVER appears as a bare
+                        number. The note carries the age of the OLDEST
+                        contributor, because the sum is only as current as
+                        that — one live machine does not refresh the rest. */}
+                    {r.latest && freshnessNote(r.latest.freshness) ? (
+                      <span className="text-status-warning">
+                        · {freshnessNote(r.latest.freshness)}
+                      </span>
+                    ) : null}
                   </p>
                 </div>
               ))}
@@ -303,6 +502,27 @@ export function FleetPowerPane({ period, onPeriodChange, rate }: FleetPowerPaneP
                 {coverageShort(coverage)}
               </p>
             )}
+
+            {/* Unknown provenance in the HISTORY, surfaced even when the
+                current snapshot is unavailable. Without this, a domain whose
+                only contributors carry an unrecognised backend would look
+                simply empty, and the reason it is empty — that the hub refused
+                to classify those readings rather than losing them — would be
+                invisible. */}
+            {(() => {
+              const hist = domainOf(data, selected) as { unknown?: { machines: number } };
+              const unknownMachines = hist?.unknown?.machines ?? 0;
+              if (unknownMachines === 0) return null;
+              return (
+                <p
+                  className="mf-table-meta mt-1"
+                  title="The hub could not identify the backend behind these readings, so they are excluded from both the measured and the modelled series rather than being guessed into one."
+                >
+                  {unknownMachines} machine{unknownMachines === 1 ? "" : "s"} reporting an
+                  unrecognised backend — excluded from both series
+                </p>
+              );
+            })()}
 
             {error && (
               <p role="status" className="mt-2 flex items-start gap-2 text-[12px] text-status-warning">
@@ -331,7 +551,7 @@ export function FleetPowerPane({ period, onPeriodChange, rate }: FleetPowerPaneP
             <div
               className="mt-3 h-[120px]"
               role="img"
-              aria-label={`${mode === "system" ? "Whole-machine" : "Component"} power in watts across the fleet, ${PERIOD_LABELS[period]}. ${
+              aria-label={`${domainLabel(selected)} power in watts across the fleet, ${PERIOD_LABELS[period]}. ${
                 coverage ? coverageDetail(coverage) : ""
               } Unreported buckets are left blank — missing data is not zero power.`}
             >
@@ -380,13 +600,7 @@ export function FleetPowerPane({ period, onPeriodChange, rate }: FleetPowerPaneP
               </ResponsiveContainer>
             </div>
 
-            <CostRow
-              cost={cost}
-              domain={costDomain}
-              period={period}
-              multiDomain={mode === "component"}
-              complete={domainOf(data, costDomain).complete === true}
-            />
+            <CostRow domain={costDomain} multiDomain={true} />
           </>
         )}
       </div>
@@ -402,74 +616,40 @@ export function FleetPowerPane({ period, onPeriodChange, rate }: FleetPowerPaneP
  * used to be a three-line note under the row; it is a tooltip now, because the
  * two words that matter are on the line itself and the rest is read once.
  *
- * The tariff has no default — an invented rate would put a confident, specific
- * price under a chart of real watts — so with none stated the row shows the
- * energy and links to the place the rate is set.
+ * Energy and cost are WITHHELD in this release; see CostRow. The tariff itself
+ * still lives in Settings and is untouched — it simply has nothing to price
+ * until energy accounting can be stated honestly.
  * ------------------------------------------------------------------------- */
-
-interface CostKind {
-  energyKWh: number;
-  cost: number | null;
-  machines: number;
-  observedFraction: number | null;
-}
-
 function CostRow({
-  cost,
   domain,
-  period,
   multiDomain,
-  complete,
 }: {
-  cost: { currency: string; perKwh: number | null; measured: CostKind; estimated: CostKind };
   domain: string;
-  period: PowerPeriod;
-  /** More than one domain is charted, so the cost must name the one it costed. */
+  /** More than one domain is charted, so the row must name the one it means. */
   multiDomain: boolean;
-  complete: boolean;
 }) {
-  const showEstimated = cost.estimated.machines > 0;
-  const partial = cost.measured.observedFraction !== null && cost.measured.observedFraction < 0.995;
-
-  // The whole of the old "A floor, not a bill" paragraph, on the row's title.
-  const why = [
-    "Energy is summed over observed windows only; unobserved time counts as nothing and is never estimated.",
-    !complete ? "Not every machine reports power." : null,
-    partial
-      ? `Readings cover ${Math.round((cost.measured.observedFraction ?? 0) * 100)}% of the ${PERIOD_LABELS[period]}.`
-      : null,
-  ]
-    .filter(Boolean)
-    .join(" ");
+  // Energy and cost are WITHHELD, not merely re-captioned.
+  //
+  // This row used to lead with a guaranteed-lower-bound phrasing over a cost
+  // and a kWh figure. It never was a lower bound. A window's mean comes from the reads that
+  // SUCCEEDED inside it, and the hub then weights that mean by the window's
+  // whole span — one successful 300 W read in a 30 s window is credited as
+  // though all thirty seconds were observed, and the unread seconds could have
+  // drawn far less. The "readings cover N% of the period" caption beside it was
+  // no better: it divided summed window spans by the period, and those spans
+  // are not deduplicated and can include time belonging to a neighbouring
+  // bucket.
+  //
+  // A number that wrong cannot be rescued by a caption, and this row has
+  // nowhere to put the qualification it would need. So it says what it does not
+  // know. Nothing here renders "0 kWh": unavailable accounting is not zero
+  // energy, and that distinction is the entire point.
+  const availability = fleetPowerEnergyAvailability();
 
   return (
     <div className="mt-3 flex flex-wrap items-baseline gap-x-2 gap-y-1 border-t border-border-subtle pt-2.5 text-[12px] leading-[1.5] text-text-tertiary">
       {multiDomain && <span className="text-text-secondary">{domainLabel(domain)}</span>}
-      {cost.perKwh === null ? (
-        <>
-          <span className="mf-metric text-text-primary">{formatKWh(cost.measured.energyKWh)}</span>
-          <Link href="/settings?tab=preferences" className="text-accent hover:underline">
-            Set a rate
-          </Link>
-        </>
-      ) : (
-        <span className="text-text-secondary" title={why}>
-          At least{" "}
-          <span className="mf-metric text-text-primary">
-            {formatMoney(cost.measured.cost, cost.currency)}
-          </span>
-          {showEstimated ? (
-            <>
-              {" · "}
-              <span className="mf-metric text-text-primary">
-                ≈{formatMoney(cost.estimated.cost, cost.currency)}
-              </span>{" "}
-              modelled, not measured
-            </>
-          ) : null}
-          <span className="text-text-tertiary"> · {formatKWh(cost.measured.energyKWh)}</span>
-        </span>
-      )}
+      <span title={availability.reason}>Energy and cost unavailable</span>
     </div>
   );
 }

--- a/dashboard/src/components/overview/FleetPowerPane.tsx
+++ b/dashboard/src/components/overview/FleetPowerPane.tsx
@@ -59,7 +59,7 @@ import {
   currentReading,
   currentDomainOf,
   domainOf,
-  domainSeries,
+  combinedSeries,
   resolveDomainChoice,
   availableDomains,
   POWER_DOMAINS,
@@ -293,9 +293,11 @@ export function FleetPowerPane({ period, onPeriodChange }: FleetPowerPaneProps) 
     writeStoredDomain(next);
   };
 
+  // Series come from BOTH sources: a capped or empty history must not hide a
+  // domain that is reporting right now.
   const series = useMemo(
-    () => (domainSeries(data, selected) as Series[]) ?? [],
-    [data, selected],
+    () => (combinedSeries(data, state.current, selected) as Series[]) ?? [],
+    [data, state.current, selected],
   );
   const rows = useMemo(() => fleetPowerChartRows(data, series), [data, series]);
   const warnings = useMemo(() => (fleetPowerWarnings(data) as string[]) ?? [], [data]);

--- a/dashboard/src/lib/fleet-power.mjs
+++ b/dashboard/src/lib/fleet-power.mjs
@@ -23,7 +23,7 @@ import { POWER_PERIODS } from "./workspace-prefs.mjs";
 
 export { POWER_PERIODS };
 
-import { freshnessOf, aggregateFreshness } from "./power-freshness.mjs";
+import { aggregateFreshness } from "./power-freshness.mjs";
 
 /** Period → what the pane calls the window in prose. */
 export const PERIOD_LABELS = {
@@ -176,7 +176,13 @@ export function domainOf(history, domain) {
 }
 
 function domainHasData(history, domain) {
-  return domainOf(history, domain).reportingMachines > 0;
+  const d = domainOf(history, domain);
+  // Unknown-provenance contributors count as DATA even though they are charted
+  // in neither series. Excluding them here would make the domain unselectable,
+  // and the explanation for why it is empty — that the hub refused to classify
+  // those readings rather than guessing — would be unreachable. An empty domain
+  // a reader can open and understand beats one that silently does not exist.
+  return d.reportingMachines > 0 || (d.unknown?.machines ?? 0) > 0;
 }
 
 /**

--- a/dashboard/src/lib/fleet-power.mjs
+++ b/dashboard/src/lib/fleet-power.mjs
@@ -344,6 +344,32 @@ export function domainSeries(history, domain) {
 }
 
 /**
+ * The series to render for a domain, from BOTH the history and the current
+ * snapshot.
+ *
+ * Deriving them from history alone loses live data. The history request is
+ * capped (the oldest rows are dropped first) and a machine that only just
+ * started reporting has almost none — so a fleet could be drawing 100 W on CPU
+ * right now, offer a CPU button, and render no readout at all behind it.
+ *
+ * A kind appears if EITHER source has it. The chart simply draws null rows for
+ * a kind with no history yet, which is the honest picture: a current value and
+ * no past to plot.
+ */
+export function combinedSeries(history, snapshot, domain) {
+  const h = domainOf(history, domain);
+  const c = currentDomainOf(snapshot, domain);
+  const series = [];
+  if (h.measured.machines > 0 || c.measured.machines > 0) {
+    series.push({ key: `${domain}:measured`, domain, kind: "measured", label: "Measured" });
+  }
+  if (h.estimated.machines > 0 || c.estimated.machines > 0) {
+    series.push({ key: `${domain}:estimated`, domain, kind: "estimated", label: "Modelled" });
+  }
+  return series;
+}
+
+/**
  * Resolve which domain to show.
  *
  * An EXPLICIT stored choice always wins, even when that domain currently has no
@@ -391,47 +417,6 @@ export function fleetPowerChartRows(history, series) {
  * simply because the current bucket has not closed.
  */
 /**
- * The most recent reading for one domain and kind, WITH its freshness.
- *
- * This used to walk back through the whole window and return the last non-null
- * bucket with no age attached, so a fleet that went dark at 02:00 still
- * headlined "142 W measured" at noon. Worse, the value it found depended on the
- * selected chart period: widening the history changed what "current" meant.
- *
- * Two things fix that, and callers must respect both:
- *
- *   - Age comes from `latestObservationEndMS`, the newest AGENT window end
- *     behind this domain, NOT from the bucket's timestamp. A bucket edge is an
- *     axis coordinate and the last one can sit in the future.
- *   - `freshness.state` decides whether the number may be presented as current.
- *     Anything but `fresh` must be shown with its age, or withheld.
- *
- * DEPRECATED for current readings. Its value still comes from the CHARTED
- * buckets, so it varies with the selected period; only the freshness attached
- * to it is honest. Current readouts must use currentReading() against the
- * snapshot endpoint instead.
- */
-export function latestReading(history, domain, kind, nowMS = Date.now()) {
-  const d = domainOf(history, domain);
-  const buckets = d.buckets;
-  const kindStats = kind === "measured" ? d.measured : d.estimated;
-
-  for (let i = buckets.length - 1; i >= 0; i -= 1) {
-    const value = kind === "measured" ? buckets[i].measured : buckets[i].estimated;
-    if (value === null) continue;
-    return {
-      watts: value,
-      machines: kind === "measured" ? buckets[i].measuredMachines : buckets[i].estimatedMachines,
-      // Retained for the axis only. Never age this.
-      timestamp: buckets[i].timestamp,
-      observedEndMS: kindStats.latestObservationEndMS,
-      freshness: freshnessOf(kindStats.latestObservationEndMS, nowMS),
-    };
-  }
-  return null;
-}
-
-/**
  * WITHHELD IN THIS RELEASE. Energy and cost are not presented at all.
  *
  * They used to be shown as "At least X kWh / $Y", i.e. a guaranteed lower
@@ -464,39 +449,6 @@ export function fleetPowerEnergyAvailability() {
     reason:
       "Energy and cost accounting is unavailable: sampled power cannot be " +
       "extrapolated into measured energy without per-observation durations.",
-  };
-}
-
-/**
- * Deprecated. See fleetPowerEnergyAvailability. Retained for callers that have
- * not yet been updated; its figures must not be displayed.
- */
-export function fleetPowerCost(history, domain, rate, period) {
-  const d = domainOf(history, domain);
-  const perKwh = rate && isFiniteNumber(rate.per_kwh) && rate.per_kwh >= 0 ? rate.per_kwh : null;
-  const hours = Object.hasOwn(PERIOD_HOURS, period) ? PERIOD_HOURS[period] : null;
-
-  const observedFraction = (kind) => {
-    if (!hours || kind.machines === 0) return null;
-    const possible = kind.machines * hours * 3600;
-    return possible > 0 ? Math.min(1, kind.observedMachineSeconds / possible) : null;
-  };
-
-  return {
-    currency: rate?.currency ?? "USD",
-    perKwh,
-    measured: {
-      energyKWh: d.measured.energyKWh,
-      cost: perKwh === null ? null : d.measured.energyKWh * perKwh,
-      machines: d.measured.machines,
-      observedFraction: observedFraction(d.measured),
-    },
-    estimated: {
-      energyKWh: d.estimated.energyKWh,
-      cost: perKwh === null ? null : d.estimated.energyKWh * perKwh,
-      machines: d.estimated.machines,
-      observedFraction: observedFraction(d.estimated),
-    },
   };
 }
 

--- a/dashboard/src/lib/fleet-power.mjs
+++ b/dashboard/src/lib/fleet-power.mjs
@@ -23,6 +23,8 @@ import { POWER_PERIODS } from "./workspace-prefs.mjs";
 
 export { POWER_PERIODS };
 
+import { freshnessOf, aggregateFreshness } from "./power-freshness.mjs";
+
 /** Period → what the pane calls the window in prose. */
 export const PERIOD_LABELS = {
   "30m": "last 30 minutes",
@@ -84,6 +86,9 @@ export function normalizeFleetPower(raw) {
       reportingMachines: count(d.reporting_machines),
       measured: normalizeKind(d.measured),
       estimated: normalizeKind(d.estimated),
+      // Readings whose backend the hub could not classify. Never folded into
+      // measured or modelled; surfaced so the omission is visible.
+      unknown: normalizeKind(d.unknown),
       buckets: d.buckets
         .filter((b) => b && isFiniteNumber(b.end_unix_ms))
         .map((b) => ({
@@ -92,6 +97,9 @@ export function normalizeFleetPower(raw) {
           measuredMachines: count(b.measured_machines),
           estimated: watts(b.estimated_watts),
           estimatedMachines: count(b.estimated_machines),
+          measuredWindowSeconds: kwh(b.measured_window_seconds),
+          estimatedWindowSeconds: kwh(b.estimated_window_seconds),
+          unknownMachines: count(b.unknown_machines),
           gap: b.gap === true,
         }))
         .sort((a, b) => a.timestamp - b.timestamp),
@@ -113,6 +121,7 @@ export function normalizeFleetPower(raw) {
       degradedMachines: count(c.degraded_machines),
       gapsDeclared: count(c.gaps_declared),
       gapBuckets: count(c.gap_buckets),
+      machinesSkewed: count(c.machines_skewed),
       truncated: c.truncated === true,
     },
   };
@@ -123,17 +132,42 @@ function normalizeKind(raw) {
   return {
     machines: count(k.machines),
     energyKWh: kwh(k.energy_kwh),
+    // Retained under its old name for compatibility, but it is a SPAN, not
+    // time observed. Nothing may present it as "% of the window measured".
     observedMachineSeconds: kwh(k.observed_machine_seconds),
+    reportingWindowSeconds: kwh(k.reporting_window_seconds),
+    // How much of those windows was actually read. The only defensible
+    // statement about coverage — and never to be multiplied into a duration,
+    // because backends sample at different cadences by design.
+    sampleCount: count(k.sample_count),
+    expectedSampleCount: count(k.expected_sample_count),
+    // The newest AGENT window end behind this figure. Freshness is judged from
+    // this, never from a chart bucket edge.
+    latestObservationEndMS: isFiniteNumber(k.latest_observation_end_unix_ms)
+      ? k.latest_observation_end_unix_ms
+      : null,
     sources: sourceList(k.sources),
   };
 }
+
+const EMPTY_KIND = {
+  machines: 0,
+  energyKWh: 0,
+  observedMachineSeconds: 0,
+  reportingWindowSeconds: 0,
+  sampleCount: 0,
+  expectedSampleCount: 0,
+  latestObservationEndMS: null,
+  sources: [],
+};
 
 const EMPTY_DOMAIN = {
   domain: "",
   complete: false,
   reportingMachines: 0,
-  measured: { machines: 0, energyKWh: 0, observedMachineSeconds: 0, sources: [] },
-  estimated: { machines: 0, energyKWh: 0, observedMachineSeconds: 0, sources: [] },
+  measured: EMPTY_KIND,
+  estimated: EMPTY_KIND,
+  unknown: EMPTY_KIND,
   buckets: [],
 };
 
@@ -146,64 +180,194 @@ function domainHasData(history, domain) {
 }
 
 /**
- * Which story this response can honestly tell. See the module comment.
- */
-export function fleetPowerMode(history) {
-  if (!history) return "none";
-  if (domainHasData(history, "system")) return "system";
-  if (domainHasData(history, "cpu") || domainHasData(history, "gpu")) return "component";
-  return "none";
-}
-
-/**
- * The lines to chart, as `{ key, label, kind, domain }`. `kind` is
- * "measured" or "estimated" and drives the stroke: a caller must render the
- * two differently AND print the label, never rely on colour.
+ * Normalise GET /api/fleet/power/current — the fleet's draw right now.
  *
- * In component mode the two domains are separate lines. They are NOT summed:
- * CPU package watts plus GPU watts is not what the machine draws from the wall
- * — it omits everything else and double-counts nothing, so it is neither a
- * component figure nor a wall figure.
+ * This is a SEPARATE request from the history on purpose. The current figure
+ * used to be read off the charted buckets, which made it depend on the selected
+ * period and let it reach hours backwards for "the last non-null value". It is
+ * now computed by the hub from each machine's newest window over a fixed
+ * lookback, with every contributor gated individually.
+ *
+ * A caller that cannot get this must render UNAVAILABLE. Falling back to the
+ * history aggregate and labelling it current would restore the exact defect
+ * this replaced.
  */
-export function fleetPowerSeries(history) {
-  const mode = fleetPowerMode(history);
-  if (mode === "system") {
-    const system = domainOf(history, "system");
-    const series = [];
-    if (system.measured.machines > 0) {
-      series.push({ key: "system:measured", domain: "system", kind: "measured", label: "Measured" });
-    }
-    if (system.estimated.machines > 0) {
-      series.push({ key: "system:estimated", domain: "system", kind: "estimated", label: "Estimated" });
-    }
-    return series;
+export function normalizeFleetPowerCurrent(raw) {
+  if (!raw || typeof raw !== "object" || !Array.isArray(raw.domains)) {
+    throw new Error("Invalid fleet power snapshot.");
   }
-  if (mode === "component") {
-    const series = [];
-    for (const domain of ["cpu", "gpu"]) {
-      const d = domainOf(history, domain);
-      if (d.measured.machines > 0) {
-        series.push({ key: `${domain}:measured`, domain, kind: "measured", label: domainLabel(domain) });
-      }
-      if (d.estimated.machines > 0) {
-        series.push({
-          key: `${domain}:estimated`,
-          domain,
-          kind: "estimated",
-          label: `${domainLabel(domain)} (estimated)`,
-        });
-      }
-    }
-    return series;
+  const domains = new Map();
+  for (const d of raw.domains) {
+    if (!d || typeof d.domain !== "string") continue;
+    domains.set(d.domain, {
+      domain: d.domain,
+      measured: normalizeCurrentSeries(d.measured),
+      estimated: normalizeCurrentSeries(d.estimated),
+      unknownMachines: count(d.unknown_machines),
+      staleMachines: count(d.stale_machines),
+      skewedMachines: count(d.skewed_machines),
+      unreadableMachines: count(d.unreadable_machines),
+    });
   }
-  return [];
+  return {
+    generatedUnixMS: isFiniteNumber(raw.generated_unix_ms) ? raw.generated_unix_ms : null,
+    lookbackMS: count(raw.lookback_ms),
+    domains,
+    machinesTotal: count(raw.machines_total),
+    machinesReporting: count(raw.machines_reporting),
+    machinesUnreadable: count(raw.machines_unreadable),
+  };
+}
+
+function normalizeCurrentSeries(raw) {
+  const k = raw && typeof raw === "object" ? raw : {};
+  return {
+    // null is unavailable. Zero would be a claim that the fleet draws nothing.
+    watts: watts(k.watts),
+    machines: count(k.machines),
+    sources: sourceList(k.sources),
+    // The sum is only as current as its OLDEST contributor, so that is what
+    // freshness must be judged from.
+    oldestContributorEndMS: isFiniteNumber(k.oldest_contributor_end_unix_ms)
+      ? k.oldest_contributor_end_unix_ms
+      : null,
+    newestContributorEndMS: isFiniteNumber(k.newest_contributor_end_unix_ms)
+      ? k.newest_contributor_end_unix_ms
+      : null,
+  };
+}
+
+const EMPTY_CURRENT_SERIES = {
+  watts: null,
+  machines: 0,
+  sources: [],
+  oldestContributorEndMS: null,
+  newestContributorEndMS: null,
+};
+
+const EMPTY_CURRENT_DOMAIN = {
+  domain: "",
+  measured: EMPTY_CURRENT_SERIES,
+  estimated: EMPTY_CURRENT_SERIES,
+  unknownMachines: 0,
+  staleMachines: 0,
+  skewedMachines: 0,
+  unreadableMachines: 0,
+};
+
+export function currentDomainOf(snapshot, domain) {
+  return snapshot?.domains?.get(domain) ?? { ...EMPTY_CURRENT_DOMAIN, domain };
 }
 
 /**
- * Recharts rows: one per bucket, one column per series key. A bucket a series
- * did not cover stays null so the line breaks there instead of being drawn
- * across time nobody observed.
+ * The current reading for one domain and kind, with freshness attached.
+ *
+ * Freshness comes from the OLDEST contributor, so one still-reporting machine
+ * cannot make a mostly-dark fleet read as current. Returns null when there is
+ * nothing to show — and null means unavailable, never zero.
  */
+export function currentReading(snapshot, domain, kind, nowMS = Date.now()) {
+  const d = currentDomainOf(snapshot, domain);
+  // Only the two kinds that carry a series exist here. An unrecognised kind is
+  // REJECTED rather than falling through to the modelled series: quietly
+  // treating "unknown" as "estimated" would put an unclassified reading behind
+  // a label that claims to know what produced it.
+  let series;
+  if (kind === "measured") series = d.measured;
+  else if (kind === "estimated") series = d.estimated;
+  else return null;
+
+  // watts === null is unavailable. A real measured 0 W is a reading and must
+  // survive: a machine can genuinely draw nothing measurable on a domain.
+  if (series.watts === null || series.machines === 0) return null;
+  return {
+    watts: series.watts,
+    machines: series.machines,
+    sources: series.sources,
+    freshness: aggregateFreshness(
+      series.oldestContributorEndMS === null ? [] : [series.oldestContributorEndMS],
+      nowMS,
+    ),
+  };
+}
+
+/** Every domain the response can chart, in a fixed, meaningful order. */
+export const POWER_DOMAINS = ["system", "cpu", "gpu", "dram"];
+
+/**
+ * Which domains actually have contributors, in POWER_DOMAINS order.
+ *
+ * This replaces the old automatic "mode": system power, when any machine had
+ * it, silently took over the whole chart and hid every other domain. That was
+ * fine while only measured system counters existed — and became actively
+ * harmful the moment a MODELLED system reading could appear, because one
+ * estimating board arriving in the fleet would evict the measured CPU and GPU
+ * history of every other machine. A single old system bucket anywhere in the
+ * selected period was enough to hold that choice for the entire window.
+ *
+ * Domain choice is now the reader's, and it is explicit.
+ */
+export function availableDomains(history) {
+  return POWER_DOMAINS.filter((d) => domainHasData(history, d));
+}
+
+/**
+ * Default domain order when the reader has expressed no preference.
+ *
+ * Components first: CPU and GPU are what most fleets actually measure, and a
+ * whole-system figure is comparatively rare and — on a board with no counter —
+ * may be modelled. Leading with system would hand the default view to an
+ * estimate while real measurements sat behind it.
+ */
+export const DOMAIN_DEFAULT_ORDER = ["cpu", "gpu", "system", "dram"];
+
+/**
+ * The lines to chart for ONE selected domain: measured and modelled shown
+ * independently, never summed and never merged.
+ *
+ * There is deliberately no "pick the interesting domain for me" here. That
+ * behaviour used to live in a fleetPowerMode()/fleetPowerSeries() pair which
+ * let whole-machine power take over the chart whenever any machine reported it,
+ * hiding every other domain — and would have let one estimating board evict the
+ * measured history of the whole fleet. Domain choice belongs to the reader.
+ */
+export function domainSeries(history, domain) {
+  const d = domainOf(history, domain);
+  const series = [];
+  if (d.measured.machines > 0) {
+    series.push({ key: `${domain}:measured`, domain, kind: "measured", label: "Measured" });
+  }
+  if (d.estimated.machines > 0) {
+    series.push({ key: `${domain}:estimated`, domain, kind: "estimated", label: "Modelled" });
+  }
+  return series;
+}
+
+/**
+ * Resolve which domain to show.
+ *
+ * An EXPLICIT stored choice always wins, even when that domain currently has no
+ * data. A reader who selected DRAM is asking to watch DRAM; silently moving
+ * them elsewhere the moment it goes quiet would make the view jump around
+ * under them and hide the very fact they selected it to see. An empty selected
+ * domain renders as empty, which is information.
+ *
+ * With no stored choice, the default is deterministic: the first domain in
+ * DOMAIN_DEFAULT_ORDER with a MEASURED contributor, then the first with any
+ * contributor at all (which may be modelled), then "cpu" so the shape is stable
+ * when nothing has reported. Callers must LATCH this once rather than
+ * recomputing it on every poll, or an arriving domain could move the view.
+ */
+export function resolveDomainChoice(history, stored) {
+  if (stored && POWER_DOMAINS.includes(stored)) return stored;
+  const measuredFirst = DOMAIN_DEFAULT_ORDER.find(
+    (d) => domainOf(history, d).measured.machines > 0,
+  );
+  if (measuredFirst) return measuredFirst;
+  const anyFirst = DOMAIN_DEFAULT_ORDER.find((d) => domainHasData(history, d));
+  return anyFirst ?? "cpu";
+}
+
 export function fleetPowerChartRows(history, series) {
   const rows = new Map();
   for (const s of series) {
@@ -226,29 +390,86 @@ export function fleetPowerChartRows(history, series) {
  * reported as a drop to nothing: the window's leading edge is usually empty
  * simply because the current bucket has not closed.
  */
-export function latestReading(history, domain, kind) {
-  const buckets = domainOf(history, domain).buckets;
+/**
+ * The most recent reading for one domain and kind, WITH its freshness.
+ *
+ * This used to walk back through the whole window and return the last non-null
+ * bucket with no age attached, so a fleet that went dark at 02:00 still
+ * headlined "142 W measured" at noon. Worse, the value it found depended on the
+ * selected chart period: widening the history changed what "current" meant.
+ *
+ * Two things fix that, and callers must respect both:
+ *
+ *   - Age comes from `latestObservationEndMS`, the newest AGENT window end
+ *     behind this domain, NOT from the bucket's timestamp. A bucket edge is an
+ *     axis coordinate and the last one can sit in the future.
+ *   - `freshness.state` decides whether the number may be presented as current.
+ *     Anything but `fresh` must be shown with its age, or withheld.
+ *
+ * DEPRECATED for current readings. Its value still comes from the CHARTED
+ * buckets, so it varies with the selected period; only the freshness attached
+ * to it is honest. Current readouts must use currentReading() against the
+ * snapshot endpoint instead.
+ */
+export function latestReading(history, domain, kind, nowMS = Date.now()) {
+  const d = domainOf(history, domain);
+  const buckets = d.buckets;
+  const kindStats = kind === "measured" ? d.measured : d.estimated;
+
   for (let i = buckets.length - 1; i >= 0; i -= 1) {
     const value = kind === "measured" ? buckets[i].measured : buckets[i].estimated;
     if (value === null) continue;
     return {
       watts: value,
       machines: kind === "measured" ? buckets[i].measuredMachines : buckets[i].estimatedMachines,
+      // Retained for the axis only. Never age this.
       timestamp: buckets[i].timestamp,
+      observedEndMS: kindStats.latestObservationEndMS,
+      freshness: freshnessOf(kindStats.latestObservationEndMS, nowMS),
     };
   }
   return null;
 }
 
 /**
- * Cost for one domain at one tariff, measured and estimated kept apart.
+ * WITHHELD IN THIS RELEASE. Energy and cost are not presented at all.
  *
- * Both figures are FLOORS. The hub sums energy over observed windows only, so
- * time no machine reported contributes nothing — never an interpolation. The
- * `observedFraction` says how much of the window is real so the pane can say
- * "over 5.2 of 6 hours observed" instead of implying a full accounting.
+ * They used to be shown as "At least X kWh / $Y", i.e. a guaranteed lower
+ * bound. They are not one, and the shortfall is not a rounding matter:
  *
- * A null rate yields null costs. There is no default tariff.
+ *   - A window's mean is the mean of the reads that SUCCEEDED inside it, and
+ *     the hub then weights that mean by the window's WHOLE span. One successful
+ *     300 W read in a 30 s window contributes 9000 W·s as though all thirty
+ *     seconds had been observed. The unread seconds could have drawn far less,
+ *     so the figure is neither an upper nor a lower bound.
+ *   - `observedFraction` compounded it by dividing summed window spans by the
+ *     period, presenting "5.2 of 6 hours observed" as measured coverage. Spans
+ *     are not deduplicated — ingest does not enforce non-overlapping windows
+ *     across streams — and a window binned by its end can carry time belonging
+ *     to the previous bucket. The ratio was not a fraction of time observed.
+ *
+ * An honest energy figure needs each observation to carry its own measured
+ * duration, which is additive protocol work and deliberately not in this
+ * change. Until then the readout is omitted rather than qualified: a number
+ * this wrong cannot be rescued by a caption, and the compact pane has nowhere
+ * to put the qualification it would need.
+ *
+ * The function is retained so callers keep compiling, and reports
+ * `available: false` with the reason. Consumers must render the reason, not a
+ * zero — "no energy accounting" is not "0 kWh".
+ */
+export function fleetPowerEnergyAvailability() {
+  return {
+    available: false,
+    reason:
+      "Energy and cost accounting is unavailable: sampled power cannot be " +
+      "extrapolated into measured energy without per-observation durations.",
+  };
+}
+
+/**
+ * Deprecated. See fleetPowerEnergyAvailability. Retained for callers that have
+ * not yet been updated; its figures must not be displayed.
  */
 export function fleetPowerCost(history, domain, rate, period) {
   const d = domainOf(history, domain);

--- a/dashboard/src/lib/fleet-power.test.mjs
+++ b/dashboard/src/lib/fleet-power.test.mjs
@@ -5,15 +5,16 @@ import {
   coverageSentence,
   domainOf,
   fleetPowerChartRows,
-  fleetPowerCost,
   domainSeries,
+  combinedSeries,
+  currentReading,
+  normalizeFleetPowerCurrent,
   resolveDomainChoice,
   availableDomains,
   fleetPowerWarnings,
   formatKWh,
   formatMoney,
   formatWatts,
-  latestReading,
   normalizeFleetPower,
   shortfallSentence,
 } from "./fleet-power.mjs";
@@ -158,29 +159,6 @@ test("a fleet with no estimates charts one line, not an empty second one", () =>
   assert.equal(series[0].kind, "measured");
 });
 
-test("an all-estimated fleet is charted, and never as a measurement", () => {
-  const history = normalizeFleetPower(
-    response({
-      domains: [
-        domain("system", {
-          reporting_machines: 2,
-          estimated: kind({ machines: 2, energy_kwh: 0.2, observed_machine_seconds: 7200, sources: ["estimate-util"] }),
-          buckets: [bucket(0, { estimated_watts: 36, estimated_machines: 2 })],
-        }),
-        domain("cpu"),
-        domain("dram"),
-        domain("gpu"),
-      ],
-    }),
-  );
-  const series = domainSeries(history, "system");
-  assert.equal(series.length, 1);
-  assert.equal(series[0].kind, "estimated");
-  assert.equal(series[0].label, "Modelled");
-  assert.equal(latestReading(history, "system", "measured"), null, "there is no measurement to report");
-  assert.equal(latestReading(history, "system", "estimated").watts, 36);
-});
-
 test("with no whole-machine counter anywhere, components are charted separately", () => {
   const history = normalizeFleetPower(
     response({
@@ -266,35 +244,6 @@ test("a bucket nobody covered stays null so the line breaks", () => {
   assert.equal(rows[2]["system:measured"], null, "an unobserved bucket is not zero watts");
   assert.equal(rows[2]["system:estimated"], null);
 });
-
-test("the latest reading skips trailing empty buckets rather than reading zero", () => {
-  const history = mixedFleet();
-  const latest = latestReading(history, "system", "measured");
-  assert.equal(latest.watts, 142);
-  assert.equal(latest.machines, 3);
-  assert.equal(latest.timestamp, T0 + 2 * 60_000);
-});
-
-test("a genuine zero-watt reading survives", () => {
-  const history = normalizeFleetPower(
-    response({
-      domains: [
-        domain("system", {
-          reporting_machines: 1,
-          measured: kind({ machines: 1 }),
-          buckets: [bucket(0, { measured_watts: 0, measured_machines: 1 })],
-        }),
-        domain("cpu"),
-        domain("dram"),
-        domain("gpu"),
-      ],
-    }),
-  );
-  assert.equal(latestReading(history, "system", "measured").watts, 0);
-  assert.equal(formatWatts(0), "0.00 W", "zero prints as a reading, not as an em dash");
-});
-
-/* --- coverage --- */
 
 test("coverage never says 'all' unless every machine reported", () => {
   assert.equal(coverageSentence(mixedFleet().coverage), "4 of 6 machines reporting power.");
@@ -384,56 +333,6 @@ test("a gapped bucket marks its chart row", () => {
 
 /* --- cost --- */
 
-test("cost keeps measured and estimated apart, and needs a stated rate", () => {
-  const history = mixedFleet();
-  const none = fleetPowerCost(history, "system", { currency: "EUR", per_kwh: null }, "1h");
-  assert.equal(none.measured.cost, null, "no rate, no cost — there is no default tariff");
-  assert.equal(none.estimated.cost, null);
-  assert.equal(none.measured.energyKWh, 0.71, "the energy is known even when the price is not");
-
-  const priced = fleetPowerCost(history, "system", { currency: "EUR", per_kwh: 0.28 }, "1h");
-  assert.ok(Math.abs(priced.measured.cost - 0.71 * 0.28) < 1e-12);
-  assert.ok(Math.abs(priced.estimated.cost - 0.09 * 0.28) < 1e-12);
-  assert.equal(priced.currency, "EUR");
-  assert.notEqual(priced.measured.cost + priced.estimated.cost, priced.measured.cost, "two costs, reported as two");
-});
-
-test("a free-power rate of zero is a price, and costs zero", () => {
-  const priced = fleetPowerCost(mixedFleet(), "system", { currency: "USD", per_kwh: 0 }, "1h");
-  assert.equal(priced.measured.cost, 0);
-  assert.notEqual(priced.measured.cost, null, "zero is a stated rate, not an absent one");
-});
-
-test("the observed fraction says how much of the window is real", () => {
-  const history = mixedFleet();
-  const cost = fleetPowerCost(history, "system", { currency: "USD", per_kwh: 0.1 }, "1h");
-  // 3 machines × 1 hour = 10800 machine-seconds possible; 10800 observed.
-  assert.equal(cost.measured.observedFraction, 1);
-  // 1 machine × 1 hour = 3600 possible; 3600 observed.
-  assert.equal(cost.estimated.observedFraction, 1);
-
-  const partial = normalizeFleetPower(
-    response({
-      domains: [
-        domain("system", {
-          reporting_machines: 2,
-          measured: kind({ machines: 2, energy_kwh: 0.1, observed_machine_seconds: 1800 }),
-          buckets: [bucket(0, { measured_watts: 100, measured_machines: 2 })],
-        }),
-        domain("cpu"),
-        domain("dram"),
-        domain("gpu"),
-      ],
-    }),
-  );
-  // 2 machines × 1 hour = 7200 possible; 1800 observed = a quarter.
-  assert.equal(fleetPowerCost(partial, "system", { currency: "USD", per_kwh: 1 }, "1h").measured.observedFraction, 0.25);
-  assert.equal(fleetPowerCost(partial, "system", null, "1h").measured.observedFraction, 0.25);
-  assert.equal(fleetPowerCost(partial, "system", null, "nonsense").measured.observedFraction, null);
-});
-
-/* --- input handling --- */
-
 test("a response that is not fleet power is refused, not half-rendered", () => {
   for (const junk of [null, undefined, 0, "", [], {}, { domains: [] }, { coverage: {} }]) {
     assert.throws(() => normalizeFleetPower(junk), /Invalid fleet power response/);
@@ -468,32 +367,6 @@ test("junk inside a valid envelope degrades field by field", () => {
   assert.equal(system.buckets.length, 2, "a bucket with no usable timestamp is dropped");
   assert.equal(system.buckets[0].measured, null, "negative watts are not a reading");
   assert.equal(system.buckets[1].measured, null, "NaN is not a reading");
-});
-
-test("buckets are sorted by time regardless of arrival order", () => {
-  const history = normalizeFleetPower(
-    response({
-      domains: [
-        domain("system", {
-          reporting_machines: 1,
-          measured: kind({ machines: 1 }),
-          buckets: [
-            bucket(2, { measured_watts: 30, measured_machines: 1 }),
-            bucket(0, { measured_watts: 10, measured_machines: 1 }),
-            bucket(1, { measured_watts: 20, measured_machines: 1 }),
-          ],
-        }),
-        domain("cpu"),
-        domain("dram"),
-        domain("gpu"),
-      ],
-    }),
-  );
-  assert.deepEqual(
-    domainOf(history, "system").buckets.map((b) => b.measured),
-    [10, 20, 30],
-  );
-  assert.equal(latestReading(history, "system", "measured").watts, 30);
 });
 
 test("a domain the hub did not send reads as empty, not as a crash", () => {
@@ -633,7 +506,7 @@ function count(source, pattern) {
 
 test("the pane drives its domain from explicit selection, not automatic mode", () => {
   assert.match(PANE, /resolveDomainChoice\(/, "the reader's choice resolves the domain");
-  assert.match(PANE, /domainSeries\(/, "series come from the selected domain");
+  assert.match(PANE, /combinedSeries\(/, "series come from history AND the current snapshot");
   assert.doesNotMatch(PANE, /fleetPowerMode\(/, "the automatic mode is gone");
   assert.doesNotMatch(PANE, /fleetPowerSeries\(/, "and so is the series function built on it");
   assert.match(PANE, /aria-label="Power domain"/, "there is a control to change it");
@@ -661,4 +534,106 @@ test("the pane reads stored preferences after mount, never during render", () =>
     "storage must not be read in the initialiser",
   );
   assert.match(PANE, /useEffect\(\(\) => \{\n\s*if \(latched\.current\) return;/, "it is read in an effect");
+});
+
+// A capped or empty history must not hide a live reading. This is behavioural,
+// not a source grep: the pane's readouts are built from these series.
+test("a current-only measured reading still produces a series and a readout", () => {
+  const emptyHistory = normalizeFleetPower(response());
+  const snapshot = normalizeFleetPowerCurrent({
+    generated_unix_ms: T0,
+    machines_total: 4,
+    machines_reporting: 1,
+    domains: [
+      {
+        domain: "cpu",
+        measured: {
+          watts: 100,
+          machines: 1,
+          sources: ["rapl-package"],
+          oldest_contributor_end_unix_ms: T0,
+          newest_contributor_end_unix_ms: T0,
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(domainSeries(emptyHistory, "cpu"), [], "history alone has nothing");
+  const series = combinedSeries(emptyHistory, snapshot, "cpu");
+  assert.equal(series.length, 1, "the live reading still earns a series");
+  assert.equal(series[0].kind, "measured");
+
+  const reading = currentReading(snapshot, "cpu", "measured", T0);
+  assert.equal(reading.watts, 100);
+  assert.equal(reading.machines, 1);
+});
+
+test("a current-only MODELLED system reading is charted as modelled", () => {
+  const emptyHistory = normalizeFleetPower(response());
+  const snapshot = normalizeFleetPowerCurrent({
+    generated_unix_ms: T0,
+    machines_total: 4,
+    machines_reporting: 1,
+    domains: [
+      {
+        domain: "system",
+        estimated: {
+          watts: 12,
+          machines: 1,
+          sources: ["estimate-util"],
+          oldest_contributor_end_unix_ms: T0,
+          newest_contributor_end_unix_ms: T0,
+        },
+      },
+    ],
+  });
+  const series = combinedSeries(emptyHistory, snapshot, "system");
+  assert.equal(series.length, 1);
+  assert.equal(series[0].kind, "estimated");
+  assert.equal(series[0].label, "Modelled");
+  assert.equal(currentReading(snapshot, "system", "measured", T0), null, "no measurement to report");
+  assert.equal(currentReading(snapshot, "system", "estimated", T0).watts, 12);
+});
+
+test("an unrecognised kind is rejected rather than read as modelled", () => {
+  const snapshot = normalizeFleetPowerCurrent({
+    generated_unix_ms: T0,
+    domains: [
+      {
+        domain: "cpu",
+        estimated: {
+          watts: 5,
+          machines: 1,
+          sources: ["estimate-util"],
+          oldest_contributor_end_unix_ms: T0,
+          newest_contributor_end_unix_ms: T0,
+        },
+      },
+    ],
+  });
+  assert.equal(currentReading(snapshot, "cpu", "unknown", T0), null);
+  assert.equal(currentReading(snapshot, "cpu", "", T0), null);
+});
+
+test("a real measured zero survives; unavailable is null, not zero", () => {
+  const snapshot = normalizeFleetPowerCurrent({
+    generated_unix_ms: T0,
+    domains: [
+      {
+        domain: "dram",
+        measured: {
+          watts: 0,
+          machines: 1,
+          sources: ["rapl-dram"],
+          oldest_contributor_end_unix_ms: T0,
+          newest_contributor_end_unix_ms: T0,
+        },
+      },
+    ],
+  });
+  const reading = currentReading(snapshot, "dram", "measured", T0);
+  assert.equal(reading.watts, 0, "a machine can genuinely measure zero on a domain");
+  // Nothing reporting at all is a different answer entirely.
+  const empty = normalizeFleetPowerCurrent({ generated_unix_ms: T0, domains: [] });
+  assert.equal(currentReading(empty, "dram", "measured", T0), null);
 });

--- a/dashboard/src/lib/fleet-power.test.mjs
+++ b/dashboard/src/lib/fleet-power.test.mjs
@@ -6,8 +6,9 @@ import {
   domainOf,
   fleetPowerChartRows,
   fleetPowerCost,
-  fleetPowerMode,
-  fleetPowerSeries,
+  domainSeries,
+  resolveDomainChoice,
+  availableDomains,
   fleetPowerWarnings,
   formatKWh,
   formatMoney,
@@ -119,7 +120,7 @@ test("measured and estimated stay two numbers, never one", () => {
   assert.equal(system.buckets[1].estimated, 18);
   // Nothing in the module produces 160. The two series are addressed
   // separately all the way to the chart rows.
-  const series = fleetPowerSeries(history);
+  const series = domainSeries(history, "system");
   assert.deepEqual(
     series.map((s) => s.kind),
     ["measured", "estimated"],
@@ -133,7 +134,7 @@ test("measured and estimated stay two numbers, never one", () => {
   // apart by stroke colour.
   assert.deepEqual(
     series.map((s) => s.label),
-    ["Measured", "Estimated"],
+    ["Measured", "Modelled"],
   );
 });
 
@@ -152,7 +153,7 @@ test("a fleet with no estimates charts one line, not an empty second one", () =>
       ],
     }),
   );
-  const series = fleetPowerSeries(history);
+  const series = domainSeries(history, "system");
   assert.equal(series.length, 1);
   assert.equal(series[0].kind, "measured");
 });
@@ -172,10 +173,10 @@ test("an all-estimated fleet is charted, and never as a measurement", () => {
       ],
     }),
   );
-  const series = fleetPowerSeries(history);
+  const series = domainSeries(history, "system");
   assert.equal(series.length, 1);
   assert.equal(series[0].kind, "estimated");
-  assert.equal(series[0].label, "Estimated");
+  assert.equal(series[0].label, "Modelled");
   assert.equal(latestReading(history, "system", "measured"), null, "there is no measurement to report");
   assert.equal(latestReading(history, "system", "estimated").watts, 36);
 });
@@ -199,8 +200,10 @@ test("with no whole-machine counter anywhere, components are charted separately"
       ],
     }),
   );
-  assert.equal(fleetPowerMode(history), "component");
-  const series = fleetPowerSeries(history);
+  // With no whole-machine counter, the default lands on a MEASURED component
+  // domain rather than an empty system one.
+  assert.equal(resolveDomainChoice(history, null), "cpu");
+  const series = [...domainSeries(history, "cpu"), ...domainSeries(history, "gpu")];
   assert.deepEqual(
     series.map((s) => s.domain),
     ["cpu", "gpu"],
@@ -212,7 +215,7 @@ test("with no whole-machine counter anywhere, components are charted separately"
   assert.equal(rows.length, 1);
 });
 
-test("system wins over components whenever any machine has a real counter", () => {
+test("one machine reporting system power does NOT take over the chart", () => {
   const history = normalizeFleetPower(
     response({
       domains: [
@@ -231,18 +234,33 @@ test("system wins over components whenever any machine has a real counter", () =
       ],
     }),
   );
-  assert.equal(fleetPowerMode(history), "system");
+  // The old rule handed the whole chart to `system` whenever ANY machine had
+  // it, hiding the five machines reporting CPU. Worse, once a MODELLED system
+  // reading could appear, one estimating board would have evicted the measured
+  // history of the entire fleet.
+  //
+  // Every domain with data is now offered, and the default prefers a measured
+  // component domain over a one-machine system reading.
+  assert.deepEqual(availableDomains(history), ["system", "cpu"]);
+  assert.equal(resolveDomainChoice(history, null), "cpu");
+  // An explicit choice is always honoured.
+  assert.equal(resolveDomainChoice(history, "system"), "system");
+  // Even for a domain with no data at all: a reader watching DRAM is asking to
+  // watch DRAM, and moving them would hide the very fact they selected it for.
+  assert.equal(resolveDomainChoice(history, "dram"), "dram");
 });
 
-test("an empty response is a mode of its own, not an empty chart", () => {
-  assert.equal(fleetPowerMode(normalizeFleetPower(response())), "none");
-  assert.equal(fleetPowerMode(null), "none");
-  assert.deepEqual(fleetPowerSeries(normalizeFleetPower(response())), []);
+test("an empty response offers no domains and charts no lines", () => {
+  const empty = normalizeFleetPower(response());
+  assert.deepEqual(availableDomains(empty), []);
+  assert.deepEqual(domainSeries(empty, "system"), []);
+  // A deterministic fallback, so the shape never depends on what arrived.
+  assert.equal(resolveDomainChoice(empty, null), "cpu");
 });
 
 test("a bucket nobody covered stays null so the line breaks", () => {
   const history = mixedFleet();
-  const series = fleetPowerSeries(history);
+  const series = domainSeries(history, "system");
   const rows = fleetPowerChartRows(history, series);
   assert.equal(rows.length, 3);
   assert.equal(rows[2]["system:measured"], null, "an unobserved bucket is not zero watts");
@@ -358,7 +376,7 @@ test("a gapped bucket marks its chart row", () => {
       ],
     }),
   );
-  const rows = fleetPowerChartRows(history, fleetPowerSeries(history));
+  const rows = fleetPowerChartRows(history, domainSeries(history, "system"));
   assert.equal(rows[0].gap, false);
   assert.equal(rows[1].gap, true);
   assert.equal(rows[1]["system:measured"], 100, "a gap flag does not blank the reading beside it");
@@ -588,8 +606,12 @@ test("the tariff is set in Settings and only displayed on the pane", () => {
   assert.doesNotMatch(PANE, /<input/, "no field on the pane");
   assert.doesNotMatch(PANE, /<select/, "no currency picker on the pane");
   assert.doesNotMatch(PANE, /onRateChange/, "the pane cannot write the rate at all");
-  assert.match(PANE, /formatMoney\(/, "it still shows what the energy cost");
-  assert.match(PANE, /Set a rate/, "and points at where the rate is set");
+  // Energy and cost are withheld in this release: sampled power cannot be
+  // extrapolated into measured energy. The pane must say so rather than print
+  // a figure, and must never print a zero in place of a missing accounting.
+  assert.doesNotMatch(PANE, /At least/, "the lower-bound claim is withdrawn");
+  assert.match(PANE, /Energy and cost unavailable/, "it says what it does not know");
+  assert.doesNotMatch(PANE, /formatMoney\(/, "no money figure while accounting is withheld");
 
   // Both halves of it moved, to the one place that owns it, and it is mounted.
   assert.match(settings, /POWER_CURRENCIES/, "currency moved too, not just the number");
@@ -601,3 +623,42 @@ test("the tariff is set in Settings and only displayed on the pane", () => {
 function count(source, pattern) {
   return (source.match(pattern) ?? []).length;
 }
+
+// --- integration contract ---
+//
+// These assert the PANE actually uses the honest helpers. Without them a helper
+// can be written, tested in isolation, and never wired up — which is exactly
+// how the automatic-mode defect survived: the pure functions were fine and the
+// component called the wrong ones.
+
+test("the pane drives its domain from explicit selection, not automatic mode", () => {
+  assert.match(PANE, /resolveDomainChoice\(/, "the reader's choice resolves the domain");
+  assert.match(PANE, /domainSeries\(/, "series come from the selected domain");
+  assert.doesNotMatch(PANE, /fleetPowerMode\(/, "the automatic mode is gone");
+  assert.doesNotMatch(PANE, /fleetPowerSeries\(/, "and so is the series function built on it");
+  assert.match(PANE, /aria-label="Power domain"/, "there is a control to change it");
+});
+
+test("the pane's current readouts come from the snapshot, never from history", () => {
+  assert.match(PANE, /currentReading\(/, "readouts read the current snapshot");
+  assert.match(PANE, /api\/fleet\/power\/current/, "which is its own request");
+  assert.doesNotMatch(PANE, /latestReading\(/, "the history walk-back must not drive a current value");
+});
+
+test("the pane states what its number is, and what is missing from it", () => {
+  assert.match(PANE, /sum of sample means/, "the figure is qualified in visible copy");
+  assert.match(PANE, /freshnessNote\(/, "a value that is not current carries its age");
+  assert.match(PANE, /unrecognised backend/, "unknown provenance is explained, not hidden");
+  assert.match(PANE, /Excluded:/, "and so are stale, skewed and unreadable contributors");
+});
+
+test("the pane reads stored preferences after mount, never during render", () => {
+  // localStorage in a useState initialiser renders differently on the server
+  // and in the browser, which React reports as a hydration mismatch.
+  assert.doesNotMatch(
+    PANE,
+    /useState<string \| null>\(\(\) => readStoredDomain\(\)\)/,
+    "storage must not be read in the initialiser",
+  );
+  assert.match(PANE, /useEffect\(\(\) => \{\n\s*if \(latched\.current\) return;/, "it is read in an effect");
+});

--- a/dashboard/src/lib/fleet-power.test.mjs
+++ b/dashboard/src/lib/fleet-power.test.mjs
@@ -637,3 +637,21 @@ test("a real measured zero survives; unavailable is null, not zero", () => {
   const empty = normalizeFleetPowerCurrent({ generated_unix_ms: T0, domains: [] });
   assert.equal(currentReading(empty, "dram", "measured", T0), null);
 });
+
+test("a domain whose only contributors are unclassified is still selectable", () => {
+  const history = normalizeFleetPower(
+    response({
+      domains: [
+        domain("system"),
+        domain("cpu"),
+        domain("dram", { unknown: kind({ machines: 1, sources: ["some-future-backend"] }) }),
+        domain("gpu"),
+      ],
+    }),
+  );
+  // It charts nothing, by design — but a reader must be able to open it and
+  // find out WHY it is empty.
+  assert.ok(availableDomains(history).includes("dram"));
+  assert.deepEqual(domainSeries(history, "dram"), []);
+  assert.equal(domainOf(history, "dram").unknown.machines, 1);
+});

--- a/dashboard/src/lib/power-freshness.mjs
+++ b/dashboard/src/lib/power-freshness.mjs
@@ -1,0 +1,146 @@
+/**
+ * One freshness policy for every power readout in the product.
+ *
+ * Three different rules used to coexist: PowerHistory treated 90s as current,
+ * a proposed fleet table used 150s, and the fleet pane's `latestReading`
+ * walked back through a whole 24-hour window and headlined the last non-null
+ * value with no age shown at all. A fleet that went dark at 02:00 could
+ * therefore show dashes in one panel and "142 W measured" in another, side by
+ * side on the same screen. That is the alert-count disagreement rebuilt: two
+ * views of one fact, disagreeing, with nothing to say which was right.
+ *
+ * So the policy lives here, once, and every surface imports it.
+ *
+ * Three rules the callers must honour:
+ *
+ *   1. AGE COMES FROM AN OBSERVATION, NEVER FROM A CHART BIN.
+ *      A bucket's `end_unix_ms` is an axis coordinate. The last bucket of a
+ *      24h view ends up to 15 minutes in the FUTURE, so measuring age from it
+ *      makes stale data look current. Age must be measured from the agent's
+ *      own window end (`latest_observation_end_unix_ms`).
+ *
+ *   2. ONE FRESH CONTRIBUTOR DOES NOT REFRESH THE REST.
+ *      An aggregate is only as current as its OLDEST contributor. Six machines
+ *      where five went dark an hour ago and one still reports is not a fresh
+ *      fleet reading; it is one machine's reading wearing a fleet's label.
+ *      `aggregateFreshness` therefore takes the worst contributor, not the best.
+ *
+ *   3. NEGATIVE AGE IS NOT FRESHNESS.
+ *      A clock running ahead produces an observation "in the future". That is
+ *      unknown, not current — a badly skewed agent would otherwise read as
+ *      permanently up to date.
+ */
+
+/**
+ * How long a power observation stays current.
+ *
+ * The agent emits a 30-second window, so anything under one window has simply
+ * not been superseded yet. Five windows allows for a missed report and the
+ * hub's own aggregation lag without declaring a working machine stale.
+ */
+export const POWER_FRESH_MS = 150_000;
+
+/**
+ * How far ahead of our clock an observation may be stamped and still be taken
+ * at face value. Deliberately small: this is timestamp resolution and transit
+ * jitter, NOT a clock-drift allowance. A reading cannot be newer than now, so
+ * anything meaningfully ahead is skew of unknown size — and unknown age must
+ * never render as a current reading. Matches the hub's
+ * fleetPowerFutureSkewToleranceMS.
+ */
+export const POWER_FUTURE_SKEW_TOLERANCE_MS = 2_000;
+
+/** Freshness states. `unavailable` means nothing ever reported. */
+export const FRESH = "fresh";
+export const STALE = "stale";
+export const SKEWED = "skewed";
+export const UNAVAILABLE = "unavailable";
+
+/**
+ * Classify one observation.
+ *
+ * `observedEndMS` must be an agent window end, not a bucket edge. Returns
+ * `{ state, ageMS }`; `ageMS` is null when there is nothing to age.
+ */
+export function freshnessOf(observedEndMS, nowMS) {
+  if (!Number.isFinite(observedEndMS) || observedEndMS <= 0) {
+    return { state: UNAVAILABLE, ageMS: null };
+  }
+  if (!Number.isFinite(nowMS)) return { state: UNAVAILABLE, ageMS: null };
+  const ageMS = nowMS - observedEndMS;
+  if (ageMS < -POWER_FUTURE_SKEW_TOLERANCE_MS) {
+    // Ahead of our clock by more than tolerance: we cannot say how old this is.
+    return { state: SKEWED, ageMS };
+  }
+  if (ageMS <= POWER_FRESH_MS) return { state: FRESH, ageMS: Math.max(0, ageMS) };
+  return { state: STALE, ageMS };
+}
+
+/**
+ * Classify an aggregate from its contributors' observation ends.
+ *
+ * The aggregate is as fresh as its OLDEST contributor, which is why this takes
+ * the minimum rather than the maximum. A single still-reporting machine must
+ * not make five dark ones look current.
+ *
+ * Any contributor whose clock is skewed makes the aggregate's age unknowable,
+ * so the whole aggregate reports `skewed` rather than a confident number.
+ */
+export function aggregateFreshness(observedEndsMS, nowMS) {
+  const ends = (observedEndsMS ?? []).filter((v) => Number.isFinite(v) && v > 0);
+  if (ends.length === 0) return { state: UNAVAILABLE, ageMS: null, contributors: 0 };
+
+  let oldest = Infinity;
+  let anySkew = false;
+  for (const end of ends) {
+    const { state } = freshnessOf(end, nowMS);
+    if (state === SKEWED) anySkew = true;
+    if (end < oldest) oldest = end;
+  }
+  if (anySkew) {
+    return { state: SKEWED, ageMS: nowMS - oldest, contributors: ends.length };
+  }
+  const worst = freshnessOf(oldest, nowMS);
+  return { ...worst, contributors: ends.length };
+}
+
+/** True only when a readout may be presented as the current value. */
+export function isCurrent(freshness) {
+  return freshness?.state === FRESH;
+}
+
+/**
+ * Short human age, e.g. "8s", "4m", "3h". Null when there is nothing to say.
+ * Callers print this beside any value that is not current, so a stale number is
+ * never shown without its age.
+ */
+export function formatAge(ageMS) {
+  if (!Number.isFinite(ageMS)) return null;
+  if (ageMS < 0) return null; // skew: the caller says "clock ahead", not an age
+  const seconds = Math.floor(ageMS / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+/**
+ * The words to put beside a reading, given its freshness. Never returns a bare
+ * number: a value that is not current always carries why.
+ */
+export function freshnessNote(freshness) {
+  switch (freshness?.state) {
+    case FRESH:
+      return null;
+    case STALE: {
+      const age = formatAge(freshness.ageMS);
+      return age ? `last reported ${age} ago` : "no recent report";
+    }
+    case SKEWED:
+      return "clock ahead of hub — age unknown";
+    default:
+      return "no reading";
+  }
+}

--- a/dashboard/src/lib/power-freshness.test.mjs
+++ b/dashboard/src/lib/power-freshness.test.mjs
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  POWER_FRESH_MS,
+  FRESH,
+  STALE,
+  SKEWED,
+  UNAVAILABLE,
+  freshnessOf,
+  aggregateFreshness,
+  isCurrent,
+  formatAge,
+  freshnessNote,
+} from "./power-freshness.mjs";
+
+const NOW = 1_700_000_000_000;
+
+test("a recent observation is current", () => {
+  const f = freshnessOf(NOW - 30_000, NOW);
+  assert.equal(f.state, FRESH);
+  assert.ok(isCurrent(f));
+});
+
+test("an old observation is stale and carries its age", () => {
+  const f = freshnessOf(NOW - 4 * 3_600_000, NOW);
+  assert.equal(f.state, STALE);
+  assert.equal(isCurrent(f), false);
+  assert.equal(formatAge(f.ageMS), "4h");
+  assert.match(freshnessNote(f), /4h ago/);
+});
+
+test("nothing ever reported is unavailable, not zero-aged", () => {
+  assert.equal(freshnessOf(null, NOW).state, UNAVAILABLE);
+  assert.equal(freshnessOf(0, NOW).state, UNAVAILABLE);
+  assert.equal(formatAge(freshnessOf(null, NOW).ageMS), null);
+});
+
+// A reading cannot be newer than now. A clock running ahead produces an
+// observation "in the future"; that is unknown age, never current.
+test("a future observation is skewed, never fresh", () => {
+  const modest = freshnessOf(NOW + 30_000, NOW);
+  assert.equal(modest.state, SKEWED, "30s ahead is skew, not a current reading");
+  assert.equal(isCurrent(modest), false);
+
+  const nearOldGrace = freshnessOf(NOW + 119_000, NOW);
+  assert.equal(nearOldGrace.state, SKEWED, "119s ahead sat inside the old two-minute grace");
+  assert.equal(isCurrent(nearOldGrace), false);
+
+  assert.match(freshnessNote(nearOldGrace), /clock ahead/);
+  // Skew must not be printed as an age.
+  assert.equal(formatAge(nearOldGrace.ageMS), null);
+});
+
+test("timestamp jitter inside tolerance is still current", () => {
+  assert.equal(freshnessOf(NOW + 500, NOW).state, FRESH);
+});
+
+// The rule that stops one machine speaking for a dark fleet.
+test("an aggregate is only as fresh as its OLDEST contributor", () => {
+  const oneFreshFiveDark = [
+    NOW - 10_000,
+    NOW - 3_600_000,
+    NOW - 3_600_000,
+    NOW - 3_600_000,
+    NOW - 3_600_000,
+    NOW - 3_600_000,
+  ];
+  const f = aggregateFreshness(oneFreshFiveDark, NOW);
+  assert.equal(f.state, STALE, "one still-reporting machine must not launder five stale ones");
+  assert.equal(f.contributors, 6);
+  assert.equal(formatAge(f.ageMS), "1h");
+});
+
+test("an aggregate whose contributors are all recent is current", () => {
+  const f = aggregateFreshness([NOW - 10_000, NOW - 20_000], NOW);
+  assert.equal(f.state, FRESH);
+  assert.ok(isCurrent(f));
+});
+
+test("one skewed contributor makes the whole aggregate's age unknowable", () => {
+  const f = aggregateFreshness([NOW - 10_000, NOW + 600_000], NOW);
+  assert.equal(f.state, SKEWED);
+  assert.equal(isCurrent(f), false);
+});
+
+test("an aggregate with no contributors is unavailable", () => {
+  assert.equal(aggregateFreshness([], NOW).state, UNAVAILABLE);
+  assert.equal(aggregateFreshness(null, NOW).state, UNAVAILABLE);
+  assert.equal(aggregateFreshness([0, null, NaN], NOW).state, UNAVAILABLE);
+});
+
+test("the freshness window is a single shared constant", () => {
+  // Three different rules used to coexist (90s, 150s, and a 24h walk-back).
+  // The exact value matters less than there being exactly one.
+  assert.equal(typeof POWER_FRESH_MS, "number");
+  assert.ok(POWER_FRESH_MS > 0);
+  assert.equal(freshnessOf(NOW - (POWER_FRESH_MS - 1), NOW).state, FRESH);
+  assert.equal(freshnessOf(NOW - (POWER_FRESH_MS + 1), NOW).state, STALE);
+});

--- a/hub/fleet_power.go
+++ b/hub/fleet_power.go
@@ -29,8 +29,20 @@ package main
 //   - No cross-domain sum. system, cpu, dram and gpu are disjoint scopes (see
 //     proto/powerhistory), so each is aggregated on its own and they are
 //     returned side by side, never added.
-//   - No interpolation across gaps. Unobserved time contributes zero energy and
-//     is reported as unobserved, which makes every energy figure a FLOOR.
+//   - No interpolation across gaps. Unobserved time contributes zero energy.
+//
+// ENERGY IS AN EXTRAPOLATION, NOT A FLOOR. This comment previously claimed
+// every energy figure was a lower bound. It is not, and the claim is withdrawn.
+// A window's mean is the mean of the samples that SUCCEEDED in it — statsAcc
+// averages over n successful reads (agent/power_history.go) — and this file
+// then weights that mean by the window's whole span. One successful 300 W read
+// in a 30 s window contributes 9000 W*s as if all 30 seconds had been observed.
+// The unread seconds could have drawn far less, so the result is neither an
+// upper nor a lower bound: it is a model built from sampled power.
+//
+// Samples and expected samples are therefore carried through to the response
+// so a client can disclose how much of each window was actually read, and no
+// consumer may describe these figures as "at least" or as measured energy.
 
 import (
 	"database/sql"
@@ -38,6 +50,7 @@ import (
 	"math"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/bokiko/bloxos/proto/powerhistory"
@@ -62,18 +75,80 @@ var fleetPowerDomains = []string{
 const (
 	fleetPowerKindMeasured  = "measured"
 	fleetPowerKindEstimated = "estimated"
+	// fleetPowerKindUnknown is a reading whose backend this hub does not
+	// recognise. It is NOT measured and NOT modelled: it is unclassified, and
+	// it is kept out of both totals rather than being folded into either.
+	fleetPowerKindUnknown = "unknown"
 )
 
-// Whether a reading is measured or modelled is decided by
-// powerhistory.IsEstimatedSource and nothing else. The protocol names that as
-// the single home of that knowledge precisely so a hub cannot drift into its
-// own string matching and mistake a future modelled backend for a counter.
+// fleetPowerMeasuredSources is the set of backend identifiers this hub knows
+// to be MEASUREMENTS. Classification fails closed: a label that is neither in
+// this set, nor the hwmon prefix, nor a known modelled source, is reported as
+// fleetPowerKindUnknown.
 //
-// The consequence worth stating: an UNLABELLED reading counts as measured,
-// because the only agents emitting unlabelled statistics predate source
-// labelling entirely and what they had was RAPL. An estimator must therefore
-// always label itself — an unlabelled estimate is indistinguishable from a
-// counter here, and would be summed into the measured total.
+// Why fail closed. The previous rule was "estimated if IsEstimatedSource, else
+// measured", which silently promoted every unrecognised label to measured. A
+// future modelled backend reaching an older hub would therefore be presented as
+// a counter reading — the exact failure the protocol's no-boolean rule exists to
+// prevent. Unknown provenance must read as unknown, never as measurement.
+var fleetPowerMeasuredSources = map[string]bool{
+	powerhistory.SourceRAPLPsys:    true,
+	powerhistory.SourceRAPLPackage: true,
+	powerhistory.SourceRAPLDRAM:    true,
+	powerhistory.SourceBattery:     true,
+	powerhistory.SourceIPMIDCMI:    true,
+}
+
+// fleetPowerClassify maps a domain's recorded backend label to a kind.
+//
+// The unlabelled case is preserved deliberately as MEASURED: the only agents
+// that emit scalar statistics without a source label predate source labelling
+// entirely, and what those builds measured was RAPL. Reclassifying them as
+// unknown would blank working history across every fleet still running them.
+// An estimator has always labelled itself, so nothing modelled can arrive
+// unlabelled.
+func fleetPowerClassify(domain, source string) string {
+	// GPU totals carry no source label by construction (see
+	// fleetPowerDomainGPU): the agent only emits one from a complete
+	// simultaneous observation of real devices.
+	if domain == fleetPowerDomainGPU {
+		return fleetPowerKindMeasured
+	}
+	if source == "" {
+		return fleetPowerKindMeasured // pre-labelling agent; RAPL by definition
+	}
+	if powerhistory.IsEstimatedSource(source) {
+		return fleetPowerKindEstimated
+	}
+	if fleetPowerMeasuredSources[source] {
+		return fleetPowerKindMeasured
+	}
+	// hwmon backends name the chip they found, so the identifier is open-ended
+	// by design and cannot be enumerated here. This classifies the reading as a
+	// MEASUREMENT only; it says nothing about what the sensor is wired across.
+	// A shunt monitor reports whatever rail it sits on, so scope belongs to the
+	// agent's domain assignment, never to this label.
+	if strings.HasPrefix(source, powerhistory.SourceHwmonPrefix) {
+		return fleetPowerKindMeasured
+	}
+	return fleetPowerKindUnknown
+}
+
+// Modelled-ness is still owned by powerhistory.IsEstimatedSource: this file
+// never pattern-matches its own way to "that looks like an estimate".
+//
+// What changed is the DEFAULT. The rule used to be "estimated if
+// IsEstimatedSource, else measured", which quietly promoted every label this
+// hub did not recognise — including a modelled backend added after this build —
+// to measured. Classification now fails closed in fleetPowerClassify: known
+// measured backends and the open-ended hwmon prefix are measured, the known
+// modelled source is modelled, and anything else is UNKNOWN and kept out of
+// both totals.
+//
+// The one deliberate exception is an UNLABELLED reading, which stays measured:
+// the only agents emitting unlabelled statistics predate source labelling
+// entirely, and what they had was RAPL. An estimator has always labelled
+// itself, so nothing modelled can arrive unlabelled.
 
 // fleetPowerSourceUnlabelled stands in for a scalar-domain reading that named
 // no backend, so "which sources are behind this number" is answerable even for
@@ -113,6 +188,19 @@ const (
 	fleetPowerMaxSilentListed = 100
 	// fleetPowerMaxSourcesListed bounds the per-domain backend list.
 	fleetPowerMaxSourcesListed = 16
+	// fleetPowerFutureSkewToleranceMS is how far ahead of the hub clock an agent
+	// window may end and still be accepted as a real observation time.
+	//
+	// It is deliberately SMALL — timestamp resolution and transit jitter, not a
+	// clock-drift allowance. An earlier draft used two minutes, which meant a
+	// window stamped 119 seconds in the future became "the newest observation"
+	// and any ordinary age check then read it as current. A reading cannot be
+	// newer than now; anything meaningfully ahead of the hub clock is skew of
+	// unknown size, and unknown age must never qualify as a current reading.
+	//
+	// Skew does not discard data: such a reading still contributes its power to
+	// history. What it loses is the right to set freshness.
+	fleetPowerFutureSkewToleranceMS = 2_000
 )
 
 // --- response ---
@@ -123,15 +211,32 @@ const (
 type FleetPowerBucket struct {
 	StartUnixMS int64 `json:"start_unix_ms"`
 	EndUnixMS   int64 `json:"end_unix_ms"`
-	// MeasuredWatts is the sum, over machines with a real counter, of each
-	// machine's time-weighted mean watts in this bucket.
+	// MeasuredWatts is the SUM OF REPORTED SAMPLE MEANS over machines with a
+	// real counter: each machine's mean over the windows it reported inside
+	// this bucket, added together. It is NOT a fleet mean over a common interval — the
+	// contributing machines' windows need not overlap, so a machine reporting
+	// only in the first half of a bucket and another only in the second half
+	// still sum. Present it with its contributor count, never as "the fleet
+	// drew N watts at this moment".
 	MeasuredWatts    *float64 `json:"measured_watts"`
 	MeasuredMachines int      `json:"measured_machines"`
+	// MeasuredWindowSeconds is the summed span of the windows behind
+	// MeasuredWatts. Compare against BucketSeconds × MeasuredMachines to see
+	// what fraction of the bucket those machines actually reported over.
+	MeasuredWindowSeconds float64 `json:"measured_window_seconds"`
 	// EstimatedWatts is the same sum over machines reporting a MODELLED
 	// figure. It is a separate series and must be labelled as an estimate
 	// wherever it is shown.
 	EstimatedWatts    *float64 `json:"estimated_watts"`
 	EstimatedMachines int      `json:"estimated_machines"`
+	// EstimatedWindowSeconds mirrors MeasuredWindowSeconds for the modelled
+	// series.
+	EstimatedWindowSeconds float64 `json:"estimated_window_seconds"`
+	// UnknownMachines counts contributors in this bucket whose backend this
+	// hub could not classify. Their watts are deliberately NOT summed into
+	// either series; the count exists so the omission is visible rather than
+	// silent.
+	UnknownMachines int `json:"unknown_machines"`
 	// Gap marks that a contributing machine declared local collection loss
 	// immediately before a window landing in this bucket. Missing data is not
 	// zero power.
@@ -142,12 +247,35 @@ type FleetPowerBucket struct {
 type FleetPowerKind struct {
 	// Machines contributed at least one reading anywhere in the window.
 	Machines int `json:"machines"`
-	// EnergyKWh is summed over observed windows only, so it is a FLOOR: time
-	// no machine observed contributes nothing rather than being interpolated.
+	// EnergyKWh EXTRAPOLATES each window's sampled mean across that window's
+	// whole span. It is NOT a floor and NOT measured energy: a window whose
+	// reads mostly failed still contributes its full span. Present it as
+	// modelled from sampled power, with SampleCount/ExpectedSampleCount
+	// disclosing how much was actually read.
 	EnergyKWh float64 `json:"energy_kwh"`
-	// ObservedMachineSeconds is machine-seconds actually covered by readings.
-	// Compare against machines × window to see how much of the window is real.
+	// ObservedMachineSeconds is DEPRECATED and was misnamed: it is the sum of
+	// reporting-window SPANS, not time actually observed. A 30 s window built
+	// from one successful read still counts 30. Retained unchanged for
+	// existing clients; use ReportingWindowSeconds and the sample counts.
 	ObservedMachineSeconds float64 `json:"observed_machine_seconds"`
+	// ReportingWindowSeconds is the honest name for the value above: summed
+	// spans of the windows that contributed.
+	ReportingWindowSeconds float64 `json:"reporting_window_seconds"`
+	// SampleCount is the number of individual sensor reads that SUCCEEDED
+	// across those windows; ExpectedSampleCount is how many the agent expected
+	// to take.
+	//
+	// Read them as evidence WEIGHT, not as a fraction of time observed. A low
+	// ratio does not locate a gap and a high one does not prove continuity:
+	// backends sample at deliberately different cadences, and IPMI samples
+	// slowly by design, so a small count can be a fully healthy backend. The
+	// counts must never be multiplied into a duration.
+	SampleCount         int64 `json:"sample_count"`
+	ExpectedSampleCount int64 `json:"expected_sample_count"`
+	// LatestObservationEndUnixMS is the end of the most recent contributing
+	// AGENT window, not a chart bin edge. Freshness must be judged from this.
+	// Zero when nothing contributed.
+	LatestObservationEndUnixMS int64 `json:"latest_observation_end_unix_ms"`
 	// Sources are the backend ids behind this number, sorted.
 	Sources []string `json:"sources"`
 }
@@ -157,12 +285,28 @@ type FleetPowerDomain struct {
 	Buckets   []FleetPowerBucket `json:"buckets"`
 	Measured  FleetPowerKind     `json:"measured"`
 	Estimated FleetPowerKind     `json:"estimated"`
-	// ReportingMachines is the union of measured and estimated machines: a
-	// machine reporting both in different buckets is counted once.
+	// Unknown holds contributors whose backend this hub cannot classify. They
+	// are reported separately and are never folded into Measured or Estimated.
+	Unknown FleetPowerKind `json:"unknown"`
+	// ReportingMachines is the union of measured, estimated AND unknown
+	// machines: a machine reporting in several kinds or buckets is counted
+	// once. It answers "how many machines are behind this domain at all",
+	// which is why unclassified contributors are included here even though
+	// their watts are excluded from both series.
 	ReportingMachines int `json:"reporting_machines"`
-	// Complete is true only when every machine in the fleet contributed to
-	// every bucket of the window. A false Complete means every total for this
-	// domain is a partial sum and must not be presented as a fleet total.
+	// AllMachinesContributed means every known machine contributed at least one
+	// reading to every bucket in this window. It is a PRESENCE statement and
+	// nothing more: it says each machine was heard from, not that the bucket
+	// was measured throughout. Use it to distinguish "some machines dropped
+	// out" from "everyone reported"; never as measurement coverage.
+	AllMachinesContributed bool `json:"all_machines_contributed"`
+	// Complete is always FALSE and is retained only so existing clients keep
+	// parsing. Stored readings cannot establish complete measurement of a
+	// bucket: window spans are not enforced non-overlapping at ingest, a window
+	// is binned by its END so it can credit time spent in the previous bucket,
+	// and a window's mean comes only from the reads that succeeded within it.
+	// Anything needing "did everyone report" should read
+	// AllMachinesContributed instead.
 	Complete bool `json:"complete"`
 }
 
@@ -186,6 +330,11 @@ type FleetPowerCoverage struct {
 	GapsDeclared int `json:"gaps_declared"`
 	// GapBuckets counts buckets in this window carrying a declared gap.
 	GapBuckets int `json:"gap_buckets"`
+	// MachinesSkewed counts machines whose newest window ended implausibly far
+	// ahead of the hub clock. Their power still contributes; what is withheld
+	// is their claim to be the freshest observation, because a skewed clock
+	// would otherwise make stale fleet data read as current.
+	MachinesSkewed int `json:"machines_skewed"`
 	// Truncated means the record cap was hit and the OLDEST part of the window
 	// was not read. WindowStartUnixMS below is then later than requested.
 	Truncated bool `json:"truncated"`
@@ -235,6 +384,8 @@ type fleetPowerInputs struct {
 type fleetPowerCell struct {
 	wattSeconds float64
 	seconds     float64
+	samples     int64
+	expected    int64
 }
 
 type fleetPowerCellKey struct {
@@ -261,15 +412,26 @@ func aggregateFleetPower(records []fleetPowerRecord, in fleetPowerInputs) FleetP
 	seriesSources := map[fleetPowerSeriesKey]map[string]bool{}
 	seriesEnergy := map[fleetPowerSeriesKey]float64{}
 	seriesObserved := map[fleetPowerSeriesKey]float64{}
+	seriesSamples := map[fleetPowerSeriesKey]int64{}
+	seriesExpected := map[fleetPowerSeriesKey]int64{}
+	seriesLatestEnd := map[fleetPowerSeriesKey]int64{}
+	skewed := map[string]bool{}
 	gapBuckets := map[string]map[int]bool{} // domain -> bucket index
 	reporting := map[string]bool{}
 
 	for i := range records {
 		rec := &records[i]
-		if rec.EndMS < in.StartMS || rec.EndMS >= endMS {
+		if rec.EndMS <= in.StartMS || rec.EndMS > endMS {
 			continue
 		}
-		idx := int((rec.EndMS - in.StartMS) / bucketMS)
+		// A reading covers the half-open interval [StartMS, EndMS), so the
+		// bucket it belongs to is the one holding the instant just BEFORE its
+		// end. Mapping EndMS directly pushed a window ending exactly on a
+		// bucket edge into the NEXT bucket, even though none of its time was
+		// spent there: a 30 s window covering [30s, 60s) of a 60 s bucket was
+		// attributed to the following minute. That both misplaced the power and
+		// made full temporal coverage of a bucket impossible to express.
+		idx := int((rec.EndMS - 1 - in.StartMS) / bucketMS)
 		if idx < 0 || idx >= in.BucketCount {
 			continue
 		}
@@ -300,10 +462,7 @@ func aggregateFleetPower(records []fleetPowerRecord, in fleetPowerInputs) FleetP
 				continue
 			}
 
-			kind := fleetPowerKindMeasured
-			if powerhistory.IsEstimatedSource(source) {
-				kind = fleetPowerKindEstimated
-			}
+			kind := fleetPowerClassify(domain, source)
 			series := fleetPowerSeriesKey{domain: domain, kind: kind}
 
 			cellKey := fleetPowerCellKey{domain: domain, kind: kind, bucket: idx, machine: rec.MachineID}
@@ -314,6 +473,21 @@ func aggregateFleetPower(records []fleetPowerRecord, in fleetPowerInputs) FleetP
 			}
 			cell.wattSeconds += mean * windowSeconds
 			cell.seconds += windowSeconds
+			cell.samples += int64(stats.Samples)
+			cell.expected += int64(rec.Expected)
+
+			// Freshness is judged from the agent's own window end, never from
+			// a chart bin edge (a bin end can sit up to a bucket width in the
+			// future). A window ending implausibly far ahead of the hub clock
+			// is clock skew: it must not count as the newest observation, or a
+			// skewed agent would make the whole fleet look freshly reported.
+			if rec.EndMS <= in.Now+fleetPowerFutureSkewToleranceMS {
+				if rec.EndMS > seriesLatestEnd[series] {
+					seriesLatestEnd[series] = rec.EndMS
+				}
+			} else {
+				skewed[rec.MachineID] = true
+			}
 
 			if seriesMachines[series] == nil {
 				seriesMachines[series] = map[string]bool{}
@@ -325,6 +499,8 @@ func aggregateFleetPower(records []fleetPowerRecord, in fleetPowerInputs) FleetP
 			seriesSources[series][fleetPowerSourceLabel(domain, source)] = true
 			seriesEnergy[series] += mean * windowSeconds / 3_600_000 // W·s -> kWh
 			seriesObserved[series] += windowSeconds
+			seriesSamples[series] += int64(stats.Samples)
+			seriesExpected[series] += int64(rec.Expected)
 			reporting[rec.MachineID] = true
 
 			if rec.Bucket.GapBefore {
@@ -349,12 +525,14 @@ func aggregateFleetPower(records []fleetPowerRecord, in fleetPowerInputs) FleetP
 				EndUnixMS:   in.StartMS + int64(idx+1)*bucketMS,
 				Gap:         gapBuckets[domain][idx],
 			}
-			b.MeasuredWatts, b.MeasuredMachines = fleetPowerBucketSum(cells, domain, fleetPowerKindMeasured, idx)
-			b.EstimatedWatts, b.EstimatedMachines = fleetPowerBucketSum(cells, domain, fleetPowerKindEstimated, idx)
-			// A machine reporting both a measured and an estimated figure for
-			// the same domain in the same bucket would be double-counted by a
-			// naive sum of the two counts, so completeness is judged on the
-			// union of the machines, not on the counts.
+			b.MeasuredWatts, b.MeasuredMachines, b.MeasuredWindowSeconds = fleetPowerBucketSum(cells, domain, fleetPowerKindMeasured, idx)
+			b.EstimatedWatts, b.EstimatedMachines, b.EstimatedWindowSeconds = fleetPowerBucketSum(cells, domain, fleetPowerKindEstimated, idx)
+			_, b.UnknownMachines, _ = fleetPowerBucketSum(cells, domain, fleetPowerKindUnknown, idx)
+			// Presence is tracked, but it is NOT sufficient for Complete; see
+			// the assignment after this loop. A machine reporting both a
+			// measured and an estimated figure would be double-counted by a
+			// naive sum of the two counts, so presence is judged on the union
+			// of machines.
 			if fleetPowerBucketMachineCount(cells, domain, idx) < total {
 				complete = false
 			}
@@ -366,6 +544,21 @@ func aggregateFleetPower(records []fleetPowerRecord, in fleetPowerInputs) FleetP
 
 		measuredKey := fleetPowerSeriesKey{domain: domain, kind: fleetPowerKindMeasured}
 		estimatedKey := fleetPowerSeriesKey{domain: domain, kind: fleetPowerKindEstimated}
+		unknownKey := fleetPowerSeriesKey{domain: domain, kind: fleetPowerKindUnknown}
+
+		buildKind := func(key fleetPowerSeriesKey) FleetPowerKind {
+			return FleetPowerKind{
+				Machines:                   len(seriesMachines[key]),
+				EnergyKWh:                  seriesEnergy[key],
+				ObservedMachineSeconds:     seriesObserved[key],
+				ReportingWindowSeconds:     seriesObserved[key],
+				SampleCount:                seriesSamples[key],
+				ExpectedSampleCount:        seriesExpected[key],
+				LatestObservationEndUnixMS: seriesLatestEnd[key],
+				Sources:                    sortedCapped(seriesSources[key], fleetPowerMaxSourcesListed),
+			}
+		}
+
 		union := map[string]bool{}
 		for id := range seriesMachines[measuredKey] {
 			union[id] = true
@@ -373,24 +566,42 @@ func aggregateFleetPower(records []fleetPowerRecord, in fleetPowerInputs) FleetP
 		for id := range seriesMachines[estimatedKey] {
 			union[id] = true
 		}
+		for id := range seriesMachines[unknownKey] {
+			union[id] = true
+		}
 
 		domains = append(domains, FleetPowerDomain{
 			Domain:  domain,
 			Buckets: buckets,
-			Measured: FleetPowerKind{
-				Machines:               len(seriesMachines[measuredKey]),
-				EnergyKWh:              seriesEnergy[measuredKey],
-				ObservedMachineSeconds: seriesObserved[measuredKey],
-				Sources:                sortedCapped(seriesSources[measuredKey], fleetPowerMaxSourcesListed),
-			},
-			Estimated: FleetPowerKind{
-				Machines:               len(seriesMachines[estimatedKey]),
-				EnergyKWh:              seriesEnergy[estimatedKey],
-				ObservedMachineSeconds: seriesObserved[estimatedKey],
-				Sources:                sortedCapped(seriesSources[estimatedKey], fleetPowerMaxSourcesListed),
-			},
+			Measured:  buildKind(measuredKey),
+			Estimated: buildKind(estimatedKey),
+			Unknown:   buildKind(unknownKey),
 			ReportingMachines: len(union),
-			Complete:          complete && len(union) == total,
+			// Complete is reported FALSE unconditionally, and that is a
+			// deliberate, conservative choice rather than an oversight.
+			//
+			// What the stored data can support is "every machine contributed
+			// something to every bucket" (computed above as `complete`). What
+			// Complete was being read as is "this bucket is a full measurement
+			// of the fleet over its whole span", and nothing here can establish
+			// that:
+			//
+			//   - Summed window spans are not a coverage measure. Ingest
+			//     validates each span as positive and bounded; it does NOT
+			//     enforce that a machine's windows are non-overlapping across
+			//     streams, so spans can double-count.
+			//   - A window is binned by its END, so a [45s,75s) record credits
+			//     all 30 of its seconds to the bucket it ends in, including
+			//     time spent in the previous one.
+			//   - A window's mean comes from the reads that SUCCEEDED in it, so
+			//     even exact span coverage is not continuous measurement.
+			//
+			// Sample counts cannot rescue it either: backends sample at
+			// deliberately different cadences (IPMI slowly by design), so a low
+			// ratio is not evidence of a gap. Until observations carry their own
+			// measured duration, "complete" is not a claim this data can make.
+			AllMachinesContributed: complete && len(union) == total,
+			Complete:               false,
 		})
 	}
 
@@ -432,6 +643,7 @@ func aggregateFleetPower(records []fleetPowerRecord, in fleetPowerInputs) FleetP
 			DegradedMachines:  in.Degraded,
 			GapsDeclared:      in.GapsDeclared,
 			GapBuckets:        len(gapBucketIndices),
+			MachinesSkewed:    len(skewed),
 			Truncated:         in.Truncated,
 		},
 	}
@@ -465,23 +677,39 @@ func fleetPowerSourceLabel(domain, source string) string {
 	return fleetPowerSourceUnlabelled
 }
 
-// fleetPowerBucketSum sums each contributing machine's time-weighted mean for
-// one bucket. Summing means is legitimate — mean power over a common interval
-// is additive — in a way summing peaks is not, which is why no peak is emitted.
-func fleetPowerBucketSum(cells map[fleetPowerCellKey]*fleetPowerCell, domain, kind string, idx int) (*float64, int) {
-	var sum float64
+// fleetPowerBucketSum adds up each contributing machine's time-weighted mean for
+// one bucket, and reports how many machines contributed and the summed span of
+// the windows behind them.
+//
+// The result is a SUM OF REPORTED SAMPLE MEANS, not a fleet mean over a shared
+// interval. An earlier comment here justified the addition on the grounds that
+// "mean power over a common interval is additive". That is true, and it is not
+// what this computes: contributors' windows need not share an interval at all.
+// Two machines each reporting 100 W over opposite halves of a bucket produce
+// 200 W, which the fleet never drew at any instant.
+//
+// Summed peaks would be worse still, which is why no peak is emitted.
+//
+// windowSeconds is returned so a consumer can see the spans involved. It is a
+// sum of raw spans, NOT a deduplicated measure of time covered: ingest does not
+// enforce that a machine's windows are non-overlapping across streams, and a
+// window is binned by its end, so its span may include time spent in the
+// previous bucket. Do not render it as a percentage of the bucket observed.
+func fleetPowerBucketSum(cells map[fleetPowerCellKey]*fleetPowerCell, domain, kind string, idx int) (*float64, int, float64) {
+	var sum, windowSeconds float64
 	machines := 0
 	for key, cell := range cells {
 		if key.domain != domain || key.kind != kind || key.bucket != idx || cell.seconds <= 0 {
 			continue
 		}
 		sum += cell.wattSeconds / cell.seconds
+		windowSeconds += cell.seconds
 		machines++
 	}
 	if machines == 0 {
-		return nil, 0
+		return nil, 0, 0
 	}
-	return &sum, machines
+	return &sum, machines, windowSeconds
 }
 
 // fleetPowerBucketMachineCount counts DISTINCT machines behind a bucket across
@@ -546,9 +774,18 @@ func (s *Server) handleFleetPowerHistory(c echo.Context) error {
 
 	// Newest-first with a cap: if the cap bites, what is dropped is the oldest
 	// end of the window, never the current readings.
+	//
+	// The predicate is (startMS, endMS] and MUST match the interval rule the
+	// aggregator applies. A reading covers [start, end), so one ending exactly
+	// at endMS lies inside the requested window and one ending exactly at
+	// startMS lies entirely before it. The previous [startMS, endMS) predicate
+	// fetched the reading that ended before the window and dropped the most
+	// recently completed one, leaving the newest bucket permanently a reading
+	// short. Changing the aggregator alone would not have fixed that: rows the
+	// query never returns cannot be re-binned.
 	rows, err := s.db.Query(`SELECT machine_id, start_unix_ms, end_unix_ms, expected_samples, payload
 		FROM power_history_records
-		WHERE end_unix_ms >= ? AND end_unix_ms < ?
+		WHERE end_unix_ms > ? AND end_unix_ms <= ?
 		ORDER BY end_unix_ms DESC LIMIT ?`, startMS, endMS, maxRecords)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to query power history"})

--- a/hub/fleet_power_latest.go
+++ b/hub/fleet_power_latest.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/powerhistory"
+	"github.com/labstack/echo/v4"
+)
+
+// GET /api/fleet/power/current — what the fleet is drawing NOW.
+//
+// This exists because "now" cannot be read off the history endpoint, and trying
+// to do so was producing a confidently wrong number.
+//
+// The old approach walked backwards through the charted buckets and headlined
+// the last non-null one. That has three separate defects, and they compound:
+//
+//  1. It depends on the selected chart period. A 30m view buckets by the
+//     minute and a 24h view by fifteen, so the same fleet produced a different
+//     "current" figure — with different contributors behind it — depending on
+//     which tab the reader had clicked. A current reading whose meaning changes
+//     with the axis is not a current reading.
+//
+//  2. It reached arbitrarily far back. A fleet that went dark at 02:00 still
+//     headlined its last known value at noon, with no age beside it, because
+//     "the last non-null bucket" is always findable inside a 24-hour window.
+//
+//  3. It aged values against BUCKET edges. A bucket boundary is an axis
+//     coordinate; the final one sits in the future by up to a bucket width.
+//
+// So this endpoint answers the question directly, from raw per-machine windows:
+//
+//   - A FIXED lookback, independent of period and of the history record cap.
+//   - The NEWEST window per machine per domain, and no reaching further back:
+//     if a machine's latest window has no CPU reading, its CPU is unavailable.
+//     A domain that stopped reporting must go quiet, not resurrect an older
+//     value.
+//   - EACH CONTRIBUTOR gated individually against the shared freshness window.
+//     One machine still reporting cannot make five dark ones current: stale
+//     machines are excluded from the sum and counted separately, so a shrinking
+//     contributor count is visible rather than silently absorbed.
+//   - Only KNOWN kinds are summed. An unclassifiable backend is counted, never
+//     added.
+//
+// What it deliberately does NOT do: report energy or cost. Instantaneous power
+// says nothing about energy without durations — see fleet_power.go.
+
+// fleetPowerCurrentLookbackMS bounds how far back a "current" reading may come
+// from. It is fixed, so the answer never depends on the chart period. Five
+// agent windows allows for a missed report and hub aggregation lag without
+// reviving genuinely stale data.
+const fleetPowerCurrentLookbackMS = 150_000
+
+// fleetPowerCurrentSeries is one domain/kind sum at this instant.
+type fleetPowerCurrentSeries struct {
+	// Watts is the sum of the fresh contributors' latest means. It is a SUM OF
+	// PER-MACHINE MEANS, not an instantaneous fleet measurement: each machine's
+	// newest window is its own 30s mean, and those windows are not synchronised
+	// across machines. Nil when no contributor is fresh — never 0.
+	Watts *float64 `json:"watts"`
+	// Machines is how many machines are behind Watts.
+	Machines int `json:"machines"`
+	// Sources names the backends contributing, so the figure can say what
+	// measured it.
+	Sources []string `json:"sources"`
+	// OldestContributorEndUnixMS is the oldest window end among the
+	// contributors. The sum is only as current as this.
+	OldestContributorEndUnixMS int64 `json:"oldest_contributor_end_unix_ms"`
+	// NewestContributorEndUnixMS is the newest, for reference only. It must not
+	// be used to age the sum: that is what let one fresh machine speak for a
+	// dark fleet.
+	NewestContributorEndUnixMS int64 `json:"newest_contributor_end_unix_ms"`
+}
+
+// fleetPowerCurrentDomain carries one domain's series plus why machines are
+// missing from them.
+type fleetPowerCurrentDomain struct {
+	Domain    string                  `json:"domain"`
+	Measured  fleetPowerCurrentSeries `json:"measured"`
+	Estimated fleetPowerCurrentSeries `json:"estimated"`
+	// UnknownMachines had a reading whose backend could not be classified. Their
+	// watts are excluded from both series; the count keeps that visible.
+	UnknownMachines int `json:"unknown_machines"`
+	// StaleMachines reported this domain, but not recently enough to count.
+	// Their last value is deliberately NOT carried forward.
+	StaleMachines int `json:"stale_machines"`
+	// UnreadableMachines had a newest row that could not be parsed or failed
+	// validation. They are unavailable rather than replaced by an older row.
+	UnreadableMachines int `json:"unreadable_machines"`
+	// SkewedMachines stamped a window implausibly ahead of the hub clock, so
+	// their age is unknown and they cannot qualify as current.
+	SkewedMachines int `json:"skewed_machines"`
+}
+
+type fleetPowerCurrent struct {
+	GeneratedUnixMS int64 `json:"generated_unix_ms"`
+	// LookbackMS is the fixed window this answer was drawn from, stated so a
+	// client need not assume it.
+	LookbackMS int64                     `json:"lookback_ms"`
+	Domains    []fleetPowerCurrentDomain `json:"domains"`
+	// MachinesTotal / MachinesReporting describe coverage of the whole fleet, so
+	// a sum over two of nine machines cannot read as a fleet total.
+	// MachinesReporting counts machines that contributed a FRESH, VALID,
+	// classifiable reading — not machines that merely have a row on disk.
+	MachinesTotal     int `json:"machines_total"`
+	MachinesReporting int `json:"machines_reporting"`
+	// MachinesUnreadable had a newest stored row that could not be decoded.
+	MachinesUnreadable int `json:"machines_unreadable"`
+}
+
+// currentAcc accumulates one domain/kind while scanning machines.
+type currentAcc struct {
+	sum      float64
+	machines int
+	sources  map[string]bool
+	oldest   int64
+	newest   int64
+}
+
+func (a *currentAcc) add(watts float64, source string, endMS int64) {
+	a.sum += watts
+	a.machines++
+	if a.sources == nil {
+		a.sources = map[string]bool{}
+	}
+	a.sources[source] = true
+	if a.oldest == 0 || endMS < a.oldest {
+		a.oldest = endMS
+	}
+	if endMS > a.newest {
+		a.newest = endMS
+	}
+}
+
+func (a *currentAcc) series() fleetPowerCurrentSeries {
+	s := fleetPowerCurrentSeries{
+		Machines:                   a.machines,
+		Sources:                    sortedCapped(a.sources, fleetPowerMaxSourcesListed),
+		OldestContributorEndUnixMS: a.oldest,
+		NewestContributorEndUnixMS: a.newest,
+	}
+	// Nil, never zero: no fresh contributor is "we cannot say", not "0 watts".
+	if a.machines > 0 {
+		sum := a.sum
+		s.Watts = &sum
+	}
+	return s
+}
+
+func (s *Server) handleFleetPowerCurrent(c echo.Context) error {
+	now := time.Now().UnixMilli()
+
+	machineIDs, err := s.fleetPowerMachineIDs()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to query machines"})
+	}
+
+	// Selection order matters, and getting it wrong is how a current reading
+	// quietly becomes a historic one.
+	//
+	// The row chosen per machine is its LATEST STORED ROW, full stop — not its
+	// latest row that happens to be fresh and valid. Filtering candidates
+	// before choosing would mean a machine whose newest window is stale, or
+	// future-skewed, or corrupt, would silently fall through to an OLDER window
+	// and present that as current. It would also make the stale and skew counts
+	// unreachable, since nothing that qualifies for them would survive the
+	// filter to be counted.
+	//
+	// So: pick the newest row first, then classify it. A machine whose newest
+	// row does not qualify contributes a REASON, never a number.
+	//
+	// The query is one indexed seek per registered machine. The index is
+	// (machine_id, end_unix_ms), so each is a descending index read of a single
+	// row, and iterating registered machines also bounds the work by the fleet
+	// — orphaned rows for a deleted machine can never inflate the denominator.
+	type latest struct {
+		endMS    int64
+		expected int
+		bucket   powerhistory.Bucket
+		corrupt  bool
+	}
+	newest := map[string]*latest{}
+	machinesUnreadable := 0
+
+	for _, id := range machineIDs {
+		var startMS, endMS int64
+		var expected int
+		var payload string
+		// The id tie-break keeps the choice deterministic when two rows share
+		// an end timestamp.
+		row := s.db.QueryRow(`SELECT start_unix_ms, end_unix_ms, expected_samples, payload
+			FROM power_history_records
+			WHERE machine_id = ?
+			ORDER BY end_unix_ms DESC, id DESC
+			LIMIT 1`, id)
+		if err := row.Scan(&startMS, &endMS, &expected, &payload); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue // this machine genuinely has no power history
+			}
+			// Any other error is a QUERY FAILURE, not an absence of data.
+			// Swallowing it here would turn a broken read into a confident
+			// "0 machines reporting" — a number nothing verified, presented as
+			// fact. Fail loudly instead.
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to query power history"})
+		}
+		var bk powerhistory.Bucket
+		if err := json.Unmarshal([]byte(payload), &bk); err != nil {
+			// A corrupt newest row makes this machine UNAVAILABLE. Falling back
+			// to an older row would answer "what is it drawing now" with a
+			// reading it has already superseded.
+			newest[id] = &latest{endMS: endMS, corrupt: true}
+			machinesUnreadable++
+			continue
+		}
+		newest[id] = &latest{endMS: endMS, expected: expected, bucket: bk}
+	}
+
+	out := fleetPowerCurrent{
+		GeneratedUnixMS:    now,
+		LookbackMS:         fleetPowerCurrentLookbackMS,
+		MachinesTotal:      len(machineIDs),
+		MachinesUnreadable: machinesUnreadable,
+		Domains:            make([]fleetPowerCurrentDomain, 0, len(fleetPowerDomains)),
+	}
+
+	// A machine counts as reporting when it contributed at least one fresh,
+	// valid, classifiable reading in ANY domain — not merely when a row for it
+	// exists.
+	contributing := map[string]bool{}
+
+	for _, domain := range fleetPowerDomains {
+		d := fleetPowerCurrentDomain{Domain: domain}
+		var measured, estimated currentAcc
+
+		for id, rec := range newest {
+			if rec.corrupt {
+				d.UnreadableMachines++
+				continue
+			}
+			stats, source, maxWatts := fleetPowerDomainStats(&rec.bucket, domain)
+			if stats == nil || stats.Samples <= 0 || stats.MeanWatts == nil {
+				continue // not reporting this domain in its newest window
+			}
+
+			// Freshness is judged BEFORE validity so a stale machine is counted
+			// as stale rather than disappearing.
+			if rec.endMS > now+fleetPowerFutureSkewToleranceMS {
+				d.SkewedMachines++
+				continue
+			}
+			if now-rec.endMS > fleetPowerCurrentLookbackMS {
+				d.StaleMachines++
+				continue
+			}
+			if err := validPowerStats(stats, rec.expected, maxWatts); err != nil {
+				d.UnreadableMachines++
+				continue
+			}
+
+			label := fleetPowerSourceLabel(domain, source)
+			switch fleetPowerClassify(domain, source) {
+			case fleetPowerKindMeasured:
+				measured.add(*stats.MeanWatts, label, rec.endMS)
+				contributing[id] = true
+			case fleetPowerKindEstimated:
+				estimated.add(*stats.MeanWatts, label, rec.endMS)
+				contributing[id] = true
+			default:
+				d.UnknownMachines++
+			}
+		}
+
+		d.Measured = measured.series()
+		d.Estimated = estimated.series()
+		out.Domains = append(out.Domains, d)
+	}
+
+	out.MachinesReporting = len(contributing)
+	return c.JSON(http.StatusOK, out)
+}

--- a/hub/fleet_power_latest_test.go
+++ b/hub/fleet_power_latest_test.go
@@ -1,0 +1,388 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/powerhistory"
+)
+
+func fpCurrent(t *testing.T, e interface {
+	ServeHTTP(http.ResponseWriter, *http.Request)
+}, token string) fleetPowerCurrent {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/power/current", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET current: %d %s", rec.Code, rec.Body.String())
+	}
+	var out fleetPowerCurrent
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v (%s)", err, rec.Body.String())
+	}
+	return out
+}
+
+func fpCurrentDomain(t *testing.T, out fleetPowerCurrent, domain string) fleetPowerCurrentDomain {
+	t.Helper()
+	for _, d := range out.Domains {
+		if d.Domain == domain {
+			return d
+		}
+	}
+	t.Fatalf("domain %q missing from current response", domain)
+	return fleetPowerCurrentDomain{}
+}
+
+// The defect this endpoint exists to remove: a stale machine must not be
+// carried into a current reading by a fresh one standing beside it.
+func TestFleetPowerCurrentExcludesStaleMachinesFromTheSum(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	for _, id := range []string{"fresh", "dark"} {
+		s.seedTestMachine(t, id)
+	}
+
+	now := time.Now().UnixMilli()
+	insertFleetPowerRow(t, s, "fresh", 1, now-30_000, now, fpSystem(100, powerhistory.SourceRAPLPsys))
+	// Reported four hours ago and has said nothing since.
+	old := now - 4*3_600_000
+	insertFleetPowerRow(t, s, "dark", 1, old-30_000, old, fpSystem(900, powerhistory.SourceRAPLPsys))
+
+	system := fpCurrentDomain(t, fpCurrent(t, e, token), powerhistory.DomainSystem)
+	if system.Measured.Watts == nil {
+		t.Fatal("the fresh machine should still produce a current reading")
+	}
+	if got := *system.Measured.Watts; got != 100 {
+		t.Fatalf("watts = %v, want 100 — the dark machine's 900 W must not be carried forward", got)
+	}
+	if system.Measured.Machines != 1 {
+		t.Fatalf("machines = %d, want 1", system.Measured.Machines)
+	}
+}
+
+// Nothing fresh anywhere is UNAVAILABLE, not zero. A fleet that went dark did
+// not start drawing no power.
+func TestFleetPowerCurrentIsUnavailableNotZeroWhenAllStale(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	s.seedTestMachine(t, "dark")
+
+	old := time.Now().UnixMilli() - 4*3_600_000
+	insertFleetPowerRow(t, s, "dark", 1, old-30_000, old, fpSystem(900, powerhistory.SourceRAPLPsys))
+
+	system := fpCurrentDomain(t, fpCurrent(t, e, token), powerhistory.DomainSystem)
+	if system.Measured.Watts != nil {
+		t.Fatalf("a dark fleet reported %v W as current", *system.Measured.Watts)
+	}
+	if system.Measured.Machines != 0 {
+		t.Fatalf("machines = %d, want 0", system.Measured.Machines)
+	}
+}
+
+// The current answer must not change with the history period, because it is not
+// drawn from the history window at all.
+func TestFleetPowerCurrentIsIndependentOfHistoryPeriod(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	s.seedTestMachine(t, "m1")
+
+	now := time.Now().UnixMilli()
+	insertFleetPowerRow(t, s, "m1", 1, now-30_000, now, fpSystem(142, powerhistory.SourceRAPLPsys))
+
+	base := fpCurrentDomain(t, fpCurrent(t, e, token), powerhistory.DomainSystem)
+	if base.Measured.Watts == nil {
+		t.Fatal("expected a current reading")
+	}
+
+	// Ask the history endpoint for every period in turn; the current endpoint's
+	// answer must be unmoved by any of it.
+	for _, period := range []string{"30m", "1h", "6h", "24h"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/fleet/power/history?period="+period, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("history %s: %d", period, rec.Code)
+		}
+
+		again := fpCurrentDomain(t, fpCurrent(t, e, token), powerhistory.DomainSystem)
+		if again.Measured.Watts == nil {
+			t.Fatalf("current went nil after asking history for %s", period)
+		}
+		if *again.Measured.Watts != *base.Measured.Watts {
+			t.Fatalf("period %s changed the current reading: %v then %v",
+				period, *base.Measured.Watts, *again.Measured.Watts)
+		}
+		if again.Measured.Machines != base.Measured.Machines {
+			t.Fatalf("period %s changed the contributor count", period)
+		}
+	}
+}
+
+// Measured and modelled are reported side by side and never added.
+func TestFleetPowerCurrentKeepsModelledSeparate(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	for _, id := range []string{"measured", "modelled"} {
+		s.seedTestMachine(t, id)
+	}
+
+	now := time.Now().UnixMilli()
+	insertFleetPowerRow(t, s, "measured", 1, now-30_000, now, fpSystem(142, powerhistory.SourceRAPLPsys))
+	insertFleetPowerRow(t, s, "modelled", 1, now-30_000, now, fpSystem(12, powerhistory.SourceEstimateUtil))
+
+	system := fpCurrentDomain(t, fpCurrent(t, e, token), powerhistory.DomainSystem)
+	if system.Measured.Watts == nil || *system.Measured.Watts != 142 {
+		t.Fatalf("measured = %v, want 142", system.Measured.Watts)
+	}
+	if system.Estimated.Watts == nil || *system.Estimated.Watts != 12 {
+		t.Fatalf("estimated = %v, want 12", system.Estimated.Watts)
+	}
+	// 154 must appear nowhere: the two are different kinds of claim.
+	if system.Measured.Machines != 1 || system.Estimated.Machines != 1 {
+		t.Fatalf("machines measured=%d estimated=%d, want 1/1",
+			system.Measured.Machines, system.Estimated.Machines)
+	}
+}
+
+// A domain absent from a machine's latest window is unavailable for that
+// machine. Reaching back to a previous window would revive a reading the
+// machine has stopped producing.
+func TestFleetPowerCurrentDoesNotReviveADomainTheLatestWindowLacks(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	s.seedTestMachine(t, "m1")
+
+	now := time.Now().UnixMilli()
+	// Older window HAS system power; the newest window does not.
+	insertFleetPowerRow(t, s, "m1", 1, now-90_000, now-60_000, fpSystem(500, powerhistory.SourceRAPLPsys))
+	insertFleetPowerRow(t, s, "m1", 2, now-30_000, now, powerhistory.Bucket{
+		CPU: fpStats(40, 40, 30),
+	})
+
+	out := fpCurrent(t, e, token)
+	system := fpCurrentDomain(t, out, powerhistory.DomainSystem)
+	if system.Measured.Watts != nil {
+		t.Fatalf("system revived a stopped reading: %v W", *system.Measured.Watts)
+	}
+	cpu := fpCurrentDomain(t, out, powerhistory.DomainCPU)
+	if cpu.Measured.Watts == nil || *cpu.Measured.Watts != 40 {
+		t.Fatalf("cpu = %v, want 40 — the domain the latest window does carry", cpu.Measured.Watts)
+	}
+}
+
+// Unknown provenance is counted, never summed.
+func TestFleetPowerCurrentCountsUnknownProvenanceWithoutSummingIt(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	s.seedTestMachine(t, "m1")
+
+	now := time.Now().UnixMilli()
+	insertFleetPowerRow(t, s, "m1", 1, now-30_000, now, fpSystem(77, "some-future-backend"))
+
+	system := fpCurrentDomain(t, fpCurrent(t, e, token), powerhistory.DomainSystem)
+	if system.Measured.Watts != nil || system.Estimated.Watts != nil {
+		t.Fatal("an unclassifiable backend was summed into a series")
+	}
+	if system.UnknownMachines != 1 {
+		t.Fatalf("UnknownMachines = %d, want 1", system.UnknownMachines)
+	}
+}
+
+// The sum is only as current as its OLDEST contributor, and says so.
+func TestFleetPowerCurrentReportsOldestContributor(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	for _, id := range []string{"a", "b"} {
+		s.seedTestMachine(t, id)
+	}
+
+	now := time.Now().UnixMilli()
+	insertFleetPowerRow(t, s, "a", 1, now-30_000, now, fpSystem(100, powerhistory.SourceRAPLPsys))
+	older := now - 100_000 // still inside the lookback, but not the newest
+	insertFleetPowerRow(t, s, "b", 1, older-30_000, older, fpSystem(50, powerhistory.SourceRAPLPsys))
+
+	system := fpCurrentDomain(t, fpCurrent(t, e, token), powerhistory.DomainSystem)
+	if system.Measured.Machines != 2 {
+		t.Fatalf("machines = %d, want 2 — both are inside the lookback", system.Measured.Machines)
+	}
+	if system.Measured.OldestContributorEndUnixMS != older {
+		t.Fatalf("oldest = %d, want %d", system.Measured.OldestContributorEndUnixMS, older)
+	}
+	if system.Measured.NewestContributorEndUnixMS != now {
+		t.Fatalf("newest = %d, want %d", system.Measured.NewestContributorEndUnixMS, now)
+	}
+}
+
+// The data-selection trap: a machine's NEWEST row is future-skewed while an
+// older row looks perfectly fresh. Choosing candidates before classifying would
+// pick the older row and present a superseded reading as current.
+func TestFleetPowerCurrentDoesNotFallBackPastASkewedNewestRow(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	s.seedTestMachine(t, "m1")
+
+	now := time.Now().UnixMilli()
+	// An older, entirely plausible reading.
+	insertFleetPowerRow(t, s, "m1", 1, now-60_000, now-30_000, fpSystem(100, powerhistory.SourceRAPLPsys))
+	// The newest row is stamped well ahead of the hub clock.
+	future := now + 600_000
+	insertFleetPowerRow(t, s, "m1", 2, future-30_000, future, fpSystem(900, powerhistory.SourceRAPLPsys))
+
+	system := fpCurrentDomain(t, fpCurrent(t, e, token), powerhistory.DomainSystem)
+	if system.Measured.Watts != nil {
+		t.Fatalf("fell back past a skewed newest row and reported %v W", *system.Measured.Watts)
+	}
+	if system.SkewedMachines != 1 {
+		t.Fatalf("SkewedMachines = %d, want 1 — the skew must be counted, not filtered away", system.SkewedMachines)
+	}
+}
+
+// A machine whose only history is stale must be COUNTED as stale, not vanish.
+func TestFleetPowerCurrentCountsAStaleOnlyMachine(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	s.seedTestMachine(t, "m1")
+
+	old := time.Now().UnixMilli() - 3_600_000
+	insertFleetPowerRow(t, s, "m1", 1, old-30_000, old, fpSystem(100, powerhistory.SourceRAPLPsys))
+
+	out := fpCurrent(t, e, token)
+	system := fpCurrentDomain(t, out, powerhistory.DomainSystem)
+	if system.StaleMachines != 1 {
+		t.Fatalf("StaleMachines = %d, want 1", system.StaleMachines)
+	}
+	if system.Measured.Watts != nil {
+		t.Fatal("a stale-only machine must contribute no watts")
+	}
+	if out.MachinesReporting != 0 {
+		t.Fatalf("MachinesReporting = %d, want 0 — a row on disk is not a report", out.MachinesReporting)
+	}
+}
+
+// MachinesReporting counts fresh valid classifiable readings, so a machine whose
+// only reading is unclassifiable is not counted as reporting.
+func TestFleetPowerCurrentUnknownOnlyMachineIsNotReporting(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	s.seedTestMachine(t, "m1")
+
+	now := time.Now().UnixMilli()
+	insertFleetPowerRow(t, s, "m1", 1, now-30_000, now, fpSystem(77, "some-future-backend"))
+
+	out := fpCurrent(t, e, token)
+	system := fpCurrentDomain(t, out, powerhistory.DomainSystem)
+	if system.UnknownMachines != 1 {
+		t.Fatalf("UnknownMachines = %d, want 1", system.UnknownMachines)
+	}
+	if out.MachinesReporting != 0 {
+		t.Fatalf("MachinesReporting = %d, want 0 — unclassified is not a reading", out.MachinesReporting)
+	}
+}
+
+// A corrupt newest row makes the machine unavailable. It must NOT quietly fall
+// back to an older row, which would answer "now" with superseded data.
+func TestFleetPowerCurrentCorruptNewestRowIsUnavailableNotAFallback(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	s.seedTestMachine(t, "m1")
+
+	now := time.Now().UnixMilli()
+	insertFleetPowerRow(t, s, "m1", 1, now-60_000, now-30_000, fpSystem(100, powerhistory.SourceRAPLPsys))
+	if _, err := s.db.Exec(`INSERT INTO power_history_records
+		(machine_id, stream_id, seq, start_unix_ms, end_unix_ms, expected_samples, payload)
+		VALUES (?, 'stream-1', ?, ?, ?, 30, ?)`,
+		"m1", 2, now-30_000, now, "{not valid json"); err != nil {
+		t.Fatalf("insert corrupt row: %v", err)
+	}
+
+	out := fpCurrent(t, e, token)
+	system := fpCurrentDomain(t, out, powerhistory.DomainSystem)
+	if system.Measured.Watts != nil {
+		t.Fatalf("a corrupt newest row revived an older reading: %v W", *system.Measured.Watts)
+	}
+	if out.MachinesUnreadable != 1 {
+		t.Fatalf("MachinesUnreadable = %d, want 1", out.MachinesUnreadable)
+	}
+	if out.MachinesReporting != 0 {
+		t.Fatalf("MachinesReporting = %d, want 0", out.MachinesReporting)
+	}
+}
+
+// Orphaned rows for a machine no longer registered must not appear at all.
+func TestFleetPowerCurrentIgnoresOrphanedRecords(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	s.seedTestMachine(t, "registered")
+
+	now := time.Now().UnixMilli()
+	insertFleetPowerRow(t, s, "registered", 1, now-30_000, now, fpSystem(100, powerhistory.SourceRAPLPsys))
+
+	out := fpCurrent(t, e, token)
+	if out.MachinesTotal != 1 {
+		t.Fatalf("MachinesTotal = %d, want 1", out.MachinesTotal)
+	}
+	if out.MachinesReporting != 1 {
+		t.Fatalf("MachinesReporting = %d, want 1", out.MachinesReporting)
+	}
+	if out.MachinesReporting > out.MachinesTotal {
+		t.Fatal("reporting exceeded the fleet size")
+	}
+}
+
+// A broken read must not become a confident "nothing is reporting". This is the
+// alert-count defect in another costume: a failed query rendered as a number.
+func TestFleetPowerCurrentFailsLoudlyWhenTheQueryBreaks(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+	token := loginAndGetToken(t, e)
+	s.seedTestMachine(t, "m1")
+
+	// The machines table stays readable; the power history does not.
+	if _, err := s.db.Exec(`DROP TABLE power_history_records`); err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/power/current", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Fatalf("a failed power query returned 200 and a snapshot: %s", rec.Body.String())
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+// Reading fleet power requires fleet.read like every other power route.
+func TestFleetPowerCurrentRequiresAuth(t *testing.T) {
+	e, s := setupTestServer(t)
+	s.markCredentialsRotated(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/power/current", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated GET: %d, want 401", rec.Code)
+	}
+}

--- a/hub/fleet_power_test.go
+++ b/hub/fleet_power_test.go
@@ -208,34 +208,72 @@ func TestFleetPowerCoverageCountsSilentMachines(t *testing.T) {
 }
 
 // Complete is the fleet-scale gpuPowerComplete: every machine, every bucket.
-func TestFleetPowerCompleteRequiresEveryMachineInEveryBucket(t *testing.T) {
+func TestFleetPowerReportsPresenceSeparatelyFromCompleteness(t *testing.T) {
 	start := int64(1_700_000_000_000)
 	full := []fleetPowerRecord{
 		fpRecord("m1", start+30_000, fpSystem(100, powerhistory.SourceRAPLPsys)),
 		fpRecord("m2", start+30_000, fpSystem(50, powerhistory.SourceRAPLPsys)),
+		fpRecord("m1", start+60_000, fpSystem(100, powerhistory.SourceRAPLPsys)),
+		fpRecord("m2", start+60_000, fpSystem(50, powerhistory.SourceRAPLPsys)),
 		fpRecord("m1", start+90_000, fpSystem(110, powerhistory.SourceRAPLPsys)),
 		fpRecord("m2", start+90_000, fpSystem(55, powerhistory.SourceRAPLPsys)),
+		fpRecord("m1", start+120_000, fpSystem(110, powerhistory.SourceRAPLPsys)),
+		fpRecord("m2", start+120_000, fpSystem(55, powerhistory.SourceRAPLPsys)),
 	}
-	hist := aggregateFleetPower(full, fpInputs([]string{"m1", "m2"}, start, 2))
-	if !fpDomain(t, hist, powerhistory.DomainSystem).Complete {
-		t.Fatal("every machine reported in every bucket; Complete must be true")
+	system := fpDomain(t, aggregateFleetPower(full, fpInputs([]string{"m1", "m2"}, start, 2)), powerhistory.DomainSystem)
+	if !system.AllMachinesContributed {
+		t.Fatal("every machine reported in every bucket; AllMachinesContributed must be true")
+	}
+	// Presence is not measurement coverage, and Complete must never imply it.
+	if system.Complete {
+		t.Fatal("Complete must stay false: stored windows cannot establish full measurement")
 	}
 
-	// Drop m2 from the second bucket — a machine that joined or dropped out
-	// mid-window. The series is still returned, but not as a fleet total.
-	partial := full[:3]
-	hist = aggregateFleetPower(partial, fpInputs([]string{"m1", "m2"}, start, 2))
-	system := fpDomain(t, hist, powerhistory.DomainSystem)
-	if system.Complete {
-		t.Fatal("a machine missing from one bucket must clear Complete")
+	// Drop m2 from the second bucket — a machine that joined or dropped out.
+	partial := []fleetPowerRecord{full[0], full[1], full[2], full[3], full[4], full[6]}
+	system = fpDomain(t, aggregateFleetPower(partial, fpInputs([]string{"m1", "m2"}, start, 2)), powerhistory.DomainSystem)
+	if system.AllMachinesContributed {
+		t.Fatal("a machine missing from one bucket must clear AllMachinesContributed")
 	}
 	if system.Buckets[1].MeasuredMachines != 1 {
 		t.Fatalf("bucket 1 machines = %d, want 1", system.Buckets[1].MeasuredMachines)
 	}
 	fpWatts(t, system.Buckets[1].MeasuredWatts, 110)
-	// The window roll-up still counts both machines: m2 reported somewhere.
 	if system.Measured.Machines != 2 {
 		t.Fatalf("window machines = %d, want 2", system.Measured.Machines)
+	}
+}
+
+// The adversarial case for any span-based coverage rule: two adjacent 30s
+// windows fill a 60s bucket by SPAN while between them carrying two successful
+// reads out of sixty. A rule that counted summed spans would call this complete
+// measurement of the minute. Complete must stay false.
+//
+// Sample ratios cannot be used to rescue such a rule either: backends sample at
+// deliberately different cadences, so a low ratio is not evidence of a gap.
+func TestFleetPowerFullSpanWithAlmostNoSamplesIsNotComplete(t *testing.T) {
+	start := int64(1_700_000_000_000)
+	first := fpSystem(300, powerhistory.SourceRAPLPsys)
+	first.System.Samples = 1
+	second := fpSystem(300, powerhistory.SourceRAPLPsys)
+	second.System.Samples = 1
+	records := []fleetPowerRecord{
+		fpRecord("m1", start+30_000, first),  // covers [0s,30s)
+		fpRecord("m1", start+60_000, second), // covers [30s,60s)
+	}
+	system := fpDomain(t, aggregateFleetPower(records, fpInputs([]string{"m1"}, start, 1)), powerhistory.DomainSystem)
+
+	if got := system.Buckets[0].MeasuredWindowSeconds; got != 60 {
+		t.Fatalf("MeasuredWindowSeconds = %v, want 60 — the span really is filled", got)
+	}
+	if system.Complete {
+		t.Fatal("60s of span built from 2 successful reads out of 60 is not complete measurement")
+	}
+	if got := system.Measured.SampleCount; got != 2 {
+		t.Fatalf("SampleCount = %d, want 2", got)
+	}
+	if got := system.Measured.ExpectedSampleCount; got != 60 {
+		t.Fatalf("ExpectedSampleCount = %d, want 60", got)
 	}
 }
 
@@ -270,9 +308,12 @@ func TestFleetPowerEmptyBucketIsNilNotZero(t *testing.T) {
 // bucket, which would spike the first or last point.
 func TestFleetPowerIgnoresReadingsOutsideWindow(t *testing.T) {
 	start := int64(1_700_000_000_000)
+	// Two 60s buckets: the request covers [start, start+120s).
 	records := []fleetPowerRecord{
-		fpRecord("m1", start-30_000, fpSystem(999, powerhistory.SourceRAPLPsys)),
-		fpRecord("m1", start+120_000, fpSystem(999, powerhistory.SourceRAPLPsys)),
+		// Ends AT the window start, so it covers [-30s, 0s) — entirely before.
+		fpRecord("m1", start, fpSystem(999, powerhistory.SourceRAPLPsys)),
+		// Ends beyond the window end, so it covers [120s, 150s) — entirely after.
+		fpRecord("m1", start+150_000, fpSystem(999, powerhistory.SourceRAPLPsys)),
 		fpRecord("m1", start+30_000, fpSystem(100, powerhistory.SourceRAPLPsys)),
 	}
 	hist := aggregateFleetPower(records, fpInputs([]string{"m1"}, start, 2))
@@ -280,6 +321,185 @@ func TestFleetPowerIgnoresReadingsOutsideWindow(t *testing.T) {
 	fpWatts(t, system.Buckets[0].MeasuredWatts, 100)
 	if system.Buckets[1].MeasuredWatts != nil {
 		t.Fatalf("out-of-window reading leaked into bucket 1: %v", *system.Buckets[1].MeasuredWatts)
+	}
+}
+
+// A window ending exactly on the requested end covers [90s, 120s), which is
+// INSIDE a [0s, 120s) request. Excluding it — as an end-exclusive comparison on
+// the end timestamp did — silently dropped the most recently completed window
+// from every response, so the newest bucket was always one reading short.
+func TestFleetPowerKeepsWindowEndingExactlyAtRequestEnd(t *testing.T) {
+	start := int64(1_700_000_000_000)
+	records := []fleetPowerRecord{
+		fpRecord("m1", start+120_000, fpSystem(100, powerhistory.SourceRAPLPsys)),
+	}
+	hist := aggregateFleetPower(records, fpInputs([]string{"m1"}, start, 2))
+	system := fpDomain(t, hist, powerhistory.DomainSystem)
+	if system.Buckets[1].MeasuredWatts == nil {
+		t.Fatal("a window ending exactly at the request end is inside it and must be kept")
+	}
+	fpWatts(t, system.Buckets[1].MeasuredWatts, 100)
+}
+
+// --- provenance classification ---
+
+// An unrecognised backend must NOT be promoted to measured. The old rule was
+// "estimated if IsEstimatedSource, else measured", so a future modelled backend
+// reaching an older hub would have been presented as a counter reading.
+func TestFleetPowerUnknownSourceIsNeitherMeasuredNorEstimated(t *testing.T) {
+	start := int64(1_700_000_000_000)
+	records := []fleetPowerRecord{
+		fpRecord("m1", start+30_000, fpSystem(100, "some-future-model-backend")),
+	}
+	hist := aggregateFleetPower(records, fpInputs([]string{"m1"}, start, 1))
+	system := fpDomain(t, hist, powerhistory.DomainSystem)
+
+	if system.Buckets[0].MeasuredWatts != nil {
+		t.Fatalf("unknown provenance was summed as measured: %v", *system.Buckets[0].MeasuredWatts)
+	}
+	if system.Buckets[0].EstimatedWatts != nil {
+		t.Fatalf("unknown provenance was summed as modelled: %v", *system.Buckets[0].EstimatedWatts)
+	}
+	if system.Buckets[0].UnknownMachines != 1 {
+		t.Fatalf("UnknownMachines = %d, want 1 — the omission must be visible", system.Buckets[0].UnknownMachines)
+	}
+	if system.Unknown.Machines != 1 {
+		t.Fatalf("Unknown.Machines = %d, want 1", system.Unknown.Machines)
+	}
+}
+
+// Agents predating source labelling emit no label, and what those builds
+// measured was RAPL. Reclassifying them would blank working history.
+func TestFleetPowerUnlabelledLegacyReadingStaysMeasured(t *testing.T) {
+	start := int64(1_700_000_000_000)
+	records := []fleetPowerRecord{fpRecord("m1", start+30_000, fpSystem(100, ""))}
+	hist := aggregateFleetPower(records, fpInputs([]string{"m1"}, start, 1))
+	system := fpDomain(t, hist, powerhistory.DomainSystem)
+	if system.Buckets[0].MeasuredWatts == nil {
+		t.Fatal("a legacy unlabelled reading must remain measured")
+	}
+	fpWatts(t, system.Buckets[0].MeasuredWatts, 100)
+}
+
+// hwmon backends name the chip they found, so the identifier is open-ended and
+// cannot be enumerated. They are measurements.
+func TestFleetPowerHwmonPrefixIsMeasured(t *testing.T) {
+	start := int64(1_700_000_000_000)
+	records := []fleetPowerRecord{
+		fpRecord("m1", start+30_000, fpSystem(100, powerhistory.SourceHwmonPrefix+"ina226")),
+	}
+	hist := aggregateFleetPower(records, fpInputs([]string{"m1"}, start, 1))
+	system := fpDomain(t, hist, powerhistory.DomainSystem)
+	if system.Buckets[0].MeasuredWatts == nil {
+		t.Fatal("an hwmon chip reading is a measurement")
+	}
+}
+
+// --- sampled coverage ---
+
+// One successful read in a 30s window must not be presented as 30 seconds of
+// observation. The span is reported as a span; how much was read is reported
+// separately, and the two are never conflated.
+func TestFleetPowerDisclosesSampleCoverageForPartiallyReadWindow(t *testing.T) {
+	start := int64(1_700_000_000_000)
+	bk := fpSystem(300, powerhistory.SourceRAPLPsys)
+	bk.System.Samples = 1 // 1 success out of 30 expected
+	records := []fleetPowerRecord{fpRecord("m1", start+30_000, bk)}
+	hist := aggregateFleetPower(records, fpInputs([]string{"m1"}, start, 1))
+	system := fpDomain(t, hist, powerhistory.DomainSystem)
+
+	if got := system.Measured.SampleCount; got != 1 {
+		t.Fatalf("SampleCount = %d, want 1", got)
+	}
+	if got := system.Measured.ExpectedSampleCount; got != 30 {
+		t.Fatalf("ExpectedSampleCount = %d, want 30", got)
+	}
+	// The span is 30s and is reported as such — but it is a span, not evidence
+	// of 30 seconds observed, and the sample counts are what say so.
+	if got := system.Measured.ReportingWindowSeconds; got != 30 {
+		t.Fatalf("ReportingWindowSeconds = %v, want 30", got)
+	}
+	if system.Complete {
+		t.Fatal("a single sample cannot make a bucket complete")
+	}
+}
+
+// Freshness must come from the agent's own window end, not a chart bin edge.
+func TestFleetPowerReportsLatestObservationEnd(t *testing.T) {
+	start := int64(1_700_000_000_000)
+	in := fpInputs([]string{"m1"}, start, 2)
+	in.Now = start + 120_000
+	records := []fleetPowerRecord{
+		fpRecord("m1", start+30_000, fpSystem(100, powerhistory.SourceRAPLPsys)),
+		fpRecord("m1", start+60_000, fpSystem(100, powerhistory.SourceRAPLPsys)),
+	}
+	hist := aggregateFleetPower(records, in)
+	system := fpDomain(t, hist, powerhistory.DomainSystem)
+	if got := system.Measured.LatestObservationEndUnixMS; got != start+60_000 {
+		t.Fatalf("LatestObservationEndUnixMS = %d, want %d (the newest AGENT window end)", got, start+60_000)
+	}
+}
+
+// A reading cannot be newer than now. A modest lead — 30s, well inside a
+// previously generous two-minute grace — must not set freshness either: an
+// ordinary age check would then read it as current.
+func TestFleetPowerModestFutureLeadDoesNotSetFreshness(t *testing.T) {
+	start := int64(1_700_000_000_000)
+	in := fpInputs([]string{"m1", "m2"}, start, 6)
+	in.Now = start + 60_000
+	records := []fleetPowerRecord{
+		fpRecord("m1", start+60_000, fpSystem(100, powerhistory.SourceRAPLPsys)),
+		// m2's window ends 30s ahead of the hub clock.
+		fpRecord("m2", start+90_000, fpSystem(100, powerhistory.SourceRAPLPsys)),
+	}
+	system := fpDomain(t, aggregateFleetPower(records, in), powerhistory.DomainSystem)
+	if got := system.Measured.LatestObservationEndUnixMS; got != start+60_000 {
+		t.Fatalf("LatestObservationEndUnixMS = %d, want %d — a future lead must not set freshness", got, start+60_000)
+	}
+}
+
+// 119s ahead sat inside the original two-minute grace and would have been
+// accepted as the newest observation, then read as current by any age check.
+func TestFleetPowerNearGraceFutureLeadDoesNotSetFreshness(t *testing.T) {
+	start := int64(1_700_000_000_000)
+	in := fpInputs([]string{"m1", "m2"}, start, 8)
+	in.Now = start + 60_000
+	records := []fleetPowerRecord{
+		fpRecord("m1", start+60_000, fpSystem(100, powerhistory.SourceRAPLPsys)),
+		fpRecord("m2", start+179_000, fpSystem(100, powerhistory.SourceRAPLPsys)), // now + 119s
+	}
+	hist := aggregateFleetPower(records, in)
+	system := fpDomain(t, hist, powerhistory.DomainSystem)
+	if got := system.Measured.LatestObservationEndUnixMS; got != start+60_000 {
+		t.Fatalf("LatestObservationEndUnixMS = %d, want %d — now+119s is skew, not the newest reading", got, start+60_000)
+	}
+	if hist.Coverage.MachinesSkewed != 1 {
+		t.Fatalf("MachinesSkewed = %d, want 1", hist.Coverage.MachinesSkewed)
+	}
+	// Skew withholds freshness; it does not discard the power.
+	if system.Measured.Machines != 2 {
+		t.Fatalf("Measured.Machines = %d, want 2 — a skewed machine still contributes power", system.Measured.Machines)
+	}
+}
+
+// A machine whose clock runs ahead must not become "the newest observation":
+// that would launder a stale fleet into looking freshly reported.
+func TestFleetPowerFutureSkewDoesNotCountAsFreshest(t *testing.T) {
+	start := int64(1_700_000_000_000)
+	in := fpInputs([]string{"m1", "m2"}, start, 4)
+	in.Now = start + 60_000
+	records := []fleetPowerRecord{
+		fpRecord("m1", start+30_000, fpSystem(100, powerhistory.SourceRAPLPsys)),
+		// m2's window ends far ahead of the hub clock.
+		fpRecord("m2", start+240_000, fpSystem(100, powerhistory.SourceRAPLPsys)),
+	}
+	hist := aggregateFleetPower(records, in)
+	system := fpDomain(t, hist, powerhistory.DomainSystem)
+	if got := system.Measured.LatestObservationEndUnixMS; got != start+30_000 {
+		t.Fatalf("LatestObservationEndUnixMS = %d, want %d — skewed clocks must not set freshness", got, start+30_000)
+	}
+	if hist.Coverage.MachinesSkewed != 1 {
+		t.Fatalf("MachinesSkewed = %d, want 1", hist.Coverage.MachinesSkewed)
 	}
 }
 

--- a/hub/main.go
+++ b/hub/main.go
@@ -311,6 +311,9 @@ func (s *Server) registerRoutes(e *echo.Echo) {
 	api.GET("/api/machines/:id/power/history", s.handlePowerHistory)
 	// Fleet-scoped power aggregation over the same rows (hub/fleet_power.go).
 	api.GET("/api/fleet/power/history", s.handleFleetPowerHistory)
+	// Current fleet draw, from a fixed lookback independent of any chart
+	// period (hub/fleet_power_latest.go).
+	api.GET("/api/fleet/power/current", s.handleFleetPowerCurrent)
 	api.DELETE("/api/machines/:id/credential", s.handleRevokeAgentCredential)
 	api.POST("/api/machines/:id/windows-re-enrollment", s.handleWindowsReenrollment)
 	api.DELETE("/api/machines/:id", s.handleDeleteMachine)

--- a/hub/rbac.go
+++ b/hub/rbac.go
@@ -155,6 +155,8 @@ var routeScopeRequirements = map[string]string{
 	// fleet.read already means every machine, and rolling up rows a reader
 	// may already fetch one machine at a time discloses nothing new.
 	routeScopeKey(http.MethodGet, "/api/fleet/power/history"): scopeFleetRead,
+	// Same telemetry, current instant rather than history: same scope.
+	routeScopeKey(http.MethodGet, "/api/fleet/power/current"): scopeFleetRead,
 }
 
 func (s *Server) permissionMiddleware(next echo.HandlerFunc) echo.HandlerFunc {


### PR DESCRIPTION
PR1 of the power-correctness work. **Server + dashboard only.** No agent, release, updater or delivery changes.

## The three claims this removes

**Energy was never a floor.** `hub/fleet_power.go`'s own header asserted "every energy figure is a FLOOR", and the pane rendered `At least $X · Y kWh` on that basis. A window's mean is the mean of the reads that *succeeded* in it, and the hub then weights that mean by the window's whole span — one successful 300 W read in a 30 s window contributes 9000 W·s as though all thirty seconds were observed. The caption beside it divided summed window spans by the period and called that coverage, but spans are not deduplicated and a window binned by its end can carry time from the previous bucket.

Energy and cost are **withheld**, not re-captioned. Nothing renders `0 kWh`: unavailable accounting is not zero energy.

**"Current" came from the chart.** The headline walked back through the charted buckets and printed the last non-null one — so it changed with the selected period, reached arbitrarily far back, and was aged against bucket edges that can sit in the future. A fleet dark since 02:00 still read "142 W measured" at noon. New `GET /api/fleet/power/current` answers that from each machine's newest window over a fixed lookback, gating every contributor individually.

**Unrecognised backends became measurements.** Classification was "estimated if `IsEstimatedSource`, else measured", so any label this hub didn't know was promoted to measured. It now fails closed: `unknown` is its own kind, excluded from both totals and counted so the exclusion is visible. Legacy unlabelled readings stay measured — those agents predate labelling and measured RAPL.

## Two bugs found while testing

- A window covering `[30s,60s)` was binned into the **next** bucket.
- The SQL predicate excluded **records ending exactly at the requested end**. Such a record lies inside the requested window, so where one existed it was dropped from the newest bucket. (It does not affect every response — a request end can sit in the future, in which case no record ends exactly on it.) Fixing the aggregator alone would not have helped: rows the query never returns cannot be re-binned.

## Completeness

`complete` now reports false and says why — spans aren't enforced non-overlapping at ingest, binning by end can credit a neighbouring bucket, and a window's mean comes only from its successful reads. Presence is exposed separately as `all_machines_contributed`.

## Domain choice

Was automatic: system power took the whole chart whenever any machine had it. Once a *modelled* system reading could appear, one estimating board would have evicted the measured CPU and GPU history of the entire fleet. Choice is now explicit, persisted, and latched once.

## Verification

- hub `go vet` + full suite exit 0; proto vet + tests exit 0
- dashboard 191 tests pass; lint exit 0 at the documented 3-warning baseline; build compiles
- rendered at 1440 and 1280 in both contrast modes against a local stub hub

### Independent verification (reviewer)

Re-ran hub `TestFleetPower*`, dashboard targeted tests and lint (pass, baseline 3 warnings), and rendered with isolated headless Playwright at **explicit 1440 / 1280 / 390 viewports in both dark and light** — all six renders confirmed at the exact viewport, with no clipped power-panel buttons, `scrollWidth == clientWidth`, the saved CPU selection preserved across reload, and no runtime or hydration errors. PNGs inspected.

Artifacts: `/private/tmp/bloxos-browser-review/{power,page}-{1440,1280,390}-{dark,light}.png`, with `results.json` and `review.cjs` alongside.

This resolves the 390 px viewport gap noted during authoring, where Chrome's interactive window floor (~519 px) prevented a true narrow render.

## Known limitations

- Energy/cost stays withheld until observations carry their own measured duration — additive protocol work, deliberately not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fleet power semantics, aggregation, and a new authenticated API that the overview depends on; behavior is more conservative but operators will see different numbers and no energy/cost line until a follow-up.
> 
> **Overview**
> **Fleet power is reframed so the UI and hub stop overstating what sampled telemetry can prove.** Energy and cost are **withheld** on the overview (no “at least” kWh/$); the hub withdraws the “energy is a floor” claim and exposes sample/window metadata instead.
> 
> **“Current” draw is no longer derived from chart history.** The dashboard calls new **`GET /api/fleet/power/current`** for headline readouts, with shared **`power-freshness`** rules (age from agent window ends, aggregate aged by oldest contributor). Stale, skewed, unreadable, and unclassified machines are called out rather than folded into totals.
> 
> **Domain view is explicit:** a segmented control (persisted in `localStorage`, latched after mount) replaces automatic “system wins” mode; series combine history and the current snapshot so live domains are not hidden by capped history.
> 
> **Hub aggregation fixes and stricter provenance:** readings are binned on `(end-1)` and history SQL uses `(start, end]` so edge windows are not dropped; backend labels **fail closed** to an `unknown` kind (legacy unlabelled stays measured); `complete` is always false with **`all_machines_contributed`** for presence; clock-skew tolerance is tightened for freshness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a79b632a004da2f4066f11c9ac1c6a90ac2426e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->