### PR TITLE
feat(delivery): ship agent payloads with the hub release [DRAFT]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,19 @@ jobs:
       - name: Test agent payload packaging and old-worker transport
         run: python3 ../scripts/test_server_bundle_agents.py
 
+      # Runs the real hub PROCESS. A loader unit test cannot catch the gate
+      # being moved after the database opens, and the fixtures need root-owned
+      # paths because the trusted-binary rule demands root ownership of every
+      # ancestor. REQUIRE_ROOT makes a missing prerequisite fail rather than
+      # skip: a skip reads exactly like a pass in the checks summary, and this
+      # file exists to catch a check that has quietly stopped running.
+      #
+      # This form proves the gate is wired and reachable. It does NOT verify
+      # the release build sets the marker — the flag is supplied here. The
+      # image-built hub is covered by the Compose smoke job.
+      - name: Hub delivery boot gate (source build)
+        run: sudo -E env "PATH=$PATH" BLOXOS_BOOT_SMOKE_REQUIRE_ROOT=1 python3 ../scripts/test_hub_bundle_boot.py
+
   # A real gate as of issue #60: the hub's DB handle and agent registry now live
   # on a Server instance, so tests build isolated servers instead of reassigning
   # package globals under leaked agent-WS goroutines. Verified stable across four

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,14 @@ jobs:
           python3 ../scripts/test_agent_bundle.py
           bash -n ../scripts/export-agent-bundle.sh
 
+      # Runs in THIS job because it needs both toolchains: the packer is
+      # Python, and it drives the hub's real Go loader over the tree an
+      # unchanged updater produced. Deliberately before publication — a
+      # tag-time test finds a broken release after the tag exists, and the
+      # fleet is who finds out.
+      - name: Test agent payload packaging and old-worker transport
+        run: python3 ../scripts/test_server_bundle_agents.py
+
   # A real gate as of issue #60: the hub's DB handle and agent registry now live
   # on a Server instance, so tests build isolated servers instead of reassigning
   # package globals under leaked agent-WS goroutines. Verified stable across four

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,11 @@ jobs:
       # This form proves the gate is wired and reachable. It does NOT verify
       # the release build sets the marker — the flag is supplied here. The
       # image-built hub is covered by the Compose smoke job.
+      - name: Test release identity gate and history
+        run: |
+          python3 ../scripts/test_release_identity.py
+          python3 ../scripts/test_release_history.py
+
       - name: Hub delivery boot gate (source build)
         run: sudo -E env "PATH=$PATH" BLOXOS_BOOT_SMOKE_REQUIRE_ROOT=1 python3 ../scripts/test_hub_bundle_boot.py
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,6 +77,28 @@ jobs:
           tags: ${{ env.DASHBOARD_IMAGE }}:latest
           cache-from: type=gha,scope=dashboard
           cache-to: type=gha,scope=dashboard,mode=max
+      # The only form that verifies the RELEASE build flags. Hardcoding -X in
+      # the source-built smoke cannot detect a Dockerfile that dropped the
+      # marker; this runs the same cases against the hub binary from the image
+      # that was just built, so a lost -ldflags entry fails here.
+      - name: Hub delivery boot gate (image build)
+        env:
+          HUB_TAG: ${{ env.HUB_IMAGE }}:latest
+        run: |
+          set -euo pipefail
+          container=$(docker create "$HUB_TAG")
+          trap 'docker rm -v "$container" >/dev/null' EXIT
+          docker cp "$container:/usr/local/bin/bloxos-hub" "$RUNNER_TEMP/bloxos-hub"
+          # Prove the image carries its managed bundle where the hub looks.
+          docker run --rm --entrypoint /bin/sh "$HUB_TAG" -c \
+            'ls -l /usr/local/bin/agents/ && test -f /usr/local/bin/agents/agent-manifest.json'
+          # The legacy paths must be hard links to the managed payloads: same
+          # inode, so they cannot drift from the bytes the catalog describes.
+          docker run --rm --entrypoint /bin/sh "$HUB_TAG" -c \
+            'test "$(stat -c %i /usr/local/bin/agents/bloxos-agent-linux-amd64)" = "$(stat -c %i /usr/local/lib/bloxos/linux/amd64/bloxos-agent)"'
+          sudo -E env "PATH=$PATH" BLOXOS_BOOT_SMOKE_REQUIRE_ROOT=1 \
+            python3 scripts/test_hub_bundle_boot.py --hub-binary "$RUNNER_TEMP/bloxos-hub"
+
       - name: Enroll the runner through the stack
         env:
           SMOKE_CONFIRM_DISPOSABLE: "1"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,9 +28,21 @@ on:
 permissions:
   contents: read
 
+# Release runs take ONE lock shared by every tag; pull requests keep the
+# per-ref group that cancels superseded runs.
+#
+# The old group was docker-${{ github.ref }} for everything, which is per-TAG —
+# so two different tags never serialised against each other at all, and both
+# could compare against the same history and then both promote. A
+# workflow-level lock spans publish AND native-bundle with no gap between
+# them, which job-level groups cannot do: a second run could take the group in
+# the moment between one job ending and the next starting.
+#
+# cancel-in-progress must be FALSE for releases. Cancelling a run midway
+# through promotion is how a half-published release happens.
 concurrency:
-  group: docker-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ startsWith(github.ref, 'refs/tags/v') && 'docker-release' || format('docker-{0}', github.ref) }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
 env:
   HUB_IMAGE: ghcr.io/${{ github.repository_owner }}/bloxos-hub
@@ -147,7 +159,9 @@ jobs:
       hub_digest: ${{ steps.hub.outputs.digest }}
       dashboard_digest: ${{ steps.dashboard.outputs.digest }}
     permissions:
-      contents: read
+      # contents: write is needed to persist the verified agent catalog to the
+      # draft release BEFORE the Docker tags are promoted.
+      contents: write
       packages: write
     steps:
       - uses: actions/checkout@v7
@@ -192,6 +206,95 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha,scope=dashboard
+      # ==== Release identity gate ====
+      #
+      # Everything below runs BEFORE promotion, and the ordering is the point.
+      # Once Docker tags move, the bytes are live and any ambiguity about what
+      # this release number means is permanent.
+      - name: Extract the canonical agent bundle from the published hub image
+        env:
+          HUB_DIGEST: ${{ steps.hub.outputs.digest }}
+          SOURCE_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: bash scripts/export-agent-bundle.sh "$HUB_IMAGE@$HUB_DIGEST" "$SOURCE_SHA" "$RELEASE_TAG" "$RUNNER_TEMP/native-agents"
+
+      # A containerised arm64 hub serves the agents built into its OWN image,
+      # and the two images are built separately from build args that could
+      # drift. Sharing an image index proves nothing about what each embedded,
+      # so both are read directly and compared to the canonical bundle.
+      - name: Extract and validate the agent bundle from each hub image platform
+        env:
+          HUB_DIGEST: ${{ steps.hub.outputs.digest }}
+        run: |
+          set -euo pipefail
+          for platform in linux/amd64 linux/arm64; do
+            arch="${platform#*/}"
+            # Resolve the index to that platform's immutable child digest. A
+            # bare `docker pull --platform` can hand back a different image
+            # from a classic store, so the shared helper picks the exact child.
+            ref=$(python3 scripts/image_platform.py --image "$HUB_IMAGE@$HUB_DIGEST" --platform "$platform")
+            docker pull --platform "$platform" "$ref"
+            actual=$(docker image inspect --format '{{.Os}}/{{.Architecture}}' "$ref")
+            test "$actual" = "$platform" || { echo "resolved $ref is $actual, wanted $platform" >&2; exit 1; }
+
+            container=$(docker create --platform "$platform" --network none "$ref")
+            mkdir -p "$RUNNER_TEMP/image-agents-$arch"
+            docker cp "$container:/usr/local/bin/agents/." "$RUNNER_TEMP/image-agents-$arch/"
+            docker rm -v "$container" >/dev/null
+
+            # Validate the PAYLOADS this image actually carries against its own
+            # catalog — sha256, size, architecture read from each image header,
+            # and one consistent release marker. Copying the catalog alone
+            # would compare two JSON documents and prove nothing about the
+            # binaries a containerised hub would serve.
+            #
+            # The catalog's own checksum is computed here rather than supplied:
+            # what is under test is payload-to-catalog agreement, and the
+            # catalog is then compared to the canonical bundle by the identity
+            # gate in the next step.
+            catalog_sha=$(sha256sum "$RUNNER_TEMP/image-agents-$arch/agent-manifest.json" | cut -d' ' -f1)
+            python3 scripts/agent_bundle.py check --bundle "$RUNNER_TEMP/image-agents-$arch" \
+              --manifest-sha256 "$catalog_sha" --allow-missing-provenance >/dev/null
+            cp "$RUNNER_TEMP/image-agents-$arch/agent-manifest.json" "$RUNNER_TEMP/image-catalog-$arch.json"
+          done
+
+      - name: Gather published and draft agent release history
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          python3 scripts/release_history.py gather --repo "$GITHUB_REPOSITORY" \
+            --output "$RUNNER_TEMP/agent-release-history.json"
+
+      - name: Verify release identity before promoting anything
+        run: |
+          python3 scripts/release_identity.py \
+            --candidate "$RUNNER_TEMP/native-agents/agent-manifest.json" \
+            --history "$RUNNER_TEMP/agent-release-history.json" \
+            --image-catalog "linux/amd64=$RUNNER_TEMP/image-catalog-amd64.json" \
+            --image-catalog "linux/arm64=$RUNNER_TEMP/image-catalog-arm64.json"
+
+      # Persist the VERIFIED catalog before the tags move. If a run dies after
+      # promotion, the images are live; without this the next run would find no
+      # record of what agent bytes they carry and would have nothing to check
+      # itself against. Crashing before promotion instead leaves an unused
+      # catalog, which is harmless.
+      - name: Persist the verified agent catalog before promotion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            prerelease_flags=()
+            if [[ "$RELEASE_TAG" == *-* ]]; then prerelease_flags=(--prerelease); fi
+            gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --verify-tag --draft \
+              "${prerelease_flags[@]}" --title "BloxOS $RELEASE_TAG" \
+              --notes "Release verification in progress. Agent identity verified; assets pending."
+          fi
+          python3 scripts/release_history.py persist --repo "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" --catalog "$RUNNER_TEMP/native-agents/agent-manifest.json"
+
       - name: Promote both images to the version and latest tags
         env:
           VERSION: ${{ github.ref_name }}
@@ -261,13 +364,21 @@ jobs:
             gh release create "$RELEASE_TAG" --verify-tag --draft "${prerelease_flags[@]}" --title "BloxOS $RELEASE_TAG" \
               --notes "Release verification passed. Native payloads are extracted from the published image; operator review and final release notes are pending. Fleet signatures are installation-specific and are not included."
           fi
-          gh release upload "$RELEASE_TAG" \
-            "$RUNNER_TEMP/native-agents/agent-manifest.json" \
+          # agent-manifest.json was already persisted before promotion. Verify
+          # the bytes agree rather than uploading again: a published catalog is
+          # evidence of what the release carries and is never overwritten.
+          python3 scripts/release_history.py persist --repo "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" --catalog "$RUNNER_TEMP/native-agents/agent-manifest.json"
+          # Never --clobber. On a retry an already-uploaded asset is compared
+          # and skipped; a differing one is an error. Replacing a published
+          # artifact silently changes what an existing release means, and
+          # anyone who already downloaded it holds something the release no
+          # longer claims.
+          python3 scripts/release_history.py upload --repo "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG" \
             "$RUNNER_TEMP/native-agents/agent-manifest.sha256" \
             "$RUNNER_TEMP/native-agents/bloxos-agent-linux-amd64" \
             "$RUNNER_TEMP/native-agents/bloxos-agent-linux-arm64" \
-            "$RUNNER_TEMP/native-agents/bloxos-agent-windows-amd64.exe"
-          gh release upload "$RELEASE_TAG" \
+            "$RUNNER_TEMP/native-agents/bloxos-agent-windows-amd64.exe" \
             "$RUNNER_TEMP/server-bundle/update-manifest.json" \
             "$RUNNER_TEMP/server-bundle/bloxos-server-linux-amd64.tar.gz" \
             "$RUNNER_TEMP/server-bundle/bloxos-server-linux-arm64.tar.gz" \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,13 +89,29 @@ jobs:
           container=$(docker create "$HUB_TAG")
           trap 'docker rm -v "$container" >/dev/null' EXIT
           docker cp "$container:/usr/local/bin/bloxos-hub" "$RUNNER_TEMP/bloxos-hub"
-          # Prove the image carries its managed bundle where the hub looks.
-          docker run --rm --entrypoint /bin/sh "$HUB_TAG" -c \
-            'ls -l /usr/local/bin/agents/ && test -f /usr/local/bin/agents/agent-manifest.json'
-          # The legacy paths must be hard links to the managed payloads: same
-          # inode, so they cannot drift from the bytes the catalog describes.
-          docker run --rm --entrypoint /bin/sh "$HUB_TAG" -c \
-            'test "$(stat -c %i /usr/local/bin/agents/bloxos-agent-linux-amd64)" = "$(stat -c %i /usr/local/lib/bloxos/linux/amd64/bloxos-agent)"'
+          # Prove the image carries its managed bundle where the hub looks, and
+          # that the compatibility paths are hard links to the SAME inode rather
+          # than duplicated bytes. Print device, inode and link count for both
+          # first: when this assertion failed it was because a cross-layer copy
+          # had quietly materialised two files, and the numbers are what made
+          # that diagnosable instead of merely red.
+          docker run --rm --entrypoint /bin/sh "$HUB_TAG" -c '
+            set -eu
+            test -f /usr/local/bin/agents/agent-manifest.json
+            for pair in \
+              "/usr/local/bin/agents/bloxos-agent-linux-amd64 /usr/local/lib/bloxos/linux/amd64/bloxos-agent" \
+              "/usr/local/bin/agents/bloxos-agent-linux-amd64 /usr/local/lib/bloxos/linux/bloxos-agent" \
+              "/usr/local/bin/agents/bloxos-agent-linux-arm64 /usr/local/lib/bloxos/linux/arm64/bloxos-agent" \
+              "/usr/local/bin/agents/bloxos-agent-windows-amd64.exe /usr/local/lib/bloxos/windows/bloxos-agent.exe"; do
+              set -- $pair
+              stat -c "%n dev=%d inode=%i links=%h size=%s" "$1" "$2"
+              test "$(stat -c %d:%i "$1")" = "$(stat -c %d:%i "$2")" || {
+                echo "NOT A HARD LINK: $1 and $2 are separate files" >&2
+                exit 1
+              }
+            done
+            echo "all compatibility paths share an inode with their managed payload"
+          '
           sudo -E env "PATH=$PATH" BLOXOS_BOOT_SMOKE_REQUIRE_ROOT=1 \
             python3 scripts/test_hub_bundle_boot.py --hub-binary "$RUNNER_TEMP/bloxos-hub"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,16 @@ on:
       - "scripts/agent_bundle.py"
       - "scripts/export-agent-bundle.sh"
       - "scripts/export-server-bundle.py"
+      # Release-integrity scripts and their tests. Without these, a change to
+      # the gate that decides what may be promoted could merge without the
+      # integration workflow ever running.
+      - "scripts/release_identity.py"
+      - "scripts/release_history.py"
+      - "scripts/image_platform.py"
+      - "scripts/test_release_identity.py"
+      - "scripts/test_release_history.py"
+      - "scripts/test_server_bundle_agents.py"
+      - "scripts/test_hub_bundle_boot.py"
       - "scripts/updater/**"
       - "scripts/tests/test_updater*.py"
       - "scripts/test_agent_bundle.py"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -194,7 +194,10 @@ jobs:
         run: bash scripts/export-agent-bundle.sh "$HUB_IMAGE@$HUB_DIGEST" "$SOURCE_SHA" "$RELEASE_TAG" "$RUNNER_TEMP/native-agents"
       - name: Extract the exact published server pair
         # Server archives are the exact published image contents, not separate
-        # source rebuilds. The updater installs hub/dashboard, not fleet agents.
+        # source rebuilds. They now also carry the agent payloads, so upgrading
+        # the hub upgrades what the fleet is offered; --agents points at the
+        # SAME directory whose files are attached as standalone assets below,
+        # and the script asserts byte equality rather than rebuilding.
         env:
           HUB_DIGEST: ${{ needs.publish.outputs.hub_digest }}
           DASHBOARD_DIGEST: ${{ needs.publish.outputs.dashboard_digest }}
@@ -203,7 +206,8 @@ jobs:
         run: |
           python3 scripts/export-server-bundle.py \
             --hub "$HUB_IMAGE@$HUB_DIGEST" --dashboard "$DASHBOARD_IMAGE@$DASHBOARD_DIGEST" \
-            --revision "$SOURCE_SHA" --version "$RELEASE_TAG" --output "$RUNNER_TEMP/server-bundle"
+            --revision "$SOURCE_SHA" --version "$RELEASE_TAG" --output "$RUNNER_TEMP/server-bundle" \
+            --agents "$RUNNER_TEMP/native-agents"
       - name: Attach server and agent assets to a draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -29,11 +29,33 @@ COPY hub/ hub/
 COPY agent/ agent/
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    mkdir -p /out/linux/amd64 /out/linux/arm64 /out/windows \
- && (cd hub   && GOOS=linux   GOARCH="$TARGETARCH" go build -ldflags="-s -w -X main.buildVersion=$BLOXOS_BUILD_VERSION -X main.buildRevision=$BLOXOS_BUILD_REVISION" -o /out/bloxos-hub .) \
- && (cd agent && GOOS=linux   GOARCH=amd64        go build -ldflags='-s -w' -o /out/linux/amd64/bloxos-agent .) \
- && (cd agent && GOOS=linux   GOARCH=arm64        go build -ldflags='-s -w' -o /out/linux/arm64/bloxos-agent .) \
- && (cd agent && GOOS=windows GOARCH=amd64        go build -ldflags='-s -w' -o /out/windows/bloxos-agent.exe .)
+    mkdir -p /out/agents \
+ && (cd hub   && GOOS=linux   GOARCH="$TARGETARCH" go build -ldflags="-s -w -X main.buildVersion=$BLOXOS_BUILD_VERSION -X main.buildRevision=$BLOXOS_BUILD_REVISION -X main.agentBundleRequired=packaged" -o /out/bloxos-hub .) \
+ && (cd agent && GOOS=linux   GOARCH=amd64        go build -ldflags='-s -w' -o /out/agents/bloxos-agent-linux-amd64 .) \
+ && (cd agent && GOOS=linux   GOARCH=arm64        go build -ldflags='-s -w' -o /out/agents/bloxos-agent-linux-arm64 .) \
+ && (cd agent && GOOS=windows GOARCH=amd64        go build -ldflags='-s -w' -o /out/agents/bloxos-agent-windows-amd64.exe .)
+
+# The catalog that the hub reads at startup, built from the bytes just
+# produced. It runs in its own stage so the runtime image never gains a Python
+# interpreter, and it uses the SAME generator and format as the release
+# catalog — one artifact identity, not a parallel in-image format.
+#
+# It omits the image digest, because the image it would name does not exist
+# yet; a plain local `docker build` also has no release tag or commit SHA. Those
+# fields are left out rather than filled with a placeholder, so nothing
+# downstream can mistake a stand-in for provenance. The artifact checks —
+# sha256, size, architecture and one consistent release marker across all three
+# platforms — are enforced here exactly as they are for a release.
+FROM alpine:3.22 AS catalog
+RUN apk add --no-cache python3
+COPY scripts/agent_bundle.py /tmp/agent_bundle.py
+COPY --from=build /out/agents/ /out/agents/
+ARG BLOXOS_BUILD_VERSION=development
+ARG BLOXOS_BUILD_REVISION=unknown
+RUN sha=$(python3 /tmp/agent_bundle.py manifest --bundle /out/agents \
+      --source "$BLOXOS_BUILD_REVISION" --version "$BLOXOS_BUILD_VERSION") \
+ && python3 /tmp/agent_bundle.py check --bundle /out/agents --manifest-sha256 "$sha" \
+      --allow-missing-provenance >/dev/null
 
 FROM alpine:3.22
 RUN apk add --no-cache ca-certificates \
@@ -45,16 +67,27 @@ RUN apk add --no-cache ca-certificates \
 # agents sit at the resolver's per-architecture defaults,
 # /usr/local/lib/bloxos/linux/<arch>/bloxos-agent.
 COPY --from=build --chown=root:root --chmod=0755 /out/bloxos-hub /usr/local/bin/bloxos-hub
-COPY --from=build --chown=root:root --chmod=0755 /out/linux/amd64/bloxos-agent /usr/local/lib/bloxos/linux/amd64/bloxos-agent
-COPY --from=build --chown=root:root --chmod=0755 /out/linux/arm64/bloxos-agent /usr/local/lib/bloxos/linux/arm64/bloxos-agent
-# Backward compatibility: the pre-per-architecture image populated this path,
-# and an existing BLOXOS_AGENT_BINARY may still point at it explicitly. Keep it
-# as a root-owned regular copy of the amd64 build — a separate COPY, not a
-# symlink, because the trusted-binary resolver rejects a symlinked final path.
-# amd64 requests resolve it; the resolver's ELF arch check keeps it away from
-# arm64 requests.
-COPY --from=build --chown=root:root --chmod=0755 /out/linux/amd64/bloxos-agent /usr/local/lib/bloxos/linux/bloxos-agent
-COPY --from=build --chown=root:root --chmod=0755 /out/windows/bloxos-agent.exe /usr/local/lib/bloxos/windows/bloxos-agent.exe
+# The managed bundle, beside the hub executable. This is the SAME hub-relative
+# layout the native server archive uses (<release>/hub/agents), so both deploy
+# modes resolve agents the same way and the one production hub build can
+# require a bundle in either.
+COPY --from=catalog --chown=root:root --chmod=0755 /out/agents/ /usr/local/bin/agents/
+# Backward compatibility for the pre-per-architecture paths, which an existing
+# BLOXOS_AGENT_BINARY may still point at explicitly.
+#
+# HARD LINKS, for two reasons. They are regular files, so the trusted-binary
+# resolver accepts them where it rejects a symlinked final path. And they are
+# the same inode, so these paths cannot drift from the managed payloads the way
+# a second COPY of the same bytes silently could — there is one set of agent
+# bytes in this image, reachable under several names.
+RUN set -eu \
+ && mkdir -p /usr/local/lib/bloxos/linux/amd64 /usr/local/lib/bloxos/linux/arm64 /usr/local/lib/bloxos/windows \
+ && ln /usr/local/bin/agents/bloxos-agent-linux-amd64     /usr/local/lib/bloxos/linux/amd64/bloxos-agent \
+ && ln /usr/local/bin/agents/bloxos-agent-linux-arm64     /usr/local/lib/bloxos/linux/arm64/bloxos-agent \
+ && ln /usr/local/bin/agents/bloxos-agent-linux-amd64     /usr/local/lib/bloxos/linux/bloxos-agent \
+ && ln /usr/local/bin/agents/bloxos-agent-windows-amd64.exe /usr/local/lib/bloxos/windows/bloxos-agent.exe \
+ && chown -R root:root /usr/local/lib/bloxos \
+ && chmod -R go-w /usr/local/lib/bloxos /usr/local/bin/agents
 # State lives in one volume: bloxos.db in the working directory, secrets,
 # setup token and signing key under $HOME/.bloxos.
 ENV HOME=/data \

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -67,27 +67,40 @@ RUN apk add --no-cache ca-certificates \
 # agents sit at the resolver's per-architecture defaults,
 # /usr/local/lib/bloxos/linux/<arch>/bloxos-agent.
 COPY --from=build --chown=root:root --chmod=0755 /out/bloxos-hub /usr/local/bin/bloxos-hub
-# The managed bundle, beside the hub executable. This is the SAME hub-relative
-# layout the native server archive uses (<release>/hub/agents), so both deploy
-# modes resolve agents the same way and the one production hub build can
-# require a bundle in either.
-COPY --from=catalog --chown=root:root --chmod=0755 /out/agents/ /usr/local/bin/agents/
-# Backward compatibility for the pre-per-architecture paths, which an existing
-# BLOXOS_AGENT_BINARY may still point at explicitly.
+# The managed bundle and the backward-compatible per-architecture paths, all
+# created inside ONE layer.
 #
-# HARD LINKS, for two reasons. They are regular files, so the trusted-binary
-# resolver accepts them where it rejects a symlinked final path. And they are
-# the same inode, so these paths cannot drift from the managed payloads the way
-# a second COPY of the same bytes silently could — there is one set of agent
-# bytes in this image, reachable under several names.
-RUN set -eu \
- && mkdir -p /usr/local/lib/bloxos/linux/amd64 /usr/local/lib/bloxos/linux/arm64 /usr/local/lib/bloxos/windows \
- && ln /usr/local/bin/agents/bloxos-agent-linux-amd64     /usr/local/lib/bloxos/linux/amd64/bloxos-agent \
- && ln /usr/local/bin/agents/bloxos-agent-linux-arm64     /usr/local/lib/bloxos/linux/arm64/bloxos-agent \
- && ln /usr/local/bin/agents/bloxos-agent-linux-amd64     /usr/local/lib/bloxos/linux/bloxos-agent \
+# agents/ sits beside the hub executable, the SAME hub-relative layout the
+# native server archive uses (<release>/hub/agents), so both deploy modes
+# resolve agents the same way and the one production hub build can require a
+# bundle in either.
+#
+# The compatibility paths are HARD LINKS, not symlinks: the trusted-binary
+# resolver rejects a symlinked final path but accepts a regular file. Sharing an
+# inode also means those paths cannot drift from the managed payloads the way a
+# second copy of the same bytes silently could.
+#
+# The single RUN is what makes the links survive. Copying the payloads in one
+# layer and linking them in another put the file and its links on opposite
+# sides of a layer boundary; the copy-up and diff then materialised them as
+# separate files, and CI measured a link count of 1 — the duplication this was
+# meant to avoid, silently. A bind mount supplies the bytes read-only without
+# committing a second copy of them to any layer.
+RUN --mount=type=bind,from=catalog,source=/out/agents,target=/tmp/agent-input,ro \
+    set -eu \
+ && mkdir -p /usr/local/bin/agents /usr/local/lib/bloxos/linux/amd64 \
+             /usr/local/lib/bloxos/linux/arm64 /usr/local/lib/bloxos/windows \
+ && cp /tmp/agent-input/bloxos-agent-linux-amd64 /tmp/agent-input/bloxos-agent-linux-arm64 \
+       /tmp/agent-input/bloxos-agent-windows-amd64.exe /tmp/agent-input/agent-manifest.json \
+       /usr/local/bin/agents/ \
+ && ln /usr/local/bin/agents/bloxos-agent-linux-amd64       /usr/local/lib/bloxos/linux/amd64/bloxos-agent \
+ && ln /usr/local/bin/agents/bloxos-agent-linux-arm64       /usr/local/lib/bloxos/linux/arm64/bloxos-agent \
+ && ln /usr/local/bin/agents/bloxos-agent-linux-amd64       /usr/local/lib/bloxos/linux/bloxos-agent \
  && ln /usr/local/bin/agents/bloxos-agent-windows-amd64.exe /usr/local/lib/bloxos/windows/bloxos-agent.exe \
- && chown -R root:root /usr/local/lib/bloxos \
- && chmod -R go-w /usr/local/lib/bloxos /usr/local/bin/agents
+ && chown -R root:root /usr/local/bin/agents /usr/local/lib/bloxos \
+ && chmod 0755 /usr/local/bin/agents/bloxos-agent-* \
+ && chmod 0644 /usr/local/bin/agents/agent-manifest.json \
+ && chmod -R go-w /usr/local/bin/agents /usr/local/lib/bloxos
 # State lives in one volume: bloxos.db in the working directory, secrets,
 # setup token and signing key under $HOME/.bloxos.
 ENV HOME=/data \

--- a/agent/release.go
+++ b/agent/release.go
@@ -30,10 +30,10 @@ import (
  * ============================================================================ */
 
 // agentRelease is the release sequence compiled into this binary.
-const agentRelease uint64 = 7
+const agentRelease uint64 = 8
 
 // agentReleaseMarker is agentRelease as the scannable literal.
-const agentReleaseMarker = "BLOXOS-AGENT-RELEASE:0000000007:"
+const agentReleaseMarker = "BLOXOS-AGENT-RELEASE:0000000008:"
 
 var (
 	embeddedReleaseOnce sync.Once

--- a/dashboard/src/app/versions/page.tsx
+++ b/dashboard/src/app/versions/page.tsx
@@ -17,9 +17,37 @@ import {
   CheckCircle2,
   Clock,
   KeyRound,
+  Package,
   ShieldCheck,
 } from "lucide-react";
 import { AgentBinaryInfo, useVersions } from "@/contexts/VersionsContext";
+
+/**
+ * The resolution POLICY in force — not a claim about any particular platform.
+ *
+ * "auto" means a managed bundle is available to the resolver. It does not mean
+ * every platform uses it: an explicit per-architecture override still wins, so
+ * an install can be on this policy and still serve an operator-pinned binary
+ * for one architecture. Labelling that "Managed" and promising that upgrading
+ * the hub upgrades the fleet would be plainly wrong on such a hub.
+ *
+ * Each binary's own `source`, shown per platform below, stays the
+ * authoritative answer to where it actually came from.
+ */
+const DELIVERY_LABEL: Record<string, string> = {
+  auto: "Managed bundle available",
+  legacy: "System paths",
+  external: "Operator-managed",
+  unusable: "Broken",
+};
+
+const DELIVERY_NOTE: Record<string, string> = {
+  auto: "Platforms resolving to the managed bundle follow this hub release; explicit overrides remain operator-managed. See each platform's source below.",
+  legacy:
+    "No bundle shipped with this hub, so agents resolve from fixed system paths. Those paths are not refreshed by a hub upgrade.",
+  external:
+    "BLOXOS_AGENT_DELIVERY=external: you manage agent binaries yourself. A hub upgrade will not change what is offered.",
+};
 import {
   agentProtocolNote,
   agentStatusLabel,
@@ -152,6 +180,27 @@ function VersionsContent() {
                   tone={data.signing_enabled ? "ok" : "critical"}
                   label={data.signing_enabled ? "Enabled" : "Disabled"}
                   Icon={data.signing_enabled ? ShieldCheck : AlertTriangle}
+                />
+              ) : (
+                <span className="text-[13px] text-text-tertiary">—</span>
+              )}
+            </dd>
+          </div>
+          <div className="flex items-baseline gap-2">
+            <dt className="mf-kicker">Delivery</dt>
+            <dd>
+              {data?.agent_delivery ? (
+                <StatusMark
+                  tone={
+                    data.agent_delivery === "unusable"
+                      ? "critical"
+                      : data.agent_delivery === "auto"
+                        ? "ok"
+                        : "warning"
+                  }
+                  label={DELIVERY_LABEL[data.agent_delivery] ?? data.agent_delivery}
+                  Icon={data.agent_delivery === "unusable" ? AlertTriangle : Package}
+                  title={data.agent_delivery_error || DELIVERY_NOTE[data.agent_delivery] || undefined}
                 />
               ) : (
                 <span className="text-[13px] text-text-tertiary">—</span>

--- a/dashboard/src/contexts/VersionsContext.tsx
+++ b/dashboard/src/contexts/VersionsContext.tsx
@@ -42,6 +42,18 @@ export interface AgentBinaryInfo {
 }
 
 export interface VersionsResponse {
+  /**
+   * Which resolution policy produced the served binaries:
+   *  - "auto"     a managed bundle shipped with the hub is in use
+   *  - "legacy"   no bundle present (a source build); system paths apply
+   *  - "external" the operator manages agent binaries themselves
+   *  - "unusable" the delivery configuration itself is broken
+   * Older hubs omit it. Each binary's own `source` says where it actually
+   * resolved from; this says which policy was in force, and the two are
+   * deliberately not derived from one another.
+   */
+  agent_delivery?: string;
+  agent_delivery_error?: string;
   signing_enabled: boolean;
   signing_disabled_reason: string;
   hub_sha: string;

--- a/docs/native-agent-upgrades.md
+++ b/docs/native-agent-upgrades.md
@@ -1,8 +1,142 @@
-# Native hub: check and stage agent updates
+# Agent delivery: how the fleet gets new agents
 
-Updating the hub executable does **not** update separately installed agent
-files. A machine that matches the hub's offered SHA is up to date **with that
-offered file**, not necessarily with the latest BloxOS release.
+**A packaged hub carries the agent binaries it serves**, and upgrading the hub
+upgrades what those platforms are offered. No payload staging step is required.
+
+Two things still are, where they apply:
+
+- **An explicit per-platform override keeps winning.** A platform pinned with
+  `BLOXOS_AGENT_BINARY_ARM64` or the like stays operator-managed; the bundle
+  does not override it. Check each platform's `source` on the Versions page.
+- **An offline-signing install must still authorise the new bytes.** Delivery
+  moves binaries; it does not sign them. See [Signatures](#signatures).
+
+Previously `bloxos-update` did not touch agent files, so a hub could run a new
+release while serving agents built weeks earlier. Machines reported "matches
+offered build" correctly — the offer was stale.
+
+## Where agents live now
+
+The hub looks for a managed bundle in `agents/` **beside its own executable**:
+
+| Install | Hub executable | Bundle |
+| --- | --- | --- |
+| Native | `<release>/hub/bloxos-hub` | `<release>/hub/agents/` |
+| Docker | `/usr/local/bin/bloxos-hub` | `/usr/local/bin/agents/` |
+
+Both server archives carry all three agent platforms, so a hub on either
+server architecture can serve any machine in the fleet.
+
+In the Docker image the older paths
+(`/usr/local/lib/bloxos/linux/<arch>/bloxos-agent` and
+`/usr/local/lib/bloxos/windows/bloxos-agent.exe`) are **hard links** to the
+managed payloads. An existing `BLOXOS_AGENT_BINARY` that points at one keeps
+working, and because they share an inode they cannot drift from the bundle.
+
+### A bad bundle stops the hub
+
+A packaged build that cannot produce a valid bundle **refuses to start**,
+before it opens the database. Missing, corrupt, mislabelled or
+wrong-architecture payloads are all fatal. This is deliberate: falling back to
+whatever binaries happen to be on disk, while reporting healthy, is exactly the
+staleness this replaces. Because nothing has been written yet, the updater's
+readiness check rejects the candidate and rolls back.
+
+The hub validates each payload's SHA-256 and size against the catalog, reads
+the architecture out of the ELF or PE header rather than trusting the
+catalog's label, and checks the release marker compiled into each binary
+against the release the catalog claims.
+
+## Precedence
+
+The override variable for a platform is `BLOXOS_AGENT_BINARY` for Linux amd64,
+`BLOXOS_AGENT_BINARY_ARM64` for Linux arm64, and `BLOXOS_AGENT_BINARY_WINDOWS`
+for Windows. When set, it is **authoritative**: that platform resolves it or
+fails, and never falls back.
+
+**Linux arm64**, in order:
+
+1. a generic `BLOXOS_AGENT_BINARY` that is set and is not the shipped default
+   path — non-authoritative and architecture-verified, so a wrong-architecture
+   binary is skipped rather than failing the platform
+2. the managed bundle
+3. `BLOXOS_AGENT_BINARY_ARM64` — authoritative, fails closed
+4. a generic `BLOXOS_AGENT_BINARY`, architecture-verified
+5. `/usr/local/lib/bloxos/linux/arm64/bloxos-agent`
+6. `/usr/local/lib/bloxos/linux/bloxos-agent` (legacy)
+7. a `bloxos-agent` sibling of the hub executable
+
+**Linux amd64**, in order:
+
+1. the managed bundle
+2. `BLOXOS_AGENT_BINARY` — authoritative, fails closed
+3. `/usr/local/lib/bloxos/linux/amd64/bloxos-agent`
+4. `/usr/local/lib/bloxos/linux/bloxos-agent` (legacy)
+5. a `bloxos-agent` sibling of the hub executable
+
+**Windows**: the managed bundle, then `BLOXOS_AGENT_BINARY_WINDOWS`
+(authoritative), then `/usr/local/lib/bloxos/windows/bloxos-agent.exe`, then a
+`bloxos-agent.exe` sibling of the hub executable.
+
+### The one exception
+
+A `BLOXOS_AGENT_BINARY` whose value is **exactly** the shipped default path is
+treated as legacy configuration, and the bundle takes precedence over it. The
+project's own systemd unit sets that variable, so without this the managed
+bundle would never be reached on a standard native install. Any other value —
+including a path that merely normalises to the default — remains an
+authoritative operator pin.
+
+Set `BLOXOS_AGENT_DELIVERY=external` to restore the full legacy resolver and
+manage agent binaries yourself. The manual procedure below then applies.
+
+## Signatures
+
+An offline install (one with `BLOXOS_UPDATE_PUBKEY` and no private key on the
+hub) can only announce a signature produced in advance. Because the hub's
+agents now live in a release directory that changes with every upgrade, there
+is nowhere stable to put a `<binary>.sig` for bytes you have not received yet.
+
+Signatures are therefore also looked up by **content address** in
+`~/.bloxos/agent-signatures/` (override with `BLOXOS_AGENT_SIGNATURE_DIR`):
+
+```
+<os>-<arch>-<sha256>.sig
+```
+
+base64 ed25519, over the same `bloxos-agent-update:v1:<os>:<sha256>` message as
+before. You can authorise bytes **before** the hub serves them; a signature for
+a release that has not arrived simply waits unused.
+
+Old signatures are never copied or regenerated for new bytes. A detached
+signature covers one specific SHA, so for different bytes it is not weak — it
+cannot verify at all, and announcing it would make every agent reject the
+update.
+
+Lookup order is `<binary>.sig`, then the content-addressed store, then the
+hub-held key. A hub that holds its own signing key needs **no pre-staged
+signature, no new key and no manual step**: the store is consulted, finds
+nothing, and the hub signs the bytes itself. When nothing can authorise a
+build, the hub logs the exact path that would fix it.
+
+The store holds data the hub verifies cryptographically, not an executable it
+serves, so it follows the installation-owned rule: owned by the user the hub
+runs as (or root) and not group- or other-writable. Under Docker that is uid
+65532 with `/data`; requiring root there would break every containerised
+install for no benefit, since an unverifiable signature is discarded anyway.
+
+---
+
+# Manual staging (external delivery only)
+
+Everything below applies when you have set `BLOXOS_AGENT_DELIVERY=external`,
+are running a hub built before managed delivery, or are managing one platform
+with an explicit override. On a packaged hub in the default `auto` mode, the
+payload staging in this section is not needed — offline signature
+authorisation, above, still is.
+
+A machine that matches the hub's offered SHA is up to date **with that offered
+file**, not necessarily with the latest BloxOS release.
 
 ### Agent is running, but drops offline after enrollment
 
@@ -99,9 +233,9 @@ key. Never upload the private key to the hub. See
 
 Installing a staged payload into an **active** serve path, or changing the
 hub's configured serve path to it, is activation. It can announce a fleet-wide
-update — even when the official payload is still numbered release 7 and the
-old served file has no release marker. Keep signing and activation behind
-your explicit rollout procedure; staging alone is not approval to activate.
+update, including when the old served file carries no release marker at all.
+Keep signing and activation behind your explicit rollout procedure; staging
+alone is not approval to activate.
 
 Protocol-2 agents reject older releases and equal-number/different-SHA
 payloads. Reuse the exact published bytes. If you rebuild and the bytes change,
@@ -109,6 +243,18 @@ the source-controlled agent release number must advance before publication.
 Do not rebuild release 7 differently and label it release 7. Old protocol-1
 agents do not enforce this rollback floor; a matching offered SHA does not
 prove that protection is present.
+
+This is now enforced in CI rather than left to care. Before any tag is
+promoted, a gate compares the candidate against every agent catalog this
+repository has published, drafts included, and refuses to proceed if the
+release number is already in use for different bytes or does not exceed the
+published floor. It also checks that both hub image platforms embed the same
+agent bytes as the standalone bundle, since the two images are built
+separately and could otherwise drift.
+
+Release 7 is a live example: ten published catalogs claim it, carrying two
+distinct sets of bytes. The gate finds this from the published history rather
+than from a hardcoded rule, and that number can never be reused.
 
 ## Release maintainers
 
@@ -126,8 +272,10 @@ Build-metadata suffixes (`+...`) and arbitrary `v...` names are rejected before
 publication because they cannot be used as these release image tags.
 
 Uploads deliberately do not overwrite existing assets or modify a published
-release. A rerun encountering either condition stops for maintainer review.
-For a partial draft upload, compare the existing asset hashes first; do not
-blindly clobber previously published agent bytes. A failed export may leave
+release. A rerun compares an already-published asset byte for byte and skips it
+when identical, and stops for maintainer review when it differs; nothing uses
+`--clobber`. The verified catalog is attached to the draft release **before**
+the Docker tags are promoted, so a run that dies mid-release still leaves a
+durable record of what agent bytes those images carry. A failed export may leave
 its new output directory for inspection, but its temporary Docker container
 is removed on a normal/error exit.

--- a/docs/native-agent-upgrades.md
+++ b/docs/native-agent-upgrades.md
@@ -49,43 +49,49 @@ against the release the catalog claims.
 
 ## Precedence
 
-The override variable for a platform is `BLOXOS_AGENT_BINARY` for Linux amd64,
-`BLOXOS_AGENT_BINARY_ARM64` for Linux arm64, and `BLOXOS_AGENT_BINARY_WINDOWS`
-for Windows. When set, it is **authoritative**: that platform resolves it or
-fails, and never falls back.
+Each platform has one override variable: `BLOXOS_AGENT_BINARY` for Linux
+amd64, `BLOXOS_AGENT_BINARY_ARM64` for Linux arm64, and
+`BLOXOS_AGENT_BINARY_WINDOWS` for Windows. **A platform's own override
+outranks the managed bundle** and is authoritative — that platform resolves it
+or fails, never falling back.
 
-**Linux arm64**, in order:
+**Linux amd64**
 
-1. a generic `BLOXOS_AGENT_BINARY` that is set and is not the shipped default
-   path — non-authoritative and architecture-verified, so a wrong-architecture
-   binary is skipped rather than failing the platform
+1. `BLOXOS_AGENT_BINARY` — authoritative, fails closed. The one exception is
+   below.
 2. the managed bundle
-3. `BLOXOS_AGENT_BINARY_ARM64` — authoritative, fails closed
-4. a generic `BLOXOS_AGENT_BINARY`, architecture-verified
-5. `/usr/local/lib/bloxos/linux/arm64/bloxos-agent`
-6. `/usr/local/lib/bloxos/linux/bloxos-agent` (legacy)
-7. a `bloxos-agent` sibling of the hub executable
-
-**Linux amd64**, in order:
-
-1. the managed bundle
-2. `BLOXOS_AGENT_BINARY` — authoritative, fails closed
 3. `/usr/local/lib/bloxos/linux/amd64/bloxos-agent`
 4. `/usr/local/lib/bloxos/linux/bloxos-agent` (legacy)
 5. a `bloxos-agent` sibling of the hub executable
 
-**Windows**: the managed bundle, then `BLOXOS_AGENT_BINARY_WINDOWS`
-(authoritative), then `/usr/local/lib/bloxos/windows/bloxos-agent.exe`, then a
-`bloxos-agent.exe` sibling of the hub executable.
+**Linux arm64**
+
+1. `BLOXOS_AGENT_BINARY_ARM64` — authoritative, fails closed, and the sole
+   candidate when set
+2. a generic `BLOXOS_AGENT_BINARY` other than the shipped default path —
+   non-authoritative and architecture-verified, so a binary built for another
+   architecture is skipped rather than failing the platform
+3. the managed bundle
+4. `/usr/local/lib/bloxos/linux/arm64/bloxos-agent`
+5. `/usr/local/lib/bloxos/linux/bloxos-agent` (legacy)
+6. a `bloxos-agent` sibling of the hub executable
+
+**Windows**
+
+1. `BLOXOS_AGENT_BINARY_WINDOWS` — authoritative, fails closed
+2. the managed bundle
+3. `/usr/local/lib/bloxos/windows/bloxos-agent.exe`
+4. a `bloxos-agent.exe` sibling of the hub executable
 
 ### The one exception
 
-A `BLOXOS_AGENT_BINARY` whose value is **exactly** the shipped default path is
-treated as legacy configuration, and the bundle takes precedence over it. The
-project's own systemd unit sets that variable, so without this the managed
-bundle would never be reached on a standard native install. Any other value —
-including a path that merely normalises to the default — remains an
-authoritative operator pin.
+A `BLOXOS_AGENT_BINARY` whose value is **exactly** the shipped default path
+(`/usr/local/lib/bloxos/linux/bloxos-agent`) is treated as legacy
+configuration, and the managed bundle takes precedence over it. The project's
+own systemd unit sets that variable, so without this exception the bundle would
+never be reached on a standard native install. Any other value — including a
+path that merely normalises to the default — remains an authoritative operator
+pin.
 
 Set `BLOXOS_AGENT_DELIVERY=external` to restore the full legacy resolver and
 manage agent binaries yourself. The manual procedure below then applies.

--- a/docs/system-updates.md
+++ b/docs/system-updates.md
@@ -93,8 +93,52 @@ the dashboard deliberately cannot submit paths, shell commands or image URLs.
 
 ## Server updates versus agent updates
 
-The native server updater replaces the hub and dashboard, not separately
-installed agent payloads. Use the [native agent guide](native-agent-upgrades.md)
-for those files. Compose images include agent payloads, so a new hub image can
-announce eligible signed agent updates. Offline-signing installations retain
-their installation-specific signing process. See [update signing](offline-update-signing.md).
+**A server update now carries the agent payloads too.** Both server archives
+ship all three agent binaries beside the hub executable, and the updater
+transports them like any other file in the release — there is no separate agent
+step and nothing to stage by hand. Compose images carry the same bundle.
+
+This is a change. The updater used to replace only the hub and dashboard, so a
+freshly updated hub kept offering whatever agent files were already on disk;
+machines reported "matches offered build" and were correct, because the offer
+itself was stale.
+
+### Three reasons the fleet can still sit on old agents
+
+They look identical on the Versions page until you read the right field, and
+the remedies are completely different.
+
+| What you see | What it means | Remedy |
+| --- | --- | --- |
+| **Delivery: System paths** or **Operator-managed** | The hub is not managing agents. Either it is a source build with no bundle, or `BLOXOS_AGENT_DELIVERY=external` is set, or an operator pin such as `BLOXOS_AGENT_BINARY` takes precedence. Upgrading the hub will not change the offer. | Remove the pin, or follow the [manual staging guide](native-agent-upgrades.md). |
+| **Signing: Disabled**, or a blocked-rollout reason | New agent bytes are present and the hub cannot authorise them. An offline install holds no private key, and no signature has been staged for these exact bytes. | Sign those bytes offline and place the signature by content address — see [native agent delivery](native-agent-upgrades.md#signatures). Nothing is wrong with the binaries. |
+| **Delivery: Broken** | The bundle failed validation. A packaged hub in this state refuses to start at all, so you will normally see a failed update and a rollback, not a running hub. | Read the hub's startup log; it names the payload and the reason. |
+
+The first is a configuration choice, the second is withheld authorisation, and
+the third is a bad artifact. Only the second leaves a healthy hub deliberately
+holding an update back.
+
+### Hub rollback and agent rollback are different things
+
+They share a word and nothing else.
+
+**Hub rollback** is the updater's. If a candidate release fails its readiness
+check — including a bad or missing agent bundle, which is refused before the
+database is even opened — the updater restores the previous release directory
+and restarts the old hub. It is automatic, local to the server, and affects no
+machine in the fleet.
+
+**Agent rollback protection** is each agent's own. A protocol-2 agent keeps a
+durable floor of the release number and SHA it is running, and refuses any
+offer that is older, or that carries the same release number with different
+bytes. Nothing on the hub can lower that floor, which is deliberate: it is what
+stops a compromised or confused hub from pushing an old agent back onto the
+fleet. Older protocol-1 agents do not enforce it.
+
+The practical consequence: rolling the hub back does NOT roll the fleet's
+agents back. Machines that already took an update keep the newer agent, and a
+rolled-back hub offering older bytes will simply be refused by them. Plan an
+agent change as a forward-only step.
+
+Offline-signing installations retain their installation-specific signing
+process. See [update signing](offline-update-signing.md).

--- a/hub/agent_binary.go
+++ b/hub/agent_binary.go
@@ -94,7 +94,7 @@ func (r agentBinaryResolver) env(name string) string {
 // managedWins reports whether the managed bundle outranks the project's own
 // shipped default for this platform.
 //
-// THE EXCEPTION, stated precisely. scripts/systemd/bloxos-hub.service ships
+// The exception. scripts/systemd/bloxos-hub.service ships
 // BLOXOS_AGENT_BINARY=/usr/local/lib/bloxos/linux/bloxos-agent. That value is
 // the PROJECT'S OWN DEFAULT, not an operator's choice — but the resolver cannot
 // tell the two apart by inspection, and as the authoritative first candidate it
@@ -120,7 +120,7 @@ func (r agentBinaryResolver) managedWins(platform agentPlatform) (string, bool) 
 	if value == "" {
 		return path, true // no override at all
 	}
-	// EXACT string comparison, deliberately. filepath.Clean would also exempt
+	// Exact string comparison, deliberately. filepath.Clean would also exempt
 	// an operator path that merely normalises to the default — something like
 	// /usr/local/lib/bloxos/linux/../linux/bloxos-agent — and that is somebody's
 	// deliberate configuration, not the project's shipped line. Only the literal
@@ -167,7 +167,7 @@ func productionAgentBinaryResolver() agentBinaryResolver {
 
 // checkManagedAgentBundle is the STARTUP gate for a packaged hub.
 //
-// It runs before anything is announced, and it fails closed. A packaged build
+// Runs before anything is announced, and fails closed. A packaged build
 // that declares a required bundle but cannot produce a valid one must not start
 // serving: if it did, it would fall through to the frozen system defaults and
 // report perfect health while handing out whatever binaries happened to be
@@ -371,11 +371,12 @@ func (r agentBinaryResolver) candidatesFor(platform agentPlatform) ([]agentBinar
 		}, nil
 	}
 
-	// A non-default arch has no dedicated override variable, so an operator
-	// points a native source build at the generic BLOXOS_AGENT_BINARY. That is a
-	// real custom choice and must keep outranking the managed bundle. It stays
-	// non-authoritative and ELF-gated, so a wrong-architecture path simply falls
-	// through to the bundle rather than failing the platform closed.
+	// An operator may point a native source build at the generic
+	// BLOXOS_AGENT_BINARY even though BLOXOS_AGENT_BINARY_ARM64 exists. That is
+	// a real custom choice and keeps outranking the bundle, but only when no
+	// explicit per-arch override is set — that one is handled below and wins
+	// outright. Non-authoritative and ELF-gated, so a wrong-architecture path
+	// falls through rather than failing the platform closed.
 	var preManaged []agentBinaryCandidate
 	if platform.Arch != defaultAgentArch {
 		if v := strings.TrimSpace(r.env("BLOXOS_AGENT_BINARY")); v != "" && v != linuxAgentBinaryDefault {
@@ -453,6 +454,15 @@ func (r agentBinaryResolver) resolve(osName, arch string) (agentBinaryResolution
 		path, err := r.validate(candidate.Path)
 		if err == nil && r.archMatch != nil && platform.OS == "linux" {
 			err = r.archMatch(path, platform.Arch)
+		}
+		if err == nil && candidate.Source == "managed-bundle" {
+			// Resolution is captured once at init, so re-bind the payload to the
+			// catalog here rather than trusting whatever is on disk now.
+			err = r.bundle.verifyPayloadIdentity(platform, path)
+			if err != nil {
+				return agentBinaryResolution{Path: path, Source: candidate.Source},
+					fmt.Errorf("managed agent bundle no longer matches its catalog: %w", err)
+			}
 		}
 		if err == nil {
 			return agentBinaryResolution{

--- a/hub/agent_binary.go
+++ b/hub/agent_binary.go
@@ -74,6 +74,61 @@ type agentBinaryResolver struct {
 	// it to verifyELFArch so a binary is only ever served for the
 	// architecture it actually is.
 	archMatch func(path, arch string) error
+	// bundle is the validated managed bundle shipped beside the hub, or nil on
+	// a source build with none. See hub/agent_bundle.go.
+	bundle *agentBundle
+	// deliveryMode is agentDeliveryAuto or agentDeliveryExternal.
+	deliveryMode string
+	// getenv is injectable so precedence can be tested without touching the
+	// process environment.
+	getenv func(string) string
+}
+
+func (r agentBinaryResolver) env(name string) string {
+	if r.getenv != nil {
+		return r.getenv(name)
+	}
+	return os.Getenv(name)
+}
+
+// managedWins reports whether the managed bundle outranks the project's own
+// shipped default for this platform.
+//
+// THE EXCEPTION, stated precisely. scripts/systemd/bloxos-hub.service ships
+// BLOXOS_AGENT_BINARY=/usr/local/lib/bloxos/linux/bloxos-agent. That value is
+// the PROJECT'S OWN DEFAULT, not an operator's choice — but the resolver cannot
+// tell the two apart by inspection, and as the authoritative first candidate it
+// pins every standard native install to a path no release ever refreshes.
+//
+// So a value EXACTLY equal to that shipped default is treated as legacy default
+// configuration and the managed bundle wins. Any other value is a genuine
+// operator pin and stays authoritative and fail-closed. Nothing on disk is
+// rewritten: no unit file is edited, no environment is mutated.
+//
+// An operator who deliberately manages binaries at that exact path sets
+// BLOXOS_AGENT_DELIVERY=external, which restores the full legacy resolver.
+func (r agentBinaryResolver) managedWins(platform agentPlatform) (string, bool) {
+	if r.bundle == nil || r.deliveryMode == agentDeliveryExternal {
+		return "", false
+	}
+	path, ok := r.bundle.pathFor(platform)
+	if !ok {
+		return "", false
+	}
+	envName := agentBinaryEnvName(platform)
+	value := strings.TrimSpace(r.env(envName))
+	if value == "" {
+		return path, true // no override at all
+	}
+	// EXACT string comparison, deliberately. filepath.Clean would also exempt
+	// an operator path that merely normalises to the default — something like
+	// /usr/local/lib/bloxos/linux/../linux/bloxos-agent — and that is somebody's
+	// deliberate configuration, not the project's shipped line. Only the literal
+	// value this project ships yields to the bundle.
+	if envName == "BLOXOS_AGENT_BINARY" && value == linuxAgentBinaryDefault {
+		return path, true
+	}
+	return "", false
 }
 
 var (
@@ -93,11 +148,65 @@ func newAgentBinaryStates() map[string]agentBinaryState {
 }
 
 func productionAgentBinaryResolver() agentBinaryResolver {
-	return agentBinaryResolver{
+	r := agentBinaryResolver{
 		executablePath: os.Executable,
 		validate:       validateTrustedAgentBinary,
 		archMatch:      verifyELFArch,
+		deliveryMode:   agentDeliveryAuto,
 	}
+	if mode, err := resolveAgentDeliveryMode(os.Getenv); err == nil {
+		r.deliveryMode = mode
+	}
+	if dir, err := r.hubExecutableDir(); err == nil {
+		if bundle, err := loadAgentBundle(dir, validateTrustedAgentBinary); err == nil {
+			r.bundle = bundle
+		}
+	}
+	return r
+}
+
+// checkManagedAgentBundle is the STARTUP gate for a packaged hub.
+//
+// It runs before anything is announced, and it fails closed. A packaged build
+// that declares a required bundle but cannot produce a valid one must not start
+// serving: if it did, it would fall through to the frozen system defaults and
+// report perfect health while handing out whatever binaries happened to be
+// sitting on disk. Failing here is what lets the existing updater's build-info
+// readiness check reject the candidate and roll back.
+//
+// A source or development build (no build-time marker) is unaffected: a missing
+// bundle is normal there and legacy discovery still applies. What is NOT
+// tolerated in either case is a bundle that exists and is broken.
+func checkManagedAgentBundle() error {
+	mode, err := resolveAgentDeliveryMode(os.Getenv)
+	if err != nil {
+		return err // an unreadable delivery mode is visible, never guessed
+	}
+
+	r := agentBinaryResolver{executablePath: os.Executable}
+	dir, err := r.hubExecutableDir()
+	if err != nil {
+		if agentBundleIsRequired() {
+			return fmt.Errorf("packaged build cannot locate its own directory: %w", err)
+		}
+		return nil
+	}
+
+	bundle, err := loadAgentBundle(dir, validateTrustedAgentBinary)
+	if err != nil {
+		// Present but invalid is fatal regardless of build kind and regardless
+		// of delivery mode: a corrupt bundle is evidence something is wrong
+		// with this install, not a reason to quietly use older binaries.
+		return fmt.Errorf("managed agent bundle is unusable: %w", err)
+	}
+	if bundle == nil && agentBundleIsRequired() && mode != agentDeliveryExternal {
+		// The whole directory is missing from a build that must carry one.
+		// Without the build-time marker this case is indistinguishable from a
+		// legitimate source build, which is exactly why the marker exists.
+		return fmt.Errorf("packaged build requires a managed agent bundle at %s, and none is present",
+			filepath.Join(dir, agentBundleDirName))
+	}
+	return nil
 }
 
 // elfMachineByArch maps a GOARCH to the ELF e_machine value its binaries
@@ -246,7 +355,10 @@ type agentBinaryCandidate struct {
 // different architecture.
 func (r agentBinaryResolver) candidatesFor(platform agentPlatform) ([]agentBinaryCandidate, error) {
 	if platform.OS == "windows" {
-		if v := strings.TrimSpace(os.Getenv("BLOXOS_AGENT_BINARY_WINDOWS")); v != "" {
+		if managed, ok := r.managedWins(platform); ok {
+			return []agentBinaryCandidate{{Path: managed, Source: "managed-bundle"}}, nil
+		}
+		if v := strings.TrimSpace(r.env("BLOXOS_AGENT_BINARY_WINDOWS")); v != "" {
 			return []agentBinaryCandidate{{Path: v, Source: "environment:BLOXOS_AGENT_BINARY_WINDOWS", Env: "BLOXOS_AGENT_BINARY_WINDOWS"}}, nil
 		}
 		executable, err := r.hubExecutableDir()
@@ -259,8 +371,24 @@ func (r agentBinaryResolver) candidatesFor(platform agentPlatform) ([]agentBinar
 		}, nil
 	}
 
+	// A non-default arch has no dedicated override variable, so an operator
+	// points a native source build at the generic BLOXOS_AGENT_BINARY. That is a
+	// real custom choice and must keep outranking the managed bundle. It stays
+	// non-authoritative and ELF-gated, so a wrong-architecture path simply falls
+	// through to the bundle rather than failing the platform closed.
+	var preManaged []agentBinaryCandidate
+	if platform.Arch != defaultAgentArch {
+		if v := strings.TrimSpace(r.env("BLOXOS_AGENT_BINARY")); v != "" && v != linuxAgentBinaryDefault {
+			preManaged = append(preManaged, agentBinaryCandidate{
+				Path: v, Source: "environment:BLOXOS_AGENT_BINARY (arch-verified)"})
+		}
+	}
+	if managed, ok := r.managedWins(platform); ok {
+		return append(preManaged, agentBinaryCandidate{Path: managed, Source: "managed-bundle"}), nil
+	}
+
 	perArchEnv := agentBinaryEnvName(platform)
-	if v := strings.TrimSpace(os.Getenv(perArchEnv)); v != "" {
+	if v := strings.TrimSpace(r.env(perArchEnv)); v != "" {
 		return []agentBinaryCandidate{{Path: v, Source: "environment:" + perArchEnv, Env: perArchEnv}}, nil
 	}
 
@@ -272,7 +400,7 @@ func (r agentBinaryResolver) candidatesFor(platform agentPlatform) ([]agentBinar
 		// systemd unit). Honor it ahead of the packaged per-arch default so an
 		// explicit operator choice wins. Non-authoritative and ELF-gated: a
 		// wrong architecture just skips to the next candidate.
-		if v := strings.TrimSpace(os.Getenv("BLOXOS_AGENT_BINARY")); v != "" {
+		if v := strings.TrimSpace(r.env("BLOXOS_AGENT_BINARY")); v != "" {
 			candidates = append(candidates, agentBinaryCandidate{Path: v, Source: "environment:BLOXOS_AGENT_BINARY (arch-verified)"})
 		}
 	}

--- a/hub/agent_binary.go
+++ b/hub/agent_binary.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 	"log"
@@ -569,5 +570,102 @@ func failAgentBinaryState(platform agentPlatform, resolution agentBinaryResoluti
 	previous := replaceAgentBinaryState(platform, state)
 	if previous.Error != state.Error || previous.SHA != "" {
 		log.Printf("version: %s agent binary unavailable: %v", platform, err)
+	}
+}
+
+// peMachineByArch maps a GOARCH to the COFF IMAGE_FILE_MACHINE value a
+// Windows PE built for it carries: AMD64 = 0x8664, ARM64 = 0xaa64.
+var peMachineByArch = map[string]uint16{archAMD64: 0x8664, archARM64: 0xaa64}
+
+func peMachineName(m uint16) string {
+	for arch, want := range peMachineByArch {
+		if want == m {
+			return arch
+		}
+	}
+	return fmt.Sprintf("machine=0x%04x", m)
+}
+
+// peMaxHeaderOffset bounds e_lfanew before it is used as a seek target. The
+// value is read OUT OF THE FILE being checked, so an unbounded one would let a
+// crafted or corrupt payload steer the read arbitrarily far into a large file.
+// Real Go PE images put their header within the first few hundred bytes; a
+// megabyte is generous and still finite.
+const peMaxHeaderOffset = 1 << 20
+
+// verifyPEArch reports whether the binary at path is a 64-bit Windows PE built
+// for arch.
+//
+// The Windows counterpart to verifyELFArch, and it exists for the same reason:
+// without it, the only thing standing between a bundle and serving amd64 bytes
+// to an arm64 machine is the manifest's own label — a claim made by the same
+// document the bundle supplies. A sha256 proves the payload is the file the
+// catalog names; it proves nothing about what the file IS. Architecture has to
+// be read from the image itself.
+//
+// Checked: the MZ stub, a bounded e_lfanew, the PE signature, the COFF machine
+// field, and the optional-header magic (PE32+). Go only emits 64-bit Windows
+// binaries, so a PE32 image here is a packaging mistake, not a supported build.
+func verifyPEArch(path, arch string) error {
+	want, ok := peMachineByArch[arch]
+	if !ok {
+		return fmt.Errorf("unsupported architecture %q", arch)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var dos [0x40]byte
+	if _, err := io.ReadFull(f, dos[:]); err != nil {
+		return fmt.Errorf("read DOS header of %s: %w", path, err)
+	}
+	if dos[0] != 'M' || dos[1] != 'Z' {
+		return fmt.Errorf("%s is not a PE binary", path)
+	}
+	offset := int64(binary.LittleEndian.Uint32(dos[0x3c:0x40]))
+	// Below the DOS header the offset would point back into the stub; above the
+	// bound it is not a header this hub will chase.
+	if offset < 0x40 || offset > peMaxHeaderOffset {
+		return fmt.Errorf("%s declares an implausible PE header offset %d", path, offset)
+	}
+
+	// Signature (4) + COFF header (20) + optional-header magic (2).
+	var hdr [26]byte
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return fmt.Errorf("seek PE header of %s: %w", path, err)
+	}
+	if _, err := io.ReadFull(f, hdr[:]); err != nil {
+		return fmt.Errorf("read PE header of %s: %w", path, err)
+	}
+	if hdr[0] != 'P' || hdr[1] != 'E' || hdr[2] != 0 || hdr[3] != 0 {
+		return fmt.Errorf("%s has no PE signature at offset %d", path, offset)
+	}
+	machine := binary.LittleEndian.Uint16(hdr[4:6])
+	if machine != want {
+		return fmt.Errorf("%s is a %s binary, not %s", path, peMachineName(machine), arch)
+	}
+	// IMAGE_NT_OPTIONAL_HDR64_MAGIC. A PE32 image would run, and would be the
+	// wrong build entirely.
+	if magic := binary.LittleEndian.Uint16(hdr[24:26]); magic != 0x020b {
+		return fmt.Errorf("%s is not a 64-bit PE binary (optional header magic 0x%04x)", path, magic)
+	}
+	return nil
+}
+
+// verifyAgentPayloadArch dispatches the architecture check by target OS.
+//
+// Every platform a bundle declares gets checked. An unrecognised OS is an
+// error rather than a skip: "we could not check this one" must never read as
+// "this one passed".
+func verifyAgentPayloadArch(osName, arch, path string) error {
+	switch osName {
+	case "linux":
+		return verifyELFArch(path, arch)
+	case "windows":
+		return verifyPEArch(path, arch)
+	default:
+		return fmt.Errorf("no architecture check for os %q", osName)
 	}
 }

--- a/hub/agent_binary.go
+++ b/hub/agent_binary.go
@@ -82,6 +82,9 @@ type agentBinaryResolver struct {
 	// getenv is injectable so precedence can be tested without touching the
 	// process environment.
 	getenv func(string) string
+	// initErr is a delivery-configuration failure detected when this resolver
+	// was built. Every resolution fails closed while it is set.
+	initErr error
 }
 
 func (r agentBinaryResolver) env(name string) string {
@@ -154,59 +157,46 @@ func productionAgentBinaryResolver() agentBinaryResolver {
 		archMatch:      verifyELFArch,
 		deliveryMode:   agentDeliveryAuto,
 	}
-	if mode, err := resolveAgentDeliveryMode(os.Getenv); err == nil {
-		r.deliveryMode = mode
-	}
-	if dir, err := r.hubExecutableDir(); err == nil {
-		if bundle, err := loadAgentBundle(dir, validateTrustedAgentBinary); err == nil {
-			r.bundle = bundle
-		}
-	}
-	return r
-}
-
-// checkManagedAgentBundle is the STARTUP gate for a packaged hub.
-//
-// Runs before anything is announced, and fails closed. A packaged build
-// that declares a required bundle but cannot produce a valid one must not start
-// serving: if it did, it would fall through to the frozen system defaults and
-// report perfect health while handing out whatever binaries happened to be
-// sitting on disk. Failing here is what lets the existing updater's build-info
-// readiness check reject the candidate and roll back.
-//
-// A source or development build (no build-time marker) is unaffected: a missing
-// bundle is normal there and legacy discovery still applies. What is NOT
-// tolerated in either case is a bundle that exists and is broken.
-func checkManagedAgentBundle() error {
+	// Errors here are RETAINED, not swallowed. Resolution is captured once at
+	// package init, so a constructor that quietly dropped a bad delivery mode or
+	// a corrupt bundle would fall through to the frozen system defaults for the
+	// life of the process — the failure this whole mechanism replaces.
 	mode, err := resolveAgentDeliveryMode(os.Getenv)
 	if err != nil {
-		return err // an unreadable delivery mode is visible, never guessed
+		r.initErr = err
+		return r
 	}
+	r.deliveryMode = mode
 
-	r := agentBinaryResolver{executablePath: os.Executable}
 	dir, err := r.hubExecutableDir()
 	if err != nil {
 		if agentBundleIsRequired() {
-			return fmt.Errorf("packaged build cannot locate its own directory: %w", err)
+			r.initErr = fmt.Errorf("packaged build cannot locate its own directory: %w", err)
 		}
-		return nil
+		return r
 	}
-
 	bundle, err := loadAgentBundle(dir, validateTrustedAgentBinary)
 	if err != nil {
-		// Present but invalid is fatal regardless of build kind and regardless
-		// of delivery mode: a corrupt bundle is evidence something is wrong
-		// with this install, not a reason to quietly use older binaries.
-		return fmt.Errorf("managed agent bundle is unusable: %w", err)
+		r.initErr = fmt.Errorf("managed agent bundle is unusable: %w", err)
+		return r
 	}
 	if bundle == nil && agentBundleIsRequired() && mode != agentDeliveryExternal {
-		// The whole directory is missing from a build that must carry one.
-		// Without the build-time marker this case is indistinguishable from a
-		// legitimate source build, which is exactly why the marker exists.
-		return fmt.Errorf("packaged build requires a managed agent bundle at %s, and none is present",
+		r.initErr = fmt.Errorf("packaged build requires a managed agent bundle at %s, and none is present",
 			filepath.Join(dir, agentBundleDirName))
+		return r
 	}
-	return nil
+	r.bundle = bundle
+	return r
+}
+
+// checkManagedAgentBundle is the startup gate for a packaged hub.
+//
+// It reports the same delivery-configuration failure the resolver retains, so a
+// packaged build that cannot produce a valid bundle refuses to start rather than
+// serving whatever binaries happen to be on disk. Failing here lets the
+// updater's readiness check reject the candidate and roll back.
+func checkManagedAgentBundle() error {
+	return productionAgentBinaryResolver().initErr
 }
 
 // elfMachineByArch maps a GOARCH to the ELF e_machine value its binaries
@@ -433,6 +423,9 @@ func (r agentBinaryResolver) hubExecutableDir() (string, error) {
 }
 
 func (r agentBinaryResolver) resolve(osName, arch string) (agentBinaryResolution, error) {
+	if r.initErr != nil {
+		return agentBinaryResolution{}, r.initErr
+	}
 	platform, err := agentPlatformFor(osName, arch)
 	if err != nil {
 		return agentBinaryResolution{}, err

--- a/hub/agent_binary.go
+++ b/hub/agent_binary.go
@@ -151,7 +151,43 @@ func newAgentBinaryStates() map[string]agentBinaryState {
 	return states
 }
 
+// The production resolver is built ONCE and retained.
+//
+// It used to be constructed afresh on every call, which was wrong in two ways
+// that compound. It re-read and re-hashed every agent payload each time — tens
+// of megabytes of sha256 on a route the Versions page polls. Worse, each call
+// produced an INDEPENDENT resolver: the one serving downloads is captured at
+// package init, so a later caller could load a different catalog, or a
+// different delivery mode, and report state the serving path does not use.
+// The startup gate had the same split — it validated a second load, not the
+// one that would actually serve.
+//
+// One instance means the gate, every resolution and the reported status all
+// describe the same catalog. Per-resolution payload identity is still
+// re-verified against that retained catalog, so a payload altered on disk
+// afterwards is still caught.
+// memoizedResolver builds its resolver at most once and returns that same
+// instance thereafter. A struct rather than package globals so a test can own
+// one, with its own constructor, and prove the behaviour without touching
+// anything another test is using.
+type memoizedResolver struct {
+	once  sync.Once
+	value agentBinaryResolver
+	build func() agentBinaryResolver
+}
+
+func (m *memoizedResolver) get() agentBinaryResolver {
+	m.once.Do(func() { m.value = m.build() })
+	return m.value
+}
+
+var productionResolverCache = &memoizedResolver{build: newProductionAgentBinaryResolver}
+
 func productionAgentBinaryResolver() agentBinaryResolver {
+	return productionResolverCache.get()
+}
+
+func newProductionAgentBinaryResolver() agentBinaryResolver {
 	r := agentBinaryResolver{
 		executablePath: os.Executable,
 		validate:       validateTrustedAgentBinary,

--- a/hub/agent_bundle.go
+++ b/hub/agent_bundle.go
@@ -193,21 +193,32 @@ func loadAgentBundle(executableDir string, validate func(string) (string, error)
 		return nil, fmt.Errorf("stat agent bundle directory: %w", err)
 	}
 
-	info, err := os.Stat(manifestPath)
-	if err != nil {
+	// Distinguish "no manifest" from "unreadable manifest" BEFORE the trust
+	// check, so the error can say which of the two an operator is looking at.
+	if _, err := os.Lstat(manifestPath); err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("agent bundle directory %s has no %s", dir, agentBundleManifestName)
 		}
 		return nil, fmt.Errorf("stat agent bundle manifest: %w", err)
 	}
-	// Bound the manifest before reading: a corrupt install must not be able to
-	// exhaust memory here.
-	if info.Size() > agentBundleManifestMaxBytes {
-		return nil, fmt.Errorf("agent bundle manifest is %d bytes, over the %d limit",
-			info.Size(), agentBundleManifestMaxBytes)
+
+	// The manifest is the document that decides which bytes this hub will hand
+	// the entire fleet, so it goes through the SAME trust check as the payloads
+	// it describes: a regular file, not a symlink, root-owned with no
+	// group/other write anywhere on its path.
+	//
+	// Stat-then-ReadFile was not enough, and the gap is not theoretical. Stat
+	// follows symlinks, so a link planted in the bundle directory would have
+	// been read from wherever it pointed. A FIFO stats as zero bytes, sails
+	// under the size limit, and then blocks or streams without end. And even
+	// for an ordinary file the size read by Stat is a different observation
+	// from the bytes read afterwards — a file being written grows between them.
+	manifestFile, err := validate(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("agent bundle manifest is not trusted: %w", err)
 	}
 
-	raw, err := os.ReadFile(manifestPath)
+	raw, err := readBoundedFile(manifestFile, agentBundleManifestMaxBytes)
 	if err != nil {
 		return nil, fmt.Errorf("read agent bundle manifest: %w", err)
 	}
@@ -286,6 +297,19 @@ func loadAgentBundle(executableDir string, validate func(string) (string, error)
 				platform, sum, artifact.SHA256)
 		}
 
+		// The payload must be built for the architecture it is filed under.
+		// A sha256 proves the bytes are the file the catalog names; it says
+		// nothing about what those bytes ARE. Without reading the image
+		// header, the only thing keeping amd64 bytes from being handed to an
+		// arm64 machine is the manifest's own label — a claim made by the same
+		// document the bundle ships. The resolver already gated Linux at
+		// resolution time; a bundle is checked for every platform it declares,
+		// Windows included, and at load, so a mislabelled payload stops the
+		// hub instead of reaching one unlucky architecture later.
+		if err := verifyAgentPayloadArch(osName, arch, verified); err != nil {
+			return nil, fmt.Errorf("agent bundle artifact %q: %w", platform, err)
+		}
+
 		// The payload must actually BE the release the catalog claims. Without
 		// this, a bundle could advertise a new release number while carrying
 		// older bytes — which is precisely how the fleet came to run agents
@@ -304,6 +328,28 @@ func loadAgentBundle(executableDir string, validate func(string) (string, error)
 	}
 
 	return bundle, nil
+}
+
+// readBoundedFile reads at most max bytes and fails if the file has more.
+//
+// The bound is enforced by the READ, not by a prior Stat. That ordering is the
+// whole point: a size observed before the read is a claim about a different
+// moment, and it is not a claim a FIFO or a growing file honours.
+func readBoundedFile(path string, max int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	// max+1 so hitting the limit exactly is distinguishable from overrunning it.
+	raw, err := io.ReadAll(io.LimitReader(f, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(raw)) > max {
+		return nil, fmt.Errorf("file is larger than the %d byte limit", max)
+	}
+	return raw, nil
 }
 
 func fileSHA256(path string) (string, error) {

--- a/hub/agent_bundle.go
+++ b/hub/agent_bundle.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// The MANAGED AGENT BUNDLE: agent payloads that travel with the hub release, so
+// upgrading the hub upgrades what the fleet is offered.
+//
+// WHY THIS EXISTS. Agent binaries were served from fixed system paths that
+// nothing in the release ever refreshed. `bloxos-update` replaces the hub and
+// the dashboard and deliberately does not touch agent files, so a hub could run
+// v1.7.1 while handing out agents built weeks earlier. Every machine then
+// reported "matches offered build" — correctly, because it matched what the hub
+// offered. The offer was simply stale, and that single fact accounted for
+// missing power on ARM boards, absent source labels, and wrong CPU inventory.
+//
+// WHY PLACEMENT ALONE WOULD NOT HAVE FIXED IT. The resolver already had a
+// `hub-executable-directory` candidate — and it sits LAST, behind the system
+// defaults. Worse, the project's own systemd unit sets BLOXOS_AGENT_BINARY,
+// which for amd64 is the authoritative, fail-closed first candidate. Dropping
+// files beside the hub binary would therefore have changed nothing on a standard
+// native install: a fix that looks right and is inert. The precedence contract
+// below is the actual mechanism; the packaging is only its transport.
+//
+// WHAT IS DELIBERATELY NOT HERE. No new manifest schema for the updater to
+// understand, no updater install logic, no self-refresh. The existing archive
+// checksum, safe extraction and copy already carry arbitrary files; the NEW hub
+// consumes and verifies its own bundle. That keeps delivery logic in one
+// component and avoids a two-step rollout.
+
+// agentBundleDirName is the bundle's directory, a direct child of the hub
+// executable's own directory.
+//
+// A direct child, not a sibling reached through "..": every path this file
+// touches is then a plain join under a directory we already trust, and no
+// traversal component ever enters a filesystem call.
+const agentBundleDirName = "agents"
+
+// agentBundleManifestName reuses the manifest scripts/agent_bundle.py already
+// produces, rather than inventing a parallel catalog format.
+const agentBundleManifestName = "agent-manifest.json"
+
+// agentBundleRequiredPlatforms is every platform a packaged bundle must carry.
+// Both server architectures ship all three, so a hub can serve any agent.
+var agentBundleRequiredPlatforms = []string{"linux/amd64", "linux/arm64", "windows/amd64"}
+
+const (
+	agentBundleManifestMaxBytes = 64 << 10
+	agentBundlePayloadMaxBytes  = 256 << 20
+)
+
+// agentBundleRequired is set at build time (-ldflags) on packaged hub builds.
+//
+// It is a plain marker and NOT a content hash on purpose. The obvious
+// alternative — embedding the manifest's SHA — cannot work: that manifest
+// includes the hub image digest, so the hub binary would have to contain a hash
+// of a document that contains a hash of the hub binary. A build-time flag
+// distinguishes "packaged, a bundle is mandatory" from "source build, a bundle
+// is optional" with no cycle.
+//
+// Empty means a development or source build: a missing bundle is then normal
+// and legacy discovery still applies.
+var agentBundleRequired = ""
+
+// agentBundleIsRequired reports whether this build must have a valid bundle.
+func agentBundleIsRequired() bool {
+	return strings.TrimSpace(agentBundleRequired) != ""
+}
+
+// agentDeliveryMode selects how agent binaries are resolved.
+const (
+	// agentDeliveryAuto is the default: a valid managed bundle takes precedence
+	// over the project's own shipped default path.
+	agentDeliveryAuto = "auto"
+	// agentDeliveryExternal preserves the FULL legacy resolver, including an
+	// intentional override that happens to equal the shipped default path. It
+	// is the escape hatch for an operator who really does manage agent binaries
+	// themselves at that location.
+	agentDeliveryExternal = "external"
+)
+
+const agentDeliveryEnv = "BLOXOS_AGENT_DELIVERY"
+
+// resolveAgentDeliveryMode reads the mode, failing closed on anything it does
+// not recognise. A misspelled mode must be visible, not silently treated as the
+// default — an operator who typed "externl" meant to change behaviour.
+func resolveAgentDeliveryMode(getenv func(string) string) (string, error) {
+	raw := strings.ToLower(strings.TrimSpace(getenv(agentDeliveryEnv)))
+	switch raw {
+	case "":
+		return agentDeliveryAuto, nil
+	case agentDeliveryAuto, agentDeliveryExternal:
+		return raw, nil
+	default:
+		return "", fmt.Errorf("%s=%q is not a known delivery mode (want %q or %q)",
+			agentDeliveryEnv, raw, agentDeliveryAuto, agentDeliveryExternal)
+	}
+}
+
+// agentBundleArtifact is one platform's payload as the manifest declares it.
+type agentBundleArtifact struct {
+	File   string `json:"file"`
+	Size   int64  `json:"size"`
+	SHA256 string `json:"sha256"`
+}
+
+// agentBundleManifest is the subset of agent-manifest.json this hub reads.
+type agentBundleManifest struct {
+	Schema       int                            `json:"schema"`
+	Version      string                         `json:"version"`
+	Source       string                         `json:"source"`
+	AgentRelease uint64                         `json:"agent_release"`
+	Artifacts    map[string]agentBundleArtifact `json:"artifacts"`
+}
+
+// agentBundle is a validated bundle: every declared artifact has been checked.
+type agentBundle struct {
+	Dir      string
+	Manifest agentBundleManifest
+	// paths maps "<os>/<arch>" to the verified absolute payload path.
+	paths map[string]string
+}
+
+// pathFor returns the verified payload for a platform, if the bundle declares
+// one. A bundle that does not declare a platform is not an error — it simply
+// has nothing to offer there, and legacy discovery continues.
+func (b *agentBundle) pathFor(platform agentPlatform) (string, bool) {
+	if b == nil {
+		return "", false
+	}
+	p, ok := b.paths[platform.OS+"/"+platform.Arch]
+	return p, ok
+}
+
+// loadAgentBundle reads and fully validates the bundle beside the hub executable.
+//
+// Validation is all-or-nothing by design. A bundle that is PRESENT BUT INVALID
+// must fail closed rather than fall through to the frozen system defaults:
+// falling through is precisely how a hub ends up quietly serving months-old
+// agents while reporting success. The caller decides what a missing bundle
+// means, via agentBundleIsRequired.
+func loadAgentBundle(executableDir string, validate func(string) (string, error)) (*agentBundle, error) {
+	dir := filepath.Join(executableDir, agentBundleDirName)
+	manifestPath := filepath.Join(dir, agentBundleManifestName)
+
+	// "No bundle at all" and "a bundle with its manifest missing" are different
+	// answers. The first is a source build; the second is a broken install, and
+	// treating it as absent would fall through to the frozen system defaults —
+	// the exact silent staleness this whole mechanism exists to end.
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat agent bundle directory: %w", err)
+	}
+
+	info, err := os.Stat(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("agent bundle directory %s has no %s", dir, agentBundleManifestName)
+		}
+		return nil, fmt.Errorf("stat agent bundle manifest: %w", err)
+	}
+	// Bound the manifest before reading it: it is attacker-shaped input in the
+	// sense that a corrupt install should not be able to exhaust memory here.
+	if info.Size() > agentBundleManifestMaxBytes {
+		return nil, fmt.Errorf("agent bundle manifest is %d bytes, over the %d limit",
+			info.Size(), agentBundleManifestMaxBytes)
+	}
+
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read agent bundle manifest: %w", err)
+	}
+
+	var manifest agentBundleManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return nil, fmt.Errorf("agent bundle manifest is not valid JSON: %w", err)
+	}
+	if manifest.Schema != 1 {
+		return nil, fmt.Errorf("agent bundle manifest schema %d is not supported", manifest.Schema)
+	}
+	if manifest.AgentRelease == 0 {
+		return nil, fmt.Errorf("agent bundle manifest declares no agent release")
+	}
+	// Every server archive carries every agent platform. A bundle short of one
+	// would let a platform quietly keep resolving to a frozen system default
+	// while the feature reported success for the others.
+	for _, required := range agentBundleRequiredPlatforms {
+		if _, ok := manifest.Artifacts[required]; !ok {
+			return nil, fmt.Errorf("agent bundle manifest does not declare %s", required)
+		}
+	}
+
+	bundle := &agentBundle{Dir: dir, Manifest: manifest, paths: map[string]string{}}
+
+	for platform, artifact := range manifest.Artifacts {
+		osName, arch, ok := strings.Cut(platform, "/")
+		if !ok {
+			return nil, fmt.Errorf("agent bundle declares malformed platform %q", platform)
+		}
+		if _, err := agentPlatformFor(osName, arch); err != nil {
+			return nil, fmt.Errorf("agent bundle declares unsupported platform %q: %w", platform, err)
+		}
+
+		// The manifest is data, not a path source. A file name carrying a
+		// separator or a parent reference would otherwise let a crafted bundle
+		// point the hub at a file outside its own directory.
+		if artifact.File == "" || artifact.File != filepath.Base(artifact.File) ||
+			strings.ContainsAny(artifact.File, `/\`) || artifact.File == "." || artifact.File == ".." {
+			return nil, fmt.Errorf("agent bundle artifact %q has an unsafe file name %q", platform, artifact.File)
+		}
+		if len(artifact.SHA256) != 64 {
+			return nil, fmt.Errorf("agent bundle artifact %q has no usable sha256", platform)
+		}
+		// A declared size is mandatory and bounded: zero would make the size
+		// check vacuous, and an absurd value signals a corrupt manifest.
+		if artifact.Size <= 0 || artifact.Size > agentBundlePayloadMaxBytes {
+			return nil, fmt.Errorf("agent bundle artifact %q declares an implausible size %d",
+				platform, artifact.Size)
+		}
+
+		payload := filepath.Join(dir, artifact.File)
+
+		// Reuse the SAME trust check every other candidate goes through: root
+		// ownership, no group/other write anywhere on the path, a regular file.
+		verified, err := validate(payload)
+		if err != nil {
+			return nil, fmt.Errorf("agent bundle artifact %q is not trusted: %w", platform, err)
+		}
+
+		payloadInfo, err := os.Stat(verified)
+		if err != nil {
+			return nil, fmt.Errorf("agent bundle artifact %q: %w", platform, err)
+		}
+		if payloadInfo.Size() != artifact.Size {
+			return nil, fmt.Errorf("agent bundle artifact %q is %d bytes, manifest says %d",
+				platform, payloadInfo.Size(), artifact.Size)
+		}
+
+		sum, err := fileSHA256(verified)
+		if err != nil {
+			return nil, fmt.Errorf("agent bundle artifact %q: %w", platform, err)
+		}
+		if !strings.EqualFold(sum, artifact.SHA256) {
+			return nil, fmt.Errorf("agent bundle artifact %q sha256 %s does not match manifest %s",
+				platform, sum, artifact.SHA256)
+		}
+
+		bundle.paths[osName+"/"+arch] = verified
+	}
+
+	return bundle, nil
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/hub/agent_bundle.go
+++ b/hub/agent_bundle.go
@@ -383,3 +383,33 @@ func agentPayloadRelease(path string) (uint64, error) {
 	}
 	return seq, nil
 }
+
+// agentDeliveryStatus reports the resolution POLICY in force, and why it is
+// unusable if it is.
+//
+// One value, at one level, and deliberately not a per-platform claim.
+// "auto" means a managed bundle is AVAILABLE to the resolver; an explicit
+// per-architecture override still outranks it, so a hub on this policy can
+// legitimately serve an operator-pinned binary for one architecture. Each
+// platform's agentBinaryState carries the `source` it actually resolved from,
+// which is the authoritative answer. Summarising that here would create two
+// fields that must agree and eventually will not.
+func agentDeliveryStatus() (string, string) {
+	resolver := productionAgentBinaryResolver()
+	if resolver.initErr != nil {
+		// A hub in this state refuses to start, so an operator normally never
+		// sees it — except on a source build, where a bundle is optional and a
+		// misconfigured delivery mode still has to be visible somewhere.
+		return "unusable", resolver.initErr.Error()
+	}
+	if resolver.deliveryMode == agentDeliveryExternal {
+		return agentDeliveryExternal, ""
+	}
+	if resolver.bundle == nil {
+		// Auto mode with nothing to manage: a source build, where legacy
+		// discovery still applies. Naming it plainly beats reporting "auto"
+		// and leaving a reader to wonder why nothing resolves to a bundle.
+		return "legacy", ""
+	}
+	return agentDeliveryAuto, ""
+}

--- a/hub/agent_bundle.go
+++ b/hub/agent_bundle.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
 )
 
 // Managed agent bundle: agent payloads that travel with the hub release, so
@@ -284,6 +286,19 @@ func loadAgentBundle(executableDir string, validate func(string) (string, error)
 				platform, sum, artifact.SHA256)
 		}
 
+		// The payload must actually BE the release the catalog claims. Without
+		// this, a bundle could advertise a new release number while carrying
+		// older bytes — which is precisely how the fleet came to run agents
+		// months behind the hub while every check reported agreement.
+		embedded, err := agentPayloadRelease(verified)
+		if err != nil {
+			return nil, fmt.Errorf("agent bundle artifact %q: %w", platform, err)
+		}
+		if embedded != manifest.AgentRelease {
+			return nil, fmt.Errorf("agent bundle artifact %q carries release %d, catalog says %d",
+				platform, embedded, manifest.AgentRelease)
+		}
+
 		bundle.paths[osName+"/"+arch] = verified
 		bundle.expected[osName+"/"+arch] = strings.ToLower(artifact.SHA256)
 	}
@@ -302,4 +317,23 @@ func fileSHA256(path string) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// agentPayloadRelease reads the release sequence compiled into a payload.
+// A payload with no marker is rejected: unnumbered builds cannot be reasoned
+// about by the release floor, so they must not be served as a managed bundle.
+func agentPayloadRelease(path string) (uint64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	seq, err := updatesigning.ExtractReleaseReader(f)
+	if err != nil {
+		return 0, fmt.Errorf("read release marker: %w", err)
+	}
+	if seq == 0 {
+		return 0, fmt.Errorf("payload carries no release marker")
+	}
+	return seq, nil
 }

--- a/hub/agent_bundle.go
+++ b/hub/agent_bundle.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 )
 
-// The MANAGED AGENT BUNDLE: agent payloads that travel with the hub release, so
+// Managed agent bundle: agent payloads that travel with the hub release, so
 // upgrading the hub upgrades what the fleet is offered.
 //
-// WHY THIS EXISTS. Agent binaries were served from fixed system paths that
+// Agent binaries were served from fixed system paths that
 // nothing in the release ever refreshed. `bloxos-update` replaces the hub and
 // the dashboard and deliberately does not touch agent files, so a hub could run
 // v1.7.1 while handing out agents built weeks earlier. Every machine then
@@ -22,7 +22,7 @@ import (
 // offered. The offer was simply stale, and that single fact accounted for
 // missing power on ARM boards, absent source labels, and wrong CPU inventory.
 //
-// WHY PLACEMENT ALONE WOULD NOT HAVE FIXED IT. The resolver already had a
+// Placement alone is not enough: the resolver already had a
 // `hub-executable-directory` candidate — and it sits LAST, behind the system
 // defaults. Worse, the project's own systemd unit sets BLOXOS_AGENT_BINARY,
 // which for amd64 is the authoritative, fail-closed first candidate. Dropping
@@ -30,7 +30,7 @@ import (
 // native install: a fix that looks right and is inert. The precedence contract
 // below is the actual mechanism; the packaging is only its transport.
 //
-// WHAT IS DELIBERATELY NOT HERE. No new manifest schema for the updater to
+// Deliberately absent: no new manifest schema for the updater to
 // understand, no updater install logic, no self-refresh. The existing archive
 // checksum, safe extraction and copy already carry arbitrary files; the NEW hub
 // consumes and verifies its own bundle. That keeps delivery logic in one
@@ -59,7 +59,7 @@ const (
 
 // agentBundleRequired is set at build time (-ldflags) on packaged hub builds.
 //
-// It is a plain marker and NOT a content hash on purpose. The obvious
+// A plain marker, not a content hash. The obvious
 // alternative — embedding the manifest's SHA — cannot work: that manifest
 // includes the hub image digest, so the hub binary would have to contain a hash
 // of a document that contains a hash of the hub binary. A build-time flag
@@ -127,6 +127,36 @@ type agentBundle struct {
 	Manifest agentBundleManifest
 	// paths maps "<os>/<arch>" to the verified absolute payload path.
 	paths map[string]string
+	// expected maps the same key to the sha256 the catalog declares. Resolution
+	// is captured once at package init, so a payload altered afterwards would
+	// otherwise be served on its recomputed hash. The catalog's identity is the
+	// authority, and it is re-checked on every resolution.
+	expected map[string]string
+}
+
+// expectedSHA returns the catalog's declared hash for a platform.
+func (b *agentBundle) expectedSHA(platform agentPlatform) (string, bool) {
+	if b == nil {
+		return "", false
+	}
+	sum, ok := b.expected[platform.OS+"/"+platform.Arch]
+	return sum, ok
+}
+
+// verifyPayloadIdentity re-checks a managed payload against the catalog.
+func (b *agentBundle) verifyPayloadIdentity(platform agentPlatform, path string) error {
+	want, ok := b.expectedSHA(platform)
+	if !ok {
+		return fmt.Errorf("no catalog entry for %s", platform)
+	}
+	got, err := fileSHA256(path)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("payload sha256 %s no longer matches the catalog entry %s", got, want)
+	}
+	return nil
 }
 
 // pathFor returns the verified payload for a platform, if the bundle declares
@@ -142,7 +172,7 @@ func (b *agentBundle) pathFor(platform agentPlatform) (string, bool) {
 
 // loadAgentBundle reads and fully validates the bundle beside the hub executable.
 //
-// Validation is all-or-nothing by design. A bundle that is PRESENT BUT INVALID
+// Validation is all-or-nothing. A bundle that is present but invalid
 // must fail closed rather than fall through to the frozen system defaults:
 // falling through is precisely how a hub ends up quietly serving months-old
 // agents while reporting success. The caller decides what a missing bundle
@@ -151,10 +181,9 @@ func loadAgentBundle(executableDir string, validate func(string) (string, error)
 	dir := filepath.Join(executableDir, agentBundleDirName)
 	manifestPath := filepath.Join(dir, agentBundleManifestName)
 
-	// "No bundle at all" and "a bundle with its manifest missing" are different
-	// answers. The first is a source build; the second is a broken install, and
-	// treating it as absent would fall through to the frozen system defaults —
-	// the exact silent staleness this whole mechanism exists to end.
+	// A missing directory is a source build; a directory without a manifest is a
+	// broken install. Treating the second as absent would fall through to the
+	// frozen system defaults, which is the staleness this replaces.
 	if _, err := os.Stat(dir); err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -169,8 +198,8 @@ func loadAgentBundle(executableDir string, validate func(string) (string, error)
 		}
 		return nil, fmt.Errorf("stat agent bundle manifest: %w", err)
 	}
-	// Bound the manifest before reading it: it is attacker-shaped input in the
-	// sense that a corrupt install should not be able to exhaust memory here.
+	// Bound the manifest before reading: a corrupt install must not be able to
+	// exhaust memory here.
 	if info.Size() > agentBundleManifestMaxBytes {
 		return nil, fmt.Errorf("agent bundle manifest is %d bytes, over the %d limit",
 			info.Size(), agentBundleManifestMaxBytes)
@@ -200,7 +229,7 @@ func loadAgentBundle(executableDir string, validate func(string) (string, error)
 		}
 	}
 
-	bundle := &agentBundle{Dir: dir, Manifest: manifest, paths: map[string]string{}}
+	bundle := &agentBundle{Dir: dir, Manifest: manifest, paths: map[string]string{}, expected: map[string]string{}}
 
 	for platform, artifact := range manifest.Artifacts {
 		osName, arch, ok := strings.Cut(platform, "/")
@@ -256,6 +285,7 @@ func loadAgentBundle(executableDir string, validate func(string) (string, error)
 		}
 
 		bundle.paths[osName+"/"+arch] = verified
+		bundle.expected[osName+"/"+arch] = strings.ToLower(artifact.SHA256)
 	}
 
 	return bundle, nil

--- a/hub/agent_bundle_packaging_test.go
+++ b/hub/agent_bundle_packaging_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPackagedTreeLoadsAndFailsClosed runs the hub's real loader over a tree
+// that the release packaging script actually produced and an UNCHANGED updater
+// actually extracted.
+//
+// Every other bundle test builds its fixture in Go, so all of them would still
+// pass if the packaging script wrote the payloads to the wrong path, or the
+// updater dropped them in transit. Those are the failures that matter here: the
+// whole point of this work is that a fix which looks correct in isolation can
+// be completely inert once something else in the chain disagrees. This test is
+// the one place where the Python that packs, the worker that transports, and
+// the Go that reads are all the real thing.
+//
+// It is driven by scripts/test_server_bundle_agents.py, which sets the
+// environment variable and asserts this test PASSED rather than skipped — a
+// skipped test proves nothing, and a test that can silently skip is one nobody
+// notices has stopped running.
+func TestPackagedTreeLoadsAndFailsClosed(t *testing.T) {
+	hubDir := os.Getenv("BLOXOS_TEST_PACKAGED_HUB_DIR")
+	if hubDir == "" {
+		t.Skip("set BLOXOS_TEST_PACKAGED_HUB_DIR; driven by scripts/test_server_bundle_agents.py")
+	}
+
+	bundle, err := loadAgentBundle(hubDir, permissive)
+	if err != nil {
+		t.Fatalf("the hub must load the bundle the release actually ships: %v", err)
+	}
+	if bundle == nil {
+		t.Fatal("packaged tree produced no bundle; the payloads are not where the hub looks for them")
+	}
+	// Both server archives carry every agent platform, so either server can
+	// serve any machine in the fleet.
+	for _, platform := range []agentPlatform{
+		{OS: "linux", Arch: archAMD64},
+		{OS: "linux", Arch: archARM64},
+		{OS: "windows", Arch: archAMD64},
+	} {
+		path, ok := bundle.pathFor(platform)
+		if !ok {
+			t.Fatalf("packaged bundle offers nothing for %s", platform)
+		}
+		if err := bundle.verifyPayloadIdentity(platform, path); err != nil {
+			t.Fatalf("packaged %s payload fails its own catalog: %v", platform, err)
+		}
+	}
+
+	// A damaged or absent required payload must stop the hub, not downgrade it
+	// to whatever agent binaries happen to be on disk. Silent fallback is
+	// precisely how a v1.7.1 hub came to serve agents built weeks earlier while
+	// every machine correctly reported "matches offered build".
+	t.Run("corrupt payload is refused", func(t *testing.T) {
+		dir := copyHubDir(t, hubDir)
+		payload := filepath.Join(dir, agentBundleDirName, "bloxos-agent-linux-arm64")
+		if err := os.WriteFile(payload, []byte("corrupted in transit"), 0o755); err != nil {
+			t.Fatalf("corrupt payload: %v", err)
+		}
+		if _, err := loadAgentBundle(dir, permissive); err == nil {
+			t.Fatal("a corrupt payload must fail the load, not fall back to the system defaults")
+		}
+	})
+
+	t.Run("missing payload is refused", func(t *testing.T) {
+		dir := copyHubDir(t, hubDir)
+		if err := os.Remove(filepath.Join(dir, agentBundleDirName, "bloxos-agent-windows-amd64.exe")); err != nil {
+			t.Fatalf("remove payload: %v", err)
+		}
+		if _, err := loadAgentBundle(dir, permissive); err == nil {
+			t.Fatal("a missing required payload must fail the load")
+		}
+	})
+}
+
+// copyHubDir copies the packaged hub directory into a temp tree so a test can
+// damage it without touching the extracted artifact other subtests read.
+//
+// It returns the copy's HUB directory, which is what the loader is given: the
+// hub executable lives at <release>/hub/bloxos-hub, so its own directory is
+// <release>/hub and the bundle is <release>/hub/agents. Passing the parent here
+// pointed the loader at a directory with no agents/ at all, where it correctly
+// reports "no bundle" — the damaged payload was never read, and both subtests
+// were failing for a reason that had nothing to do with what they claim to test.
+func copyHubDir(t *testing.T, hubDir string) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "release")
+	target := filepath.Join(root, "hub")
+	if err := os.MkdirAll(filepath.Join(target, agentBundleDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(hubDir, agentBundleDirName))
+	if err != nil {
+		t.Fatalf("read packaged agents: %v", err)
+	}
+	for _, entry := range entries {
+		body, err := os.ReadFile(filepath.Join(hubDir, agentBundleDirName, entry.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", entry.Name(), err)
+		}
+		if err := os.WriteFile(filepath.Join(target, agentBundleDirName, entry.Name()), body, 0o755); err != nil {
+			t.Fatalf("write %s: %v", entry.Name(), err)
+		}
+	}
+	return target
+}

--- a/hub/agent_bundle_packaging_test.go
+++ b/hub/agent_bundle_packaging_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -107,4 +108,81 @@ func copyHubDir(t *testing.T, hubDir string) string {
 		}
 	}
 	return target
+}
+
+// The production resolver must be built ONCE and retained.
+//
+// This is deliberately driven through an injected constructor rather than the
+// package-level cache. A test that simply called productionAgentBinaryResolver()
+// twice would compare two nil bundles in an ordinary `go test` — there is no
+// bundle beside the test binary — and would pass just as happily against the
+// old constructor that rebuilt every time. It has to observe a constructor
+// that would return something DIFFERENT on a second call.
+func TestTheProductionResolverIsBuiltOnceAndShared(t *testing.T) {
+	root := fullFixture(t)
+	loaded, err := loadAgentBundle(root, permissive)
+	if err != nil || loaded == nil {
+		t.Fatalf("fixture must load: %v", err)
+	}
+
+	calls := 0
+	build := func() agentBinaryResolver {
+		calls++
+		if calls == 1 {
+			return agentBinaryResolver{bundle: loaded, deliveryMode: agentDeliveryAuto}
+		}
+		// What a rebuild would pick up: a catalog that has since changed on
+		// disk, or a delivery mode that no longer matches what is serving.
+		return agentBinaryResolver{
+			bundle:       &agentBundle{Dir: "rebuilt", paths: map[string]string{}, expected: map[string]string{}},
+			deliveryMode: agentDeliveryExternal,
+			initErr:      errors.New("rebuilt after the on-disk catalog changed"),
+		}
+	}
+
+	cache := &memoizedResolver{build: build}
+	first, second := cache.get(), cache.get()
+
+	if calls != 1 {
+		t.Fatalf("the resolver was constructed %d times; the startup gate, resolution and "+
+			"reported status would each describe a different catalog", calls)
+	}
+	if first.bundle != second.bundle {
+		t.Fatal("the retained bundle was replaced by a later construction")
+	}
+	if second.bundle != loaded {
+		t.Fatal("a later call returned the rebuilt catalog rather than the one being served")
+	}
+	if second.deliveryMode != agentDeliveryAuto || second.initErr != nil {
+		t.Fatalf("a later call reported rebuilt state: mode=%q err=%v",
+			second.deliveryMode, second.initErr)
+	}
+
+	// CONTROL. Without memoisation the same constructor yields the divergence
+	// above, so these assertions genuinely depend on the retained instance.
+	calls = 0
+	unmemoized := build()
+	rebuilt := build()
+	if unmemoized.bundle == rebuilt.bundle || rebuilt.initErr == nil {
+		t.Fatal("the fixture does not diverge on a second construction, so the test above " +
+			"would pass with or without memoisation")
+	}
+}
+
+// The startup gate and the reported status must both come from the retained
+// instance, so neither can disagree with what is actually served.
+func TestTheGateAndStatusComeFromTheServingResolver(t *testing.T) {
+	retained := productionAgentBinaryResolver()
+
+	if gateErr := checkManagedAgentBundle(); (gateErr != nil) != (retained.initErr != nil) {
+		t.Fatalf("gate and retained resolver disagree: gate=%v retained=%v",
+			gateErr, retained.initErr)
+	}
+	status, statusErr := agentDeliveryStatus()
+	if retained.initErr != nil && status != "unusable" {
+		t.Fatalf("a retained init error must be reported, got %q/%q", status, statusErr)
+	}
+	if retained.initErr == nil && status == "unusable" {
+		t.Fatalf("status reports unusable while the serving resolver is healthy: %q", statusErr)
+	}
 }

--- a/hub/agent_bundle_test.go
+++ b/hub/agent_bundle_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
 )
 
 // bundleFixture writes a bundle whose manifest matches its payloads.
@@ -37,15 +39,23 @@ func bundleFixture(t *testing.T, platforms map[string]string) string {
 		} else if platform == "windows/amd64" {
 			name = "bloxos-agent-windows-amd64.exe"
 		}
+		marker, err := updatesigning.ReleaseMarker(8)
+		if err != nil {
+			t.Fatalf("marker: %v", err)
+		}
 		path := filepath.Join(dir, name)
-		if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		if err := os.WriteFile(path, []byte(body+marker), 0o755); err != nil {
 			t.Fatalf("write payload: %v", err)
 		}
 		sum, err := fileSHA256(path)
 		if err != nil {
 			t.Fatalf("sha: %v", err)
 		}
-		artifacts[platform] = agentBundleArtifact{File: name, Size: int64(len(body)), SHA256: sum}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		artifacts[platform] = agentBundleArtifact{File: name, Size: info.Size(), SHA256: sum}
 	}
 	manifest := agentBundleManifest{Schema: 1, Version: "v9.9.9", Source: "abc", AgentRelease: 8, Artifacts: artifacts}
 	raw, err := json.Marshal(manifest)
@@ -341,5 +351,36 @@ func TestRetainedInitErrorFailsEveryResolution(t *testing.T) {
 	r.initErr = errors.New("bundle went bad")
 	if _, err := r.resolve("linux", archAMD64); err == nil {
 		t.Fatal("a retained delivery error must fail closed on every resolution")
+	}
+}
+
+// A bundle must not advertise a release its bytes do not carry: that mismatch
+// is how a fleet ends up running agents months behind the hub while every
+// check reports agreement.
+func TestBundleRejectsPayloadWhoseReleaseMarkerDisagreesWithTheCatalog(t *testing.T) {
+	root := fullFixture(t)
+	stale, err := updatesigning.ReleaseMarker(7) // catalog says 8
+	if err != nil {
+		t.Fatalf("marker: %v", err)
+	}
+	payload := filepath.Join(root, agentBundleDirName, "bloxos-agent-linux-amd64")
+	body := []byte("amd64-agent" + stale)
+	if err := os.WriteFile(payload, body, 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Keep the catalog self-consistent so ONLY the marker disagrees.
+	manifestPath := filepath.Join(root, agentBundleDirName, agentBundleManifestName)
+	raw, _ := os.ReadFile(manifestPath)
+	var m map[string]any
+	_ = json.Unmarshal(raw, &m)
+	sum, _ := fileSHA256(payload)
+	entry := m["artifacts"].(map[string]any)["linux/amd64"].(map[string]any)
+	entry["sha256"] = sum
+	entry["size"] = float64(len(body))
+	out, _ := json.Marshal(m)
+	_ = os.WriteFile(manifestPath, out, 0o644)
+
+	if _, err := loadAgentBundle(root, permissive); err == nil {
+		t.Fatal("a payload whose release marker disagrees with the catalog must be rejected")
 	}
 }

--- a/hub/agent_bundle_test.go
+++ b/hub/agent_bundle_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -325,5 +326,20 @@ func TestAlteredManagedPayloadIsRejectedAtResolution(t *testing.T) {
 	}
 	if _, err := r.resolve("linux", archAMD64); err == nil {
 		t.Fatal("a payload altered after load must not be served")
+	}
+}
+
+// A delivery-configuration failure must fail every resolution, not just startup.
+func TestRetainedInitErrorFailsEveryResolution(t *testing.T) {
+	root := fullFixture(t)
+	r := resolverWithBundle(t, root, map[string]string{}, agentDeliveryAuto)
+	r.archMatch = nil
+	if _, err := r.resolve("linux", archAMD64); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	r.initErr = errors.New("bundle went bad")
+	if _, err := r.resolve("linux", archAMD64); err == nil {
+		t.Fatal("a retained delivery error must fail closed on every resolution")
 	}
 }

--- a/hub/agent_bundle_test.go
+++ b/hub/agent_bundle_test.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// bundleFixture writes a bundle whose manifest matches its payloads.
+// fullFixture builds a complete bundle. Every packaged bundle carries all three
+// platforms, so a partial one is not a case that can exist.
+func fullFixture(t *testing.T) string {
+	t.Helper()
+	return bundleFixture(t, map[string]string{
+		"linux/amd64":   "amd64-agent",
+		"linux/arm64":   "arm64-agent",
+		"windows/amd64": "windows-agent",
+	})
+}
+
+func bundleFixture(t *testing.T, platforms map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, agentBundleDirName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	artifacts := map[string]agentBundleArtifact{}
+	for platform, body := range platforms {
+		name := "bloxos-agent-" + filepath.Base(platform)
+		if platform == "linux/amd64" {
+			name = "bloxos-agent-linux-amd64"
+		} else if platform == "linux/arm64" {
+			name = "bloxos-agent-linux-arm64"
+		} else if platform == "windows/amd64" {
+			name = "bloxos-agent-windows-amd64.exe"
+		}
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+			t.Fatalf("write payload: %v", err)
+		}
+		sum, err := fileSHA256(path)
+		if err != nil {
+			t.Fatalf("sha: %v", err)
+		}
+		artifacts[platform] = agentBundleArtifact{File: name, Size: int64(len(body)), SHA256: sum}
+	}
+	manifest := agentBundleManifest{Schema: 1, Version: "v9.9.9", Source: "abc", AgentRelease: 8, Artifacts: artifacts}
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, agentBundleManifestName), raw, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return root
+}
+
+// permissive stands in for validateTrustedAgentBinary in tests: the real one
+// demands root ownership, which a test temp dir does not have.
+func permissive(path string) (string, error) {
+	if _, err := os.Stat(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func TestAgentBundleLoadsAndVerifiesEveryDeclaredArtifact(t *testing.T) {
+	root := fullFixture(t)
+	bundle, err := loadAgentBundle(root, permissive)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if bundle == nil {
+		t.Fatal("bundle is nil")
+	}
+	if bundle.Manifest.AgentRelease != 8 {
+		t.Fatalf("agent release = %d, want 8", bundle.Manifest.AgentRelease)
+	}
+	// All three platforms travel together, in both server archives.
+	for _, p := range []agentPlatform{
+		{OS: "linux", Arch: archAMD64}, {OS: "linux", Arch: archARM64}, {OS: "windows", Arch: archAMD64},
+	} {
+		if _, ok := bundle.pathFor(p); !ok {
+			t.Fatalf("bundle does not carry %s", p)
+		}
+	}
+}
+
+// A tampered or truncated payload must not be served.
+func TestAgentBundleRejectsPayloadThatDoesNotMatchItsManifest(t *testing.T) {
+	root := fullFixture(t)
+	payload := filepath.Join(root, agentBundleDirName, "bloxos-agent-linux-amd64")
+	if err := os.WriteFile(payload, []byte("tampered"), 0o755); err != nil {
+		t.Fatalf("tamper: %v", err)
+	}
+	if _, err := loadAgentBundle(root, permissive); err == nil {
+		t.Fatal("a payload that does not match its manifest must be rejected")
+	}
+}
+
+// A manifest is DATA. A file name carrying a path must never become a path.
+func TestAgentBundleRejectsUnsafeFileName(t *testing.T) {
+	root := fullFixture(t)
+	manifestPath := filepath.Join(root, agentBundleDirName, agentBundleManifestName)
+	raw, _ := os.ReadFile(manifestPath)
+	var m map[string]any
+	_ = json.Unmarshal(raw, &m)
+	arts := m["artifacts"].(map[string]any)
+	entry := arts["linux/amd64"].(map[string]any)
+	entry["file"] = "../../etc/passwd"
+	out, _ := json.Marshal(m)
+	_ = os.WriteFile(manifestPath, out, 0o644)
+
+	if _, err := loadAgentBundle(root, permissive); err == nil {
+		t.Fatal("a traversing file name must be rejected before any filesystem call")
+	}
+}
+
+// An absent bundle is not an error here; the caller decides what it means.
+func TestAgentBundleAbsentIsNotAnError(t *testing.T) {
+	bundle, err := loadAgentBundle(t.TempDir(), permissive)
+	if err != nil {
+		t.Fatalf("absent bundle should not error: %v", err)
+	}
+	if bundle != nil {
+		t.Fatal("expected nil bundle")
+	}
+}
+
+// --- the precedence contract ---
+
+func resolverWithBundle(t *testing.T, root string, env map[string]string, mode string) agentBinaryResolver {
+	t.Helper()
+	bundle, err := loadAgentBundle(root, permissive)
+	if err != nil {
+		t.Fatalf("load bundle: %v", err)
+	}
+	return agentBinaryResolver{
+		executablePath: func() (string, error) { return filepath.Join(root, "bloxos-hub"), nil },
+		validate:       permissive,
+		bundle:         bundle,
+		deliveryMode:   mode,
+		getenv:         func(k string) string { return env[k] },
+	}
+}
+
+func firstCandidate(t *testing.T, r agentBinaryResolver, platform agentPlatform) agentBinaryCandidate {
+	t.Helper()
+	c, err := r.candidatesFor(platform)
+	if err != nil {
+		t.Fatalf("candidates: %v", err)
+	}
+	if len(c) == 0 {
+		t.Fatal("no candidates")
+	}
+	return c[0]
+}
+
+// THE CASE THAT MAKES THE WHOLE FEATURE WORK. The project's own systemd unit
+// sets BLOXOS_AGENT_BINARY to the legacy default path. Treated as a custom pin
+// it would shadow the bundle on every standard native install, and shipping
+// agents in the release would change nothing.
+func TestManagedBundleBeatsTheProjectsOwnShippedDefault(t *testing.T) {
+	root := fullFixture(t)
+	r := resolverWithBundle(t, root,
+		map[string]string{"BLOXOS_AGENT_BINARY": linuxAgentBinaryDefault}, agentDeliveryAuto)
+
+	got := firstCandidate(t, r, agentPlatform{OS: "linux", Arch: archAMD64})
+	if got.Source != "managed-bundle" {
+		t.Fatalf("source = %q, want managed-bundle — the shipped default must not pin a packaged hub", got.Source)
+	}
+}
+
+// A genuine operator pin still wins and stays fail-closed.
+func TestACustomOverrideStillOutranksTheManagedBundle(t *testing.T) {
+	root := fullFixture(t)
+	r := resolverWithBundle(t, root,
+		map[string]string{"BLOXOS_AGENT_BINARY": "/opt/mine/bloxos-agent"}, agentDeliveryAuto)
+
+	got := firstCandidate(t, r, agentPlatform{OS: "linux", Arch: archAMD64})
+	if got.Source != "environment:BLOXOS_AGENT_BINARY" {
+		t.Fatalf("source = %q, want the operator's own override to win", got.Source)
+	}
+	if got.Env == "" {
+		t.Fatal("an operator override must remain authoritative (fail-closed)")
+	}
+}
+
+// The escape hatch restores the full legacy resolver, including an INTENTIONAL
+// override that happens to equal the shipped default path.
+func TestExternalDeliveryModeRestoresTheLegacyResolver(t *testing.T) {
+	root := fullFixture(t)
+	r := resolverWithBundle(t, root,
+		map[string]string{"BLOXOS_AGENT_BINARY": linuxAgentBinaryDefault}, agentDeliveryExternal)
+
+	got := firstCandidate(t, r, agentPlatform{OS: "linux", Arch: archAMD64})
+	if got.Source != "environment:BLOXOS_AGENT_BINARY" {
+		t.Fatalf("source = %q, want the legacy override honoured in external mode", got.Source)
+	}
+}
+
+func TestManagedBundleServesWindowsToo(t *testing.T) {
+	root := fullFixture(t)
+	r := resolverWithBundle(t, root, map[string]string{}, agentDeliveryAuto)
+
+	got := firstCandidate(t, r, agentPlatform{OS: "windows", Arch: archAMD64})
+	if got.Source != "managed-bundle" {
+		t.Fatalf("source = %q, want managed-bundle — Windows must not be left frozen", got.Source)
+	}
+}
+
+// A packaged bundle must carry every platform. A bundle short of one would let
+// that platform keep resolving to a frozen system default while the others
+// looked healthy — partial success is the failure mode this replaces.
+func TestBundleMissingAPlatformIsRejected(t *testing.T) {
+	root := bundleFixture(t, map[string]string{
+		"linux/amd64":   "amd64-agent",
+		"windows/amd64": "windows-agent",
+	})
+	if _, err := loadAgentBundle(root, permissive); err == nil {
+		t.Fatal("a bundle without linux/arm64 must be rejected, not partially served")
+	}
+}
+
+// An operator pointing a native arm64 source build at the generic variable is a
+// real custom choice, and must still outrank the bundle.
+func TestGenericOverrideForNonDefaultArchStillPrecedesTheBundle(t *testing.T) {
+	root := fullFixture(t)
+	r := resolverWithBundle(t, root,
+		map[string]string{"BLOXOS_AGENT_BINARY": "/opt/mine/arm64-agent"}, agentDeliveryAuto)
+
+	got := firstCandidate(t, r, agentPlatform{OS: "linux", Arch: archARM64})
+	if got.Source != "environment:BLOXOS_AGENT_BINARY (arch-verified)" {
+		t.Fatalf("source = %q, want the arch-verified generic override first", got.Source)
+	}
+}
+
+// But the project's own shipped default in that same variable does NOT count as
+// a custom arm64 pin.
+func TestShippedDefaultIsNotACustomArm64Pin(t *testing.T) {
+	root := fullFixture(t)
+	r := resolverWithBundle(t, root,
+		map[string]string{"BLOXOS_AGENT_BINARY": linuxAgentBinaryDefault}, agentDeliveryAuto)
+
+	got := firstCandidate(t, r, agentPlatform{OS: "linux", Arch: archARM64})
+	if got.Source != "managed-bundle" {
+		t.Fatalf("source = %q, want managed-bundle", got.Source)
+	}
+}
+
+// A path that merely NORMALISES to the shipped default is somebody's deliberate
+// configuration, not the project's line, and keeps its authority.
+func TestAPathThatOnlyNormalisesToTheDefaultIsStillCustom(t *testing.T) {
+	root := fullFixture(t)
+	r := resolverWithBundle(t, root,
+		map[string]string{"BLOXOS_AGENT_BINARY": "/usr/local/lib/bloxos/linux/../linux/bloxos-agent"},
+		agentDeliveryAuto)
+
+	got := firstCandidate(t, r, agentPlatform{OS: "linux", Arch: archAMD64})
+	if got.Source != "environment:BLOXOS_AGENT_BINARY" {
+		t.Fatalf("source = %q, want the operator's own value honoured", got.Source)
+	}
+}
+
+// A present directory with no manifest is BROKEN, not absent: treating it as
+// absent would fall through to the frozen system defaults.
+func TestBundleDirectoryWithoutManifestIsInvalidNotAbsent(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, agentBundleDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, err := loadAgentBundle(root, permissive); err == nil {
+		t.Fatal("a bundle directory with no manifest must be an error")
+	}
+}
+
+// A misspelled delivery mode is visible, never silently treated as the default.
+func TestUnknownDeliveryModeFailsClosed(t *testing.T) {
+	if _, err := resolveAgentDeliveryMode(func(string) string { return "externl" }); err == nil {
+		t.Fatal("an unrecognised delivery mode must be an error, not a guess")
+	}
+	mode, err := resolveAgentDeliveryMode(func(string) string { return "" })
+	if err != nil || mode != agentDeliveryAuto {
+		t.Fatalf("empty mode = %q, %v; want auto", mode, err)
+	}
+}

--- a/hub/agent_bundle_test.go
+++ b/hub/agent_bundle_test.go
@@ -286,3 +286,44 @@ func TestUnknownDeliveryModeFailsClosed(t *testing.T) {
 		t.Fatalf("empty mode = %q, %v; want auto", mode, err)
 	}
 }
+
+// An explicit per-arch override wins outright, even alongside a generic one.
+func TestExplicitArm64OverrideBeatsBothGenericAndBundle(t *testing.T) {
+	root := fullFixture(t)
+	r := resolverWithBundle(t, root, map[string]string{
+		"BLOXOS_AGENT_BINARY":       "/opt/generic/bloxos-agent",
+		"BLOXOS_AGENT_BINARY_ARM64": "/opt/explicit/bloxos-agent",
+	}, agentDeliveryAuto)
+
+	got := firstCandidate(t, r, agentPlatform{OS: "linux", Arch: archARM64})
+	if got.Source != "environment:BLOXOS_AGENT_BINARY_ARM64" {
+		t.Fatalf("source = %q, want the explicit per-arch override first", got.Source)
+	}
+	if got.Env == "" {
+		t.Fatal("an explicit per-arch override must stay authoritative")
+	}
+	cands, _ := r.candidatesFor(agentPlatform{OS: "linux", Arch: archARM64})
+	if len(cands) != 1 {
+		t.Fatalf("explicit override must be the only candidate, got %d", len(cands))
+	}
+}
+
+// Resolution is captured once at init, so a payload swapped afterwards must be
+// rejected against the catalog rather than served on its recomputed hash.
+func TestAlteredManagedPayloadIsRejectedAtResolution(t *testing.T) {
+	root := fullFixture(t)
+	r := resolverWithBundle(t, root, map[string]string{}, agentDeliveryAuto)
+	r.archMatch = nil
+
+	if _, err := r.resolve("linux", archAMD64); err != nil {
+		t.Fatalf("baseline resolve failed: %v", err)
+	}
+
+	payload := filepath.Join(root, agentBundleDirName, "bloxos-agent-linux-amd64")
+	if err := os.WriteFile(payload, []byte("swapped-after-load"), 0o755); err != nil {
+		t.Fatalf("swap: %v", err)
+	}
+	if _, err := r.resolve("linux", archAMD64); err == nil {
+		t.Fatal("a payload altered after load must not be served")
+	}
+}

--- a/hub/agent_bundle_test.go
+++ b/hub/agent_bundle_test.go
@@ -1,14 +1,52 @@
 package main
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/bokiko/bloxos/proto/updatesigning"
 )
+
+// agentImageHeader builds a minimal but genuine executable header for a
+// platform, so fixtures exercise the real architecture check rather than
+// skipping past it. A fixture made of plain text would have forced the check to
+// be optional in tests, and an optional check is one nothing proves runs.
+func agentImageHeader(t *testing.T, osName, arch string) []byte {
+	t.Helper()
+	if osName == "windows" {
+		machine, ok := peMachineByArch[arch]
+		if !ok {
+			t.Fatalf("no PE machine for arch %q", arch)
+		}
+		// MZ stub, e_lfanew at 0x3c, PE signature + COFF header + the
+		// optional-header magic the verifier reads.
+		const peOffset = 0x80
+		img := make([]byte, peOffset+26)
+		img[0], img[1] = 'M', 'Z'
+		binary.LittleEndian.PutUint32(img[0x3c:], peOffset)
+		copy(img[peOffset:], []byte{'P', 'E', 0, 0})
+		binary.LittleEndian.PutUint16(img[peOffset+4:], machine)
+		binary.LittleEndian.PutUint16(img[peOffset+24:], 0x020b) // PE32+
+		return img
+	}
+	machine, ok := elfMachineByArch[arch]
+	if !ok {
+		t.Fatalf("no ELF machine for arch %q", arch)
+	}
+	img := make([]byte, 64)
+	copy(img, []byte{0x7f, 'E', 'L', 'F', 2, 1, 1, 0})
+	binary.LittleEndian.PutUint16(img[16:], 2) // ET_EXEC
+	binary.LittleEndian.PutUint16(img[18:], machine)
+	binary.LittleEndian.PutUint32(img[20:], 1) // EV_CURRENT
+	return img
+}
 
 // bundleFixture writes a bundle whose manifest matches its payloads.
 // fullFixture builds a complete bundle. Every packaged bundle carries all three
@@ -43,8 +81,9 @@ func bundleFixture(t *testing.T, platforms map[string]string) string {
 		if err != nil {
 			t.Fatalf("marker: %v", err)
 		}
+		osName, arch, _ := strings.Cut(platform, "/")
 		path := filepath.Join(dir, name)
-		if err := os.WriteFile(path, []byte(body+marker), 0o755); err != nil {
+		if err := os.WriteFile(path, append(agentImageHeader(t, osName, arch), (body+marker)...), 0o755); err != nil {
 			t.Fatalf("write payload: %v", err)
 		}
 		sum, err := fileSHA256(path)
@@ -68,11 +107,22 @@ func bundleFixture(t *testing.T, platforms map[string]string) string {
 	return root
 }
 
-// permissive stands in for validateTrustedAgentBinary in tests: the real one
-// demands root ownership, which a test temp dir does not have.
+// permissive stands in for validateTrustedAgentBinary in tests. It relaxes
+// EXACTLY ONE of the real check's rules — root ownership, which a test temp dir
+// can never satisfy — and keeps the rest. The regular-file and symlink rules
+// stay, because tests below depend on them holding: a stub that waved through
+// anything os.Stat could see would make those tests pass without the behaviour
+// they name existing.
 func permissive(path string) (string, error) {
-	if _, err := os.Stat(path); err != nil {
+	info, err := os.Lstat(path)
+	if err != nil {
 		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("path is a symlink")
+	}
+	if !info.Mode().IsRegular() {
+		return "", errors.New("path is not a regular file")
 	}
 	return path, nil
 }
@@ -382,5 +432,209 @@ func TestBundleRejectsPayloadWhoseReleaseMarkerDisagreesWithTheCatalog(t *testin
 
 	if _, err := loadAgentBundle(root, permissive); err == nil {
 		t.Fatal("a payload whose release marker disagrees with the catalog must be rejected")
+	}
+}
+
+// A sha256 proves a payload is the file the catalog names. It proves nothing
+// about what that file IS, so the architecture has to come from the image.
+func TestBundleRejectsAPayloadBuiltForAnotherArchitecture(t *testing.T) {
+	root := bundleFixture(t, map[string]string{
+		"linux/amd64":   "amd64-agent",
+		"linux/arm64":   "arm64-agent",
+		"windows/amd64": "windows-agent",
+	})
+	dir := filepath.Join(root, agentBundleDirName)
+	// Rebuild the arm64 slot around an amd64 image, then make the manifest
+	// agree with it: size and sha256 both check out, and only reading the ELF
+	// header can tell that the bytes are for the wrong machine.
+	restamp(t, dir, "linux/arm64", "bloxos-agent-linux-arm64",
+		append(agentImageHeader(t, "linux", "amd64"), mustMarker(t, 8)...))
+
+	if _, err := loadAgentBundle(root, permissive); err == nil {
+		t.Fatal("an arm64 slot carrying an amd64 image must be rejected")
+	} else if !strings.Contains(err.Error(), "arm64") {
+		t.Fatalf("the error should name the mismatched architecture, got: %v", err)
+	}
+}
+
+// Windows is carried, not excluded, so it is checked like everything else.
+func TestBundleRejectsAWindowsPayloadThatIsNotAPEImage(t *testing.T) {
+	root := fullFixture(t)
+	dir := filepath.Join(root, agentBundleDirName)
+	restamp(t, dir, "windows/amd64", "bloxos-agent-windows-amd64.exe",
+		append(agentImageHeader(t, "linux", "amd64"), mustMarker(t, 8)...))
+
+	if _, err := loadAgentBundle(root, permissive); err == nil {
+		t.Fatal("a windows slot carrying an ELF image must be rejected")
+	}
+}
+
+func TestBundleRejectsAWindowsPayloadBuiltForAnotherArchitecture(t *testing.T) {
+	root := fullFixture(t)
+	dir := filepath.Join(root, agentBundleDirName)
+	restamp(t, dir, "windows/amd64", "bloxos-agent-windows-amd64.exe",
+		append(agentImageHeader(t, "windows", "arm64"), mustMarker(t, 8)...))
+
+	if _, err := loadAgentBundle(root, permissive); err == nil {
+		t.Fatal("a windows/amd64 slot carrying an arm64 PE must be rejected")
+	}
+}
+
+// The control for the three tests above: the same fixture machinery, unaltered,
+// must LOAD. Without this, a bundle rejected for some unrelated reason would
+// make all of them pass while the architecture check did nothing.
+func TestTheArchitectureFixturesThemselvesLoad(t *testing.T) {
+	if _, err := loadAgentBundle(fullFixture(t), permissive); err != nil {
+		t.Fatalf("the unaltered fixture must load, else the rejection tests prove nothing: %v", err)
+	}
+}
+
+// The manifest decides which bytes the whole fleet is offered, so it gets the
+// same trust check as the payloads it describes. os.Stat follows symlinks; a
+// link planted here would have been read from wherever it pointed.
+func TestBundleRejectsASymlinkedManifest(t *testing.T) {
+	root := fullFixture(t)
+	dir := filepath.Join(root, agentBundleDirName)
+	manifest := filepath.Join(dir, agentBundleManifestName)
+	elsewhere := filepath.Join(t.TempDir(), "planted.json")
+	raw, err := os.ReadFile(manifest)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if err := os.WriteFile(elsewhere, raw, 0o644); err != nil {
+		t.Fatalf("write planted manifest: %v", err)
+	}
+	if err := os.Remove(manifest); err != nil {
+		t.Fatalf("remove manifest: %v", err)
+	}
+	if err := os.Symlink(elsewhere, manifest); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// Note the content is BYTE-IDENTICAL to the manifest that just loaded, so
+	// the only thing under test is that the link itself is refused.
+	if _, err := loadAgentBundle(root, permissive); err == nil {
+		t.Fatal("a symlinked manifest must be rejected even when its content is valid")
+	}
+}
+
+// A FIFO stats as zero bytes, so a size limit taken from Stat waves it through
+// — and the read that follows blocks or streams without end. The bound has to
+// be enforced by the read.
+func TestBundleRejectsAManifestThatIsNotARegularFile(t *testing.T) {
+	root := fullFixture(t)
+	manifest := filepath.Join(root, agentBundleDirName, agentBundleManifestName)
+	if err := os.Remove(manifest); err != nil {
+		t.Fatalf("remove manifest: %v", err)
+	}
+	if err := syscall.Mkfifo(manifest, 0o644); err != nil {
+		t.Skipf("cannot create a FIFO here: %v", err)
+	}
+	// If this ever hangs instead of failing, the bound is being read from Stat
+	// again. A FIFO with no writer blocks forever on open.
+	done := make(chan error, 1)
+	go func() {
+		_, err := loadAgentBundle(root, permissive)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a manifest that is not a regular file must be rejected")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("loading blocked on a FIFO manifest; the size bound is not being enforced by the read")
+	}
+}
+
+func TestBundleRejectsAnOversizedManifest(t *testing.T) {
+	root := fullFixture(t)
+	manifest := filepath.Join(root, agentBundleDirName, agentBundleManifestName)
+	if err := os.WriteFile(manifest, make([]byte, agentBundleManifestMaxBytes+1), 0o644); err != nil {
+		t.Fatalf("write oversized manifest: %v", err)
+	}
+	if _, err := loadAgentBundle(root, permissive); err == nil {
+		t.Fatal("a manifest over the size limit must be rejected")
+	}
+}
+
+func mustMarker(t *testing.T, seq uint64) []byte {
+	t.Helper()
+	marker, err := updatesigning.ReleaseMarker(seq)
+	if err != nil {
+		t.Fatalf("marker: %v", err)
+	}
+	return []byte(marker)
+}
+
+// restamp replaces one platform's payload and updates the manifest to match, so
+// the size and sha256 checks pass and the test isolates what it means to.
+func restamp(t *testing.T, dir, platform, name string, body []byte) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, body, 0o755); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	sum, err := fileSHA256(path)
+	if err != nil {
+		t.Fatalf("sha: %v", err)
+	}
+	manifestPath := filepath.Join(dir, agentBundleManifestName)
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var manifest agentBundleManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	manifest.Artifacts[platform] = agentBundleArtifact{File: name, Size: int64(len(body)), SHA256: sum}
+	out, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, out, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+// The offset the verifier seeks to is read OUT OF the file it is checking, so
+// it is attacker- and corruption-controlled and has to be bounded before use.
+func TestVerifyPEArchRejectsMalformedImages(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string, body []byte) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, body, 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		return path
+	}
+
+	good := agentImageHeader(t, "windows", archAMD64)
+	if err := verifyPEArch(write("good.exe", good), archAMD64); err != nil {
+		t.Fatalf("a well-formed amd64 PE must pass, else the rejections below prove nothing: %v", err)
+	}
+
+	wild := append([]byte(nil), good...)
+	binary.LittleEndian.PutUint32(wild[0x3c:], 1<<30)
+	if err := verifyPEArch(write("wild.exe", wild), archAMD64); err == nil {
+		t.Fatal("an out-of-range PE header offset must be refused, not seeked to")
+	}
+
+	backIntoStub := append([]byte(nil), good...)
+	binary.LittleEndian.PutUint32(backIntoStub[0x3c:], 0x10)
+	if err := verifyPEArch(write("stub.exe", backIntoStub), archAMD64); err == nil {
+		t.Fatal("a PE header offset pointing back into the DOS stub must be refused")
+	}
+
+	// Go emits only 64-bit Windows binaries; a PE32 image is a packaging error.
+	pe32 := append([]byte(nil), good...)
+	binary.LittleEndian.PutUint16(pe32[0x80+24:], 0x010b)
+	if err := verifyPEArch(write("pe32.exe", pe32), archAMD64); err == nil {
+		t.Fatal("a 32-bit PE must be refused")
+	}
+
+	if err := verifyPEArch(write("short.exe", []byte("MZ")), archAMD64); err == nil {
+		t.Fatal("a truncated image must be refused, not read past its end")
 	}
 }

--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -862,7 +862,16 @@ func (s *Server) handleListVersions(c echo.Context) error {
 		byArch[platform.OS][platform.Arch] = currentAgentBinaryStateFor(platform.OS, platform.Arch)
 	}
 
+	// Delivery mode is reported ONCE, at the top level. Per-binary `source`
+	// already says where each platform actually resolved from, and repeating a
+	// derived summary next to it is how two fields that must agree start
+	// disagreeing. This answers the different question: which resolution
+	// policy is in force.
+	delivery, deliveryErr := agentDeliveryStatus()
+
 	return c.JSON(http.StatusOK, map[string]interface{}{
+		"agent_delivery":          delivery,
+		"agent_delivery_error":    deliveryErr,
 		"signing_enabled":         signingEnabled,
 		"signing_disabled_reason": signingDisabledReason,
 		"hub_sha":                 linuxState.SHA,

--- a/hub/fleet_power.go
+++ b/hub/fleet_power.go
@@ -571,11 +571,11 @@ func aggregateFleetPower(records []fleetPowerRecord, in fleetPowerInputs) FleetP
 		}
 
 		domains = append(domains, FleetPowerDomain{
-			Domain:  domain,
-			Buckets: buckets,
-			Measured:  buildKind(measuredKey),
-			Estimated: buildKind(estimatedKey),
-			Unknown:   buildKind(unknownKey),
+			Domain:            domain,
+			Buckets:           buckets,
+			Measured:          buildKind(measuredKey),
+			Estimated:         buildKind(estimatedKey),
+			Unknown:           buildKind(unknownKey),
 			ReportingMachines: len(union),
 			// Complete is reported FALSE unconditionally, and that is a
 			// deliberate, conservative choice rather than an oversight.

--- a/hub/main.go
+++ b/hub/main.go
@@ -241,6 +241,13 @@ func main() {
 		log.Fatalf("RBAC route audit failed: %v", err)
 	}
 
+	// Refuse to start on a broken agent-delivery configuration. Serving anyway
+	// would fall back to whatever agent binaries are on disk while reporting
+	// healthy, which is the stale-agent failure this replaces.
+	if err := checkManagedAgentBundle(); err != nil {
+		log.Fatalf("agent delivery: %v", err)
+	}
+
 	listenAddr := os.Getenv("HUB_LISTEN")
 	if listenAddr == "" {
 		listenAddr = "127.0.0.1:4000"

--- a/hub/main.go
+++ b/hub/main.go
@@ -250,7 +250,6 @@ func main() {
 		log.Fatalf("RBAC route audit failed: %v", err)
 	}
 
-
 	listenAddr := os.Getenv("HUB_LISTEN")
 	if listenAddr == "" {
 		listenAddr = "127.0.0.1:4000"

--- a/hub/main.go
+++ b/hub/main.go
@@ -151,6 +151,15 @@ var (
 )
 
 func main() {
+	// A filesystem and configuration prerequisite, checked before anything
+	// mutates installation state. Rejecting invalid packaging here means a bad
+	// candidate never reaches migrations, signing-key setup or background loops;
+	// serving anyway would fall back to whatever agent binaries are on disk
+	// while reporting healthy, which is the stale-agent failure this replaces.
+	if err := checkManagedAgentBundle(); err != nil {
+		log.Fatalf("agent delivery: %v", err)
+	}
+
 	var err error
 	// Phase 11 — `foreign_keys=on` is load-bearing: ON DELETE CASCADE on
 	// user_pinned_machines / user_saved_filters relies on it being set per
@@ -241,12 +250,6 @@ func main() {
 		log.Fatalf("RBAC route audit failed: %v", err)
 	}
 
-	// Refuse to start on a broken agent-delivery configuration. Serving anyway
-	// would fall back to whatever agent binaries are on disk while reporting
-	// healthy, which is the stale-agent failure this replaces.
-	if err := checkManagedAgentBundle(); err != nil {
-		log.Fatalf("agent delivery: %v", err)
-	}
 
 	listenAddr := os.Getenv("HUB_LISTEN")
 	if listenAddr == "" {

--- a/hub/update_signing.go
+++ b/hub/update_signing.go
@@ -391,8 +391,23 @@ func announcedSignatureForArch(osName, arch, sha string) string {
 	if sha == "" {
 		return ""
 	}
+	// Order is deliberate and strictly additive. The adjacent .sig stays
+	// FIRST, so an operator already managing signatures that way sees no
+	// change; the content-addressed store is consulted only when that finds
+	// nothing; the hub-held key remains last and untouched, so a hub-held-key
+	// install never reaches the store and needs no new key or manual step.
 	if sig := detachedSignatureFor(agentBinaryPathForArch(osName, arch), osName, sha); sig != "" {
 		return sig
 	}
-	return signAgentRelease(osName, sha)
+	if sig := contentAddressedSignatureFor(osName, arch, sha); sig != "" {
+		return sig
+	}
+	if sig := signAgentRelease(osName, sha); sig != "" {
+		return sig
+	}
+	// Nothing can authorise these bytes. Say so, with the path that would fix
+	// it: the symptom otherwise is silence — the fleet simply never gets
+	// offered the build, and nothing in the log explains why.
+	reportMissingAgentAuthorization(osName, arch, sha)
+	return ""
 }

--- a/hub/update_signing_store.go
+++ b/hub/update_signing_store.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
+)
+
+/* ----------------------------------------------------------------------------
+ * Content-addressed detached signatures
+ *
+ * The problem this solves appears the moment agent binaries ship with the hub.
+ * An offline install holds no private key, so it can only announce a signature
+ * somebody produced beforehand. Until now that signature had to sit at
+ * <binary>.sig — beside a binary at a fixed system path that the operator
+ * placed and maintained. When the hub brings its own agents, those binaries
+ * live in a release directory that changes every upgrade, and the operator has
+ * nowhere stable to put a signature for bytes they have not received yet.
+ *
+ * Copying or regenerating the old signatures is NOT an option and never was.
+ * A detached ed25519 signature covers a specific message containing a specific
+ * SHA. New bytes mean a new SHA, so an old signature is not weak for them, it
+ * is cryptographically meaningless — it cannot verify, and announcing it would
+ * make every agent in the fleet reject the update.
+ *
+ * So the store is content-addressed: a signature is filed under the (os, arch,
+ * sha256) it actually covers. An operator can authorise bytes IN ADVANCE, and
+ * a signature for a release the hub is not yet serving simply sits unused until
+ * that release arrives. Nothing has to be re-staged at upgrade time.
+ *
+ * Lookup order is unchanged in spirit and strictly additive:
+ *
+ *   1. <binary>.sig adjacent to the served binary — existing behaviour, still
+ *      first, so an operator who manages signatures that way is unaffected.
+ *   2. this store, by content address.
+ *   3. the hub-held signing key — existing behaviour, untouched.
+ *
+ * A hub-held-key install therefore needs no new key, no new directory and no
+ * manual step: it never reaches step 2 with anything to do.
+ *
+ * OWNERSHIP. This is state, not a served executable, and the two have
+ * different rules. Agent binaries are root-owned because the hub hands them to
+ * machines that will run them. A signature is data the hub verifies
+ * cryptographically before use, and it lives in the hub's own state
+ * directory — which under Docker is /data owned by uid 65532, not root.
+ * Demanding root here would break every containerised install for no security
+ * gain, because a forged signature cannot verify against the pinned public key
+ * and is discarded. The rule is therefore INSTALLATION-owned: owned by the
+ * user the hub runs as (or root), and not writable by group or others.
+ * ---------------------------------------------------------------------------- */
+
+// agentSignatureDirName is the store, inside the hub's existing state
+// directory. Nothing is created here by the hub: its absence simply means no
+// signatures were staged, which is the normal case for a hub-held-key install.
+const agentSignatureDirName = "agent-signatures"
+
+// agentSignatureEnv overrides the store location for operators whose state
+// directory is not where signatures are managed.
+const agentSignatureEnv = "BLOXOS_AGENT_SIGNATURE_DIR"
+
+// agentSignatureMaxBytes bounds a read. A base64 ed25519 signature is 88
+// bytes; the allowance covers whitespace and a trailing newline with room to
+// spare, and stops a mis-staged multi-gigabyte file from being read into
+// memory on an announcement path.
+const agentSignatureMaxBytes = 4 << 10
+
+// signatureNotFound is logged once per (os, arch, sha) rather than on every
+// announcement, so a hub with no authorisation for a release says so clearly
+// instead of flooding the log.
+var signatureNotFound sync.Map
+
+// agentSignatureDir returns the configured store, or "" when none applies.
+func agentSignatureDir() string {
+	if custom := strings.TrimSpace(os.Getenv(agentSignatureEnv)); custom != "" {
+		return custom
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".bloxos", agentSignatureDirName)
+}
+
+// agentSignatureName is the content address: platform plus the exact bytes.
+//
+// Callers must go through agentSignatureAddress, which is what establishes
+// that the components are safe. This function only formats them.
+func agentSignatureName(osName, arch, sha string) string {
+	return fmt.Sprintf("%s-%s-%s.sig", osName, arch, strings.ToLower(sha))
+}
+
+// agentSignatureAddress validates an identity and returns its file name.
+//
+// Nothing reaches a filesystem call until this passes. The OS and architecture
+// are resolved through the same helper the rest of the hub uses, so they come
+// back as one of a fixed set of known values rather than as whatever the
+// caller supplied, and the SHA must be exactly 64 hex characters. A separator
+// or a parent reference in any component therefore cannot survive to become
+// part of a path — the earlier version only checked that the strings were
+// non-empty, which is not the same thing at all.
+func agentSignatureAddress(osName, arch, sha string) (string, agentPlatform, bool) {
+	platform, err := agentPlatformFor(osName, arch)
+	if err != nil {
+		return "", agentPlatform{}, false
+	}
+	sha = strings.ToLower(strings.TrimSpace(sha))
+	if len(sha) != 64 {
+		return "", agentPlatform{}, false
+	}
+	for _, character := range sha {
+		if !strings.ContainsRune("0123456789abcdef", character) {
+			return "", agentPlatform{}, false
+		}
+	}
+	return agentSignatureName(platform.OS, platform.Arch, sha), platform, true
+}
+
+// readInstallationOwnedFile reads a state file the hub owns, with a hard bound.
+//
+// The bound is enforced by the READ, not by a prior Stat: a size observed
+// beforehand is a claim about a different moment, and a FIFO reports zero and
+// then blocks forever.
+//
+// O_NONBLOCK is what actually makes that FIFO case safe, and its absence was a
+// comment describing protection the flags did not provide: opening a FIFO with
+// no writer BLOCKS IN open(), so the fstat that would have rejected it is
+// never reached. O_NOFOLLOW refuses a symlinked final path, and the mode is
+// checked on the descriptor actually opened rather than on a path that could
+// have been swapped in between.
+func readInstallationOwnedFile(path string, max int64) ([]byte, error) {
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	if err := requireInstallationOwned(info, path); err != nil {
+		return nil, err
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(file, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(raw)) > max {
+		return nil, fmt.Errorf("%s is larger than the %d byte limit", path, max)
+	}
+	return raw, nil
+}
+
+// requireInstallationOwned enforces the state-file rule: owned by the user the
+// hub runs as (or root), and not writable by group or others.
+func requireInstallationOwned(info os.FileInfo, path string) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("cannot inspect ownership of %s", path)
+	}
+	self := uint32(os.Geteuid())
+	if stat.Uid != self && stat.Uid != 0 {
+		return fmt.Errorf("%s is owned by uid %d, want the hub's own uid %d or root",
+			path, stat.Uid, self)
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return fmt.Errorf("%s mode %04o is group- or other-writable", path, info.Mode().Perm())
+	}
+	return nil
+}
+
+// contentAddressedSignatureFor returns a staged signature for exactly these
+// bytes, or "" when none is both present and valid.
+//
+// It NEVER returns a signature it has not verified against the pinned public
+// key. A signature that does not verify is worse than none: announcing it
+// makes every agent reject the update, so a bad file must not be passed along
+// just because it was present.
+func contentAddressedSignatureFor(osName, arch, sha string) string {
+	name, platform, ok := agentSignatureAddress(osName, arch, sha)
+	if !ok {
+		return ""
+	}
+	dir := agentSignatureDir()
+	if dir == "" {
+		return ""
+	}
+
+	updateSigningMu.RLock()
+	pub := updateSigningPub
+	updateSigningMu.RUnlock()
+	if pub == nil {
+		// No pinned key means nothing here could be verified, and an
+		// unverified signature must never be announced.
+		return ""
+	}
+
+	path := filepath.Join(dir, name)
+	raw, err := readInstallationOwnedFile(path, agentSignatureMaxBytes)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			// A file that exists but cannot be trusted is an operator problem
+			// worth naming; a file that is simply absent is the normal case.
+			log.Printf("update signing: staged signature %s is unusable: %v", path, err)
+		}
+		return ""
+	}
+
+	sigB64 := strings.TrimSpace(string(raw))
+	if sigB64 == "" {
+		return ""
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(sigB64); err != nil || len(decoded) != 64 {
+		log.Printf("update signing: staged signature %s is not a valid ed25519 signature", path)
+		return ""
+	}
+	if err := updatesigning.Verify(pub, platform.OS, sha, sigB64); err != nil {
+		log.Printf("update signing: staged signature %s does not verify for %s sha %s (%v); "+
+			"it was produced for different bytes and agents would reject it",
+			path, platform.OS, versionShortSHA(sha), err)
+		return ""
+	}
+	return sigB64
+}
+
+// reportMissingAgentAuthorization states, once per set of bytes, that an
+// offline install has nothing to announce and exactly what would fix it.
+//
+// The Versions view already reports the blocked state; what was missing was
+// the remedy. This names the exact path to stage, so the operator does not
+// have to work out the content address themselves.
+func reportMissingAgentAuthorization(osName, arch, sha string) {
+	if sha == "" {
+		return
+	}
+	key := osName + "/" + arch + "/" + sha
+	if _, seen := signatureNotFound.LoadOrStore(key, true); seen {
+		return
+	}
+	dir := agentSignatureDir()
+	log.Printf("update signing: no authorization for the %s/%s agent (sha %s) — this hub holds no "+
+		"signing key, so it can only announce a signature staged in advance. Sign these exact "+
+		"bytes offline and place the base64 signature at %s. Agents keep running; they will not "+
+		"be offered this build until then.",
+		osName, arch, versionShortSHA(sha),
+		filepath.Join(dir, agentSignatureName(osName, arch, sha)))
+}

--- a/hub/update_signing_store_test.go
+++ b/hub/update_signing_store_test.go
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/bokiko/bloxos/proto/updatesigning"
+)
+
+// withPinnedKey installs a public key for the duration of a test and returns a
+// signer for it.
+func withPinnedKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	updateSigningMu.Lock()
+	previousPub, previousB64 := updateSigningPub, updateSigningPubB64
+	updateSigningPub = pub
+	updateSigningPubB64 = base64.StdEncoding.EncodeToString(pub)
+	updateSigningMu.Unlock()
+	t.Cleanup(func() {
+		updateSigningMu.Lock()
+		updateSigningPub, updateSigningPubB64 = previousPub, previousB64
+		updateSigningMu.Unlock()
+	})
+	return priv
+}
+
+func signFor(t *testing.T, priv ed25519.PrivateKey, osName, sha string) string {
+	t.Helper()
+	return base64.StdEncoding.EncodeToString(ed25519.Sign(priv, updateSigningMessage(osName, sha)))
+}
+
+// stageSignature writes a signature into a store the test owns, and points the
+// hub at it.
+func stageSignature(t *testing.T, osName, arch, sha, sig string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod store: %v", err)
+	}
+	t.Setenv(agentSignatureEnv, dir)
+	path := filepath.Join(dir, agentSignatureName(osName, arch, sha))
+	if sig != "" {
+		if err := os.WriteFile(path, []byte(sig+"\n"), 0o644); err != nil {
+			t.Fatalf("write signature: %v", err)
+		}
+	}
+	return path
+}
+
+const testSHA = "3f1a0c9d5e7b2a4c6d8e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e"
+
+func TestStagedSignatureIsFoundByContentAddress(t *testing.T) {
+	priv := withPinnedKey(t)
+	sig := signFor(t, priv, "linux", testSHA)
+	stageSignature(t, "linux", archARM64, testSHA, sig)
+
+	if got := contentAddressedSignatureFor("linux", archARM64, testSHA); got != sig {
+		t.Fatalf("staged signature was not found: got %q", got)
+	}
+}
+
+// The point of content addressing: authorise bytes BEFORE the hub serves them.
+func TestASignatureForBytesTheHubDoesNotYetServeSimplyWaits(t *testing.T) {
+	priv := withPinnedKey(t)
+	future := strings.Repeat("ab", 32)
+	dir := t.TempDir()
+	t.Setenv(agentSignatureEnv, dir)
+	if err := os.WriteFile(filepath.Join(dir, agentSignatureName("linux", archAMD64, future)),
+		[]byte(signFor(t, priv, "linux", future)), 0o644); err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+
+	// Nothing for the release being served now...
+	if got := contentAddressedSignatureFor("linux", archAMD64, testSHA); got != "" {
+		t.Fatalf("a signature for other bytes must not be offered, got %q", got)
+	}
+	// ...and it is there the moment those bytes arrive.
+	if got := contentAddressedSignatureFor("linux", archAMD64, future); got == "" {
+		t.Fatal("the staged signature must apply once the hub serves those bytes")
+	}
+}
+
+// A signature that does not verify is WORSE than none: announcing it makes
+// every agent in the fleet reject the update.
+func TestASignatureThatDoesNotVerifyIsNeverAnnounced(t *testing.T) {
+	priv := withPinnedKey(t)
+	// Correctly formed, correctly signed — for different bytes.
+	other := strings.Repeat("cd", 32)
+	stageSignature(t, "linux", archAMD64, testSHA, signFor(t, priv, "linux", other))
+
+	if got := contentAddressedSignatureFor("linux", archAMD64, testSHA); got != "" {
+		t.Fatalf("a signature for other bytes must be refused, got %q", got)
+	}
+}
+
+func TestSignatureFromAnotherKeyIsRefused(t *testing.T) {
+	withPinnedKey(t)
+	_, stranger, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	stageSignature(t, "linux", archAMD64, testSHA, signFor(t, stranger, "linux", testSHA))
+
+	if got := contentAddressedSignatureFor("linux", archAMD64, testSHA); got != "" {
+		t.Fatalf("a signature from an unpinned key must be refused, got %q", got)
+	}
+}
+
+func TestMalformedStagedSignaturesAreRefused(t *testing.T) {
+	withPinnedKey(t)
+	for name, body := range map[string]string{
+		"not base64":   "!!!!not-base64!!!!",
+		"wrong length": base64.StdEncoding.EncodeToString([]byte("too short")),
+		"empty":        "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv(agentSignatureEnv, dir)
+			if err := os.WriteFile(filepath.Join(dir, agentSignatureName("linux", archAMD64, testSHA)),
+				[]byte(body), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if got := contentAddressedSignatureFor("linux", archAMD64, testSHA); got != "" {
+				t.Fatalf("got %q", got)
+			}
+		})
+	}
+}
+
+// Without a pinned key nothing here could be checked, and an unverified
+// signature must never be announced.
+func TestNoPinnedKeyMeansNoStagedSignatureIsUsed(t *testing.T) {
+	priv := withPinnedKey(t)
+	sig := signFor(t, priv, "linux", testSHA)
+	stageSignature(t, "linux", archAMD64, testSHA, sig)
+
+	updateSigningMu.Lock()
+	updateSigningPub = nil
+	updateSigningMu.Unlock()
+
+	if got := contentAddressedSignatureFor("linux", archAMD64, testSHA); got != "" {
+		t.Fatalf("without a pinned key nothing may be announced, got %q", got)
+	}
+}
+
+// State files follow the INSTALLATION-owned rule, not the root-only rule that
+// governs served executables: under Docker the hub runs as uid 65532 and owns
+// /data, and demanding root would break every containerised install.
+func TestAWorldWritableSignatureIsRefused(t *testing.T) {
+	priv := withPinnedKey(t)
+	sig := signFor(t, priv, "linux", testSHA)
+	path := stageSignature(t, "linux", archAMD64, testSHA, sig)
+
+	if got := contentAddressedSignatureFor("linux", archAMD64, testSHA); got != sig {
+		t.Fatalf("control failed: a well-owned signature must be accepted, got %q", got)
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if got := contentAddressedSignatureFor("linux", archAMD64, testSHA); got != "" {
+		t.Fatalf("a group/other-writable signature must be refused, got %q", got)
+	}
+}
+
+func TestASymlinkedSignatureIsRefused(t *testing.T) {
+	priv := withPinnedKey(t)
+	sig := signFor(t, priv, "linux", testSHA)
+	path := stageSignature(t, "linux", archAMD64, testSHA, sig)
+
+	elsewhere := filepath.Join(t.TempDir(), "planted.sig")
+	if err := os.WriteFile(elsewhere, []byte(sig), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := os.Symlink(elsewhere, path); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// The content is byte-identical, so only the link itself is under test.
+	if got := contentAddressedSignatureFor("linux", archAMD64, testSHA); got != "" {
+		t.Fatalf("a symlinked signature must be refused, got %q", got)
+	}
+}
+
+func TestAnOversizedSignatureIsRefused(t *testing.T) {
+	withPinnedKey(t)
+	dir := t.TempDir()
+	t.Setenv(agentSignatureEnv, dir)
+	if err := os.WriteFile(filepath.Join(dir, agentSignatureName("linux", archAMD64, testSHA)),
+		make([]byte, agentSignatureMaxBytes+1), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := contentAddressedSignatureFor("linux", archAMD64, testSHA); got != "" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// The content address must distinguish architectures: the same release has
+// different bytes per platform, and each needs its own signature.
+func TestTheContentAddressSeparatesPlatforms(t *testing.T) {
+	priv := withPinnedKey(t)
+	sig := signFor(t, priv, "linux", testSHA)
+	stageSignature(t, "linux", archAMD64, testSHA, sig)
+
+	if got := contentAddressedSignatureFor("linux", archARM64, testSHA); got != "" {
+		t.Fatalf("an amd64 signature must not answer for arm64, got %q", got)
+	}
+	if got := contentAddressedSignatureFor("windows", archAMD64, testSHA); got != "" {
+		t.Fatalf("a linux signature must not answer for windows, got %q", got)
+	}
+}
+
+// A hub that holds its own key must never consult the store: no new key, no
+// new directory, no manual step for an ordinary install.
+func TestTheHubHeldKeyPathIsUnchanged(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	updateSigningMu.Lock()
+	previousPub, previousPriv := updateSigningPub, updateSigningKey
+	updateSigningPub, updateSigningKey = pub, priv
+	updateSigningMu.Unlock()
+	t.Cleanup(func() {
+		updateSigningMu.Lock()
+		updateSigningPub, updateSigningKey = previousPub, previousPriv
+		updateSigningMu.Unlock()
+	})
+	// Point the store at a directory that does not exist: nothing may depend
+	// on it.
+	t.Setenv(agentSignatureEnv, filepath.Join(t.TempDir(), "absent"))
+
+	sig := announcedSignatureForArch("linux", archAMD64, testSHA)
+	if sig == "" {
+		t.Fatal("a hub holding its own key must still sign, with no store present")
+	}
+	if err := updatesigning.Verify(pub, "linux", testSHA, sig); err != nil {
+		t.Fatalf("hub-held signature must verify: %v", err)
+	}
+}
+
+// A FIFO with no writer blocks in open(), BEFORE any fstat that would reject
+// it. O_NONBLOCK is what makes the check reachable; without it this test hangs
+// rather than fails, which is why it is bounded.
+func TestAFifoSignatureDoesNotBlock(t *testing.T) {
+	withPinnedKey(t)
+	dir := t.TempDir()
+	t.Setenv(agentSignatureEnv, dir)
+	path := filepath.Join(dir, agentSignatureName("linux", archAMD64, testSHA))
+	if err := syscall.Mkfifo(path, 0o644); err != nil {
+		t.Skipf("cannot create a FIFO here: %v", err)
+	}
+
+	done := make(chan string, 1)
+	go func() { done <- contentAddressedSignatureFor("linux", archAMD64, testSHA) }()
+	select {
+	case got := <-done:
+		if got != "" {
+			t.Fatalf("a FIFO must never be treated as a signature, got %q", got)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("reading a FIFO blocked; O_NONBLOCK is missing and the regular-file check is unreachable")
+	}
+}
+
+// The content address is built only from validated components. Before this,
+// the inputs were merely checked for being non-empty.
+func TestAMalformedIdentityNeverReachesTheFilesystem(t *testing.T) {
+	withPinnedKey(t)
+	dir := t.TempDir()
+	t.Setenv(agentSignatureEnv, dir)
+
+	// A file that WOULD be read if the identity were accepted verbatim.
+	planted := filepath.Join(dir, "planted.sig")
+	if err := os.WriteFile(planted, []byte("irrelevant"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	for name, identity := range map[string][3]string{
+		"traversal in sha":  {"linux", archAMD64, "../../etc/shadow"},
+		"traversal in arch": {"linux", "../../..", testSHA},
+		"short sha":         {"linux", archAMD64, "abc"},
+		"non-hex sha":       {"linux", archAMD64, strings.Repeat("z", 64)},
+		"unknown arch":      {"linux", "mips64", testSHA},
+		"empty everything":  {"", "", ""},
+		"separator in sha":  {"linux", archAMD64, "a/b" + strings.Repeat("c", 61)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, _, ok := agentSignatureAddress(identity[0], identity[1], identity[2]); ok {
+				t.Fatalf("%v must not produce a content address", identity)
+			}
+			if got := contentAddressedSignatureFor(identity[0], identity[1], identity[2]); got != "" {
+				t.Fatalf("got %q", got)
+			}
+		})
+	}
+}
+
+// The OS component is the one case that is NEUTRALISED rather than rejected,
+// and the distinction is worth stating: normalizeAgentOS maps anything that is
+// not "windows" to "linux", so the value that reaches the path is always one
+// of two fixed tokens and never the caller's string. A traversal there cannot
+// survive — it is replaced, not passed through — so the safety property holds
+// by a different mechanism than for the SHA and architecture.
+func TestATraversalInTheOSComponentIsReplacedNotPassedThrough(t *testing.T) {
+	name, platform, ok := agentSignatureAddress("../../etc", archAMD64, testSHA)
+	if !ok {
+		t.Fatal("the OS component is normalised, so this resolves rather than failing")
+	}
+	if platform.OS != "linux" {
+		t.Fatalf("OS was not normalised to a fixed token: %q", platform.OS)
+	}
+	if strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		t.Fatalf("content address %q carries a path component", name)
+	}
+}
+
+// The control for the test above: a well-formed identity DOES produce an
+// address, so the rejections mean something.
+func TestAWellFormedIdentityProducesItsAddress(t *testing.T) {
+	name, platform, ok := agentSignatureAddress("Linux", "x86_64", strings.ToUpper(testSHA))
+	if !ok {
+		t.Fatal("a valid identity must produce an address")
+	}
+	if platform.OS != "linux" || platform.Arch != archAMD64 {
+		t.Fatalf("identity was not normalised: %+v", platform)
+	}
+	if name != "linux-"+archAMD64+"-"+testSHA+".sig" {
+		t.Fatalf("unexpected content address %q", name)
+	}
+}

--- a/scripts/agent_bundle.py
+++ b/scripts/agent_bundle.py
@@ -89,13 +89,40 @@ def inspect_payloads(directory):
     return next(iter(releases)), artifacts
 
 
+# Provenance fields and how each is spelled when it IS present. The catalog
+# built inside the hub image cannot carry all of them — the image digest does
+# not exist until the image it would describe has been built, and a plain local
+# `docker build` has no release tag or git SHA either.
+#
+# Unavailable provenance is OMITTED, never faked. A placeholder all-zero SHA or
+# a self-referential digest would be a field that looks like evidence and is
+# not, and every later check against it would pass while proving nothing.
+PROVENANCE = {
+    "source": (lambda v: re.fullmatch(r"[0-9a-f]{40}", v), "expected full source commit SHA"),
+    "version": (lambda v: VERSION.fullmatch(v) and len(v) <= 129, "expected vX.Y.Z or vX.Y.Z-prerelease"),
+    "image_digest": (lambda v: re.fullmatch(r"sha256:[0-9a-f]{64}", v), "expected image digest"),
+}
+# Placeholders the Dockerfile defaults to. They mean "not known", so they are
+# treated as absent rather than recorded as fact.
+UNKNOWN = {"unknown", "development", "", None}
+
+
+def provenance_of(values):
+    """Validate every provenance value that is present; drop the unknown ones."""
+    present = {}
+    for field, value in values.items():
+        if value in UNKNOWN:
+            continue
+        check_value, message = PROVENANCE[field]
+        require(isinstance(value, str) and check_value(value), f"{message}: {field}")
+        present[field] = value
+    return present
+
+
 def create_manifest(directory, source, version, image_digest):
-    require(re.fullmatch(r"[0-9a-f]{40}", source), "expected full source commit SHA")
-    validate_tag(version)
-    require(re.fullmatch(r"sha256:[0-9a-f]{64}", image_digest), "expected image digest")
     release, artifacts = inspect_payloads(directory)
-    manifest = {"schema": 1, "version": version, "source": source,
-                "image_digest": image_digest, "agent_release": release, "artifacts": artifacts}
+    manifest = {"schema": 1, "agent_release": release, "artifacts": artifacts,
+                **provenance_of({"source": source, "version": version, "image_digest": image_digest})}
     data = (json.dumps(manifest, sort_keys=True, indent=2) + "\n").encode()
     # The release builder refuses to overwrite a previous manifest.
     with (directory / MANIFEST).open("xb") as stream:
@@ -103,15 +130,28 @@ def create_manifest(directory, source, version, image_digest):
     return hashlib.sha256(data).hexdigest()
 
 
-def check(directory, manifest_sha):
+def check(directory, manifest_sha, require_provenance=True):
+    """Verify a catalog and its payloads.
+
+    require_provenance=False is for the catalog built INSIDE the hub image,
+    which legitimately cannot name the image it lives in. It relaxes exactly
+    one thing: whether a provenance field must be PRESENT. Any field that IS
+    present is still validated strictly, and the artifact checks — sha256,
+    size, architecture, a single consistent release marker, all three platforms
+    — are mandatory either way. Those are what decide which bytes the fleet is
+    offered; provenance only says where they came from.
+    """
     require(HEX.fullmatch(manifest_sha), "supply the trusted 64-character manifest SHA256")
     data = read_regular(directory / MANIFEST, 64 * 1024)
     require(hashlib.sha256(data).hexdigest() == manifest_sha, "manifest SHA256 mismatch")
     manifest = json.loads(data)
     require(isinstance(manifest, dict) and manifest.get("schema") == 1, "unsupported manifest")
-    validate_tag(manifest.get("version"))
-    require(re.fullmatch(r"[0-9a-f]{40}", str(manifest.get("source", ""))), "invalid source SHA")
-    require(re.fullmatch(r"sha256:[0-9a-f]{64}", str(manifest.get("image_digest", ""))), "invalid image digest")
+    for field, (check_value, message) in PROVENANCE.items():
+        value = manifest.get(field)
+        if value is None:
+            require(not require_provenance, f"release catalog is missing {field}")
+            continue
+        require(isinstance(value, str) and check_value(value), f"invalid {field}: {message}")
     release, artifacts = inspect_payloads(directory)
     require(type(manifest.get("agent_release")) is int and manifest["agent_release"] == release,
             "manifest/binary release mismatch")
@@ -187,11 +227,14 @@ def main():
         p = commands.add_parser(name)
         p.add_argument("--bundle", required=True, type=Path)
         if name == "manifest":
-            p.add_argument("--source", required=True)
-            p.add_argument("--version", required=True)
-            p.add_argument("--image-digest", required=True)
+            # Not required: an in-image build catalog omits what it cannot know.
+            p.add_argument("--source", default=None)
+            p.add_argument("--version", default=None)
+            p.add_argument("--image-digest", default=None)
         else:
             p.add_argument("--manifest-sha256", required=True)
+            p.add_argument("--allow-missing-provenance", action="store_true",
+                           help="for the catalog built inside the hub image")
         if name == "stage":
             p.add_argument("--staging-root", required=True, type=Path)
     args = parser.parse_args()
@@ -201,7 +244,8 @@ def main():
         elif args.command == "manifest":
             print(create_manifest(args.bundle, args.source, args.version, args.image_digest))
         elif args.command == "check":
-            print(json.dumps(check(args.bundle, args.manifest_sha256), indent=2))
+            print(json.dumps(check(args.bundle, args.manifest_sha256,
+                                   require_provenance=not args.allow_missing_provenance), indent=2))
             print("Payloads match the supplied manifest. Fleet signatures must be verified separately. No changes made.")
         else:
             print(f"Staged at {stage(args.bundle, args.manifest_sha256, args.staging_root)}")

--- a/scripts/agent_bundle.py
+++ b/scripts/agent_bundle.py
@@ -54,14 +54,19 @@ def read_regular(path, limit):
 def identity(data, platform):
     require(len(data) >= 64, f"truncated binary: {platform}")
     if platform.startswith("linux/"):
-        require(data[:6] == b"\x7fELF\x02\x01", f"expected 64-bit little-endian ELF: {platform}")
+        # Byte 6 is EI_VERSION. The hub's loader requires EV_CURRENT, so this
+        # must too: a validator that accepts what the consumer rejects lets a
+        # release pass packaging and then fail at hub startup, which is the
+        # worst possible place to find out.
+        require(data[:7] == b"\x7fELF\x02\x01\x01", f"expected 64-bit little-endian ELF: {platform}")
         machine = struct.unpack_from("<H", data, 18)[0]
         require(machine == {"linux/amd64": 62, "linux/arm64": 183}[platform],
                 f"wrong ELF architecture: {platform}")
     else:
         require(data[:2] == b"MZ", "expected Windows PE executable")
         offset = struct.unpack_from("<I", data, 60)[0]
-        require(offset + 26 <= len(data) and data[offset:offset + 4] == b"PE\0\0",
+        # Below the DOS header the offset points back into the stub.
+        require(64 <= offset and offset + 26 <= len(data) and data[offset:offset + 4] == b"PE\0\0",
                 "invalid PE header")
         require(struct.unpack_from("<H", data, offset + 4)[0] == 0x8664
                 and struct.unpack_from("<H", data, offset + 24)[0] == 0x20B,

--- a/scripts/export-agent-bundle.sh
+++ b/scripts/export-agent-bundle.sh
@@ -21,9 +21,14 @@ container_id=$(docker create --platform linux/amd64 --network none "$image_ref")
 [[ "$container_id" =~ ^[0-9a-f]{64}$ ]] || { echo "invalid export container ID" >&2; exit 1; }
 trap 'docker rm -v "$container_id" >/dev/null' EXIT
 mkdir -m 0700 -- "$output_dir"
-docker cp "$container_id:/usr/local/lib/bloxos/linux/amd64/bloxos-agent" "$output_dir/bloxos-agent-linux-amd64"
-docker cp "$container_id:/usr/local/lib/bloxos/linux/arm64/bloxos-agent" "$output_dir/bloxos-agent-linux-arm64"
-docker cp "$container_id:/usr/local/lib/bloxos/windows/bloxos-agent.exe" "$output_dir/bloxos-agent-windows-amd64.exe"
+# Copy from the image's own managed bundle, under the canonical names. The
+# legacy /usr/local/lib/bloxos paths are hard links to these same inodes, so
+# either source yields identical bytes; taking them from here means the release
+# catalog describes the very files the containerised hub serves, under the very
+# names it serves them by.
+docker cp "$container_id:/usr/local/bin/agents/bloxos-agent-linux-amd64" "$output_dir/bloxos-agent-linux-amd64"
+docker cp "$container_id:/usr/local/bin/agents/bloxos-agent-linux-arm64" "$output_dir/bloxos-agent-linux-arm64"
+docker cp "$container_id:/usr/local/bin/agents/bloxos-agent-windows-amd64.exe" "$output_dir/bloxos-agent-windows-amd64.exe"
 manifest_sha=$(python3 "$script_dir/agent_bundle.py" manifest --bundle "$output_dir" \
   --source "$source_sha" --version "$release_tag" --image-digest "${image_ref##*@}")
 printf '%s  agent-manifest.json\n' "$manifest_sha" > "$output_dir/agent-manifest.sha256"

--- a/scripts/export-server-bundle.py
+++ b/scripts/export-server-bundle.py
@@ -7,9 +7,15 @@ from pathlib import Path
 import re
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
 import zipapp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import agent_bundle  # noqa: E402  (same directory; the canonical payload checker)
+
+AGENT_DIR = "agents"
 
 
 def run(args):
@@ -50,6 +56,121 @@ def export(image, platform, source, destination, revision):
         subprocess.run(["docker", "rm", "-v", container], check=True, stdout=subprocess.DEVNULL)
 
 
+def stage_agents(source, tree, hub_image, version, revision):
+    """Place the published agent payloads beside the hub binary they travel with.
+
+    `agents/` is a DIRECT CHILD of the hub executable's own directory, which is
+    what the hub looks for. The updater needs no change to carry it: it already
+    extracts every member of the archive and copytree's the whole staged tree,
+    and it installs the hub at <release>/hub/bloxos-hub — so <release>/hub/agents
+    lands exactly where the resolver expects with no new manifest schema, no
+    install logic and no second rollout step.
+
+    The bytes are COPIED, never rebuilt. A rebuild here would produce a second
+    set of agent binaries that are not the ones published as standalone assets,
+    and the fleet would then be offered bytes nobody ever checked. So the source
+    is the same directory whose files are attached to the release, and equality
+    is asserted rather than assumed.
+    """
+    # The sidecar is itself a published release asset, so checking against it
+    # ties the packed bytes to a value operators can independently see.
+    digest = agent_bundle.read_regular(source / "agent-manifest.sha256", 4096).decode().split()[0]
+    manifest = agent_bundle.check(source, digest)
+
+    # Bind the bundle to THIS export. A valid bundle is not automatically the
+    # RIGHT bundle: without this, any correctly-signed older bundle could be
+    # packed beside a new hub, and the result would be a brand-new release that
+    # once again offers the fleet stale agents — the precise failure this work
+    # exists to end, reintroduced by the mechanism meant to fix it.
+    #
+    # export-agent-bundle.sh derives the catalog from one exact image, so in
+    # this pipeline the catalog's identity must equal the export's. Referencing
+    # an older immutable bundle on purpose is a different feature and would need
+    # an explicit server-to-bundle reference, never silent acceptance of
+    # whatever directory was passed in.
+    expected = {"image_digest": hub_image.split("@", 1)[1], "source": revision, "version": version}
+    mismatched = {key: (manifest.get(key), want) for key, want in expected.items() if manifest.get(key) != want}
+    if mismatched:
+        raise ValueError("Agent bundle does not belong to this server release: "
+                         + "; ".join(f"{key} is {got!r}, expected {want!r}"
+                                     for key, (got, want) in sorted(mismatched.items())))
+
+    destination = tree / "hub" / AGENT_DIR
+    destination.mkdir()
+    names = [agent_bundle.MANIFEST, *agent_bundle.FILES.values()]
+    for name in names:
+        data = agent_bundle.read_regular(source / name,
+                                         64 * 1024 if name == agent_bundle.MANIFEST else agent_bundle.MAX_BINARY)
+        with (destination / name).open("xb") as stream:
+            stream.write(data)
+        # Assert equality against the source bytes, per file. A copy that
+        # silently truncated or substituted would otherwise be discovered by
+        # the fleet rather than by the release build.
+        if (destination / name).read_bytes() != data:
+            raise ValueError("Packed agent payload does not match the published bytes: " + name)
+        (destination / name).chmod(0o644 if name == agent_bundle.MANIFEST else 0o755)
+
+    # Re-run the full check on the DESTINATION: manifest SHA, per-payload
+    # sha256/size, architecture read from each image header, and a single
+    # consistent release marker across all three platforms.
+    if agent_bundle.check(destination, digest) != manifest:
+        raise ValueError("Packed agent bundle does not match the published agent bundle")
+    return manifest
+
+
+def verify_packed_agents(archive, manifest):
+    """Prove the payload BYTES survived into the archive, at the path the hub reads.
+
+    Checking member names would only prove something with the right name is
+    present. The archive is the artifact that actually ships, so the bytes
+    inside it are what has to be hashed — a truncated, substituted or aliased
+    entry passes a name check and fails the fleet.
+    """
+    prefix = "hub/" + AGENT_DIR + "/"
+    required = {agent_bundle.MANIFEST, *agent_bundle.FILES.values()}
+    found = {}
+    with tarfile.open(archive, "r:gz") as target:
+        for member in target.getmembers():
+            if not member.name.startswith(prefix):
+                continue
+            name = member.name[len(prefix):]
+            if "/" in name:
+                raise ValueError("Agent bundle directory has unexpected nesting: " + member.name)
+            # A hardlink or symlink entry resolves to bytes chosen elsewhere in
+            # the archive, so it is never an acceptable stand-in for a payload.
+            if not member.isfile() or member.issym() or member.islnk():
+                raise ValueError("Agent bundle entry is not a regular file: " + member.name)
+            if name in found:
+                raise ValueError("Agent bundle contains a duplicate entry: " + member.name)
+            if name not in required:
+                raise ValueError("Agent bundle contains an unexpected file: " + member.name)
+            stream = target.extractfile(member)
+            if stream is None:
+                raise ValueError("Agent bundle entry has no content: " + member.name)
+            found[name] = stream.read()
+
+    missing = sorted(required - set(found))
+    if missing:
+        raise ValueError("Server archive is missing agent payloads: " + ", ".join(missing))
+
+    # The archived catalog must be the same document that was verified, byte
+    # for byte — not merely a parseable manifest.
+    if json.loads(found[agent_bundle.MANIFEST]) != manifest:
+        raise ValueError("Archived agent catalog differs from the verified catalog")
+
+    # Every server architecture carries every agent platform, so a hub on either
+    # server can serve any machine in the fleet.
+    for platform, name in agent_bundle.FILES.items():
+        artifact = manifest["artifacts"].get(platform)
+        if artifact is None:
+            raise ValueError("Packed agent bundle does not declare " + platform)
+        if artifact["file"] != name:
+            raise ValueError("Packed agent bundle renames " + platform)
+        if len(found[name]) != artifact["size"] or \
+                hashlib.sha256(found[name]).hexdigest() != artifact["sha256"]:
+            raise ValueError("Archived agent payload does not match the catalog: " + name)
+
+
 def pack_tree(tree, archive):
     root = tree.resolve()
     for entry in tree.rglob("*"):
@@ -81,6 +202,11 @@ def main():
     parser.add_argument("--revision", required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--output", type=Path, required=True)
+    # Required, not optional: a server archive without agents is the exact
+    # failure this work exists to end — a new hub that keeps offering the fleet
+    # whatever agent binaries happen to already be on disk.
+    parser.add_argument("--agents", type=Path, required=True,
+                        help="directory of published agent payloads from export-agent-bundle.sh")
     args = parser.parse_args()
     if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?", args.version) or not re.fullmatch(r"[0-9a-f]{40}", args.revision):
         parser.error("Expected release tag and full revision")
@@ -88,6 +214,9 @@ def main():
         if not re.fullmatch(r"ghcr\.io/bokiko/bloxos-" + name + r"@sha256:[0-9a-f]{64}", getattr(args, name)):
             parser.error("Image references must be canonical digest-pinned BloxOS images")
     args.output.mkdir(mode=0o700, parents=False, exist_ok=False)
+    # No schema bump. The updater verifies the archive checksum and extracts
+    # safely already; adding agent payloads inside the archive needs nothing new
+    # from it, and a schema change would force old workers to be upgraded first.
     manifest = {"schema": 1, "version": args.version, "revision": args.revision,
                 "images": {"hub": args.hub, "dashboard": args.dashboard}, "native": {}}
     for arch in ("amd64", "arm64"):
@@ -96,6 +225,7 @@ def main():
             (tree / "hub").mkdir()
             (tree / "dashboard").mkdir()
             export(args.hub, "linux/" + arch, "/usr/local/bin/bloxos-hub", tree / "hub" / "bloxos-hub", args.revision)
+            agents = stage_agents(args.agents, tree, args.hub, args.version, args.revision)
             export(args.dashboard, "linux/" + arch, "/app/.", tree / "dashboard", args.revision)
             if not (tree / "dashboard" / "server.js").is_file():
                 raise ValueError("Exported dashboard has no standalone server")
@@ -104,6 +234,7 @@ def main():
             name = f"bloxos-server-linux-{arch}.tar.gz"
             archive = args.output / name
             pack_tree(tree, archive)
+            verify_packed_agents(archive, agents)
             manifest["native"][arch] = {"file": name, "sha256": hashlib.sha256(archive.read_bytes()).hexdigest()}
     (args.output / "update-manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
     with tempfile.TemporaryDirectory(prefix="bloxos-updater-release-") as directory:

--- a/scripts/export-server-bundle.py
+++ b/scripts/export-server-bundle.py
@@ -125,6 +125,12 @@ def verify_packed_agents(archive, manifest):
     present. The archive is the artifact that actually ships, so the bytes
     inside it are what has to be hashed — a truncated, substituted or aliased
     entry passes a name check and fails the fleet.
+
+    The PAYLOADS are compared byte for byte, via sha256 and size against the
+    catalog. The CATALOG itself is compared as parsed JSON, so re-serialisation
+    whitespace is tolerated: the manifest's own integrity is already pinned by
+    its sidecar SHA in stage_agents, and there is no security value in failing
+    a release over a reformatted but semantically identical document.
     """
     prefix = "hub/" + AGENT_DIR + "/"
     required = {agent_bundle.MANIFEST, *agent_bundle.FILES.values()}
@@ -153,8 +159,8 @@ def verify_packed_agents(archive, manifest):
     if missing:
         raise ValueError("Server archive is missing agent payloads: " + ", ".join(missing))
 
-    # The archived catalog must be the same document that was verified, byte
-    # for byte — not merely a parseable manifest.
+    # The archived catalog must be the same catalog that was verified — not
+    # merely a parseable manifest that happens to be present.
     if json.loads(found[agent_bundle.MANIFEST]) != manifest:
         raise ValueError("Archived agent catalog differs from the verified catalog")
 

--- a/scripts/image_platform.py
+++ b/scripts/image_platform.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Resolve a multi-platform image index to one platform's immutable child digest.
+
+A thin wrapper so the workflow does not re-implement the resolution. The logic
+lives in export-server-bundle.py's platform_image, which already handles the
+classic-store collision where `docker pull --platform` can hand back a
+different image than the index entry for that platform.
+"""
+import argparse
+import importlib.util
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "export_server_bundle", Path(__file__).resolve().parent / "export-server-bundle.py")
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--platform", required=True)
+    args = parser.parse_args()
+    print(_module.platform_image(args.image, args.platform))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release_history.py
+++ b/scripts/release_history.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Gather published agent release history, and persist a catalog immutably.
+
+Two jobs, both about the same thing: what a release number has already meant.
+
+`gather` collects every agent catalog this repository has ever published, so
+the identity gate can compare a candidate against all of them. It includes
+DRAFT releases deliberately. The release workflow promotes Docker tags before
+it attaches draft assets, so a release whose images are already live and whose
+agents are already being served can still be a draft — treating drafts as
+absent would read such a release as never having happened. It also includes the
+candidate tag's OWN catalog, because a previous run may already have persisted
+and promoted it; "its own catalog is not history" is false the moment a retry
+exists.
+
+FAILURE IS NEVER ABSENCE. The only reason a release contributes nothing is that
+its asset list positively does not contain a catalog. A listing error, a
+download error, an auth failure or a parse error is fatal. The alternative is
+far worse than a failed build: a timeout while fetching the NEWEST release
+would silently erase the floor, and the older history that still loaded would
+let a stale or conflicting candidate sail through a check that reported success.
+
+`persist` writes the verified catalog to the draft release BEFORE the Docker
+tags are promoted. If a run dies between promotion and asset upload, the images
+are live but nothing records what agent bytes they carry, and the next run has
+no history to check itself against. Persisting first means a crash can leave an
+unused catalog — harmless — instead of unrecorded published bytes.
+
+Persistence is idempotent and never destructive: re-uploading an identical
+catalog is a no-op, and a DIFFERENT catalog under the same tag is an error
+rather than an overwrite. An asset that has already been published is evidence,
+and evidence does not get replaced because a later run disagreed with it.
+"""
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+CATALOG_ASSET = "agent-manifest.json"
+
+
+class HistoryError(Exception):
+    """A lookup that did not complete. Never treated as 'nothing found'."""
+
+
+def gh(*args):
+    """Run gh and return TEXT stdout. For listings and commands, never assets."""
+    result = subprocess.run(["gh", *args], text=True, capture_output=True)
+    if result.returncode != 0:
+        raise HistoryError(f"gh {' '.join(args[:3])} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def gh_bytes(*args):
+    """Run gh and return stdout as RAW BYTES, with stderr decoded only for the error.
+
+    Release assets are agent binaries and tarballs. Reading them through a
+    text-mode pipe decodes arbitrary bytes as UTF-8 and rewrites line endings,
+    so a retry comparing an existing asset would either raise a decode error or
+    — worse — compare data that the transport had already altered and declare a
+    conflict that does not exist. The bytes have to arrive unmodified, which
+    also matters for the catalog: its sidecar checksum covers exact bytes.
+    """
+    result = subprocess.run(["gh", *args], capture_output=True)
+    if result.returncode != 0:
+        raise HistoryError(f"gh {' '.join(args[:3])} failed: "
+                           f"{result.stderr.decode('utf-8', 'replace').strip()}")
+    return result.stdout
+
+
+def list_releases(repo):
+    """Every release — drafts included — with its asset names and ids.
+
+    Uses the paginated API rather than `gh release list --limit N`: a limit is
+    a silent truncation, and the releases it would drop are the oldest ones,
+    which are exactly where a reused release number would be hiding.
+    """
+    raw = gh("api", "--paginate", f"repos/{repo}/releases",
+             "--jq", '.[] | {tag: .tag_name, draft: .draft, '
+                     'assets: [.assets[] | {name: .name, id: .id}]}')
+    releases = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            releases.append(json.loads(line))
+        except ValueError as error:
+            raise HistoryError(f"could not parse release listing: {error}")
+    return releases
+
+
+def fetch_asset(repo, asset_id):
+    return gh_bytes("api", "-H", "Accept: application/octet-stream",
+                    f"repos/{repo}/releases/assets/{asset_id}")
+
+
+def raw_asset_of(repo, release, name, fetch=None):
+    """One named asset's RAW BYTES, or None only when it positively has none."""
+    assets = release.get("assets")
+    if assets is None:
+        raise HistoryError(f"release {release.get('tag')!r} returned no asset list")
+    match = next((asset for asset in assets if asset.get("name") == name), None)
+    if match is None:
+        # Confirmed absent: the asset list loaded and does not contain one.
+        # This is the ONLY path that contributes nothing without failing.
+        return None
+    body = (fetch or fetch_asset)(repo, match["id"])
+    # Test fetchers may hand back text; the real one always returns bytes.
+    return body.encode() if isinstance(body, str) else body
+
+
+def upload(repo, tag, paths, releases=None, fetch=None):
+    """Attach assets, comparing rather than overwriting anything already there.
+
+    A retry must be able to finish a partially-uploaded release, but --clobber
+    is the wrong tool for it: replacing a published artifact silently changes
+    what an existing release means, and anyone who already downloaded it has
+    something the release no longer claims. So an identical asset is skipped
+    and a differing one is an error.
+    """
+    listing = list_releases(repo) if releases is None else releases
+    current = next((release for release in listing if release.get("tag") == tag), None)
+    results = []
+    for path in paths:
+        path = Path(path)
+        name = path.name
+        existing = None if current is None else raw_asset_of(repo, current, name, fetch=fetch)
+        if existing is not None:
+            if existing == path.read_bytes():
+                results.append(f"{name}: already published and identical, skipped")
+                continue
+            raise HistoryError(
+                f"{tag} already has a DIFFERENT {name} attached. A published asset is never "
+                f"overwritten; if these bytes are correct they belong under a new release.")
+        gh("release", "upload", tag, str(path), "--repo", repo)
+        results.append(f"{name}: uploaded")
+    return results
+
+
+def raw_catalog_of(repo, release, fetch=None):
+    """The release's catalog as RAW BYTES, or None only when it positively has none."""
+    return raw_asset_of(repo, release, CATALOG_ASSET, fetch=fetch)
+
+
+def catalog_of(repo, release, fetch=None):
+    """The release's agent catalog, parsed, or None when it positively has none."""
+    raw = raw_catalog_of(repo, release, fetch=fetch)
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except ValueError as error:
+        raise HistoryError(f"release {release.get('tag')!r} has an unreadable "
+                           f"{CATALOG_ASSET}: {error}")
+
+
+def gather(repo, releases=None, fetch=None):
+    """Build {release_number: [artifacts, ...]}, retaining EVERY catalog.
+
+    Never collapsed to one entry per number: if a number was published twice
+    with different bytes, collapsing would overwrite the first with the second
+    and destroy the very evidence the identity gate exists to find.
+    """
+    history = {}
+    for release in (list_releases(repo) if releases is None else releases):
+        catalog = catalog_of(repo, release, fetch=fetch)
+        if catalog is None:
+            continue
+        number = catalog.get("agent_release")
+        artifacts = catalog.get("artifacts")
+        if not isinstance(number, int) or isinstance(number, bool) or not isinstance(artifacts, dict):
+            raise HistoryError(f"release {release.get('tag')!r} has a malformed {CATALOG_ASSET}")
+        history.setdefault(str(number), []).append(artifacts)
+    return history
+
+
+def persist(repo, tag, catalog_path, releases=None, fetch=None):
+    """Attach the catalog to this tag's draft release, idempotently.
+
+    Equality is RAW BYTES, not parsed JSON. agent-manifest.sha256 is a checksum
+    over the catalog's exact bytes, so two semantically identical documents that
+    serialise differently are not interchangeable here: keeping the old
+    formatting while publishing a sidecar computed over the new formatting
+    produces a checksum that does not match the file it names, and every
+    download that verifies it fails.
+    """
+    candidate = Path(catalog_path).read_bytes()
+    listing = list_releases(repo) if releases is None else releases
+    current = next((release for release in listing if release.get("tag") == tag), None)
+
+    if current is not None:
+        existing = raw_catalog_of(repo, current, fetch=fetch)
+        if existing is not None:
+            if existing == candidate:
+                return f"{CATALOG_ASSET} already published for {tag} and matches; nothing to do"
+            raise HistoryError(
+                f"{tag} already has a DIFFERENT {CATALOG_ASSET} attached (byte comparison).\n"
+                f"A published catalog is evidence of what that release carries and is never "
+                f"overwritten; its sidecar checksum covers those exact bytes. If these bytes "
+                f"are correct, they belong under a new release.")
+
+    gh("release", "upload", tag, str(catalog_path), "--repo", repo)
+    return f"{CATALOG_ASSET} persisted for {tag} before promotion"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    g = commands.add_parser("gather", help="emit release -> [artifacts] as JSON")
+    g.add_argument("--repo", required=True)
+    g.add_argument("--output", required=True, type=Path)
+
+    p = commands.add_parser("persist", help="attach a verified catalog to the draft release")
+    p.add_argument("--repo", required=True)
+    p.add_argument("--tag", required=True)
+    p.add_argument("--catalog", required=True, type=Path)
+
+    u = commands.add_parser("upload", help="attach assets without ever overwriting one")
+    u.add_argument("--repo", required=True)
+    u.add_argument("--tag", required=True)
+    u.add_argument("files", nargs="+", type=Path)
+
+    args = parser.parse_args()
+    try:
+        if args.command == "gather":
+            history = gather(args.repo)
+            args.output.write_text(json.dumps(history, indent=2, sort_keys=True) + "\n")
+            print(f"gathered {len(history)} agent release(s) from published and draft releases")
+        elif args.command == "persist":
+            print(persist(args.repo, args.tag, args.catalog))
+        else:
+            for line in upload(args.repo, args.tag, args.files):
+                print(line)
+    except HistoryError as error:
+        sys.stderr.write(f"release history: {error}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release_identity.py
+++ b/scripts/release_identity.py
@@ -2,11 +2,19 @@
 """Release identity gate: a (platform, release) pair names exactly one set of bytes.
 
 The agent release number is how the fleet decides whether an offer is newer
-than what it runs. If the same number can ever name different bytes, that
-decision is meaningless — two machines both "on release 9" may be running
-different binaries, and a floor check comparing numbers will happily approve a
-downgrade. This runs BEFORE promotion, because after a tag is published the
-ambiguity is permanent.
+than what it runs. If the same number can ever name different bytes, two
+machines both "on release 9" are running different binaries, and the number
+stops describing anything.
+
+What that actually breaks is the rollout, not the rollback floor. A protocol-2
+agent pins release number AND sha, so it REJECTS an offer carrying its own
+number with different bytes — correctly, and permanently: the fleet simply
+stops taking the update, and every affected machine stalls on a build nobody
+can replace without a number bump. Older protocol-1 agents do not enforce that
+pairing at all, so for them the same ambiguity is silent.
+
+This runs BEFORE promotion, because after a tag is published the ambiguity is
+permanent.
 
 Four things it enforces:
 

--- a/scripts/release_identity.py
+++ b/scripts/release_identity.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Release identity gate: a (platform, release) pair names exactly one set of bytes.
+
+The agent release number is how the fleet decides whether an offer is newer
+than what it runs. If the same number can ever name different bytes, that
+decision is meaningless — two machines both "on release 9" may be running
+different binaries, and a floor check comparing numbers will happily approve a
+downgrade. This runs BEFORE promotion, because after a tag is published the
+ambiguity is permanent.
+
+Four things it enforces:
+
+  * A release number already used with DIFFERENT bytes can never be reused.
+  * A retry of the same release with IDENTICAL bytes is idempotent and passes,
+    so a re-run of a failed workflow is not a dead end.
+  * A new release number must exceed the historical floor, so numbering only
+    ever moves forward.
+  * Both hub image platforms must embed the SAME agent bytes as the canonical
+    standalone bundle.
+
+That last one is not paranoia. Native server exports copy the canonical bundle,
+but a containerised arm64 hub serves the agents built into its own image. The
+two images are built separately, on different platforms, from build args that
+could drift. Sharing a hub image index says nothing about what those images
+embedded — so the payload maps are compared directly.
+
+History is passed IN. Remote lookup belongs in the workflow, where credentials
+and the network live; this file stays a pure decision so it can be tested.
+"""
+import argparse
+import json
+from pathlib import Path
+import sys
+
+# Every agent platform a catalog must describe. A catalog short of one would
+# let that platform's identity go unchecked while the others reported fine.
+AGENT_PLATFORMS = frozenset({"linux/amd64", "linux/arm64", "windows/amd64"})
+
+# Both hub image platforms must be presented. A non-empty check is not enough:
+# supplying only amd64 would "pass" while arm64 — the one built on a different
+# platform, and therefore the one that can actually drift — went unexamined.
+HUB_IMAGE_PLATFORMS = frozenset({"linux/amd64", "linux/arm64"})
+
+HEX = "0123456789abcdef"
+
+
+class IdentityError(Exception):
+    """A release that must not be promoted."""
+
+
+def artifact_map(catalog):
+    """The identity of a catalog: platform -> (sha256, size). Nothing else.
+
+    File names and provenance are deliberately excluded. Renaming a payload
+    does not make it different bytes, and provenance legitimately differs
+    between an in-image catalog and a release catalog describing the same
+    binaries.
+    """
+    artifacts = catalog.get("artifacts")
+    if not isinstance(artifacts, dict):
+        raise IdentityError("catalog declares no artifacts")
+    if set(artifacts) != AGENT_PLATFORMS:
+        raise IdentityError(
+            f"catalog must describe exactly {sorted(AGENT_PLATFORMS)}, got {sorted(artifacts)}")
+    identity = {}
+    for platform, artifact in artifacts.items():
+        if not isinstance(artifact, dict):
+            raise IdentityError(f"catalog entry for {platform} is not an object")
+        sha = str(artifact.get("sha256", "")).lower()
+        size = artifact.get("size")
+        # bool is an int in Python, and True would sail through a > 0 test.
+        if len(sha) != 64 or any(character not in HEX for character in sha):
+            raise IdentityError(f"catalog entry for {platform} has no usable sha256")
+        if not isinstance(size, int) or isinstance(size, bool) or size <= 0:
+            raise IdentityError(f"catalog entry for {platform} has no usable size")
+        identity[platform] = (sha, size)
+    return identity
+
+
+def release_of(catalog):
+    release = catalog.get("agent_release")
+    if not isinstance(release, int) or isinstance(release, bool) or release <= 0:
+        raise IdentityError("catalog declares no usable agent_release")
+    return release
+
+
+def describe(identity):
+    return ", ".join(f"{platform}={sha[:12]}…" for platform, (sha, _) in sorted(identity.items()))
+
+
+def check_history(candidate, history):
+    """Compare the candidate against every catalog already published or drafted.
+
+    `history` maps release number -> LIST of artifact maps, one per catalog
+    found. Every catalog is retained rather than collapsed to one map per
+    number, because collapsing is itself a way to lose the finding: if a number
+    was published twice with different bytes, the second would simply overwrite
+    the first and the ambiguity would be invisible to the check meant to catch
+    it. Divergence is therefore detected generically, from the data, with no
+    release number special-cased — including release 7, whose existing
+    divergence this gate discovers rather than assumes.
+
+    History MUST include draft releases: the workflow promotes Docker tags
+    before it attaches draft assets, so a release whose images are already live
+    can still be a draft. Gating on published releases alone would read such a
+    release as absent and wave through a conflicting reuse of its number.
+    """
+    if not history:
+        # This repository has published agent releases. An empty history means
+        # the gatherer failed, and "we found nothing" must never be allowed to
+        # establish a floor of zero and approve any number at all.
+        raise IdentityError(
+            "no published agent release history was found; this repository has "
+            "published releases, so an empty history means the lookup failed")
+
+    release = release_of(candidate)
+    identity = artifact_map(candidate)
+    floor = max(history)
+    known = history.get(release)
+
+    if known is not None:
+        distinct = {tuple(sorted(entry.items())) for entry in known}
+        if len(distinct) > 1:
+            raise IdentityError(
+                f"release {release} has already been published with {len(distinct)} different "
+                f"sets of bytes, so what that number identifies is ambiguous and it can never "
+                f"be reused; bump the agent release instead")
+        if known[0] != identity:
+            raise IdentityError(
+                f"release {release} is already published with DIFFERENT bytes\n"
+                f"  published: {describe(known[0])}\n"
+                f"  candidate: {describe(identity)}\n"
+                f"a release number names one set of bytes; bump the agent release")
+        # Identical bytes, so nothing about that release changes. But promoting
+        # it now would still offer the fleet an OLDER identity than the one
+        # already published, which is a downgrade dressed as a retry.
+        if release < floor:
+            raise IdentityError(
+                f"release {release} matches its published bytes, but release {floor} has since "
+                f"been published; re-running an older release must not lower the offered "
+                f"release identity")
+        return f"release {release} already published with identical bytes; idempotent retry"
+
+    if release <= floor:
+        raise IdentityError(
+            f"release {release} does not exceed the published floor {floor}; "
+            f"numbering must move forward")
+    return f"release {release} is new and above the floor {floor}"
+
+
+def check_image_platforms(candidate, image_catalogs):
+    """Every hub image must embed the same agent bytes as the canonical bundle."""
+    missing = HUB_IMAGE_PLATFORMS - set(image_catalogs)
+    if missing:
+        raise IdentityError(
+            f"no catalog supplied for hub image platform(s) {sorted(missing)}; "
+            f"an unexamined platform must not read as a passing one")
+    unexpected = set(image_catalogs) - HUB_IMAGE_PLATFORMS
+    if unexpected:
+        raise IdentityError(f"unexpected hub image platform(s) {sorted(unexpected)}")
+    canonical = artifact_map(candidate)
+    canonical_release = release_of(candidate)
+    for platform, catalog in sorted(image_catalogs.items()):
+        if release_of(catalog) != canonical_release:
+            raise IdentityError(
+                f"hub image {platform} embeds agent release {release_of(catalog)}, "
+                f"canonical bundle says {canonical_release}")
+        embedded = artifact_map(catalog)
+        if embedded != canonical:
+            raise IdentityError(
+                f"hub image {platform} embeds different agent bytes than the canonical bundle\n"
+                f"  image:     {describe(embedded)}\n"
+                f"  canonical: {describe(canonical)}\n"
+                f"a build-arg or toolchain drift between image platforms would do this; "
+                f"sharing an image index does not make the embedded payloads equal")
+    return f"all {len(image_catalogs)} hub image platforms embed the canonical agent bytes"
+
+
+def load_history(raw):
+    """Parse {"<release>": [artifacts, ...]} into release -> list of artifact maps.
+
+    A LIST per release, never a single map: see check_history. A lone object is
+    accepted and wrapped, so a gatherer that emits one catalog per number is
+    not silently misread as something else.
+    """
+    history = {}
+    for release, entries in (raw or {}).items():
+        if isinstance(entries, dict):
+            entries = [entries]
+        if not isinstance(entries, list) or not entries:
+            raise IdentityError(f"history for release {release} is not a list of catalogs")
+        history[int(release)] = [artifact_map({"artifacts": entry}) for entry in entries]
+    return history
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--candidate", required=True, type=Path,
+                        help="the canonical standalone agent-manifest.json")
+    parser.add_argument("--history", required=True, type=Path,
+                        help="JSON of release -> artifacts, gathered from published AND draft releases")
+    parser.add_argument("--image-catalog", action="append", default=[], metavar="PLATFORM=PATH",
+                        help="agent catalog extracted from one hub image; repeat per platform")
+    args = parser.parse_args()
+
+    candidate = json.loads(args.candidate.read_text())
+    history = load_history(json.loads(args.history.read_text()))
+    catalogs = {}
+    for entry in args.image_catalog:
+        platform, _, path = entry.partition("=")
+        if not platform or not path:
+            parser.error(f"--image-catalog expects PLATFORM=PATH, got {entry!r}")
+        catalogs[platform] = json.loads(Path(path).read_text())
+
+    try:
+        print(check_history(candidate, history))
+        print(check_image_platforms(candidate, catalogs))
+    except IdentityError as error:
+        sys.stderr.write(f"release identity: {error}\n")
+        return 1
+    print("Release identity verified. Safe to promote.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_agent_bundle.py
+++ b/scripts/test_agent_bundle.py
@@ -15,7 +15,7 @@ import agent_bundle as bundle
 def fixture(platform, release=7):
     data = bytearray(128)
     if platform.startswith("linux/"):
-        data[:6] = b"\x7fELF\x02\x01"
+        data[:7] = b"\x7fELF\x02\x01\x01"  # EI_VERSION must be EV_CURRENT, as real builds are
         struct.pack_into("<H", data, 18, 62 if platform == "linux/amd64" else 183)
     else:
         data[:2] = b"MZ"

--- a/scripts/test_agent_bundle.py
+++ b/scripts/test_agent_bundle.py
@@ -229,9 +229,9 @@ case "$1" in
           test "$4" = --network; test "$5" = none; printf '%064d' 0 ;;
   cp) [[ "$FAIL_EXPORT" != copy ]] || exit 9
       case "$2" in
-        *:/usr/local/lib/bloxos/linux/amd64/bloxos-agent) name=bloxos-agent-linux-amd64 ;;
-        *:/usr/local/lib/bloxos/linux/arm64/bloxos-agent) name=bloxos-agent-linux-arm64 ;;
-        *:/usr/local/lib/bloxos/windows/bloxos-agent.exe) name=bloxos-agent-windows-amd64.exe ;;
+        *:/usr/local/bin/agents/bloxos-agent-linux-amd64) name=bloxos-agent-linux-amd64 ;;
+        *:/usr/local/bin/agents/bloxos-agent-linux-arm64) name=bloxos-agent-linux-arm64 ;;
+        *:/usr/local/bin/agents/bloxos-agent-windows-amd64.exe) name=bloxos-agent-windows-amd64.exe ;;
         *) exit 10 ;;
       esac
       cp "$FIXTURES/$name" "$3" ;;
@@ -290,6 +290,51 @@ esac
         self.assertFalse((output / bundle.MANIFEST).exists())
         self.assertTrue(log.splitlines()[-1].startswith("rm -v "))
         self.assertEqual((self.active / "bloxos-agent").read_bytes(), b"existing agent")
+
+
+class InImageCatalogTests(unittest.TestCase):
+    """The catalog built inside the hub image cannot name the image it lives in."""
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.bundle = Path(self.temp.name) / "agents"
+        self.bundle.mkdir()
+        for platform, name in bundle.FILES.items():
+            (self.bundle / name).write_bytes(fixture(platform, release=11))
+
+    def test_unknown_provenance_is_omitted_never_faked(self):
+        # Exactly what a plain local `docker build` supplies.
+        digest = bundle.create_manifest(self.bundle, "unknown", "development", None)
+        recorded = json.loads((self.bundle / bundle.MANIFEST).read_text())
+        for field in ("source", "version", "image_digest"):
+            self.assertNotIn(field, recorded,
+                             f"{field} was recorded from a placeholder; it must be omitted instead")
+
+        # The artifact checks stay mandatory: this is what decides which bytes
+        # the fleet is offered.
+        checked = bundle.check(self.bundle, digest, require_provenance=False)
+        self.assertEqual(checked["agent_release"], 11)
+        self.assertEqual(sorted(checked["artifacts"]), sorted(bundle.FILES))
+
+    def test_a_release_catalog_must_still_carry_full_provenance(self):
+        digest = bundle.create_manifest(self.bundle, "unknown", "development", None)
+        with self.assertRaises(ValueError) as caught:
+            bundle.check(self.bundle, digest)
+        self.assertIn("missing", str(caught.exception))
+
+    def test_present_provenance_is_validated_strictly_either_way(self):
+        with self.assertRaises(ValueError):
+            bundle.create_manifest(self.bundle, "not-a-sha", None, None)
+        with self.assertRaises(ValueError):
+            bundle.create_manifest(self.bundle, None, "1.2.3", None)
+        with self.assertRaises(ValueError):
+            bundle.create_manifest(self.bundle, None, None, "sha256:xyz")
+
+    def test_a_missing_platform_is_refused_with_or_without_provenance(self):
+        (self.bundle / bundle.FILES["windows/amd64"]).unlink()
+        with self.assertRaises((ValueError, OSError)):
+            bundle.create_manifest(self.bundle, None, None, None)
 
 
 if __name__ == "__main__":

--- a/scripts/test_hub_bundle_boot.py
+++ b/scripts/test_hub_bundle_boot.py
@@ -31,6 +31,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import pwd
 import shutil
 import socket
 import subprocess
@@ -47,9 +48,6 @@ import agent_bundle as bundle
 from test_agent_bundle import fixture
 
 REPO = Path(__file__).resolve().parent.parent
-# Root-owned and not group/other writable on every supported runner, which the
-# trusted-path rule requires of every ancestor of a payload.
-FIXTURE_PARENT = Path("/opt")
 RELEASE = 12
 READY_TIMEOUT = 60.0
 
@@ -91,6 +89,34 @@ def unavailable():
     return reason
 
 
+def fixture_parent():
+    """A directory whose whole ancestry already satisfies the trusted-path rule.
+
+    /opt was the obvious choice and the wrong one: on a GitHub runner it is
+    mode 0777, so the trusted-path check refused a PERFECTLY VALID bundle and
+    the three negative cases passed for a reason that had nothing to do with
+    the gate. Root's own home is root-owned and not group/other writable.
+
+    The ancestry is VERIFIED rather than assumed, and never relaxed by
+    chmod'ing a shared directory — loosening a system path to make a test pass
+    is how a test starts changing the machine it runs on.
+    """
+    home = Path(pwd.getpwuid(0).pw_dir)
+    current = home.resolve()
+    while True:
+        try:
+            info = current.stat()
+        except OSError as error:
+            raise AssertionError(f"cannot inspect {current}: {error}")
+        if info.st_uid != 0:
+            raise AssertionError(f"{current} is owned by uid {info.st_uid}, want root")
+        if info.st_mode & 0o022:
+            raise AssertionError(f"{current} mode {info.st_mode & 0o7777:04o} is group- or other-writable")
+        if current.parent == current:
+            return home
+        current = current.parent
+
+
 def free_port():
     with socket.socket() as probe:
         probe.bind(("127.0.0.1", 0))
@@ -112,7 +138,7 @@ class HubBootGateTests(unittest.TestCase):
         # A unique directory, created by this run and removed by it. Never a
         # fixed path: a test that rmtree's a predictable location on entry will
         # eventually delete something an operator put there.
-        cls.root = Path(tempfile.mkdtemp(prefix="bloxos-boot-smoke-", dir=FIXTURE_PARENT))
+        cls.root = Path(tempfile.mkdtemp(prefix="bloxos-boot-smoke-", dir=fixture_parent()))
         cls.root.chmod(0o755)
         cls.scratch = tempfile.mkdtemp(prefix="bloxos-boot-scratch-")
 
@@ -180,13 +206,29 @@ class HubBootGateTests(unittest.TestCase):
             process.kill()
             return process.communicate()[0] or ""
 
-    def refuses(self, hub):
-        """Run a hub expected to die at the gate; assert it did, before the DB."""
+    def refuses(self, hub, *expected):
+        """Run a hub expected to die at the gate; assert it did, for the RIGHT reason.
+
+        `expected` names substrings specific to the defect under test. A
+        generic "agent delivery" match is not enough: every refusal carries it,
+        so any one of these cases could pass while the hub was actually
+        rejecting something else entirely. That is not hypothetical — all three
+        negative cases were passing on a runner where the FIXTURE PATH was the
+        real complaint.
+        """
         process, workdir, _ = self.start(hub)
         output = self.drain(process)
         self.assertIsNotNone(process.poll(), "the hub must exit, not start")
         self.assertNotEqual(process.returncode, 0, output[-2000:])
         self.assertIn("agent delivery", output, output[-2000:])
+        for fragment in expected:
+            self.assertIn(fragment, output,
+                          f"expected the gate to complain about {fragment!r}; got:\n{output[-2000:]}")
+        # The trusted-path rule must never be what failed: that would mean the
+        # fixture, not the payload, is what the hub objected to.
+        self.assertNotIn("group- or other-writable", output,
+                         "the fixture path was refused, so this case proves nothing about "
+                         "the defect it names")
         self.assertFalse((workdir / "bloxos.db").exists(),
                          "the database was created before the gate refused; a rejected "
                          "candidate must not mutate installation state")
@@ -226,12 +268,13 @@ class HubBootGateTests(unittest.TestCase):
         """The case that needs the build-time marker to be set at all."""
         hub = self.release_tree("missing")
         shutil.rmtree(hub / "agents")
-        self.refuses(hub)
+        self.refuses(hub, "requires a managed agent bundle", "none is present")
 
     def test_a_corrupt_payload_stops_the_process_before_the_database(self):
         hub = self.release_tree("corrupt")
         (hub / "agents" / bundle.FILES["linux/arm64"]).write_bytes(b"corrupted in transit")
-        self.refuses(hub)
+        # Truncation trips the size check before the hash is ever computed.
+        self.refuses(hub, "linux/arm64", "manifest says")
 
     def test_a_payload_for_the_wrong_architecture_stops_the_process(self):
         """Only reading the image header can catch this one.
@@ -256,7 +299,8 @@ class HubBootGateTests(unittest.TestCase):
         (agents / bundle.MANIFEST).write_text(json.dumps(catalog, sort_keys=True, indent=2) + "\n")
         (agents / bundle.MANIFEST).chmod(0o644)
 
-        self.refuses(hub)
+        # Size and sha256 both agree; only the ELF machine field disagrees.
+        self.refuses(hub, "linux/arm64", "binary, not arm64")
 
 
 if __name__ == "__main__":

--- a/scripts/test_hub_bundle_boot.py
+++ b/scripts/test_hub_bundle_boot.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Boot smoke for the packaged hub: does the delivery gate actually gate?
+
+Every other test in this area checks loadAgentBundle as a function. None of
+them can catch the two ways this feature silently stops existing:
+
+  * the -ldflags marker is not set, so agentBundleIsRequired() is false and a
+    missing bundle is waved through. That was the real state of the tree until
+    today — the flag was set by nothing at all.
+  * the call at the top of main() is moved, removed, or ends up after the
+    database opens, so a rejected candidate has already mutated installation
+    state by the time anyone notices.
+
+So this runs the real hub BINARY and checks process-level outcomes. The
+invariant it asserts is the one that matters for rollback: a hub that cannot
+prove its agent payloads exits BEFORE creating the database, so the updater's
+readiness check can reject the candidate and roll back to a release that works.
+
+WHICH BINARY MATTERS. Built from source with -X supplied here, this proves the
+gate is wired and reachable. It does NOT prove the release build sets the flag
+— hardcoding the flag cannot detect a Dockerfile that dropped it. Pass
+--hub-binary to run the same cases against a hub extracted from the actual
+built image, which is the only form that verifies release build flags.
+
+Needs root-owned fixture paths, because the trusted-binary rule requires root
+ownership and no group/other write on every ancestor. /tmp is world-writable,
+so fixtures live in a unique directory under a root-owned parent.
+"""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import agent_bundle as bundle
+from test_agent_bundle import fixture
+
+REPO = Path(__file__).resolve().parent.parent
+# Root-owned and not group/other writable on every supported runner, which the
+# trusted-path rule requires of every ancestor of a payload.
+FIXTURE_PARENT = Path("/opt")
+RELEASE = 12
+READY_TIMEOUT = 60.0
+
+# A skip is indistinguishable from a pass in a CI summary, and this file exists
+# precisely to catch a check that has quietly stopped running. GitHub runners
+# are not root, so without this the whole thing would skip in CI forever and
+# report green. CI sets BLOXOS_BOOT_SMOKE_REQUIRE_ROOT=1 and invokes under
+# sudo; if root or the toolchain is then missing, that is a failure, not a skip.
+REQUIRE_ROOT = os.environ.get("BLOXOS_BOOT_SMOKE_REQUIRE_ROOT") == "1"
+HUB_BINARY_ENV = "BLOXOS_BOOT_SMOKE_HUB_BINARY"
+
+
+def prebuilt():
+    """The hub to test, if one was supplied. Read late, never cached.
+
+    Deliberately a function. When this was a module-level constant paired with
+    a @skipIf decorator, both were evaluated at IMPORT — before __main__ ever
+    parsed --hub-binary. On a runner with no Go toolchain that meant a
+    perfectly valid --hub-binary still reported "needs the go toolchain", and
+    under REQUIRE_ROOT it raised before the option could be read at all.
+    """
+    return os.environ.get(HUB_BINARY_ENV, "")
+
+
+def unavailable():
+    """Why this cannot run here, or None. Raises when CI demanded it run."""
+    supplied = prebuilt()
+    reason = None
+    if os.geteuid() != 0:
+        reason = "needs root to build root-owned fixture paths"
+    elif supplied and not Path(supplied).is_file():
+        reason = f"--hub-binary {supplied} does not exist"
+    elif not supplied and not shutil.which("go"):
+        reason = "needs the go toolchain, or --hub-binary"
+    if reason and REQUIRE_ROOT:
+        raise AssertionError(
+            f"BLOXOS_BOOT_SMOKE_REQUIRE_ROOT=1 but the smoke cannot run: {reason}. "
+            "Skipping here would hide whether the boot gate works.")
+    return reason
+
+
+def free_port():
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+class HubBootGateTests(unittest.TestCase):
+    """The gate must stop the PROCESS, not merely return an error."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Availability is decided HERE, not at import, so it sees the final
+        # --hub-binary. A class decorator could not: it runs before __main__.
+        reason = unavailable()
+        if reason:
+            raise unittest.SkipTest(reason)
+        supplied = prebuilt()
+
+        # A unique directory, created by this run and removed by it. Never a
+        # fixed path: a test that rmtree's a predictable location on entry will
+        # eventually delete something an operator put there.
+        cls.root = Path(tempfile.mkdtemp(prefix="bloxos-boot-smoke-", dir=FIXTURE_PARENT))
+        cls.root.chmod(0o755)
+        cls.scratch = tempfile.mkdtemp(prefix="bloxos-boot-scratch-")
+
+        cls.binary = cls.root / "bloxos-hub-packaged"
+        if supplied:
+            # The form that actually verifies release build flags. No Go needed.
+            shutil.copyfile(supplied, cls.binary)
+            cls.provenance = f"prebuilt {supplied}"
+        else:
+            subprocess.run(
+                ["go", "build", "-ldflags", "-X main.agentBundleRequired=packaged",
+                 "-o", str(cls.binary), "."],
+                cwd=REPO / "hub", check=True,
+                env=dict(os.environ,
+                         GOCACHE=os.path.join(cls.scratch, "gocache"),
+                         GOMODCACHE=os.path.join(cls.scratch, "gomod"),
+                         GOFLAGS="-buildvcs=false"))
+            cls.provenance = "source build with -X supplied by this test"
+        cls.binary.chmod(0o755)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Only what this run created.
+        shutil.rmtree(cls.root, ignore_errors=True)
+        shutil.rmtree(cls.scratch, ignore_errors=True)
+
+    def release_tree(self, name):
+        """A root-owned <release>/hub/{bloxos-hub,agents/} laid out like an install."""
+        hub = self.root / name / "hub"
+        agents = hub / "agents"
+        agents.mkdir(mode=0o755, parents=True)
+        for platform, payload in bundle.FILES.items():
+            target = agents / payload
+            target.write_bytes(fixture(platform, release=RELEASE))
+            target.chmod(0o755)
+        digest = bundle.create_manifest(agents, None, None, None)
+        (agents / bundle.MANIFEST).chmod(0o644)
+        bundle.check(agents, digest, require_provenance=False)
+        shutil.copyfile(self.binary, hub / "bloxos-hub")
+        (hub / "bloxos-hub").chmod(0o755)
+        for path in (self.root / name, hub, agents):
+            os.chown(path, 0, 0)
+            path.chmod(0o755)
+        return hub
+
+    def start(self, hub):
+        """Launch the hub in a scratch workdir. Returns (process, workdir, url)."""
+        workdir = Path(tempfile.mkdtemp(prefix="hub-boot-", dir=self.scratch))
+        port = free_port()
+        url = f"http://127.0.0.1:{port}"
+        environment = dict(os.environ, HOME=str(workdir),
+                           HUB_LISTEN=f"127.0.0.1:{port}",
+                           # Without one of these the hub refuses to start on
+                           # CORS grounds, which has nothing to do with the gate.
+                           PUBLIC_URL=url)
+        process = subprocess.Popen([str(hub / "bloxos-hub")], cwd=workdir,
+                                   env=environment, text=True,
+                                   stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        return process, workdir, url
+
+    def drain(self, process):
+        try:
+            return process.communicate(timeout=READY_TIMEOUT)[0] or ""
+        except subprocess.TimeoutExpired:
+            process.kill()
+            return process.communicate()[0] or ""
+
+    def refuses(self, hub):
+        """Run a hub expected to die at the gate; assert it did, before the DB."""
+        process, workdir, _ = self.start(hub)
+        output = self.drain(process)
+        self.assertIsNotNone(process.poll(), "the hub must exit, not start")
+        self.assertNotEqual(process.returncode, 0, output[-2000:])
+        self.assertIn("agent delivery", output, output[-2000:])
+        self.assertFalse((workdir / "bloxos.db").exists(),
+                         "the database was created before the gate refused; a rejected "
+                         "candidate must not mutate installation state")
+
+    # The control. Without it every refusal below could be passing for an
+    # unrelated reason — and "it created a database" is not enough, because a
+    # hub can initialise one and then die seconds later. Readiness means the
+    # process is serving.
+    def test_a_valid_bundle_serves_traffic(self):
+        process, workdir, url = self.start(self.release_tree("valid"))
+        try:
+            deadline = time.monotonic() + READY_TIMEOUT
+            last = None
+            while time.monotonic() < deadline:
+                if process.poll() is not None:
+                    self.fail("the hub exited before becoming ready:\n"
+                              + self.drain(process)[-3000:])
+                try:
+                    with urllib.request.urlopen(url + "/health", timeout=2) as answer:
+                        if answer.status == 200:
+                            break
+                except (urllib.error.URLError, OSError, TimeoutError) as error:
+                    last = error
+                time.sleep(0.25)
+            else:
+                process.kill()
+                self.fail(f"hub never became ready at {url}/health (last: {last})\n"
+                          + self.drain(process)[-3000:])
+
+            self.assertIsNone(process.poll(), "the hub must still be running once ready")
+            self.assertTrue((workdir / "bloxos.db").exists())
+        finally:
+            process.kill()
+            process.communicate()
+
+    def test_a_missing_bundle_stops_the_process_before_the_database(self):
+        """The case that needs the build-time marker to be set at all."""
+        hub = self.release_tree("missing")
+        shutil.rmtree(hub / "agents")
+        self.refuses(hub)
+
+    def test_a_corrupt_payload_stops_the_process_before_the_database(self):
+        hub = self.release_tree("corrupt")
+        (hub / "agents" / bundle.FILES["linux/arm64"]).write_bytes(b"corrupted in transit")
+        self.refuses(hub)
+
+    def test_a_payload_for_the_wrong_architecture_stops_the_process(self):
+        """Only reading the image header can catch this one.
+
+        The catalog is restamped BY HAND rather than regenerated: create_manifest
+        runs the same architecture check, so regenerating would fail in Python
+        and the hub process would never start — the test would pass without the
+        gate under test ever running.
+        """
+        hub = self.release_tree("wrongarch")
+        agents = hub / "agents"
+        payload = agents / bundle.FILES["linux/arm64"]
+        body = fixture("linux/amd64", release=RELEASE)
+        payload.write_bytes(body)
+
+        catalog = json.loads((agents / bundle.MANIFEST).read_text())
+        catalog["artifacts"]["linux/arm64"] = {
+            "file": bundle.FILES["linux/arm64"],
+            "size": len(body),
+            "sha256": hashlib.sha256(body).hexdigest(),
+        }
+        (agents / bundle.MANIFEST).write_text(json.dumps(catalog, sort_keys=True, indent=2) + "\n")
+        (agents / bundle.MANIFEST).chmod(0o644)
+
+        self.refuses(hub)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hub-binary", default=None,
+                        help="hub extracted from a built image; the only form that "
+                             "verifies the release build actually sets the marker")
+    known, rest = parser.parse_known_args()
+    if known.hub_binary:
+        os.environ[HUB_BINARY_ENV] = known.hub_binary
+    unittest.main(argv=[sys.argv[0]] + rest, verbosity=2)

--- a/scripts/test_release_history.py
+++ b/scripts/test_release_history.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Offline tests for the release history gatherer. Releases and assets injected."""
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from release_history import CATALOG_ASSET, HistoryError, catalog_of, gather, persist, upload
+
+PLATFORMS = ("linux/amd64", "linux/arm64", "windows/amd64")
+
+
+def artifacts(seed):
+    return {platform: {"file": platform, "size": 100 + index,
+                       "sha256": f"{seed:02x}{index:02x}" + "0" * 60}
+            for index, platform in enumerate(PLATFORMS)}
+
+
+def catalog(release, seed):
+    return {"schema": 1, "agent_release": release, "artifacts": artifacts(seed)}
+
+
+def release_entry(tag, asset_id=None, draft=False):
+    assets = [] if asset_id is None else [{"name": CATALOG_ASSET, "id": asset_id}]
+    # Releases carry other assets too; the catalog must be found among them.
+    assets.append({"name": "bloxos-update", "id": 9000})
+    return {"tag": tag, "draft": draft, "assets": assets}
+
+
+def fetcher(bodies):
+    def fetch(repo, asset_id):
+        if asset_id not in bodies:
+            raise HistoryError(f"asset {asset_id} could not be downloaded")
+        return json.dumps(bodies[asset_id])
+    return fetch
+
+
+def fetcher_bytes(bodies):
+    """A fetcher that returns RAW BYTES, as the real one does."""
+    def fetch(repo, asset_id):
+        if asset_id not in bodies:
+            raise HistoryError(f"asset {asset_id} could not be downloaded")
+        return bodies[asset_id]
+    return fetch
+
+
+class GatherTests(unittest.TestCase):
+    def test_every_catalog_is_retained_per_release_number(self):
+        releases = [release_entry("v1.7.0", 1), release_entry("v1.7.1", 2)]
+        history = gather("owner/repo", releases, fetcher({1: catalog(7, 0xaa), 2: catalog(7, 0xbb)}))
+        self.assertEqual(len(history["7"]), 2,
+                         "both catalogs must survive; collapsing them destroys the divergence "
+                         "the identity gate exists to find")
+
+    def test_drafts_are_included(self):
+        releases = [release_entry("v2.0.0", 1, draft=True)]
+        history = gather("owner/repo", releases, fetcher({1: catalog(9, 0xaa)}))
+        self.assertIn("9", history,
+                      "tags are promoted before draft assets attach, so a draft release can "
+                      "already be serving agents")
+
+    # The only path that may contribute nothing without failing.
+    def test_a_release_with_no_catalog_asset_is_genuinely_absent(self):
+        releases = [release_entry("v1.0.0", None), release_entry("v1.7.1", 2)]
+        history = gather("owner/repo", releases, fetcher({2: catalog(7, 0xaa)}))
+        self.assertEqual(sorted(history), ["7"])
+
+    # The failure this test guards is the dangerous one: a timeout on the
+    # NEWEST release silently erases the floor, and the older history that did
+    # load lets a stale candidate pass a check that reported success.
+    def test_a_download_failure_is_fatal_not_absence(self):
+        releases = [release_entry("v1.7.1", 1), release_entry("v2.0.0", 2)]
+        with self.assertRaises(HistoryError) as caught:
+            gather("owner/repo", releases, fetcher({1: catalog(7, 0xaa)}))  # 2 unavailable
+        self.assertIn("could not be downloaded", str(caught.exception))
+
+    def test_a_missing_asset_list_is_fatal(self):
+        with self.assertRaises(HistoryError):
+            gather("owner/repo", [{"tag": "v1.0.0", "draft": False}], fetcher({}))
+
+    def test_an_unparseable_catalog_is_fatal(self):
+        def fetch(repo, asset_id):
+            return "{not json"
+        with self.assertRaises(HistoryError) as caught:
+            gather("owner/repo", [release_entry("v1.0.0", 1)], fetch)
+        self.assertIn("unreadable", str(caught.exception))
+
+    def test_a_malformed_catalog_is_fatal(self):
+        for broken in ({"agent_release": "seven", "artifacts": artifacts(1)},
+                       {"agent_release": True, "artifacts": artifacts(1)},
+                       {"agent_release": 7, "artifacts": "not a map"},
+                       {"artifacts": artifacts(1)}):
+            with self.subTest(catalog=broken), self.assertRaises(HistoryError):
+                gather("owner/repo", [release_entry("v1.0.0", 1)], fetcher({1: broken}))
+
+    # A retry runs after a previous run may already have persisted and promoted
+    # this very tag, so its catalog IS history.
+    def test_the_candidate_tags_own_catalog_is_included(self):
+        releases = [release_entry("v2.0.0", 1)]
+        history = gather("owner/repo", releases, fetcher({1: catalog(9, 0xaa)}))
+        self.assertIn("9", history)
+
+    def test_pagination_keeps_every_page(self):
+        # The gatherer is handed the full listing; this proves nothing is
+        # dropped when that listing spans many releases, which is what the
+        # removed --limit 200 would eventually have truncated.
+        releases, bodies = [], {}
+        for index in range(250):
+            releases.append(release_entry(f"v1.0.{index}", index + 1))
+            bodies[index + 1] = catalog(index + 1, index % 256)
+        history = gather("owner/repo", releases, fetcher(bodies))
+        self.assertEqual(len(history), 250)
+        self.assertIn("250", history)
+
+
+class CatalogLookupTests(unittest.TestCase):
+    def test_the_catalog_is_found_among_other_assets(self):
+        entry = release_entry("v1.0.0", 5)
+        self.assertEqual(catalog_of("owner/repo", entry, fetcher({5: catalog(3, 0x01)}))["agent_release"], 3)
+
+    def test_an_absent_catalog_returns_none(self):
+        self.assertIsNone(catalog_of("owner/repo", release_entry("v1.0.0", None), fetcher({})))
+
+
+class PersistTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.path = Path(self.temp.name) / CATALOG_ASSET
+        self.path.write_text(json.dumps(catalog(9, 0xaa)))
+
+    def test_an_identical_existing_catalog_is_a_no_op(self):
+        releases = [release_entry("v2.0.0", 1)]
+        message = persist("owner/repo", "v2.0.0", self.path, releases, fetcher({1: catalog(9, 0xaa)}))
+        self.assertIn("nothing to do", message)
+
+    def test_a_conflicting_existing_catalog_is_never_overwritten(self):
+        releases = [release_entry("v2.0.0", 1)]
+        with self.assertRaises(HistoryError) as caught:
+            persist("owner/repo", "v2.0.0", self.path, releases, fetcher({1: catalog(9, 0xbb)}))
+        self.assertIn("never", str(caught.exception))
+
+    def test_a_download_failure_does_not_become_permission_to_upload(self):
+        releases = [release_entry("v2.0.0", 1)]
+        with self.assertRaises(HistoryError):
+            persist("owner/repo", "v2.0.0", self.path, releases, fetcher({}))
+
+
+class BinaryAssetTests(unittest.TestCase):
+    """Release assets are agent binaries and tarballs, not text.
+
+    Reading them through a text-mode pipe decodes arbitrary bytes as UTF-8 and
+    rewrites line endings, so a retry comparing an existing asset would either
+    raise a decode error or compare data the transport had already altered and
+    report a conflict that does not exist.
+    """
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+
+    def write(self, name, body):
+        path = Path(self.temp.name) / name
+        path.write_bytes(body)
+        return path
+
+    # A real ELF header, a NUL run, a lone 0x80 continuation byte (invalid
+    # UTF-8), and a CRLF that text mode would rewrite.
+    BINARY = b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8 + b"\x80\xfe\xff" + b"line\r\nline"
+
+    def test_an_identical_binary_asset_is_skipped_on_retry(self):
+        path = self.write("bloxos-agent-linux-amd64", self.BINARY)
+        releases = [release_entry("v2.0.0", None)]
+        releases[0]["assets"].append({"name": path.name, "id": 42})
+
+        results = upload("owner/repo", "v2.0.0", [path], releases,
+                         fetcher_bytes({42: self.BINARY}))
+        self.assertEqual(results, [f"{path.name}: already published and identical, skipped"])
+
+    def test_a_differing_binary_asset_is_never_overwritten(self):
+        path = self.write("bloxos-agent-linux-amd64", self.BINARY)
+        releases = [release_entry("v2.0.0", None)]
+        releases[0]["assets"].append({"name": path.name, "id": 42})
+
+        with self.assertRaises(HistoryError) as caught:
+            upload("owner/repo", "v2.0.0", [path], releases,
+                   fetcher_bytes({42: self.BINARY + b"\x01"}))
+        self.assertIn("never", str(caught.exception))
+
+    def test_catalog_persistence_compares_exact_bytes(self):
+        """Semantically identical JSON with different formatting is NOT the same
+        asset: agent-manifest.sha256 covers the catalog's exact bytes."""
+        body = json.dumps(catalog(9, 0xaa), indent=2).encode()
+        path = self.write(CATALOG_ASSET, body)
+        releases = [release_entry("v2.0.0", 1)]
+
+        # Byte-identical: a no-op.
+        self.assertIn("nothing to do",
+                      persist("owner/repo", "v2.0.0", path, releases, fetcher_bytes({1: body})))
+
+        # Same object, different serialisation: refused, because the published
+        # sidecar checksum names those other bytes.
+        reformatted = json.dumps(catalog(9, 0xaa), separators=(",", ":")).encode()
+        self.assertNotEqual(reformatted, body)
+        with self.assertRaises(HistoryError):
+            persist("owner/repo", "v2.0.0", path, releases, fetcher_bytes({1: reformatted}))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_release_identity.py
+++ b/scripts/test_release_identity.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Offline tests for the release identity gate. No network: history is passed in."""
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from release_identity import (
+    IdentityError,
+    check_history,
+    check_image_platforms,
+    load_history,
+)
+
+PLATFORMS = ("linux/amd64", "linux/arm64", "windows/amd64")
+
+
+def artifacts(seed):
+    return {platform: {"file": platform, "size": 100 + index,
+                       "sha256": f"{seed:02x}{index:02x}" + "0" * 60}
+            for index, platform in enumerate(PLATFORMS)}
+
+
+def catalog(release, seed):
+    return {"schema": 1, "agent_release": release, "artifacts": artifacts(seed)}
+
+
+def history(**releases):
+    """releases maps "<number>" to one seed, or a list of seeds for a divergent one."""
+    raw = {}
+    for release, seeds in releases.items():
+        raw[release] = [artifacts(seed) for seed in (seeds if isinstance(seeds, list) else [seeds])]
+    return load_history(raw)
+
+
+class HistoryTests(unittest.TestCase):
+    def test_a_new_release_above_the_floor_passes(self):
+        self.assertIn("above the floor", check_history(catalog(9, 0xaa), history(**{"8": 0xbb})))
+
+    def test_reusing_a_number_with_different_bytes_is_refused(self):
+        with self.assertRaises(IdentityError) as caught:
+            check_history(catalog(8, 0xaa), history(**{"8": 0xbb}))
+        self.assertIn("DIFFERENT bytes", str(caught.exception))
+
+    # A re-run of a failed workflow must not be a dead end.
+    def test_retrying_a_release_with_identical_bytes_is_idempotent(self):
+        self.assertIn("idempotent", check_history(catalog(8, 0xaa), history(**{"8": 0xaa})))
+
+    # Numbers absent from history, so this exercises the FLOOR rule rather than
+    # the conflicting-bytes rule; a number already in history is refused by a
+    # different branch with a different message.
+    def test_an_unused_number_at_or_below_the_floor_is_refused(self):
+        for release in (5, 7):
+            with self.subTest(release=release), self.assertRaises(IdentityError) as caught:
+                check_history(catalog(release, 0xcc), history(**{"6": 0x11, "8": 0x22}))
+            self.assertIn("floor", str(caught.exception).lower())
+
+
+
+
+class DivergentHistoryTests(unittest.TestCase):
+    """Ambiguity is detected FROM THE DATA, with no release number special-cased.
+
+    Release 7 was published more than once with different bytes before this
+    gate existed. Hardcoding that fact would have handled exactly one case and
+    silently missed the next, so the gate finds it generically — and would find
+    the same problem at any other number.
+    """
+
+    def test_any_ambiguous_number_can_never_be_reused(self):
+        divergent = history(**{"7": [0xaa, 0xbb]})
+        # Even bytes matching one of the published variants: what that number
+        # identifies is no longer decidable, so "it matches" means nothing.
+        for seed in (0xaa, 0xbb, 0xcc):
+            with self.subTest(seed=seed), self.assertRaises(IdentityError) as caught:
+                check_history(catalog(7, seed), divergent)
+            self.assertIn("never be reused", str(caught.exception))
+
+    def test_ambiguity_is_not_limited_to_release_seven(self):
+        with self.assertRaises(IdentityError) as caught:
+            check_history(catalog(12, 0xaa), history(**{"12": [0xaa, 0xbb]}))
+        self.assertIn("ambiguous", str(caught.exception))
+
+    # The failure mode to avoid: a gate permanently stuck because the past is
+    # inconsistent.
+    def test_inconsistent_history_does_not_block_future_releases(self):
+        self.assertIn("above the floor",
+                      check_history(catalog(8, 0xcc), history(**{"7": [0xaa, 0xbb]})))
+
+    def test_a_divergent_release_still_raises_the_floor(self):
+        with self.assertRaises(IdentityError):
+            check_history(catalog(6, 0xcc), history(**{"7": [0xaa, 0xbb]}))
+
+    # Collapsing history to one map per number would overwrite the first
+    # catalog with the second, and the divergence would vanish before the check
+    # that exists to find it ever ran.
+    def test_history_retains_every_catalog_for_a_number(self):
+        self.assertEqual(len(history(**{"7": [0xaa, 0xbb]})[7]), 2)
+
+
+class FloorAndDowngradeTests(unittest.TestCase):
+    def test_an_empty_history_fails_closed(self):
+        """This repository HAS published releases, so nothing found means the
+        lookup failed — and a failed lookup must never establish a floor of 0
+        and approve any number at all."""
+        with self.assertRaises(IdentityError) as caught:
+            check_history(catalog(9, 0xaa), {})
+        self.assertIn("lookup failed", str(caught.exception))
+
+    def test_re_promoting_an_older_identical_release_is_refused(self):
+        """Idempotence must not become a downgrade.
+
+        Re-running release 8 after 9 exists changes nothing about 8, but
+        promoting it now would offer the fleet an older identity than the one
+        already published.
+        """
+        with self.assertRaises(IdentityError) as caught:
+            check_history(catalog(8, 0xaa), history(**{"8": 0xaa, "9": 0xbb}))
+        self.assertIn("lower the offered release identity", str(caught.exception))
+
+    def test_re_promoting_the_current_release_is_still_idempotent(self):
+        self.assertIn("idempotent",
+                      check_history(catalog(9, 0xbb), history(**{"8": 0xaa, "9": 0xbb})))
+
+
+class ImagePlatformTests(unittest.TestCase):
+    """Sharing a hub image index does not make the embedded payloads equal."""
+
+    def test_matching_platforms_pass(self):
+        candidate = catalog(9, 0xaa)
+        message = check_image_platforms(candidate, {
+            "linux/amd64": catalog(9, 0xaa), "linux/arm64": catalog(9, 0xaa)})
+        self.assertIn("canonical agent bytes", message)
+
+    def test_one_drifted_platform_is_refused(self):
+        candidate = catalog(9, 0xaa)
+        with self.assertRaises(IdentityError) as caught:
+            check_image_platforms(candidate, {
+                "linux/amd64": catalog(9, 0xaa), "linux/arm64": catalog(9, 0xbb)})
+        self.assertIn("linux/arm64", str(caught.exception))
+
+    def test_a_platform_embedding_another_release_is_refused(self):
+        with self.assertRaises(IdentityError) as caught:
+            check_image_platforms(catalog(9, 0xaa), {
+                "linux/amd64": catalog(9, 0xaa), "linux/arm64": catalog(8, 0xaa)})
+        self.assertIn("release", str(caught.exception))
+
+    # "We could not check" must never read as "it passed".
+    def test_supplying_no_image_catalogs_is_refused(self):
+        with self.assertRaises(IdentityError):
+            check_image_platforms(catalog(9, 0xaa), {})
+
+    # A non-empty check would accept amd64 alone — and arm64, built on a
+    # different platform, is precisely the one that can drift.
+    def test_a_single_platform_is_not_enough(self):
+        with self.assertRaises(IdentityError) as caught:
+            check_image_platforms(catalog(9, 0xaa), {"linux/amd64": catalog(9, 0xaa)})
+        self.assertIn("linux/arm64", str(caught.exception))
+
+    def test_an_unexpected_platform_is_refused(self):
+        with self.assertRaises(IdentityError):
+            check_image_platforms(catalog(9, 0xaa), {
+                "linux/amd64": catalog(9, 0xaa), "linux/arm64": catalog(9, 0xaa),
+                "darwin/arm64": catalog(9, 0xaa)})
+
+    def test_identity_ignores_file_names_but_not_bytes(self):
+        candidate = catalog(9, 0xaa)
+        renamed = catalog(9, 0xaa)
+        for platform in renamed["artifacts"]:
+            renamed["artifacts"][platform]["file"] = "renamed-" + platform
+        check_image_platforms(candidate, {"linux/amd64": renamed, "linux/arm64": renamed})
+
+        resized = catalog(9, 0xaa)
+        resized["artifacts"]["linux/amd64"]["size"] += 1
+        with self.assertRaises(IdentityError):
+            check_image_platforms(candidate, {"linux/amd64": resized, "linux/arm64": candidate})
+
+
+class MalformedInputTests(unittest.TestCase):
+    def broken(self, mutate):
+        entry = catalog(9, 0xaa)
+        mutate(entry)
+        return entry
+
+    def test_a_catalog_without_usable_identity_is_refused(self):
+        def drop_platform(entry):
+            del entry["artifacts"]["windows/amd64"]
+
+        def bad_sha(entry):
+            entry["artifacts"]["linux/amd64"]["sha256"] = "z" * 64  # right length, not hex
+
+        def short_sha(entry):
+            entry["artifacts"]["linux/amd64"]["sha256"] = "abc"
+
+        def zero_size(entry):
+            entry["artifacts"]["linux/amd64"]["size"] = 0
+
+        def bool_size(entry):
+            # bool is an int in Python, so True would sail through "size > 0".
+            entry["artifacts"]["linux/amd64"]["size"] = True
+
+        def bool_release(entry):
+            entry["agent_release"] = True
+
+        def zero_release(entry):
+            entry["agent_release"] = 0
+
+        for mutate in (drop_platform, bad_sha, short_sha, zero_size, bool_size,
+                       bool_release, zero_release):
+            with self.subTest(case=mutate.__name__), self.assertRaises(IdentityError):
+                check_history(self.broken(mutate), history(**{"8": 0xbb}))
+
+
+class CommandLineTests(unittest.TestCase):
+    def run_gate(self, candidate, hist, images):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "candidate.json").write_text(json.dumps(candidate))
+            (root / "history.json").write_text(json.dumps(hist))
+            command = [sys.executable, str(Path(__file__).with_name("release_identity.py")),
+                       "--candidate", str(root / "candidate.json"),
+                       "--history", str(root / "history.json")]
+            for platform, image in images.items():
+                path = root / (platform.replace("/", "-") + ".json")
+                path.write_text(json.dumps(image))
+                command += ["--image-catalog", f"{platform}={path}"]
+            return subprocess.run(command, capture_output=True, text=True)
+
+    def test_a_good_release_exits_zero(self):
+        result = self.run_gate(catalog(9, 0xaa), {"8": [artifacts(0xbb)]},
+                               {"linux/amd64": catalog(9, 0xaa), "linux/arm64": catalog(9, 0xaa)})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Safe to promote", result.stdout)
+
+    def test_a_conflicting_release_exits_nonzero(self):
+        result = self.run_gate(catalog(8, 0xaa), {"8": [artifacts(0xbb)]},
+                               {"linux/amd64": catalog(8, 0xaa), "linux/arm64": catalog(8, 0xaa)})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("release identity:", result.stderr)
+        self.assertNotIn("Safe to promote", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_server_bundle_agents.py
+++ b/scripts/test_server_bundle_agents.py
@@ -25,13 +25,16 @@ scripts/test_hub_bundle_boot.py, which runs the real hub process.
 """
 import hashlib
 import importlib.util
+import json
 import os
 from pathlib import Path
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import unittest
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -166,6 +169,51 @@ class ServerBundleAgentTests(unittest.TestCase):
         self.assertIn("--- PASS: TestPackagedTreeLoadsAndFailsClosed",
                       result.stdout, result.stdout + result.stderr)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    # The pack helper above builds ONE archive and calls the internals directly,
+    # so it would still pass if main() packed agents for amd64 and silently
+    # skipped arm64. Both server architectures must carry all three agent
+    # platforms — an arm64 hub that cannot serve a Windows machine is exactly
+    # the kind of gap that only shows up on the one board nobody tested.
+    def test_main_packs_every_agent_into_both_server_archives(self):
+        output = self.root / "release-assets"
+        hub_image = HUB_IMAGE
+        dashboard_image = "ghcr.io/bokiko/bloxos-dashboard@sha256:" + "c" * 64
+
+        def fake_export(image, platform, source, destination, revision):
+            """Stand in for Docker; everything after extraction stays real."""
+            self.assertEqual(revision, SOURCE_SHA)
+            arch = platform.split("/")[1]
+            if source.endswith("bloxos-hub"):
+                Path(destination).write_bytes(native_harness.fake_elf(arch))
+            else:
+                shutil.copytree(self.tree / "dashboard", destination, dirs_exist_ok=True)
+
+        argv = ["export-server-bundle.py", "--hub", hub_image, "--dashboard", dashboard_image,
+                "--revision", SOURCE_SHA, "--version", VERSION,
+                "--output", str(output), "--agents", str(self.agents)]
+        with mock.patch.object(export_server_bundle, "export", fake_export), \
+                mock.patch.object(export_server_bundle.subprocess, "run"), \
+                mock.patch.object(export_server_bundle.zipapp, "create_archive"), \
+                mock.patch.object(sys, "argv", argv):
+            export_server_bundle.main()
+
+        published = json.loads((output / "update-manifest.json").read_text())
+        self.assertEqual(sorted(published["native"]), ["amd64", "arm64"])
+        for arch in ("amd64", "arm64"):
+            archive = output / f"bloxos-server-linux-{arch}.tar.gz"
+            self.assertEqual(
+                hashlib.sha256(archive.read_bytes()).hexdigest(),
+                published["native"][arch]["sha256"],
+                f"{arch} manifest checksum does not describe the archive it names")
+            with tarfile.open(archive, "r:gz") as target:
+                packed = {m.name: target.extractfile(m).read()
+                          for m in target.getmembers()
+                          if m.isfile() and m.name.startswith("hub/agents/")}
+            for name in [bundle.MANIFEST, *bundle.FILES.values()]:
+                self.assertEqual(packed.get("hub/agents/" + name),
+                                 (self.agents / name).read_bytes(),
+                                 f"{arch} server archive is missing or altering {name}")
 
     def test_a_server_archive_without_agents_is_refused(self):
         """The failure this whole change exists to prevent."""

--- a/scripts/test_server_bundle_agents.py
+++ b/scripts/test_server_bundle_agents.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Old-worker transport smoke for agent payloads. No Docker, network or signing.
+
+This runs BEFORE publication, deliberately. A tag-time test discovers a broken
+release after the tag exists, and the fleet is exactly who finds out.
+
+What it proves, end to end, with the real components:
+
+  1. The release packer places the published agent bytes at hub/agents/.
+  2. An UNCHANGED updater carries them through intact — both its raw
+     safe_extract_tar and its real NativeAdapter.stage, which is the path that
+     actually runs on a host: download, verify, extract, copytree, fsync.
+  3. The new hub's own loader accepts the result, and fails closed when a
+     required payload is missing or damaged.
+
+Step 2 is the load-bearing one. The whole delivery design rests on the claim
+that no updater change is needed, and this is what makes that a tested claim
+rather than a reading of the source.
+
+SCOPE, stated plainly so nothing here is mistaken for more than it is: this
+file proves transport and loader acceptance. It does NOT prove hub readiness —
+that the packaged build carries its -ldflags marker, or that the boot gate
+refuses to start. A loader unit test cannot catch a missing build flag. That is
+scripts/test_hub_bundle_boot.py, which runs the real hub process.
+"""
+import hashlib
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import agent_bundle as bundle
+from test_agent_bundle import fixture
+from updater import engine
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "tests"))
+import test_updater_native as native_harness
+
+# The packer's filename is hyphenated, so it is loaded by path rather than
+# given an import-friendly alias in the repo.
+_spec = importlib.util.spec_from_file_location(
+    "export_server_bundle", Path(__file__).resolve().parent / "export-server-bundle.py")
+export_server_bundle = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(export_server_bundle)
+
+REPO = Path(__file__).resolve().parent.parent
+SOURCE_SHA = "0" * 40
+IMAGE_DIGEST = "sha256:" + "a" * 64
+HUB_IMAGE = "ghcr.io/bokiko/bloxos-hub@" + IMAGE_DIGEST
+VERSION = "v9.9.9"
+RELEASE = 9
+
+
+class ServerBundleAgentTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+
+        # The published agent payloads, exactly as export-agent-bundle.sh
+        # produces them: three binaries, a manifest, and the manifest's sidecar
+        # SHA that is itself a release asset.
+        self.agents = self.root / "native-agents"
+        self.agents.mkdir()
+        for platform, name in bundle.FILES.items():
+            (self.agents / name).write_bytes(fixture(platform, release=RELEASE))
+        digest = bundle.create_manifest(self.agents, SOURCE_SHA, VERSION, IMAGE_DIGEST)
+        (self.agents / "agent-manifest.sha256").write_text(f"{digest}  agent-manifest.json\n")
+
+        # A server tree shaped like an exported one.
+        self.tree = self.root / "tree"
+        (self.tree / "hub").mkdir(parents=True)
+        (self.tree / "dashboard" / ".next").mkdir(parents=True)
+        # A real ELF: the updater verifies the staged hub's architecture before
+        # any downtime, so a placeholder never reaches the copytree under test.
+        (self.tree / "hub" / "bloxos-hub").write_bytes(native_harness.fake_elf("amd64"))
+        (self.tree / "dashboard" / "server.js").write_bytes(b"// standalone")
+        (self.tree / "dashboard" / ".next" / "BUILD_ID").write_bytes(b"abc")
+
+    def stage(self):
+        return export_server_bundle.stage_agents(
+            self.agents, self.tree, HUB_IMAGE, VERSION, SOURCE_SHA)
+
+    def pack(self):
+        manifest = self.stage()
+        archive = self.root / "bloxos-server-linux-amd64.tar.gz"
+        export_server_bundle.pack_tree(self.tree, archive)
+        export_server_bundle.verify_packed_agents(archive, manifest)
+        return archive
+
+    def transport(self, archive):
+        """Extract with the UNCHANGED updater the fleet already runs."""
+        destination = self.root / "extracted"
+        engine.safe_extract_tar(str(archive), str(destination))
+        return destination
+
+    def test_the_real_native_stage_publishes_the_agents(self):
+        """The path a host actually takes, not just the extractor beneath it.
+
+        safe_extract_tar alone leaves out everything NativeAdapter.stage does
+        around it — the checksum gate, the validation that runs before any
+        downtime, and the copytree into the versioned release directory. If any
+        of those dropped or refused the new files, extraction tests would still
+        pass and the fleet would still be offered stale agents.
+        """
+        archive = self.pack()
+        with tempfile.TemporaryDirectory() as workdir:
+            configuration = native_harness.native_config(workdir)
+            adapter, manifest = native_harness.adapter_with_bundle(
+                workdir, configuration, native_harness.Runner())
+            # Serve the archive we just packed, under its real checksum.
+            body = archive.read_bytes()
+            manifest["native"]["amd64"]["sha256"] = hashlib.sha256(body).hexdigest()
+            adapter._fetch = lambda url, limit: body
+
+            adapter.stage(manifest, os.path.join(configuration["state_dir"], "transaction", "release"))
+            release = Path(adapter.journal.get("release_dir"))
+
+            # The hub runs from <release>/hub/bloxos-hub, so this is the exact
+            # directory pairing the loader depends on.
+            self.assertTrue((release / "hub" / "bloxos-hub").is_file())
+            published = release / "hub" / "agents"
+            for name in [bundle.MANIFEST, *bundle.FILES.values()]:
+                self.assertEqual((published / name).read_bytes(), (self.agents / name).read_bytes(),
+                                 f"{name} did not survive the real native stage")
+            digest = (self.agents / "agent-manifest.sha256").read_text().split()[0]
+            self.assertEqual(bundle.check(published, digest)["agent_release"], RELEASE)
+
+    def test_published_bytes_reach_the_hub_directory_unchanged(self):
+        extracted = self.transport(self.pack())
+        packed = extracted / "hub" / "agents"
+
+        for name in [bundle.MANIFEST, *bundle.FILES.values()]:
+            self.assertTrue((packed / name).is_file(), f"{name} did not survive transport")
+            self.assertEqual(
+                hashlib.sha256((packed / name).read_bytes()).hexdigest(),
+                hashlib.sha256((self.agents / name).read_bytes()).hexdigest(),
+                f"{name} differs from the published standalone asset")
+
+        # The hub binary's own directory is the one the loader searches, so
+        # agents/ has to be its direct child and not a sibling of the tree root.
+        self.assertTrue((extracted / "hub" / "bloxos-hub").is_file())
+
+        # The payloads still pass the canonical check after the round trip.
+        digest = (self.agents / "agent-manifest.sha256").read_text().split()[0]
+        self.assertEqual(bundle.check(packed, digest)["agent_release"], RELEASE)
+
+    def test_the_real_hub_loader_accepts_the_transported_tree(self):
+        extracted = self.transport(self.pack())
+        if not shutil.which("go"):
+            self.skipTest("go toolchain not available")
+
+        environment = dict(os.environ)
+        environment["BLOXOS_TEST_PACKAGED_HUB_DIR"] = str(extracted / "hub")
+        result = subprocess.run(
+            ["go", "test", "-count=1", "-v", "-run", "TestPackagedTreeLoadsAndFailsClosed", "./"],
+            cwd=REPO / "hub", env=environment, text=True, capture_output=True)
+        # A skip would let this file report success while proving nothing, so
+        # the driver asserts the test actually ran.
+        self.assertIn("--- PASS: TestPackagedTreeLoadsAndFailsClosed",
+                      result.stdout, result.stdout + result.stderr)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_a_server_archive_without_agents_is_refused(self):
+        """The failure this whole change exists to prevent."""
+        archive = self.root / "empty.tar.gz"
+        export_server_bundle.pack_tree(self.tree, archive)
+        manifest = bundle.check(self.agents, (self.agents / "agent-manifest.sha256").read_text().split()[0])
+        with self.assertRaises(ValueError):
+            export_server_bundle.verify_packed_agents(archive, manifest)
+
+    def test_packing_refuses_payloads_that_fail_their_manifest(self):
+        (self.agents / "bloxos-agent-linux-arm64").write_bytes(fixture("linux/arm64", release=RELEASE) + b"x")
+        with self.assertRaises(ValueError):
+            self.stage()
+
+    def test_packing_refuses_a_payload_built_for_the_wrong_architecture(self):
+        (self.agents / "bloxos-agent-linux-arm64").write_bytes(fixture("linux/amd64", release=RELEASE))
+        with self.assertRaises(ValueError):
+            self.stage()
+
+    # A valid bundle is not automatically the RIGHT bundle. Packing last
+    # release's agents beside this release's hub would produce a fresh release
+    # that once again offers the fleet stale binaries.
+    def test_an_agent_bundle_from_another_release_is_refused(self):
+        for field, value in (("image_digest", "sha256:" + "b" * 64),
+                             ("source", "1" * 40),
+                             ("version", "v9.9.8")):
+            with self.subTest(field=field):
+                kwargs = {"hub_image": HUB_IMAGE, "version": VERSION, "revision": SOURCE_SHA}
+                kwargs["hub_image" if field == "image_digest" else
+                       "version" if field == "version" else "revision"] = (
+                    "ghcr.io/bokiko/bloxos-hub@" + value if field == "image_digest" else value)
+                tree = Path(self.temp.name) / ("tree-" + field)
+                (tree / "hub").mkdir(parents=True)
+                with self.assertRaises(ValueError) as caught:
+                    export_server_bundle.stage_agents(self.agents, tree, **kwargs)
+                self.assertIn("does not belong to this server release", str(caught.exception))
+
+    # The archive is what actually ships, so its BYTES are what must match.
+    # A name check would pass all of these.
+    def test_a_tampered_archive_is_refused(self):
+        manifest = self.stage()
+        packed = self.tree / "hub" / "agents"
+        cases = {
+            "truncated payload": lambda: (packed / "bloxos-agent-linux-amd64").write_bytes(b"short"),
+            "substituted payload": lambda: (packed / "bloxos-agent-linux-arm64").write_bytes(
+                fixture("linux/arm64", release=RELEASE) + b"pad"),
+            "rewritten catalog": lambda: (packed / bundle.MANIFEST).write_text("{}"),
+        }
+        for label, tamper in cases.items():
+            with self.subTest(case=label):
+                original = {p.name: p.read_bytes() for p in packed.iterdir()}
+                tamper()
+                archive = Path(self.temp.name) / (label.replace(" ", "-") + ".tar.gz")
+                export_server_bundle.pack_tree(self.tree, archive)
+                with self.assertRaises(ValueError):
+                    export_server_bundle.verify_packed_agents(archive, manifest)
+                for name, body in original.items():
+                    (packed / name).write_bytes(body)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> **DRAFT — incomplete, no merge requested.** Opened early, on Codex's instruction, so Docker/Compose and native CI start running against the packaging changes while the remaining work lands. Do not review as a finished change.

Based on `fix/fleet-power-honest-claims` (PR #232) while that is unmerged, so the diff shows only delivery changes. Will be retargeted and rebased onto `main` once PR1 lands.

## The problem

`bloxos-update` replaces the hub and dashboard and deliberately does not touch agent files. A v1.7.1 hub therefore served agents built weeks earlier, and every machine reported "matches offered build" — correctly. The offer was stale. That single fact accounted for missing power on both RK3588 boards, absent source labels fleet-wide, and wrong big.LITTLE CPU inventory.

**Placement alone would not have fixed it.** The resolver already had a `hub-executable-directory` candidate sitting *last*, behind the system defaults, and the project's own systemd unit sets `BLOXOS_AGENT_BINARY`, which for amd64 is the authoritative fail-closed *first* candidate. Shipping agents in the release without the precedence contract would have changed nothing.

## What is here so far

**Resolution and validation.** The hub discovers a bundle at `<hub executable dir>/agents/`, and a present-but-invalid bundle is fatal rather than a fallback to frozen defaults — falling through is precisely how a hub ends up quietly serving months-old agents while reporting success. Delivery-config errors are retained on the resolver and fail every resolution; the startup gate is the first statement of `main()`, before the database opens. Catalog identity is re-checked on every resolution, and each payload's embedded release marker is cross-checked against the catalog.

**Architecture is read from the image, not the label.** A sha256 proves a payload is the file the catalog names; it says nothing about what those bytes *are*. Every declared platform is now verified at load — `verifyELFArch` for Linux, a new `verifyPEArch` for Windows. The PE header offset is read out of the file under test, so it is bounded before being used as a seek target.

**The manifest is trusted like a payload.** It was `Stat`'d and then read. `Stat` follows symlinks; a FIFO stats as zero bytes, passes the size limit, and then blocks forever — confirmed, the previous loader hangs on one indefinitely. It now goes through the same trust check as the payloads it describes, with the bound enforced by the read.

**Packaging.** Both server archives carry all three agent payloads plus the catalog under `hub/agents/`. The bytes are copied from the same directory published as standalone assets and asserted equal, never rebuilt. **Nothing in the updater changes** — `safe_extract_tar` has no allowlist and `stage()` copytrees the whole extracted tree — and there is no manifest schema bump, which would have forced workers to be upgraded before they could carry the thing that upgrades them.

**One layout for both deploy modes.** `agentBundleRequired` was set by nothing, so the "a packaged build must have a bundle" path had never been reachable. It could not simply be added, since the archive's hub *is* the Docker binary and containerised hubs had no bundle. Both modes now use `agents/` beside the hub executable, with the legacy `/usr/local/lib/bloxos` paths as **hard links** to the managed payloads — regular files, so the resolver accepts them, and the same inode, so they cannot drift from the managed bytes.

**In-image catalog omits what it cannot know.** The image digest does not exist until the image exists, and a local `docker build` has no tag or commit SHA. Those fields are left out rather than filled with a placeholder: a fake all-zero SHA is a field that looks like evidence and is not. Artifact checks stay mandatory in both cases; release catalogs still require full provenance strictly.

## Testing

`scripts/test_server_bundle_agents.py` packs, transports and loads with the real components: the real packer, the unchanged updater (both `safe_extract_tar` and `NativeAdapter.stage`, the path a host actually takes), and the hub's own Go loader over the resulting tree — asserting it PASSED rather than skipped.

That cross-component test immediately earned itself: it caught the packer's ELF check accepting an `EI_VERSION` the hub's loader rejects. Real Go builds set `EV_CURRENT`, so the packer was aligned to the stricter reading rather than the hub loosened — validators that disagree let a release pass packaging and fail at hub startup.

Every rejection test is paired with a control that must still load, and the five loader-hardening tests were confirmed to fail against the previous loader.

## Not done yet

- Release identity gate (`agentRelease` bump, published `(platform, release) → SHA` immutability before promotion)
- Content-addressed signature lookup
- Durable automatic staged rollout — planned as a dependent follow-up PR so this artifact-delivery change stays independently reviewable
- Docs and the Versions UI

**Neither PR is a release on its own.** Merging this alone is not completion of the agent self-update work.

## Verification gap, stated plainly

Docker is not available on the machine this was written on, so the image build is **unverified locally** and this CI run is its first real test. That is why the draft is open now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX
