### PR TITLE
feat(rollout): durable automatic staged agent rollout

### DIFF
--- a/dashboard/src/app/versions/page.tsx
+++ b/dashboard/src/app/versions/page.tsx
@@ -20,7 +20,7 @@ import {
   Package,
   ShieldCheck,
 } from "lucide-react";
-import { AgentBinaryInfo, useVersions } from "@/contexts/VersionsContext";
+import { AgentBinaryInfo, AgentRolloutStatus, useVersions } from "@/contexts/VersionsContext";
 
 /**
  * The resolution POLICY in force — not a claim about any particular platform.
@@ -222,6 +222,53 @@ function VersionsContent() {
             </dd>
           </div>
         </dl>
+
+        {/* Staged rollout, per platform. Without this a held or halted rollout
+            is visible only in the hub log, and the page shows update_pending on
+            every agent indefinitely — a rollout that stopped looks exactly like
+            one still in progress. */}
+        {data?.agent_rollout && Object.keys(data.agent_rollout).length > 0 && (
+          <dl className="mt-4 flex flex-col gap-2 border-t border-border-subtle pt-3">
+            {Object.entries(data.agent_rollout).map(([platform, raw]) => {
+              const entry = raw as Partial<AgentRolloutStatus> & {
+                unavailable?: string;
+                reason?: string;
+              };
+              const unavailable = entry.unavailable ?? (entry.status === "unavailable" ? entry.reason : undefined);
+              if (unavailable) {
+                return (
+                  <div key={platform} className="flex items-baseline gap-2">
+                    <dt className="mf-kicker">{platform === "unavailable" ? "Rollout" : platform}</dt>
+                    <dd>
+                      <StatusMark tone="critical" label="Unavailable" Icon={AlertTriangle} detail={unavailable} />
+                    </dd>
+                  </div>
+                );
+              }
+              const halted = entry.status === "halted";
+              return (
+                <div key={platform} className="flex items-baseline gap-2">
+                  <dt className="mf-kicker">{platform}</dt>
+                  <dd className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                    <StatusMark
+                      tone={halted ? "critical" : "ok"}
+                      label={halted ? "Halted" : "Automatic"}
+                      Icon={halted ? AlertTriangle : Play}
+                      detail={entry.summary}
+                      title={halted ? entry.halt_reason : undefined}
+                    />
+                    <span className="text-[12px] text-text-tertiary">
+                      {entry.updated ?? 0} updated · {entry.validated ?? 0} validated ·{" "}
+                      {entry.pending ?? 0} pending
+                      {(entry.withheld ?? 0) > 0 ? ` · ${entry.withheld} withheld` : ""}
+                      {(entry.failed ?? 0) > 0 ? ` · ${entry.failed} failed` : ""}
+                    </span>
+                  </dd>
+                </div>
+              );
+            })}
+          </dl>
+        )}
         <div className="mf-intro-actions">
           <button type="button" onClick={refresh} disabled={loading} className={MF_BUTTON}>
             <RefreshCw className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`} aria-hidden />

--- a/dashboard/src/app/versions/page.tsx
+++ b/dashboard/src/app/versions/page.tsx
@@ -20,7 +20,20 @@ import {
   Package,
   ShieldCheck,
 } from "lucide-react";
-import { AgentBinaryInfo, AgentRolloutStatus, useVersions } from "@/contexts/VersionsContext";
+import { AgentBinaryInfo, useVersions } from "@/contexts/VersionsContext";
+// The rollout render lives in a pure, separately tested module: the hub sends
+// the controller-wide sentinel as a STRING and this page used to cast every
+// value to an object, so a hub with no controller displayed a green
+// "Automatic · 0 updated · 0 validated · 0 pending".
+import {
+  rolloutEntries,
+  rolloutBadge,
+  rolloutCountsLabel,
+  rolloutReasonLines,
+  rolloutCandidateLabel,
+  rolloutRecoveryAction,
+  operatorPauseLabel,
+} from "@/lib/rollout-status.mjs";
 
 /**
  * The resolution POLICY in force — not a claim about any particular platform.
@@ -56,7 +69,7 @@ import {
   buildBinaryCards,
 } from "@/lib/versions-honesty.mjs";
 import { useAuth } from "@/contexts/AuthContext";
-import { StatusCell, StatusMark } from "@/components/MonoformStatus";
+import { StatusCell, StatusMark, type MonoformTone } from "@/components/MonoformStatus";
 import {
   MF_BUTTON,
   MF_PANEL_HEAD,
@@ -158,6 +171,11 @@ function VersionsContent() {
   // card — its error names the missing build.
   const binaryCards = buildBinaryCards(data);
 
+  // One normalisation, shared by the per-platform rows and the fleet controls,
+  // so the two can never disagree about which platforms are halted.
+  const rollout = rolloutEntries(data?.agent_rollout);
+  const recovery = rolloutRecoveryAction(rollout, data?.rollout_paused ?? false);
+
   useEffect(() => {
     refresh();
   }, [refresh]);
@@ -207,14 +225,21 @@ function VersionsContent() {
               )}
             </dd>
           </div>
+          {/* The operator pause, named as itself.
+              This was "Rollout: Active/Paused", which was already loose and
+              became wrong once the automatic failure breaker was removed: the
+              flag now means only that nobody has pressed pause. A halted
+              platform, or a hub with no controller at all, still showed
+              "Active". Health is a per-platform claim and is made below. */}
           <div className="flex items-baseline gap-2">
-            <dt className="mf-kicker">Rollout</dt>
+            <dt className="mf-kicker">Operator pause</dt>
             <dd>
               {data ? (
                 <StatusMark
                   tone={data.rollout_paused ? "warning" : "ok"}
-                  label={data.rollout_paused ? "Paused" : "Active"}
+                  label={operatorPauseLabel(data.rollout_paused)}
                   Icon={data.rollout_paused ? Pause : Play}
+                  detail={data.rollout_paused ? data.pause_reason || undefined : undefined}
                 />
               ) : (
                 <span className="text-[13px] text-text-tertiary">—</span>
@@ -227,42 +252,50 @@ function VersionsContent() {
             is visible only in the hub log, and the page shows update_pending on
             every agent indefinitely — a rollout that stopped looks exactly like
             one still in progress. */}
-        {data?.agent_rollout && Object.keys(data.agent_rollout).length > 0 && (
+        {rollout.length > 0 && (
           <dl className="mt-4 flex flex-col gap-2 border-t border-border-subtle pt-3">
-            {Object.entries(data.agent_rollout).map(([platform, raw]) => {
-              const entry = raw as Partial<AgentRolloutStatus> & {
-                unavailable?: string;
-                reason?: string;
-              };
-              const unavailable = entry.unavailable ?? (entry.status === "unavailable" ? entry.reason : undefined);
-              if (unavailable) {
-                return (
-                  <div key={platform} className="flex items-baseline gap-2">
-                    <dt className="mf-kicker">{platform === "unavailable" ? "Rollout" : platform}</dt>
-                    <dd>
-                      <StatusMark tone="critical" label="Unavailable" Icon={AlertTriangle} detail={unavailable} />
-                    </dd>
-                  </div>
-                );
-              }
-              const halted = entry.status === "halted";
+            {rollout.map((entry) => {
+              const badge = rolloutBadge(entry);
+              const counts = rolloutCountsLabel(entry);
+              const reasons = rolloutReasonLines(entry);
+              // Which build these counts are about. The hub only picks up a
+              // new candidate when a reservation runs, so with the pause on it
+              // can serve one build while the rollout still describes the
+              // previous one — and "observed on this build" would quietly
+              // attach the old counts to the new binary.
+              const candidate = rolloutCandidateLabel(entry);
+              // Narrowed here rather than asserted: the helper is plain JS, so
+              // this is the boundary where an unexpected tone would otherwise
+              // reach the renderer untyped. Anything that is not "ok" renders
+              // as critical, which is the safe direction for a status mark.
+              const tone: MonoformTone = badge.tone === "ok" ? "ok" : "critical";
               return (
-                <div key={platform} className="flex items-baseline gap-2">
-                  <dt className="mf-kicker">{platform}</dt>
+                <div key={entry.key} className="flex items-baseline gap-2">
+                  <dt className="mf-kicker">{entry.platform}</dt>
                   <dd className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
                     <StatusMark
-                      tone={halted ? "critical" : "ok"}
-                      label={halted ? "Halted" : "Automatic"}
-                      Icon={halted ? AlertTriangle : Play}
-                      detail={entry.summary}
-                      title={halted ? entry.halt_reason : undefined}
+                      tone={tone}
+                      label={badge.label}
+                      Icon={tone === "ok" ? Play : AlertTriangle}
+                      detail={badge.detail || undefined}
+                      title={badge.detail || undefined}
                     />
-                    <span className="text-[12px] text-text-tertiary">
-                      {entry.updated ?? 0} updated · {entry.validated ?? 0} validated ·{" "}
-                      {entry.pending ?? 0} pending
-                      {(entry.withheld ?? 0) > 0 ? ` · ${entry.withheld} withheld` : ""}
-                      {(entry.failed ?? 0) > 0 ? ` · ${entry.failed} failed` : ""}
-                    </span>
+                    {candidate && (
+                      <span
+                        className="text-[12px] text-text-tertiary font-mono"
+                        title={`Tracking candidate ${candidate.full}`}
+                      >
+                        build {candidate.short}
+                      </span>
+                    )}
+                    {counts && <span className="text-[12px] text-text-tertiary">{counts}</span>}
+                    {/* Named machines, because a withheld or failed count with
+                        no names cannot be acted on. */}
+                    {reasons.map((line) => (
+                      <span key={line} className="text-[12px] text-text-tertiary">
+                        {line}
+                      </span>
+                    ))}
                   </dd>
                 </div>
               );
@@ -313,36 +346,62 @@ function VersionsContent() {
               </p>
             </section>
 
+            {/* The operator pause and platform halts are DIFFERENT things.
+                This card headlined "Active" whenever nobody had pressed pause,
+                which since the automatic breaker's removal says nothing about
+                whether anything is rolling out. Worse, the only recovery
+                control appeared when the pause was on — so a halted platform
+                with the pause off offered the operator a Pause button and
+                nothing else. Per-platform health is stated above; this card is
+                the fleet-wide controls and says which one it is. */}
             <section className="mf-panel">
               <div className={MF_PANEL_HEAD}>
                 <h2 className={MF_PANEL_TITLE}>Fleet rollout</h2>
                 <StatusCell
                   tone={data.rollout_paused ? "warning" : "ok"}
-                  label={data.rollout_paused ? "Paused" : "Active"}
+                  label={`Operator pause: ${operatorPauseLabel(data.rollout_paused)}`}
                   Icon={data.rollout_paused ? Pause : CheckCircle2}
                 />
               </div>
               <div className="flex flex-wrap items-center justify-between gap-4 px-6 py-4">
                 <div className="min-w-0">
                   <p className="text-[13px] text-text-secondary">
-                    Controls update announcements for every platform.
+                    {data.rollout_paused
+                      ? "Update announcements are held for every platform until an operator resumes."
+                      : "No operator hold. Each platform's own state is shown above."}
                   </p>
                   {data.rollout_paused && data.pause_reason && (
                     <p className="mt-1.5 text-xs text-text-tertiary">Reason: {data.pause_reason}</p>
                   )}
+                  {recovery.retryAvailable && (
+                    <p className="mt-1.5 text-xs text-text-tertiary">{recovery.detail}</p>
+                  )}
                 </div>
-                {canManageRollout &&
-                  (data.rollout_paused ? (
-                    <button type="button" onClick={resumeRollout} className="mf-action inline-flex items-center gap-2">
-                      <Play className="w-3.5 h-3.5" aria-hidden />
-                      Resume rollout
-                    </button>
-                  ) : (
-                    <button type="button" onClick={pauseRollout} className={MF_BUTTON}>
-                      <Pause className="w-3.5 h-3.5" aria-hidden />
-                      Pause rollout
-                    </button>
-                  ))}
+                {canManageRollout && (
+                  <div className="flex flex-wrap items-center gap-2">
+                    {/* One endpoint serves both: it clears the pause AND gives
+                        every halted platform a new attempt, in one
+                        transaction. Hence a single button when the pause is on
+                        and something is halted — two would imply the operator
+                        could do one without the other. */}
+                    {(data.rollout_paused || recovery.retryAvailable) && (
+                      <button
+                        type="button"
+                        onClick={resumeRollout}
+                        className="mf-action inline-flex items-center gap-2"
+                      >
+                        <Play className="w-3.5 h-3.5" aria-hidden />
+                        {recovery.label}
+                      </button>
+                    )}
+                    {!data.rollout_paused && (
+                      <button type="button" onClick={pauseRollout} className={MF_BUTTON}>
+                        <Pause className="w-3.5 h-3.5" aria-hidden />
+                        Pause rollout
+                      </button>
+                    )}
+                  </div>
+                )}
               </div>
             </section>
 

--- a/dashboard/src/contexts/VersionsContext.tsx
+++ b/dashboard/src/contexts/VersionsContext.tsx
@@ -41,6 +41,28 @@ export interface AgentBinaryInfo {
   release?: number;
 }
 
+export interface AgentRolloutStatus {
+  platform: string;
+  generation: number;
+  candidate_sha: string;
+  stage: number;
+  status: string;
+  halt_reason?: string;
+  summary: string;
+  /** Machines this generation has SEEN running the candidate, whatever
+   * happened to their validation afterwards. */
+  updated: number;
+  /** The subset that completed its dwell. */
+  validated: number;
+  /** Reserved or offered: not yet known to be running it. */
+  pending: number;
+  /** Ineligible, with reasons. Not failures, and they do not halt. */
+  withheld: number;
+  withheld_reasons?: Record<string, string>;
+  failed: number;
+  failed_reasons?: Record<string, string>;
+}
+
 export interface VersionsResponse {
   /**
    * Which resolution policy produced the served binaries:
@@ -54,6 +76,17 @@ export interface VersionsResponse {
    */
   agent_delivery?: string;
   agent_delivery_error?: string;
+  /**
+   * Staged rollout state per platform ("linux/amd64", …), or a single
+   * `unavailable` key when the controller could not be built.
+   *
+   * `status` is durable: "active" means the automatic policy is enabled, NOT
+   * that something is being sent right now. "halted" needs a person.
+   * `summary` is derived for display — whether a fleet is caught up is a
+   * statement about machines that happen to be connected, so it is never
+   * stored. Older hubs omit the whole field.
+   */
+  agent_rollout?: Record<string, AgentRolloutStatus | { unavailable?: string; status?: string; reason?: string }>;
   signing_enabled: boolean;
   signing_disabled_reason: string;
   hub_sha: string;

--- a/dashboard/src/contexts/VersionsContext.tsx
+++ b/dashboard/src/contexts/VersionsContext.tsx
@@ -50,11 +50,18 @@ export interface AgentRolloutStatus {
   halt_reason?: string;
   summary: string;
   /** Machines this generation has SEEN running the candidate, whatever
-   * happened to their validation afterwards. */
+   * happened to their validation afterwards. HISTORICAL: the hub latches it,
+   * so a machine counted here may since have failed, rolled back, or gone
+   * offline. It is "observed on this build in this rollout", never "is on
+   * this build now". */
   updated: number;
   /** The subset that completed its dwell. */
   validated: number;
-  /** Reserved or offered: not yet known to be running it. */
+  /** Running the candidate with the dwell still accruing. Neither pending nor
+   * validated — without it a canary mid-dwell showed every count at zero. */
+  validating?: number;
+  /** Reserved or offered. Reservation happens BEFORE the write to the socket,
+   * so this includes attempts never sent: pending offers, not offered. */
   pending: number;
   /** Ineligible, with reasons. Not failures, and they do not halt. */
   withheld: number;
@@ -82,9 +89,13 @@ export interface VersionsResponse {
    *
    * `status` is durable: "active" means the automatic policy is enabled, NOT
    * that something is being sent right now. "halted" needs a person.
-   * `summary` is derived for display — whether a fleet is caught up is a
-   * statement about machines that happen to be connected, so it is never
-   * stored. Older hubs omit the whole field.
+   * `summary` is derived for display — it counts SLOTS, which exist only for
+   * machines this generation reserved one for, so it never claims the
+   * connected fleet is caught up. Older hubs omit the whole field.
+   *
+   * Render this through `@/lib/rollout-status.mjs`, never by casting entries
+   * to objects: the values are heterogeneous by design and an unrecognised
+   * one must read as unavailable rather than as a healthy zero.
    */
   agent_rollout?: Record<string, AgentRolloutStatus | { unavailable?: string; status?: string; reason?: string }>;
   signing_enabled: boolean;

--- a/dashboard/src/lib/rollout-status.mjs
+++ b/dashboard/src/lib/rollout-status.mjs
@@ -34,6 +34,22 @@ export function normalizeRolloutEntry(key, value) {
     return { key, platform: value.platform ?? key, state: ROLLOUT_UNAVAILABLE,
              reason: value.reason || "the hub could not read this platform's rollout state" };
   }
+  // Anything that is not a status this build understands is UNAVAILABLE, not
+  // healthy. Defaulting the other way is the same defect in a second costume:
+  // `{}` — a truncated response, a field an older hub never sent, a status
+  // added by a newer one — would render a green "Automatic · 0 · 0 · 0",
+  // which is indistinguishable from a rollout that has genuinely just begun.
+  // An unrecognised status means the page does not know, and it must say so.
+  if (value.status !== ROLLOUT_ACTIVE && value.status !== ROLLOUT_HALTED) {
+    return {
+      key,
+      platform: value.platform ?? key,
+      state: ROLLOUT_UNAVAILABLE,
+      reason: value.status
+        ? `the hub reported a rollout status this page does not understand: ${value.status}`
+        : "the hub reported no rollout status for this platform",
+    };
+  }
   const counts = {
     updated: value.updated ?? 0,
     validated: value.validated ?? 0,
@@ -49,6 +65,12 @@ export function normalizeRolloutEntry(key, value) {
     reason: value.status === ROLLOUT_HALTED ? value.halt_reason || "" : "",
     summary: value.summary || "",
     counts,
+    // The build these counts are about. It is NOT necessarily what the hub
+    // serves right now: a new candidate is only picked up when a reservation
+    // runs, so while the operator pause is on the hub can serve one build and
+    // the rollout still describe the previous one. Without this on screen,
+    // "observed on this build" silently attaches old counts to a new binary.
+    candidate: typeof value.candidate_sha === "string" ? value.candidate_sha : "",
     withheldReasons: value.withheld_reasons ?? {},
     failedReasons: value.failed_reasons ?? {},
   };
@@ -77,20 +99,28 @@ export function rolloutBadge(entry) {
 /**
  * Counts, with their scope stated.
  *
- * "Updated" is about THIS rollout: machines it has seen running the candidate,
- * including any whose validation later failed — they are demonstrably on the
- * new build. It is not a fleet total, and machines that were already current
- * and so never needed a slot are not represented at all.
+ * "Updated" is HISTORICAL and scoped to this rollout: machines it has at some
+ * point seen running the candidate, including any that later failed, rolled
+ * back, or disconnected. It is not "currently on this build" and not a fleet
+ * total — machines that were already current, and so never needed a slot, are
+ * not represented at all. Hence "observed on this build", which is the claim
+ * the underlying latch actually supports.
  */
 export function rolloutCountsLabel(entry) {
   if (entry.state === ROLLOUT_UNAVAILABLE) return "";
   const { updated, validated, validating, pending, withheld, failed } = entry.counts;
   const parts = [
-    `${updated} on this build`,
+    `${updated} observed on this build`,
     `${validated} validated`,
   ];
   if (validating > 0) parts.push(`${validating} validating`);
-  if (pending > 0) parts.push(`${pending} offered`);
+  // "Pending attempts" — not "offered", and not "pending offers" either. A
+  // slot is RESERVED before the write to the socket, so this includes
+  // attempts never sent; and a resume can open a fresh validation attempt for
+  // a machine already running the candidate, which correctly gets no
+  // announcement at all. Either of the other words would assert a send, or a
+  // rejection, that the hub is not in a position to know about.
+  if (pending > 0) parts.push(`${pending} pending attempts`);
   if (withheld > 0) parts.push(`${withheld} withheld`);
   if (failed > 0) parts.push(`${failed} failed`);
   return parts.join(" · ");
@@ -116,4 +146,52 @@ export function rolloutReasonLines(entry) {
  */
 export function operatorPauseLabel(paused) {
   return paused ? "On" : "Off";
+}
+
+/**
+ * The candidate this rollout is tracking, short form plus the full SHA.
+ *
+ * Null when there is nothing trustworthy to name — an unavailable entry has no
+ * counts and no candidate, and inventing one would imply the page knows which
+ * build the (absent) numbers describe.
+ */
+export function rolloutCandidateLabel(entry) {
+  if (entry.state === ROLLOUT_UNAVAILABLE) return null;
+  const full = entry.candidate || "";
+  if (!/^[0-9a-f]{7,}$/i.test(full)) return null;
+  return { short: full.slice(0, 7), full };
+}
+
+/**
+ * The fleet-wide recovery action, and whether there is anything to recover.
+ *
+ * The operator pause and a platform halt are different things and were being
+ * conflated. Before the automatic breaker was removed a halt usually arrived
+ * alongside a pause, so "Resume" appeared; now a halt sets no fleet flag at
+ * all, and a halted platform with the pause off offered the operator nothing
+ * but a Pause button — the one control that cannot help.
+ *
+ * One endpoint covers both, and it is FLEET-WIDE: it clears the pause and
+ * gives every halted platform a new attempt, in one transaction. The wording
+ * must not imply the operator can retry one platform, because they cannot.
+ *
+ * An UNAVAILABLE entry is never retryable. The hub could not read that state,
+ * so there is nothing to give an attempt to, and resume refuses outright when
+ * the controller is missing — offering the button would promise a recovery
+ * that cannot happen.
+ */
+export function rolloutRecoveryAction(entries, paused) {
+  const halted = (entries ?? [])
+    .filter((entry) => entry.state === ROLLOUT_HALTED)
+    .map((entry) => entry.platform);
+  const retryAvailable = halted.length > 0;
+  let label = "Resume rollout";
+  if (paused && retryAvailable) label = "Resume and retry halted rollouts";
+  else if (!paused && retryAvailable) label = "Retry halted rollouts";
+  return {
+    halted,
+    retryAvailable,
+    label,
+    detail: retryAvailable ? `Retries every halted platform: ${halted.join(", ")}` : "",
+  };
 }

--- a/dashboard/src/lib/rollout-status.mjs
+++ b/dashboard/src/lib/rollout-status.mjs
@@ -1,0 +1,119 @@
+/**
+ * Rollout status, turned into what the Versions page should show.
+ *
+ * Pure and separately tested, because the render is where this went wrong:
+ * the hub sends `agent_rollout.unavailable` as a STRING, the component cast
+ * every value to an object, and a hub with no rollout controller displayed a
+ * green "Automatic · 0 updated · 0 validated · 0 pending" — the healthiest
+ * possible badge for a rollout that cannot run at all.
+ */
+
+export const ROLLOUT_UNAVAILABLE = "unavailable";
+export const ROLLOUT_HALTED = "halted";
+export const ROLLOUT_ACTIVE = "active";
+
+/**
+ * Normalise one entry of the agent_rollout map.
+ *
+ * Two shapes arrive here and they are not interchangeable:
+ *   "unavailable": "<reason>"            — a string, the whole controller
+ *   "<platform>": { status, summary, … } — one platform
+ * plus a per-platform read failure, which is an object whose status is
+ * "unavailable" and which carries a reason rather than any counts.
+ */
+export function normalizeRolloutEntry(key, value) {
+  if (typeof value === "string") {
+    return { key, platform: key === ROLLOUT_UNAVAILABLE ? "Rollout" : key,
+             state: ROLLOUT_UNAVAILABLE, reason: value };
+  }
+  if (!value || typeof value !== "object") {
+    return { key, platform: key, state: ROLLOUT_UNAVAILABLE,
+             reason: "the hub reported no usable rollout state" };
+  }
+  if (value.status === ROLLOUT_UNAVAILABLE) {
+    return { key, platform: value.platform ?? key, state: ROLLOUT_UNAVAILABLE,
+             reason: value.reason || "the hub could not read this platform's rollout state" };
+  }
+  const counts = {
+    updated: value.updated ?? 0,
+    validated: value.validated ?? 0,
+    validating: value.validating ?? 0,
+    pending: value.pending ?? 0,
+    withheld: value.withheld ?? 0,
+    failed: value.failed ?? 0,
+  };
+  return {
+    key,
+    platform: value.platform ?? key,
+    state: value.status === ROLLOUT_HALTED ? ROLLOUT_HALTED : ROLLOUT_ACTIVE,
+    reason: value.status === ROLLOUT_HALTED ? value.halt_reason || "" : "",
+    summary: value.summary || "",
+    counts,
+    withheldReasons: value.withheld_reasons ?? {},
+    failedReasons: value.failed_reasons ?? {},
+  };
+}
+
+export function rolloutEntries(agentRollout) {
+  if (!agentRollout || typeof agentRollout !== "object") return [];
+  return Object.entries(agentRollout).map(([key, value]) => normalizeRolloutEntry(key, value));
+}
+
+/**
+ * The badge for one entry. "Automatic" describes the POLICY being enabled, not
+ * that anything is happening — the counts and summary carry progress.
+ */
+export function rolloutBadge(entry) {
+  switch (entry.state) {
+    case ROLLOUT_UNAVAILABLE:
+      return { tone: "critical", label: "Unavailable", detail: entry.reason };
+    case ROLLOUT_HALTED:
+      return { tone: "critical", label: "Halted", detail: entry.reason };
+    default:
+      return { tone: "ok", label: "Automatic", detail: entry.summary };
+  }
+}
+
+/**
+ * Counts, with their scope stated.
+ *
+ * "Updated" is about THIS rollout: machines it has seen running the candidate,
+ * including any whose validation later failed — they are demonstrably on the
+ * new build. It is not a fleet total, and machines that were already current
+ * and so never needed a slot are not represented at all.
+ */
+export function rolloutCountsLabel(entry) {
+  if (entry.state === ROLLOUT_UNAVAILABLE) return "";
+  const { updated, validated, validating, pending, withheld, failed } = entry.counts;
+  const parts = [
+    `${updated} on this build`,
+    `${validated} validated`,
+  ];
+  if (validating > 0) parts.push(`${validating} validating`);
+  if (pending > 0) parts.push(`${pending} offered`);
+  if (withheld > 0) parts.push(`${withheld} withheld`);
+  if (failed > 0) parts.push(`${failed} failed`);
+  return parts.join(" · ");
+}
+
+/** Per-machine reasons, so a withheld or failed machine is nameable. */
+export function rolloutReasonLines(entry) {
+  if (entry.state === ROLLOUT_UNAVAILABLE) return [];
+  return [
+    ...Object.entries(entry.withheldReasons ?? {}).map(([id, why]) => `${id} withheld: ${why}`),
+    ...Object.entries(entry.failedReasons ?? {}).map(([id, why]) => `${id} failed: ${why}`),
+  ];
+}
+
+/**
+ * The FLEET-level control, which is the operator pause and nothing else.
+ *
+ * It used to be labelled "Rollout: Active/Paused", which was already loose and
+ * became wrong when the automatic failure breaker was removed: the flag now
+ * means only that a person has not pressed pause. A halted platform, or a hub
+ * with no controller at all, would still have shown "Active". Health belongs
+ * to the per-platform rows.
+ */
+export function operatorPauseLabel(paused) {
+  return paused ? "On" : "Off";
+}

--- a/dashboard/src/lib/rollout-status.test.mjs
+++ b/dashboard/src/lib/rollout-status.test.mjs
@@ -7,6 +7,8 @@ import {
   rolloutBadge,
   rolloutCountsLabel,
   rolloutReasonLines,
+  rolloutCandidateLabel,
+  rolloutRecoveryAction,
   operatorPauseLabel,
 } from "./rollout-status.mjs";
 
@@ -41,7 +43,7 @@ test("a halted platform is critical and names its reason", () => {
   const [entry] = rolloutEntries({
     "linux/arm64": {
       platform: "linux/arm64", status: "halted",
-      halt_reason: "pi-01: never accepted the update offer",
+      halt_reason: "pi-01: update was not confirmed within the attempt window",
       summary: "halted — needs an operator", updated: 1, validated: 1,
     },
   });
@@ -50,7 +52,7 @@ test("a halted platform is critical and names its reason", () => {
   assert.equal(badge.label, "Halted");
   assert.match(badge.detail, /pi-01/);
   // A halt does not erase what already shipped.
-  assert.match(rolloutCountsLabel(entry), /1 on this build/);
+  assert.match(rolloutCountsLabel(entry), /1 observed on this build/);
 });
 
 test("an active platform mid-dwell reports validating, not silence", () => {
@@ -63,7 +65,7 @@ test("an active platform mid-dwell reports validating, not silence", () => {
   assert.equal(rolloutBadge(entry).label, "Automatic");
   const label = rolloutCountsLabel(entry);
   assert.match(label, /1 validating/);
-  assert.match(label, /1 on this build/);
+  assert.match(label, /1 observed on this build/);
 });
 
 test("withheld and failed machines are nameable", () => {
@@ -71,7 +73,7 @@ test("withheld and failed machines are nameable", () => {
     "windows/amd64": {
       status: "active", updated: 0, validated: 0, withheld: 1, failed: 1,
       withheld_reasons: { drops: "no pinned update key" },
-      failed_reasons: { "win-02": "never accepted the update offer" },
+      failed_reasons: { "win-02": "update was not confirmed within the attempt window" },
     },
   });
   const lines = rolloutReasonLines(entry);
@@ -83,9 +85,11 @@ test("counts state their scope rather than implying a fleet total", () => {
   const [entry] = rolloutEntries({
     "linux/amd64": { status: "active", updated: 2, validated: 2 },
   });
-  // "2 on this build", not "2 updated" — machines that were already current
-  // never needed a slot and are not represented here at all.
-  assert.match(rolloutCountsLabel(entry), /2 on this build/);
+  // "2 observed on this build", not "2 updated" and not "2 on this build":
+  // the underlying flag is a latch, so it is a statement about what this
+  // rollout has seen, not about what those machines are running now. Machines
+  // that were already current never needed a slot and are absent entirely.
+  assert.match(rolloutCountsLabel(entry), /2 observed on this build/);
   assert.doesNotMatch(rolloutCountsLabel(entry), /fleet/);
 });
 
@@ -106,4 +110,105 @@ test("the fleet control is labelled as the operator pause it is", () => {
 test("an absent agent_rollout yields nothing to render", () => {
   assert.deepEqual(rolloutEntries(undefined), []);
   assert.deepEqual(rolloutEntries(null), []);
+});
+
+// An empty object is what a truncated response, an older hub, or a field
+// rename produces. Treating it as active gave the healthiest possible badge —
+// the same defect as the string sentinel, reached by a different route.
+test("an entry with no status is unavailable, not a green zero", () => {
+  const [entry] = rolloutEntries({ "linux/amd64": {} });
+  assert.equal(entry.state, "unavailable");
+  const badge = rolloutBadge(entry);
+  assert.equal(badge.tone, "critical");
+  assert.equal(badge.label, "Unavailable");
+  assert.equal(rolloutCountsLabel(entry), "");
+  // Control: the same entry WITH a known status is not swept up by this.
+  const [ok] = rolloutEntries({ "linux/amd64": { status: "active" } });
+  assert.equal(ok.state, "active");
+});
+
+test("a status this page does not understand is unavailable and says so", () => {
+  const [entry] = rolloutEntries({ "linux/amd64": { status: "draining", updated: 9 } });
+  assert.equal(entry.state, "unavailable");
+  assert.match(rolloutBadge(entry).detail, /draining/);
+  // Its counts are not borrowed to decorate a state we cannot interpret.
+  assert.equal(rolloutCountsLabel(entry), "");
+});
+
+// A slot is RESERVED before the socket write, so "pending" includes attempts
+// that were never sent — and a resume opens one for machines already running
+// the candidate, which are never announced to at all. Both "offered" and
+// "pending offers" assert something about a send that the hub cannot know.
+test("pending is labelled as pending attempts, never as an offer", () => {
+  const [entry] = rolloutEntries({
+    "linux/amd64": { status: "active", updated: 0, validated: 0, pending: 2 },
+  });
+  const label = rolloutCountsLabel(entry);
+  assert.match(label, /2 pending attempts/);
+  assert.doesNotMatch(label, /offer/);
+});
+
+// A halt sets no fleet flag. With the pause off, the old page offered only a
+// Pause button — the operator could not retry at all without first pausing
+// something that was not running.
+test("a halted platform offers a retry even with the operator pause off", () => {
+  const entries = rolloutEntries({
+    "linux/amd64": { status: "halted", halt_reason: "pi-01: update was not confirmed within the attempt window" },
+    "windows/amd64": { status: "active", updated: 1, validated: 1 },
+  });
+  const action = rolloutRecoveryAction(entries, false);
+  assert.equal(action.retryAvailable, true);
+  assert.deepEqual(action.halted, ["linux/amd64"]);
+  assert.match(action.label, /Retry halted/);
+  // One endpoint, fleet-wide: the wording must not promise per-platform scope.
+  assert.match(action.detail, /every halted platform/);
+});
+
+test("with the pause on, one action clears it and retries", () => {
+  const entries = rolloutEntries({ "linux/amd64": { status: "halted", halt_reason: "x" } });
+  const action = rolloutRecoveryAction(entries, true);
+  assert.equal(action.retryAvailable, true);
+  assert.match(action.label, /Resume and retry/);
+});
+
+test("nothing halted means nothing to retry", () => {
+  const entries = rolloutEntries({ "linux/amd64": { status: "active", updated: 2, validated: 2 } });
+  assert.equal(rolloutRecoveryAction(entries, false).retryAvailable, false);
+  assert.equal(rolloutRecoveryAction(entries, false).detail, "");
+});
+
+// An unreadable controller is not a halt. Resume refuses outright without a
+// controller, so offering retry would promise a recovery that cannot happen.
+test("an unavailable rollout never claims to be resumable", () => {
+  const entries = rolloutEntries({
+    unavailable: "agent rollout controller unavailable: no such table: agent_rollout_slot",
+  });
+  const action = rolloutRecoveryAction(entries, false);
+  assert.equal(action.retryAvailable, false);
+  assert.deepEqual(action.halted, []);
+  // Control: the same call DOES offer retry when something is genuinely halted.
+  assert.equal(rolloutRecoveryAction(rolloutEntries({ p: { status: "halted" } }), false).retryAvailable, true);
+});
+
+// The counts describe the build the rollout is tracking, which is not always
+// the build the hub now serves: with the pause on, no reservation runs, so a
+// new binary can be served while the rollout still describes the previous one.
+test("each platform names the build its counts are about", () => {
+  const sha = "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90";
+  const [entry] = rolloutEntries({
+    "linux/amd64": { status: "active", candidate_sha: sha, updated: 1, validated: 1 },
+  });
+  const label = rolloutCandidateLabel(entry);
+  assert.equal(label.short, "a1b2c3d");
+  assert.equal(label.full, sha);
+});
+
+test("an unavailable entry names no build, because it has no counts either", () => {
+  const [entry] = rolloutEntries({ unavailable: "controller unavailable" });
+  assert.equal(rolloutCandidateLabel(entry), null);
+  // And a platform whose candidate is missing or junk does not get a fake one.
+  const [empty] = rolloutEntries({ "linux/amd64": { status: "active" } });
+  assert.equal(rolloutCandidateLabel(empty), null);
+  const [junk] = rolloutEntries({ "linux/amd64": { status: "active", candidate_sha: "n/a" } });
+  assert.equal(rolloutCandidateLabel(junk), null);
 });

--- a/dashboard/src/lib/rollout-status.test.mjs
+++ b/dashboard/src/lib/rollout-status.test.mjs
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  normalizeRolloutEntry,
+  rolloutEntries,
+  rolloutBadge,
+  rolloutCountsLabel,
+  rolloutReasonLines,
+  operatorPauseLabel,
+} from "./rollout-status.mjs";
+
+// The ACTUAL shape the hub sends for a missing controller: a bare string under
+// the "unavailable" key, alongside object-valued platform entries.
+const UNAVAILABLE_PAYLOAD = {
+  unavailable: "agent rollout controller unavailable: no such table: agent_rollout_slot",
+};
+
+test("a missing controller is never shown as a healthy rollout", () => {
+  const [entry] = rolloutEntries(UNAVAILABLE_PAYLOAD);
+  const badge = rolloutBadge(entry);
+  assert.equal(badge.tone, "critical");
+  assert.equal(badge.label, "Unavailable");
+  assert.match(badge.detail, /agent_rollout_slot/);
+  // And no counts are invented for it. Rendering "0 updated · 0 validated"
+  // beside a green badge was the live bug: the healthiest possible display for
+  // a rollout that cannot run at all.
+  assert.equal(rolloutCountsLabel(entry), "");
+});
+
+test("a per-platform read failure is unavailable, not absent", () => {
+  const [entry] = rolloutEntries({
+    "linux/amd64": { status: "unavailable", reason: "database is locked" },
+  });
+  assert.equal(entry.state, "unavailable");
+  assert.equal(rolloutBadge(entry).tone, "critical");
+  assert.match(rolloutBadge(entry).detail, /locked/);
+});
+
+test("a halted platform is critical and names its reason", () => {
+  const [entry] = rolloutEntries({
+    "linux/arm64": {
+      platform: "linux/arm64", status: "halted",
+      halt_reason: "pi-01: never accepted the update offer",
+      summary: "halted — needs an operator", updated: 1, validated: 1,
+    },
+  });
+  const badge = rolloutBadge(entry);
+  assert.equal(badge.tone, "critical");
+  assert.equal(badge.label, "Halted");
+  assert.match(badge.detail, /pi-01/);
+  // A halt does not erase what already shipped.
+  assert.match(rolloutCountsLabel(entry), /1 on this build/);
+});
+
+test("an active platform mid-dwell reports validating, not silence", () => {
+  const [entry] = rolloutEntries({
+    "linux/amd64": {
+      status: "active", summary: "1 validating",
+      updated: 1, validated: 0, validating: 1, pending: 0,
+    },
+  });
+  assert.equal(rolloutBadge(entry).label, "Automatic");
+  const label = rolloutCountsLabel(entry);
+  assert.match(label, /1 validating/);
+  assert.match(label, /1 on this build/);
+});
+
+test("withheld and failed machines are nameable", () => {
+  const [entry] = rolloutEntries({
+    "windows/amd64": {
+      status: "active", updated: 0, validated: 0, withheld: 1, failed: 1,
+      withheld_reasons: { drops: "no pinned update key" },
+      failed_reasons: { "win-02": "never accepted the update offer" },
+    },
+  });
+  const lines = rolloutReasonLines(entry);
+  assert.ok(lines.some((line) => line.includes("drops") && line.includes("pinned")));
+  assert.ok(lines.some((line) => line.includes("win-02")));
+});
+
+test("counts state their scope rather than implying a fleet total", () => {
+  const [entry] = rolloutEntries({
+    "linux/amd64": { status: "active", updated: 2, validated: 2 },
+  });
+  // "2 on this build", not "2 updated" — machines that were already current
+  // never needed a slot and are not represented here at all.
+  assert.match(rolloutCountsLabel(entry), /2 on this build/);
+  assert.doesNotMatch(rolloutCountsLabel(entry), /fleet/);
+});
+
+test("a malformed entry is unavailable rather than silently empty", () => {
+  assert.equal(normalizeRolloutEntry("linux/amd64", null).state, "unavailable");
+  assert.equal(normalizeRolloutEntry("linux/amd64", 42).state, "unavailable");
+});
+
+// The fleet-level flag means one thing only: whether a person pressed pause.
+// Labelling it "Rollout: Active" survived the automatic breaker's removal and
+// became wrong — a halted platform, or a hub with no controller, still showed
+// Active.
+test("the fleet control is labelled as the operator pause it is", () => {
+  assert.equal(operatorPauseLabel(false), "Off");
+  assert.equal(operatorPauseLabel(true), "On");
+});
+
+test("an absent agent_rollout yields nothing to render", () => {
+  assert.deepEqual(rolloutEntries(undefined), []);
+  assert.deepEqual(rolloutEntries(null), []);
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -248,9 +248,17 @@ updates until the agent's key is pinned through a trusted provisioning path.
 
 `announceDecision` is shared by the announcement path and versions API. It
 fails closed for protocol-v1 agents when no valid signature is available, the
-transport is plaintext, or the update key is unpinned. Withheld agents do not
-create reconnect expectations. A circuit breaker pauses rollout after repeated
-genuine failures.
+transport is plaintext, or the update key is unpinned. Withheld agents are recorded as
+held, with a reason, and re-evaluated as soon as they become eligible; a
+refusal to announce is not a rollout failure.
+
+Announcements are made by one scheduler, in stages: a single canary per
+platform, then batches of two, each machine validated by 60 seconds of
+continuous telemetry on the connection that reported the new build. Slots are
+durable, so a hub restart resumes rather than restarts. A failed attempt halts
+that platform only, and stays halted until an operator retries — there is no
+automatic fleet-wide breaker. See [versions](versions.md) for the operator
+view.
 
 Linux verifies the update, replaces its executable atomically, and relies on
 systemd plus an `OnFailure` recovery unit to restore `.prev` after repeated

--- a/docs/offline-update-signing.md
+++ b/docs/offline-update-signing.md
@@ -37,8 +37,9 @@ the hub. The private Ed25519 key stays on the offline build host.
   On hubs with the durable operator-pause fix, a manual pause is saved in
   `hub_settings` and survives both served-SHA changes and hub restarts. Only
   an explicit Resume clears it. A database error must not be mistaken for a
-  successful pause/resume. The automatic failure breaker is separate and may
-  reset when a served binary changes.
+  successful pause/resume. A platform halt is separate from the operator pause
+  and is cleared by the same Resume/retry action; see
+  [versions](versions.md#automatic-staged-rollout).
 - **v1.2.0 and earlier do not have durable pause.** Upgrade the hub first, or
   keep the hub stopped and agent connectivity controlled during activation.
   Never rely on racing to re-pause after replacing an artifact.

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -50,9 +50,67 @@ stops new update announcements fleet-wide; it cannot cancel an update already
 announced or in progress. Failed pause/resume writes return an error instead of
 claiming success, and unreadable saved state withholds announcements.
 
-The automatic circuit breaker can also pause after repeated rollout failures;
-it is separate from the saved operator pause. v1.2.0 and earlier do not enforce
-the durable pause, including after a downgrade. See
-[update recovery](agent-update-recovery.md) for the failure/rollback paths and
-[offline update signing](offline-update-signing.md) for detached-signature
-operation.
+v1.2.0 and earlier do not enforce the durable pause, including after a
+downgrade. See [update recovery](agent-update-recovery.md) for the
+failure/rollback paths and [offline update signing](offline-update-signing.md)
+for detached-signature operation.
+
+## Automatic staged rollout
+
+When the hub begins serving a new agent binary, it rolls the fleet forward on
+its own, per platform (`linux/amd64`, `linux/arm64`, `windows/amd64`). Each
+platform progresses independently: one platform halting does not stop another.
+
+**Stages.** One machine first — the canary. Only after it validates does the
+next stage open, at two machines at a time. A stage advances only when nothing
+is still outstanding in it *and* at least one machine in it actually validated,
+so a stage in which every candidate was held back cannot advance on having
+proven nothing.
+
+**What validation means.** A machine is validated when it reports running the
+new build and then keeps sending telemetry on that same connection,
+continuously, for 60 seconds — no gap longer than 45 seconds, and the dwell is
+measured between telemetry frames rather than against the clock, so silence
+cannot complete it. Reconnecting restarts it: the proof belongs to a
+connection, not to a machine.
+
+This is a **liveness** check and nothing more. It says the new agent starts,
+stays up, and keeps reporting. It does **not** prove any particular feature
+still works. Verify behaviour you care about yourself.
+
+**Pause versus halt.** These are different and the Versions page names them
+separately:
+
+| | Operator pause | Platform halt |
+|---|---|---|
+| Set by | a person, via **Pause rollout** | the hub, when an attempt fails |
+| Scope | the whole fleet | one platform |
+| Survives restart | yes | yes |
+| Cleared by | **Resume** | **Retry halted rollouts** (the same action) |
+
+A halt does **not** set the operator pause. A halted platform with the pause
+off is not "paused" — it is stopped and waiting for a person.
+
+**Retrying.** One action covers both: it clears the operator pause and gives
+every halted platform a fresh attempt, in one transaction — all of it or none.
+It is fleet-wide; there is no per-platform retry. A failed attempt is otherwise
+terminal, so nothing moves until you use it.
+
+**Machines that were offline.** A machine that was not connected during a
+stage is not skipped. It has no slot, is not counted, and is picked up by a
+later pass on capacity alone — no reconnect, version change, or operator action
+needed. This is also why the counts on the Versions page describe the machines
+this rollout reserved a slot for, not the fleet: a machine already on the build
+never needed one.
+
+**Which build the counts describe.** Each platform row names the candidate SHA
+it is tracking. That is not always what the hub serves right now — a new
+candidate is only picked up when the rollout next reserves a slot, so while the
+pause is on the hub can serve one build while the rollout still describes the
+previous one. Compare the row's build against **Served binaries** before
+reading the counts.
+
+**A hub update is not a fleet update.** `bloxos-update` finishing successfully
+means the server is on the new release. The agents are not: they roll out
+afterwards, over stages, and a halted or paused platform may never get there.
+The Versions page is where that is answered.

--- a/hub/agent_rollout.go
+++ b/hub/agent_rollout.go
@@ -89,10 +89,24 @@ const (
 )
 
 // Platform statuses.
+// Platform statuses. Only two are persisted, deliberately.
+//
+// There is no durable "complete". Whether the fleet is caught up is a
+// statement about machines that happen to be connected right now, so writing
+// it down created a state that had to be UNWOUND when a late machine appeared
+// — and that reopen transition was a hole: a first stage in which every
+// machine was withheld had nothing outstanding, completed having proven
+// nothing, and then reopened at batch size, putting two machines on an
+// untested build with no canary ever having passed.
+//
+// The stage is the only authority on canary-versus-batch. A late machine
+// enters whatever stage the platform is actually in: stage 0 until a canary
+// validates, the batch stage afterwards. Nothing can bypass that, because
+// there is no transition to bypass it with. "Caught up" is derived for display
+// and never stored.
 const (
-	rolloutActive   = "active"
-	rolloutComplete = "complete"
-	rolloutHalted   = "halted"
+	rolloutActive = "active"
+	rolloutHalted = "halted"
 )
 
 // rolloutEvidence is dwell evidence for one machine. Memory only.
@@ -123,9 +137,6 @@ type rolloutEvidence struct {
 	// metrics frame. Hub receipt time throughout: an agent's own timestamp is
 	// its claim about itself, and a stalled one keeps asserting freshness.
 	lastMetrics time.Time
-	// touched is the last time this record was written, used only to bound how
-	// many records one machine may accumulate.
-	touched time.Time
 }
 
 type rolloutController struct {
@@ -329,36 +340,6 @@ func (c *rolloutController) reserve(platform, machineID, candidate string, relea
 	}
 	now := c.now()
 
-	// "Complete" means the fleet was caught up at the time, NOT that the
-	// rollout is closed forever. A machine that was offline through the whole
-	// rollout, or was enrolled afterwards, still needs the candidate — so its
-	// arrival reopens the batch stage. Validated history is preserved: the
-	// stage is not rewound and healthy slots stay healthy, so reopening costs
-	// no re-validation of machines that already passed.
-	if st.Status == rolloutComplete {
-		var existing int
-		if err := tx.QueryRow(`SELECT COUNT(*) FROM agent_rollout_slot
-			WHERE platform = ? AND generation = ? AND machine_id = ? AND state = ?`,
-			platform, st.Generation, machineID, rolloutHealthy).Scan(&existing); err != nil {
-			return nil, "", err
-		}
-		if existing > 0 {
-			return stop("") // this machine is already validated
-		}
-		reopened := st.Stage
-		if reopened < 1 {
-			reopened = 1 // never send a late arrival through the canary again
-		}
-		st.Stage = reopened
-		st.Status = rolloutActive
-		if _, err := tx.Exec(`UPDATE agent_rollout_platform
-			SET status = ?, stage = ?, updated_unix_ms = ?
-			WHERE platform = ? AND generation = ?`,
-			rolloutActive, reopened, now.UnixMilli(), platform, st.Generation); err != nil {
-			return nil, "", err
-		}
-	}
-
 	// An existing slot for this machine in this generation decides the answer.
 	var state string
 	var attempt, resends int
@@ -498,7 +479,7 @@ func (c *rolloutController) forgetEvidence(machineID string) {
 // back running the candidate, that question is answered by the machine rather
 // than by bookkeeping the hub lost.
 func (c *rolloutController) observeRunningCandidate(platform, machineID string, generation int64) error {
-	_, err := c.db.Exec(`UPDATE agent_rollout_slot SET state = ?
+	_, err := c.db.Exec(`UPDATE agent_rollout_slot SET state = ?, ran_candidate = 1
 		WHERE platform = ? AND generation = ? AND machine_id = ? AND state IN (?, ?)`,
 		rolloutObserved, platform, generation, machineID, rolloutReserved, rolloutOffered)
 	return err
@@ -515,6 +496,14 @@ func (c *rolloutController) markOffered(r *rolloutReservation) error {
 }
 
 // withhold records an eligibility refusal, visibly and without halting.
+//
+// It will NOT convert an existing reserved, offered or observed slot. Freshly
+// ineligible machines are checked before they ever reserve, so a row in one of
+// those states is an attempt already under way — quite possibly one whose
+// write landed and whose mark was lost. Turning it into a withheld row would
+// release capacity for an offer that may be live, and let another machine
+// become canary alongside it. Those attempts are resolved by evidence or by
+// their own timeout, never by a later refusal.
 func (c *rolloutController) withhold(platform, machineID, candidate string, release uint64, reason string) error {
 	tx, err := c.db.Begin()
 	if err != nil {
@@ -531,9 +520,9 @@ func (c *rolloutController) withhold(platform, machineID, candidate string, rele
 		VALUES (?, ?, ?, ?, 0, ?, ?, NULL, ?, ?)
 		ON CONFLICT (platform, generation, machine_id) DO UPDATE SET
 			state = excluded.state, reason = excluded.reason
-		WHERE agent_rollout_slot.state IN (?, ?)`,
+		WHERE agent_rollout_slot.state = ?`,
 		platform, st.Generation, machineID, st.Stage, rolloutWithheld, now, now, reason,
-		rolloutWithheld, rolloutReserved); err != nil {
+		rolloutWithheld); err != nil {
 		return err
 	}
 	return tx.Commit()
@@ -610,7 +599,6 @@ func (c *rolloutController) observeCandidateReport(platform, machineID string, c
 	// It does not advance the dwell, because being told a version is not the
 	// same as observing a machine work.
 	ev.sawCandidate = true
-	ev.touched = c.now()
 }
 
 // noteMetrics records a metrics frame and restarts the dwell if the connection
@@ -652,6 +640,15 @@ func (c *rolloutController) observeTelemetry(platform, machineID string, conn *C
 
 // evidenceFor returns this connection's own record, creating it if needed.
 // Caller holds c.mu.
+//
+// Records are NOT pruned. They live exactly as long as their handler:
+// unregisterAgentConnection drops each connection's record as it exits, and a
+// displaced socket is closed, so it exits too. A size backstop was worse than
+// nothing here — its eviction order used a timestamp that only advances on a
+// write, while an agent reports its version once on connect, so the record
+// holding a hard-won sawCandidate looked stale precisely because nothing had
+// needed to touch it. Churn on other sockets would then discard the live
+// connection's proof and the dwell could never complete until it reconnected.
 func (c *rolloutController) evidenceFor(platform, machineID string, conn *ConnectedAgent) *rolloutEvidence {
 	key := rolloutKey(platform, machineID)
 	byConn := c.evidence[key]
@@ -661,30 +658,10 @@ func (c *rolloutController) evidenceFor(platform, machineID string, conn *Connec
 	}
 	ev := byConn[conn]
 	if ev == nil {
-		ev = &rolloutEvidence{conn: conn, touched: c.now()}
+		ev = &rolloutEvidence{conn: conn}
 		byConn[conn] = ev
-		c.pruneLocked(key, byConn)
 	}
 	return ev
-}
-
-// rolloutMaxEvidencePerMachine bounds records kept for one machine. A machine
-// that reconnects repeatedly would otherwise accumulate one per socket; a
-// disconnect normally removes its own, and this covers the case where it does
-// not.
-const rolloutMaxEvidencePerMachine = 4
-
-func (c *rolloutController) pruneLocked(key string, byConn map[*ConnectedAgent]*rolloutEvidence) {
-	for len(byConn) > rolloutMaxEvidencePerMachine {
-		var oldest *ConnectedAgent
-		var oldestAt time.Time
-		for conn, ev := range byConn {
-			if oldest == nil || ev.touched.Before(oldestAt) {
-				oldest, oldestAt = conn, ev.touched
-			}
-		}
-		delete(byConn, oldest)
-	}
 }
 
 // forgetConnection drops a connection's evidence when its socket goes away.
@@ -902,16 +879,6 @@ func (c *rolloutController) tick(platform string) error {
 	return nil
 }
 
-// markComplete records that every eligible machine the hub can currently see
-// is validated. Reversible by definition — see reserve().
-func (c *rolloutController) markComplete(platform string) error {
-	_, err := c.db.Exec(`UPDATE agent_rollout_platform
-		SET status = ?, updated_unix_ms = ?
-		WHERE platform = ? AND status = ?`,
-		rolloutComplete, c.now().UnixMilli(), platform, rolloutActive)
-	return err
-}
-
 func (c *rolloutController) platformState(platform string) (*rolloutPlatformState, error) {
 	var st rolloutPlatformState
 	st.Platform = platform
@@ -933,12 +900,24 @@ type rolloutStatus struct {
 	Generation int64  `json:"generation"`
 	Candidate  string `json:"candidate_sha"`
 	Stage      int    `json:"stage"`
+	// Status is the DURABLE state: active or halted. Active means the
+	// automatic policy is enabled, not that something is being sent right now.
 	Status     string `json:"status"`
 	HaltReason string `json:"halt_reason,omitempty"`
-	// Updated counts machines RUNNING the candidate — validated ones and
-	// those still proving themselves. Counting only validated slots would
-	// report a machine that has already taken the update as not updated,
-	// which reads as a stalled rollout when it is a working one.
+	// Summary is derived for display and never stored. Whether a fleet is
+	// caught up is a statement about machines that happen to be connected, so
+	// persisting it created a state that had to be unwound when a late machine
+	// appeared — and that reopen path could skip the canary entirely.
+	Summary string `json:"summary"`
+	// Updated counts machines this generation has SEEN running the candidate,
+	// whatever happened to their validation afterwards. Deriving it from the
+	// current state instead meant a machine whose dwell failed stopped being
+	// counted as updated the moment it failed — leaving "0 updated, 1 failed"
+	// for a machine demonstrably on the new build.
+	//
+	// It is a count for THIS generation's slots only. Machines that were
+	// already current, and so never needed one, are not represented here at
+	// all; MachinesTotal on the fleet endpoints is the denominator, not this.
 	Updated int `json:"updated"`
 	// Validated is the subset that has completed its dwell.
 	Validated int `json:"validated"`
@@ -960,7 +939,7 @@ func (c *rolloutController) status(platform string) (*rolloutStatus, error) {
 		Stage: st.Stage, Status: st.Status, HaltReason: st.HaltReason,
 		WithheldReason: map[string]string{}, FailedReason: map[string]string{}}
 
-	rows, err := c.db.Query(`SELECT machine_id, state, reason FROM agent_rollout_slot
+	rows, err := c.db.Query(`SELECT machine_id, state, reason, ran_candidate FROM agent_rollout_slot
 		WHERE platform = ? AND generation = ?`, platform, st.Generation)
 	if err != nil {
 		return nil, err
@@ -968,16 +947,18 @@ func (c *rolloutController) status(platform string) (*rolloutStatus, error) {
 	defer rows.Close()
 	for rows.Next() {
 		var machineID, state, reason string
-		if err := rows.Scan(&machineID, &state, &reason); err != nil {
+		var ranCandidate int
+		if err := rows.Scan(&machineID, &state, &reason, &ranCandidate); err != nil {
 			return nil, err
+		}
+		if ranCandidate == 1 || state == rolloutHealthy {
+			out.Updated++
 		}
 		switch state {
 		case rolloutHealthy:
 			out.Validated++
-			out.Updated++
 		case rolloutObserved:
 			// Running the candidate, dwell still accruing.
-			out.Updated++
 		case rolloutReserved, rolloutOffered:
 			out.Pending++
 		case rolloutWithheld:
@@ -988,7 +969,31 @@ func (c *rolloutController) status(platform string) (*rolloutStatus, error) {
 			out.FailedReason[machineID] = reason
 		}
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out.Summary = rolloutSummary(out)
+	return out, nil
+}
+
+// rolloutSummary describes a platform in words an operator can act on.
+func rolloutSummary(st *rolloutStatus) string {
+	switch {
+	case st.Status == rolloutHalted:
+		return "halted — needs an operator: " + st.HaltReason
+	case st.Pending > 0:
+		return fmt.Sprintf("updating: %d in flight, %d validated", st.Pending, st.Validated)
+	case st.Validated == 0 && st.Withheld > 0:
+		return fmt.Sprintf("waiting for an eligible machine: %d withheld", st.Withheld)
+	case st.Validated == 0:
+		return "waiting for an eligible machine"
+	case st.Failed > 0:
+		return fmt.Sprintf("%d validated, %d failed", st.Validated, st.Failed)
+	default:
+		// Only about machines currently connected: an offline one is not
+		// evidence of anything, which is why this is never written down.
+		return fmt.Sprintf("caught up among eligible connected machines: %d validated", st.Validated)
+	}
 }
 
 // resume clears a halt and gives every failed slot a NEW attempt.

--- a/hub/agent_rollout.go
+++ b/hub/agent_rollout.go
@@ -1,0 +1,965 @@
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+/* ============================================================================
+ * Staged agent rollout
+ *
+ * One canary per platform, then fixed batches of two, advancing on their own
+ * with no operator action. A platform that fails an attempt halts and waits
+ * for a person.
+ *
+ * Two rules shape everything here.
+ *
+ * HEALTH IS NOT A MATCHING SHA. A machine reporting the candidate proves the
+ * bytes arrived, not that they work: an agent can report its version and die
+ * seconds later, and the report survives its socket. So a slot becomes healthy
+ * only after the candidate is reported ON THE CURRENT CONNECTION and that same
+ * connection then stays up, delivering hub-received telemetry, for the dwell.
+ * Any disconnect, stale telemetry or hub restart resets the dwell to nothing.
+ *
+ * DURABILITY IS FOR DECISIONS, NOT FOR EVIDENCE. Reservations, stage and
+ * completed outcomes are persisted, because losing them re-sends updates and
+ * loses progress. Dwell evidence is never persisted, because it belongs to a
+ * live connection: writing it down would let a restart resurrect proof about a
+ * socket that no longer exists. The controller therefore starts with no
+ * evidence at all, which is the correct post-restart state by construction
+ * rather than by remembering to clear it.
+ * ============================================================================ */
+
+const (
+	// rolloutDwell is how long one connection must stay up, delivering
+	// telemetry, after reporting the candidate.
+	rolloutDwell = 60 * time.Second
+	// rolloutTelemetryGap bounds the silence allowed BETWEEN frames during a
+	// dwell, and must be shorter than the dwell. At 90s against a 60s dwell a
+	// single report followed by silence would satisfy health at 60s having
+	// proven nothing after the first instant. Agents report about every 30s,
+	// so 45s tolerates one missed frame and no more.
+	rolloutTelemetryGap = 45 * time.Second
+	// Capacity: one canary, then fixed batches of two. Deliberately flat —
+	// an exponential ladder reaches the whole fleet in a handful of stages,
+	// which is the blast radius this exists to bound.
+	rolloutCanaryCapacity = 1
+	rolloutBatchCapacity  = 2
+	// rolloutAttemptTimeout bounds one attempt: reserve, offer, and prove
+	// health. Generous, because an agent restarts and reconnects inside it.
+	rolloutAttemptTimeout = 10 * time.Minute
+	// rolloutMaxResends bounds AUTOMATIC crash-recovery sends within one
+	// attempt. Recovery is at-least-once and must not become unbounded replay.
+	//
+	// It deliberately does not bound operator retries. Using one counter for
+	// both meant that once automatic recovery had spent it, Resume cleared the
+	// halt and then found every slot permanently unretryable — the halt looked
+	// resolved and nothing moved.
+	rolloutMaxResends = 3
+	// rolloutRestartGrace is added once to every live deadline when the
+	// controller is built, so hub downtime is not charged to an attempt.
+	rolloutRestartGrace = 5 * time.Minute
+)
+
+// Slot states.
+const (
+	// rolloutReserved holds capacity; nothing has been written to a socket.
+	rolloutReserved = "reserved"
+	// rolloutOffered means the announcement write returned successfully.
+	rolloutOffered = "offered"
+	// rolloutObserved means the machine is running the candidate, established
+	// from a hub-received report rather than from an announcement we made.
+	rolloutObserved = "observed"
+	// rolloutHealthy is terminal success and persists as historical progress.
+	rolloutHealthy = "healthy"
+	// rolloutFailed is terminal until an operator resume creates a new attempt.
+	rolloutFailed = "failed"
+	// rolloutWithheld is an eligibility refusal — no signature, no pinned key,
+	// an unusable transport, a floor mismatch. NOT a failure: it does not halt
+	// the platform, does not consume capacity, and is re-evaluated every tick.
+	rolloutWithheld = "withheld"
+)
+
+// Platform statuses.
+const (
+	rolloutActive   = "active"
+	rolloutComplete = "complete"
+	rolloutHalted   = "halted"
+)
+
+// rolloutEvidence is dwell evidence for one machine. Memory only.
+type rolloutEvidence struct {
+	// conn identifies the connection this evidence belongs to. The pointer IS
+	// the identity: a replaced socket is a different pointer, so evidence
+	// cannot survive a reconnect. agentRunningVersions is keyed by machine and
+	// does survive one, which is exactly why it cannot establish health alone.
+	conn *ConnectedAgent
+	// generation and candidate name what this evidence is evidence FOR.
+	// Without them, one connection that proved itself on candidate A would
+	// hand that same dwell to candidate B's slot the instant B was reserved —
+	// the machine is still running A, and nothing would have checked.
+	generation int64
+	candidate  string
+	// sawCandidate is whether that exact SHA was reported on THIS connection.
+	// A report from a previous socket does not carry over.
+	sawCandidate bool
+	// dwellStart is when continuous METRICS coverage began, by hub receipt
+	// time. Zero until the first metrics frame after the candidate report.
+	dwellStart time.Time
+	// lastMetrics is the hub receipt time of the last METRICS frame.
+	//
+	// Deliberately separate from version reports. A version report says which
+	// bytes are running; it says nothing about whether the machine is being
+	// monitored, and an agent that re-reports its version on a timer while
+	// reporting nothing else would otherwise satisfy a dwell without a single
+	// metrics frame. Hub receipt time throughout: an agent's own timestamp is
+	// its claim about itself, and a stalled one keeps asserting freshness.
+	lastMetrics time.Time
+}
+
+type rolloutController struct {
+	db  *sql.DB
+	now func() time.Time
+
+	mu sync.Mutex
+	// evidence is keyed platform + "\x00" + machineID. Empty at construction.
+	evidence map[string]*rolloutEvidence
+	// sending claims a (platform, generation, machine, attempt) for one
+	// goroutine, so concurrent recovery triggers cannot both resend.
+	sending map[string]bool
+
+	// owns reports whether a connection is the one the registry currently
+	// holds for a machine. This is THE ownership boundary for evidence.
+	//
+	// Pointer inequality alone is not it. A displaced old socket can still be
+	// readable for a while, and letting any different pointer replace the
+	// record would let those late frames wipe out the current connection's
+	// valid proof — a denial of progress driven by the very socket that lost
+	// the machine. The registry is the authority on who owns it now.
+	owns func(machineID string, conn *ConnectedAgent) bool
+}
+
+// attachRegistry points the controller at the live agent registry.
+func (c *rolloutController) attachRegistry(owns func(string, *ConnectedAgent) bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.owns = owns
+}
+
+// ownsConnection defaults to true only when no registry is attached, which is
+// the case in unit tests that drive the controller directly.
+func (c *rolloutController) ownsConnection(machineID string, conn *ConnectedAgent) bool {
+	c.mu.Lock()
+	owns := c.owns
+	c.mu.Unlock()
+	if owns == nil {
+		return true
+	}
+	return owns(machineID, conn)
+}
+
+// ownsLocked is ownsConnection for a caller that already holds c.mu. The
+// registry callback takes the agent registry's own lock, never this one, so
+// calling it here does not invert a lock order.
+func (c *rolloutController) ownsLocked(machineID string, conn *ConnectedAgent) bool {
+	if c.owns == nil {
+		return true
+	}
+	return c.owns(machineID, conn)
+}
+
+func rolloutKey(platform, machineID string) string {
+	return platform + "\x00" + machineID
+}
+
+func rolloutCapacity(stage int) int {
+	if stage <= 0 {
+		return rolloutCanaryCapacity
+	}
+	return rolloutBatchCapacity
+}
+
+// newRolloutController builds the controller and reconciles what a restart
+// invalidated.
+//
+// It starts with no dwell evidence, which is the whole point: every in-flight
+// health claim dies with the process that observed it. Durable reservations
+// survive, so nothing is needlessly re-sent, and live deadlines get one grace
+// extension so hub downtime is not charged against an attempt.
+func newRolloutController(db *sql.DB, now func() time.Time) (*rolloutController, error) {
+	if now == nil {
+		now = time.Now
+	}
+	c := &rolloutController{db: db, now: now, evidence: map[string]*rolloutEvidence{}}
+	if err := c.reconcileAfterRestart(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// reconcileAfterRestart grants each live attempt ONE deadline extension.
+//
+// Bounded per attempt, durably. Extending on every construction would hand a
+// crash loop unlimited time: a hub restarting every thirty seconds would push
+// deadlines forward forever and an attempt that can never succeed would never
+// be declared failed either. grace_used is cleared only when a new attempt
+// begins, so a subsequent restart cannot re-grant it.
+func (c *rolloutController) reconcileAfterRestart() error {
+	// max(existing, now+grace): a blanket assignment would SHORTEN a
+	// ten-minute attempt with nine minutes left to a five-minute one, so a
+	// restart could fail an attempt sooner than no restart at all.
+	grace := c.now().Add(rolloutRestartGrace).UnixMilli()
+	_, err := c.db.Exec(`UPDATE agent_rollout_slot
+		SET deadline_unix_ms = MAX(deadline_unix_ms, ?), grace_used = 1
+		WHERE state IN (?, ?, ?) AND grace_used = 0`,
+		grace, rolloutReserved, rolloutOffered, rolloutObserved)
+	return err
+}
+
+// rolloutPlatformState is one platform's durable row.
+type rolloutPlatformState struct {
+	Platform   string
+	Generation int64
+	Candidate  string
+	Release    uint64
+	Stage      int
+	Status     string
+	HaltReason string
+}
+
+// loadPlatform reads a platform's row inside tx, creating or re-generating it
+// for the current candidate.
+//
+// A changed candidate starts a NEW GENERATION rather than editing the row in
+// place. Keying slots by SHA alone is not enough: rolling out B and then back
+// to A would find A's old rows and treat its earlier stages as already done.
+// A generation only ever moves forward, so no earlier stage can be revived.
+func (c *rolloutController) loadPlatform(tx *sql.Tx, platform, candidate string, release uint64) (rolloutPlatformState, error) {
+	var st rolloutPlatformState
+	st.Platform = platform
+	row := tx.QueryRow(`SELECT generation, candidate_sha, candidate_release, stage, status, halt_reason
+		FROM agent_rollout_platform WHERE platform = ?`, platform)
+	err := row.Scan(&st.Generation, &st.Candidate, &st.Release, &st.Stage, &st.Status, &st.HaltReason)
+
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		st = rolloutPlatformState{Platform: platform, Generation: 1, Candidate: candidate,
+			Release: release, Stage: 0, Status: rolloutActive}
+		if _, err := tx.Exec(`INSERT INTO agent_rollout_platform
+			(platform, generation, candidate_sha, candidate_release, stage, status, halt_reason, updated_unix_ms)
+			VALUES (?, ?, ?, ?, 0, ?, '', ?)`,
+			platform, st.Generation, candidate, release, rolloutActive, c.now().UnixMilli()); err != nil {
+			return st, err
+		}
+		return st, nil
+	case err != nil:
+		return st, err
+	}
+
+	if st.Candidate != candidate {
+		st.Generation++
+		st.Candidate = candidate
+		st.Release = release
+		st.Stage = 0
+		st.Status = rolloutActive
+		st.HaltReason = ""
+		if _, err := tx.Exec(`UPDATE agent_rollout_platform
+			SET generation = ?, candidate_sha = ?, candidate_release = ?, stage = 0,
+			    status = ?, halt_reason = '', updated_unix_ms = ?
+			WHERE platform = ?`,
+			st.Generation, candidate, release, rolloutActive, c.now().UnixMilli(), platform); err != nil {
+			return st, err
+		}
+	}
+	return st, nil
+}
+
+// rolloutReservation is what a caller needs to carry a send through.
+type rolloutReservation struct {
+	Platform   string
+	Generation int64
+	MachineID  string
+	Stage      int
+	Attempt    int
+	// Resend is true when this reservation recovers an attempt whose socket
+	// write may or may not have happened. The caller must treat delivery as
+	// at-least-once.
+	Resend bool
+}
+
+// reserve takes one slot for a machine, or reports why it did not.
+//
+// The capacity check, the stage read and the insert are ONE transaction, and
+// the DSN sets _txlock=immediate so it holds SQLite's write lock from BEGIN.
+// That is what bounds concurrency between DIFFERENT machines: a unique key on
+// (machine, candidate) only ever deduplicates repeat calls for the SAME
+// machine, and two distinct machines racing for the final slot would both have
+// inserted. Here one transaction observes the other's row and backs off.
+func (c *rolloutController) reserve(platform, machineID, candidate string, release uint64) (*rolloutReservation, string, error) {
+	if candidate == "" {
+		return nil, "no candidate binary", nil
+	}
+	tx, err := c.db.Begin()
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	st, err := c.loadPlatform(tx, platform, candidate, release)
+	if err != nil {
+		return nil, "", err
+	}
+	// Commit before every early return. loadPlatform may have inserted the
+	// platform row or bumped its generation, and the deferred Rollback would
+	// silently undo that — leaving a candidate change to be re-detected and
+	// re-bumped forever without a reservation ever being made. The same shape
+	// made the exhausted-attempt branch below roll its own halt back.
+	stop := func(reason string) (*rolloutReservation, string, error) {
+		if err := tx.Commit(); err != nil {
+			return nil, "", err
+		}
+		return nil, reason, nil
+	}
+
+	if st.Status == rolloutHalted {
+		return stop("rollout halted: " + st.HaltReason)
+	}
+	now := c.now()
+
+	// "Complete" means the fleet was caught up at the time, NOT that the
+	// rollout is closed forever. A machine that was offline through the whole
+	// rollout, or was enrolled afterwards, still needs the candidate — so its
+	// arrival reopens the batch stage. Validated history is preserved: the
+	// stage is not rewound and healthy slots stay healthy, so reopening costs
+	// no re-validation of machines that already passed.
+	if st.Status == rolloutComplete {
+		var existing int
+		if err := tx.QueryRow(`SELECT COUNT(*) FROM agent_rollout_slot
+			WHERE platform = ? AND generation = ? AND machine_id = ? AND state = ?`,
+			platform, st.Generation, machineID, rolloutHealthy).Scan(&existing); err != nil {
+			return nil, "", err
+		}
+		if existing > 0 {
+			return stop("") // this machine is already validated
+		}
+		reopened := st.Stage
+		if reopened < 1 {
+			reopened = 1 // never send a late arrival through the canary again
+		}
+		st.Stage = reopened
+		st.Status = rolloutActive
+		if _, err := tx.Exec(`UPDATE agent_rollout_platform
+			SET status = ?, stage = ?, updated_unix_ms = ?
+			WHERE platform = ? AND generation = ?`,
+			rolloutActive, reopened, now.UnixMilli(), platform, st.Generation); err != nil {
+			return nil, "", err
+		}
+	}
+
+	// An existing slot for this machine in this generation decides the answer.
+	var state string
+	var attempt, resends int
+	var offered sql.NullInt64
+	var deadline int64
+	err = tx.QueryRow(`SELECT state, attempt, resend_count, offered_unix_ms, deadline_unix_ms
+		FROM agent_rollout_slot WHERE platform = ? AND generation = ? AND machine_id = ?`,
+		platform, st.Generation, machineID).Scan(&state, &attempt, &resends, &offered, &deadline)
+	switch {
+	case err == nil:
+		switch state {
+		case rolloutHealthy:
+			return stop("") // already done; a duplicate trigger changes nothing
+		case rolloutFailed:
+			return stop("attempt failed; operator resume required")
+		case rolloutOffered, rolloutObserved:
+			// Already announced and awaiting proof. A duplicate trigger must
+			// not resend or extend the deadline.
+			return stop("")
+		case rolloutWithheld:
+			// Eligibility refusals are re-evaluated by the caller each tick;
+			// clearing the row lets a now-eligible machine be reserved.
+			if _, err := tx.Exec(`DELETE FROM agent_rollout_slot
+				WHERE platform = ? AND generation = ? AND machine_id = ?`,
+				platform, st.Generation, machineID); err != nil {
+				return nil, "", err
+			}
+		case rolloutReserved:
+			// Reserved but never marked offered. Either the process died
+			// before the write, or after it and before the mark — the durable
+			// state is identical and the hub cannot tell them apart. Recovery
+			// is a bounded resend under the SAME slot identity; delivery is
+			// at-least-once and is not claimed otherwise.
+			// Expiry first: resending into an attempt that has already run
+			// out of time would restart the clock by the back door.
+			if now.UnixMilli() > deadline {
+				if err := c.failSlotTx(tx, st, machineID, "never accepted the update offer"); err != nil {
+					return nil, "", err
+				}
+				return stop("attempt window expired")
+			}
+			if resends >= rolloutMaxResends {
+				if err := c.failSlotTx(tx, st, machineID, "exhausted automatic resend budget"); err != nil {
+					return nil, "", err
+				}
+				return stop("exhausted automatic resend budget")
+			}
+			// The DEADLINE AND GRACE ARE PRESERVED. An automatic resend is
+			// recovery within one attempt, not a new one: refreshing either
+			// would let a crash loop buy unlimited time, which is what the
+			// per-attempt bound exists to prevent. A new window is the
+			// operator's to grant, through resume().
+			if _, err := tx.Exec(`UPDATE agent_rollout_slot SET resend_count = resend_count + 1
+				WHERE platform = ? AND generation = ? AND machine_id = ?`,
+				platform, st.Generation, machineID); err != nil {
+				return nil, "", err
+			}
+			if err := tx.Commit(); err != nil {
+				return nil, "", err
+			}
+			return &rolloutReservation{Platform: platform, Generation: st.Generation,
+				MachineID: machineID, Stage: st.Stage, Attempt: attempt, Resend: true}, "", nil
+		}
+	case !errors.Is(err, sql.ErrNoRows):
+		return nil, "", err
+	}
+
+	// Capacity is OUTSTANDING UNVALIDATED work, not a lifetime row count.
+	// Healthy, failed and withheld rows accumulate for the life of a
+	// generation and must never shrink the batch.
+	var outstanding int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM agent_rollout_slot
+		WHERE platform = ? AND generation = ? AND state IN (?, ?, ?)`,
+		platform, st.Generation, rolloutReserved, rolloutOffered, rolloutObserved).Scan(&outstanding); err != nil {
+		return nil, "", err
+	}
+	if outstanding >= rolloutCapacity(st.Stage) {
+		return stop("") // the batch is full; this machine waits its turn
+	}
+
+	if _, err := tx.Exec(`INSERT INTO agent_rollout_slot
+		(platform, generation, machine_id, stage, attempt, state, reserved_unix_ms, offered_unix_ms, deadline_unix_ms, reason)
+		VALUES (?, ?, ?, ?, 1, ?, ?, NULL, ?, '')`,
+		platform, st.Generation, machineID, st.Stage, rolloutReserved,
+		now.UnixMilli(), now.Add(rolloutAttemptTimeout).UnixMilli()); err != nil {
+		return nil, "", err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, "", err
+	}
+	return &rolloutReservation{Platform: platform, Generation: st.Generation,
+		MachineID: machineID, Stage: st.Stage, Attempt: 1}, "", nil
+}
+
+// releaseBeforeSend gives a reservation back without recording an attempt.
+//
+// Used when the send boundary finds the rollout paused or the candidate
+// changed. The row is DELETED rather than marked: capacity must not be held by
+// something that was never offered, and the machine must stay eligible once
+// the operator resumes.
+//
+// The delete is conditioned on generation, attempt AND still being reserved,
+// so it can only ever remove the row this caller created. A blind delete would
+// race another path that has already offered or observed the slot and would
+// throw away a real attempt — or worse, real progress.
+func (c *rolloutController) releaseBeforeSend(r *rolloutReservation) error {
+	_, err := c.db.Exec(`DELETE FROM agent_rollout_slot
+		WHERE platform = ? AND generation = ? AND machine_id = ?
+		  AND attempt = ? AND state = ?`,
+		r.Platform, r.Generation, r.MachineID, r.Attempt, rolloutReserved)
+	return err
+}
+
+// markOffered records that the announcement write returned.
+func (c *rolloutController) markOffered(r *rolloutReservation) error {
+	_, err := c.db.Exec(`UPDATE agent_rollout_slot
+		SET state = ?, offered_unix_ms = ?
+		WHERE platform = ? AND generation = ? AND machine_id = ? AND attempt = ? AND state = ?`,
+		rolloutOffered, c.now().UnixMilli(),
+		r.Platform, r.Generation, r.MachineID, r.Attempt, rolloutReserved)
+	return err
+}
+
+// withhold records an eligibility refusal, visibly and without halting.
+func (c *rolloutController) withhold(platform, machineID, candidate string, release uint64, reason string) error {
+	tx, err := c.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	st, err := c.loadPlatform(tx, platform, candidate, release)
+	if err != nil {
+		return err
+	}
+	now := c.now().UnixMilli()
+	if _, err := tx.Exec(`INSERT INTO agent_rollout_slot
+		(platform, generation, machine_id, stage, attempt, state, reserved_unix_ms, offered_unix_ms, deadline_unix_ms, reason)
+		VALUES (?, ?, ?, ?, 0, ?, ?, NULL, ?, ?)
+		ON CONFLICT (platform, generation, machine_id) DO UPDATE SET
+			state = excluded.state, reason = excluded.reason
+		WHERE agent_rollout_slot.state IN (?, ?)`,
+		platform, st.Generation, machineID, st.Stage, rolloutWithheld, now, now, reason,
+		rolloutWithheld, rolloutReserved); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (c *rolloutController) failSlotTx(tx *sql.Tx, st rolloutPlatformState, machineID, reason string) error {
+	if _, err := tx.Exec(`UPDATE agent_rollout_slot SET state = ?, reason = ?
+		WHERE platform = ? AND generation = ? AND machine_id = ?`,
+		rolloutFailed, reason, st.Platform, st.Generation, machineID); err != nil {
+		return err
+	}
+	// One failed attempt halts the platform. There is no separate failure
+	// counter: exposure is already bounded to a canary or a pair, so a second
+	// data point would cost another machine to learn the same thing.
+	_, err := tx.Exec(`UPDATE agent_rollout_platform
+		SET status = ?, halt_reason = ?, updated_unix_ms = ?
+		WHERE platform = ? AND generation = ?`,
+		rolloutHalted, fmt.Sprintf("%s: %s", machineID, reason), c.now().UnixMilli(),
+		st.Platform, st.Generation)
+	return err
+}
+
+/* ----------------------------------------------------------------------------
+ * Health evidence — bound to a connection, never to a machine
+ *
+ * agentRunningVersions is keyed by machine ID and survives a socket
+ * replacement, so a machine that reported the candidate, dropped, and
+ * reconnected would still "match" — and a brand-new socket would inherit proof
+ * it never produced. That map stays for the UI and for compatibility, but it
+ * cannot establish health on its own.
+ *
+ * Everything below is keyed on the *ConnectedAgent pointer. A replaced socket
+ * is a different pointer, so evidence cannot carry across a reconnect, and the
+ * registry is consulted so a displaced old socket cannot supply evidence for a
+ * machine it no longer owns.
+ * -------------------------------------------------------------------------- */
+
+// observeCandidateReport records that a machine reported the candidate SHA ON
+// THIS CONNECTION. Dwell starts here, at hub receipt time.
+func (c *rolloutController) observeCandidateReport(platform, machineID string, conn *ConnectedAgent,
+	generation int64, running, candidate string) {
+	if conn == nil || candidate == "" {
+		return
+	}
+	if !c.ownsConnection(machineID, conn) {
+		return // a displaced socket cannot report on the machine's behalf
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := rolloutKey(platform, machineID)
+	ev := c.evidence[key]
+	if ev == nil || ev.conn != conn || ev.generation != generation || !strings.EqualFold(ev.candidate, candidate) {
+		// A different socket, a different generation, or different bytes:
+		// start from nothing rather than inherit somebody else's dwell.
+		ev = &rolloutEvidence{conn: conn, generation: generation, candidate: strings.ToLower(candidate)}
+		c.evidence[key] = ev
+	}
+	if !strings.EqualFold(running, candidate) {
+		// Reporting something else on this connection ends any dwell: the
+		// machine is not on the candidate now, whatever it said before.
+		ev.sawCandidate = false
+		ev.dwellStart = time.Time{}
+		return
+	}
+	// A version report establishes WHICH BYTES are running and nothing more.
+	// It does not advance the dwell, because being told a version is not the
+	// same as observing a machine work.
+	ev.sawCandidate = true
+}
+
+// noteMetrics records a metrics frame and restarts the dwell if the connection
+// went quiet for longer than the allowed gap.
+//
+// The gap is measured BEFORE lastMetrics is overwritten. Overwriting first
+// would let a single post-silence frame launder the silence: the connection
+// would look freshly alive, the dwell start would be untouched, and a machine
+// that went quiet for the whole window would be declared healthy on the
+// strength of two endpoints with nothing between them.
+func (e *rolloutEvidence) noteMetrics(now time.Time) {
+	switch {
+	case !e.sawCandidate:
+		// Nothing to accrue toward yet.
+		e.lastMetrics = now
+		e.dwellStart = time.Time{}
+		return
+	case e.dwellStart.IsZero():
+		e.dwellStart = now
+	case !e.lastMetrics.IsZero() && now.Sub(e.lastMetrics) > rolloutTelemetryGap:
+		e.dwellStart = now
+	}
+	e.lastMetrics = now
+}
+
+// observeTelemetry records a hub-received frame on this connection.
+//
+// Hub receipt time, never an agent timestamp: a stalled agent can keep
+// asserting its own freshness, and a clock that is wrong makes the claim
+// meaningless either way.
+func (c *rolloutController) observeTelemetry(platform, machineID string, conn *ConnectedAgent) {
+	if conn == nil {
+		return
+	}
+	key := rolloutKey(platform, machineID)
+	if !c.ownsConnection(machineID, conn) {
+		// A displaced socket's frames are dropped outright. They must neither
+		// sustain a dwell nor destroy the current connection's evidence.
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ev := c.evidence[key]
+	if ev == nil || ev.conn != conn {
+		// The ownership check above happened OUTSIDE this lock, so a
+		// registration could have changed in between and this frame could be
+		// the displaced one by the time it arrives here. Re-check under the
+		// lock before discarding: an existing record that belongs to the
+		// current owner is never replaced by a different connection, so a late
+		// frame from a losing socket cannot wipe out valid proof.
+		if ev != nil && c.ownsLocked(machineID, ev.conn) {
+			return
+		}
+		ev = &rolloutEvidence{conn: conn}
+		c.evidence[key] = ev
+	}
+	ev.noteMetrics(c.now())
+}
+
+// forgetConnection drops evidence when a socket goes away.
+func (c *rolloutController) forgetConnection(platform, machineID string, conn *ConnectedAgent) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := rolloutKey(platform, machineID)
+	if ev := c.evidence[key]; ev != nil && (conn == nil || ev.conn == conn) {
+		delete(c.evidence, key)
+	}
+}
+
+// dwellSatisfied reports whether this machine has proven itself on the
+// connection the registry currently owns for it.
+func (c *rolloutController) dwellSatisfied(s *Server, platform, machineID string,
+	generation int64, candidate string) (bool, string) {
+	c.mu.Lock()
+	ev := c.evidence[rolloutKey(platform, machineID)]
+	var conn *ConnectedAgent
+	var sawCandidate bool
+	var evGeneration int64
+	var evCandidate string
+	var dwellStart, lastMetrics time.Time
+	if ev != nil {
+		conn, sawCandidate, dwellStart, lastMetrics = ev.conn, ev.sawCandidate, ev.dwellStart, ev.lastMetrics
+		evGeneration, evCandidate = ev.generation, ev.candidate
+	}
+	c.mu.Unlock()
+
+	if ev == nil || conn == nil {
+		return false, "no live connection evidence"
+	}
+	if evGeneration != generation || !strings.EqualFold(evCandidate, candidate) {
+		return false, "evidence is for a different candidate"
+	}
+	// The registry decides who owns the machine right now. A displaced socket
+	// may still be readable and must not vouch for anything.
+	if !c.ownsConnection(machineID, conn) {
+		return false, "evidence belongs to a replaced connection"
+	}
+	_ = s
+	if !sawCandidate {
+		return false, "candidate not reported on this connection"
+	}
+	if dwellStart.IsZero() {
+		return false, "no metrics observed since the candidate was reported"
+	}
+	now := c.now()
+	if now.Sub(lastMetrics) > rolloutTelemetryGap {
+		return false, "metrics stale on this connection"
+	}
+	// The dwell is measured between METRICS FRAMES, not against the clock.
+	// Comparing now against the start would complete a dwell during silence,
+	// so the endpoint has to be an observation rather than a timer expiring.
+	if lastMetrics.Sub(dwellStart) < rolloutDwell {
+		return false, "dwell in progress"
+	}
+	return true, ""
+}
+
+/* ----------------------------------------------------------------------------
+ * Send ownership
+ *
+ * Durable state alone does not prevent two goroutines from both re-sending a
+ * recovered attempt: they can read the same row before either writes. An
+ * in-process claim per (platform, generation, machine, attempt) makes a send
+ * single-owner within this hub, on top of the durable state that makes it
+ * single-owner across restarts.
+ * -------------------------------------------------------------------------- */
+
+func (c *rolloutController) claimSend(r *rolloutReservation) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.sending == nil {
+		c.sending = map[string]bool{}
+	}
+	key := fmt.Sprintf("%s\x00%d\x00%s\x00%d", r.Platform, r.Generation, r.MachineID, r.Attempt)
+	if c.sending[key] {
+		return false
+	}
+	c.sending[key] = true
+	return true
+}
+
+func (c *rolloutController) releaseSend(r *rolloutReservation) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.sending, fmt.Sprintf("%s\x00%d\x00%s\x00%d", r.Platform, r.Generation, r.MachineID, r.Attempt))
+}
+
+/* ----------------------------------------------------------------------------
+ * Progression
+ *
+ * The loop owns advancement. Triggers (a connect, a version report, a resume)
+ * only wake it; none of them decides anything, which is what keeps racing
+ * triggers from each advancing a stage or resending an attempt.
+ * -------------------------------------------------------------------------- */
+
+// tick promotes validated slots, advances stages and expires attempts for one
+// platform. It takes no lock across socket I/O and performs none.
+func (c *rolloutController) tick(s *Server, platform string) error {
+	st, err := c.platformState(platform)
+	if err != nil || st == nil || st.Status != rolloutActive {
+		return err
+	}
+
+	rows, err := c.db.Query(`SELECT machine_id, state, deadline_unix_ms
+		FROM agent_rollout_slot
+		WHERE platform = ? AND generation = ? AND state IN (?, ?, ?)`,
+		platform, st.Generation, rolloutReserved, rolloutOffered, rolloutObserved)
+	if err != nil {
+		return err
+	}
+	type live struct {
+		machineID string
+		state     string
+		deadline  int64
+	}
+	var outstanding []live
+	for rows.Next() {
+		var l live
+		if err := rows.Scan(&l.machineID, &l.state, &l.deadline); err != nil {
+			rows.Close()
+			return err
+		}
+		outstanding = append(outstanding, l)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+
+	now := c.now()
+	for _, l := range outstanding {
+		if ok, _ := c.dwellSatisfied(s, platform, l.machineID, st.Generation, st.Candidate); ok {
+			if _, err := c.db.Exec(`UPDATE agent_rollout_slot SET state = ?, reason = ''
+				WHERE platform = ? AND generation = ? AND machine_id = ?`,
+				rolloutHealthy, platform, st.Generation, l.machineID); err != nil {
+				return err
+			}
+			continue
+		}
+		if now.UnixMilli() > l.deadline {
+			reason := "did not prove a healthy connection within the attempt window"
+			if l.state == rolloutReserved {
+				reason = "never accepted the update offer"
+			}
+			tx, err := c.db.Begin()
+			if err != nil {
+				return err
+			}
+			if err := c.failSlotTx(tx, *st, l.machineID, reason); err != nil {
+				_ = tx.Rollback()
+				return err
+			}
+			if err := tx.Commit(); err != nil {
+				return err
+			}
+			return nil // halted; nothing further advances this platform
+		}
+	}
+
+	// Advancement is ONE statement, with both conditions evaluated inside it.
+	//
+	// Counting first and then updating does not work, and a compare-on-stage
+	// does not rescue it: a reservation admitted between the count and the
+	// write does not change the stage, so the update still fires and the stage
+	// advances past work that was just accepted. The subqueries below are
+	// evaluated under the same write lock as the update itself, so no
+	// reservation can slip between them.
+	//
+	// Two conditions, both necessary. NOT EXISTS outstanding is "this stage
+	// has nothing left in flight". EXISTS healthy is "this stage actually
+	// proved something" — without it, a platform with no slots at all would
+	// advance on every tick and be at batch size before its first machine ever
+	// connected, and a stage whose every candidate was WITHHELD would advance
+	// having learned nothing about the build.
+	result, err := c.db.Exec(`UPDATE agent_rollout_platform
+		SET stage = stage + 1, updated_unix_ms = ?
+		WHERE platform = ? AND generation = ? AND status = ? AND stage = ?
+		  AND NOT EXISTS (
+		        SELECT 1 FROM agent_rollout_slot s
+		        WHERE s.platform = agent_rollout_platform.platform
+		          AND s.generation = agent_rollout_platform.generation
+		          AND s.stage = agent_rollout_platform.stage
+		          AND s.state IN (?, ?, ?))
+		  AND EXISTS (
+		        SELECT 1 FROM agent_rollout_slot s
+		        WHERE s.platform = agent_rollout_platform.platform
+		          AND s.generation = agent_rollout_platform.generation
+		          AND s.stage = agent_rollout_platform.stage
+		          AND s.state = ?)`,
+		now.UnixMilli(), platform, st.Generation, rolloutActive, st.Stage,
+		rolloutReserved, rolloutOffered, rolloutObserved, rolloutHealthy)
+	if err != nil {
+		return err
+	}
+	_, _ = result.RowsAffected()
+	return nil
+}
+
+// markComplete records that every eligible machine the hub can currently see
+// is validated. Reversible by definition — see reserve().
+func (c *rolloutController) markComplete(platform string) error {
+	_, err := c.db.Exec(`UPDATE agent_rollout_platform
+		SET status = ?, updated_unix_ms = ?
+		WHERE platform = ? AND status = ?`,
+		rolloutComplete, c.now().UnixMilli(), platform, rolloutActive)
+	return err
+}
+
+func (c *rolloutController) platformState(platform string) (*rolloutPlatformState, error) {
+	var st rolloutPlatformState
+	st.Platform = platform
+	err := c.db.QueryRow(`SELECT generation, candidate_sha, candidate_release, stage, status, halt_reason
+		FROM agent_rollout_platform WHERE platform = ?`, platform).
+		Scan(&st.Generation, &st.Candidate, &st.Release, &st.Stage, &st.Status, &st.HaltReason)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &st, nil
+}
+
+// rolloutStatus is what an operator is shown.
+type rolloutStatus struct {
+	Platform   string `json:"platform"`
+	Generation int64  `json:"generation"`
+	Candidate  string `json:"candidate_sha"`
+	Stage      int    `json:"stage"`
+	Status     string `json:"status"`
+	HaltReason string `json:"halt_reason,omitempty"`
+	// Updated counts machines RUNNING the candidate — validated ones and
+	// those still proving themselves. Counting only validated slots would
+	// report a machine that has already taken the update as not updated,
+	// which reads as a stalled rollout when it is a working one.
+	Updated int `json:"updated"`
+	// Validated is the subset that has completed its dwell.
+	Validated int `json:"validated"`
+	// Pending is reserved or offered: not yet known to be running it.
+	Pending int `json:"pending"`
+	// Withheld machines are ineligible, with reasons. Not failures.
+	Withheld       int               `json:"withheld"`
+	WithheldReason map[string]string `json:"withheld_reasons,omitempty"`
+	Failed         int               `json:"failed"`
+	FailedReason   map[string]string `json:"failed_reasons,omitempty"`
+}
+
+func (c *rolloutController) status(platform string) (*rolloutStatus, error) {
+	st, err := c.platformState(platform)
+	if err != nil || st == nil {
+		return nil, err
+	}
+	out := &rolloutStatus{Platform: platform, Generation: st.Generation, Candidate: st.Candidate,
+		Stage: st.Stage, Status: st.Status, HaltReason: st.HaltReason,
+		WithheldReason: map[string]string{}, FailedReason: map[string]string{}}
+
+	rows, err := c.db.Query(`SELECT machine_id, state, reason FROM agent_rollout_slot
+		WHERE platform = ? AND generation = ?`, platform, st.Generation)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var machineID, state, reason string
+		if err := rows.Scan(&machineID, &state, &reason); err != nil {
+			return nil, err
+		}
+		switch state {
+		case rolloutHealthy:
+			out.Validated++
+			out.Updated++
+		case rolloutObserved:
+			// Running the candidate, dwell still accruing.
+			out.Updated++
+		case rolloutReserved, rolloutOffered:
+			out.Pending++
+		case rolloutWithheld:
+			out.Withheld++
+			out.WithheldReason[machineID] = reason
+		case rolloutFailed:
+			out.Failed++
+			out.FailedReason[machineID] = reason
+		}
+	}
+	return out, rows.Err()
+}
+
+// resume clears a halt and gives every failed slot a NEW attempt.
+//
+// Without the new attempt this is inert: failed rows are terminal, so an
+// operator would clear the halt and watch nothing happen. A fresh attempt
+// number also resets the restart grace, so recovery gets its own bounded
+// window rather than inheriting an exhausted one.
+func (c *rolloutController) resume(platform string) error {
+	tx, err := c.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Read the platform row through THIS transaction. Calling platformState
+	// here used c.db while the transaction already held the only pooled
+	// connection, and resume deadlocked outright.
+	var generation int64
+	if err := tx.QueryRow(`SELECT generation FROM agent_rollout_platform WHERE platform = ?`,
+		platform).Scan(&generation); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return tx.Commit()
+		}
+		return err
+	}
+	now := c.now()
+	// Every failed slot, with NO attempt cap. An operator asking again is a
+	// decision, not a retry budget; bounding it by the automatic resend
+	// counter is what made Resume clear the halt and then move nothing.
+	if _, err := tx.Exec(`UPDATE agent_rollout_slot
+		SET state = ?, attempt = attempt + 1, resend_count = 0, grace_used = 0,
+		    offered_unix_ms = NULL, deadline_unix_ms = ?, reason = ''
+		WHERE platform = ? AND generation = ? AND state = ?`,
+		rolloutReserved, now.Add(rolloutAttemptTimeout).UnixMilli(),
+		platform, generation, rolloutFailed); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`UPDATE agent_rollout_platform
+		SET status = ?, halt_reason = '', updated_unix_ms = ?
+		WHERE platform = ? AND generation = ?`,
+		rolloutActive, now.UnixMilli(), platform, generation); err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/hub/agent_rollout.go
+++ b/hub/agent_rollout.go
@@ -63,6 +63,10 @@ const (
 	// rolloutRestartGrace is added once to every live deadline when the
 	// controller is built, so hub downtime is not charged to an attempt.
 	rolloutRestartGrace = 5 * time.Minute
+	// rolloutTickInterval is how often the single scheduler evaluates dwell
+	// and advancement. Short relative to the dwell, so a validated machine
+	// does not wait long to be promoted.
+	rolloutTickInterval = 10 * time.Second
 )
 
 // Slot states.

--- a/hub/agent_rollout.go
+++ b/hub/agent_rollout.go
@@ -472,6 +472,38 @@ func (c *rolloutController) releaseBeforeSend(r *rolloutReservation) error {
 	return err
 }
 
+// forgetEvidence drops a machine's in-memory dwell evidence.
+//
+// Durable slots are NOT touched here: they are deleted inside the machine's
+// own delete transaction, so a rollback keeps them.
+func (c *rolloutController) forgetEvidence(machineID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key := range c.evidence {
+		if strings.HasSuffix(key, "\x00"+machineID) {
+			delete(c.evidence, key)
+		}
+	}
+}
+
+// observeRunningCandidate records that a machine is running the candidate.
+//
+// reserved or offered only. Terminal states are left alone: a healthy slot has
+// already been validated, and a failed one is the operator's to retry — a
+// report arriving afterwards must not quietly reopen either.
+//
+// This is also how the ambiguous crash window resolves. A process that died
+// between the socket write and the mark leaves a slot that says "reserved"
+// whether or not the agent ever received the offer; when the machine comes
+// back running the candidate, that question is answered by the machine rather
+// than by bookkeeping the hub lost.
+func (c *rolloutController) observeRunningCandidate(platform, machineID string, generation int64) error {
+	_, err := c.db.Exec(`UPDATE agent_rollout_slot SET state = ?
+		WHERE platform = ? AND generation = ? AND machine_id = ? AND state IN (?, ?)`,
+		rolloutObserved, platform, generation, machineID, rolloutReserved, rolloutOffered)
+	return err
+}
+
 // markOffered records that the announcement write returned.
 func (c *rolloutController) markOffered(r *rolloutReservation) error {
 	_, err := c.db.Exec(`UPDATE agent_rollout_slot
@@ -971,7 +1003,15 @@ func (c *rolloutController) resume(platform string) error {
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
+	if err := c.resumeTx(tx, platform); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
 
+// resumeTx is resume inside a caller's transaction, so an operator resume can
+// clear the pause and retry the failed attempts as one atomic change.
+func (c *rolloutController) resumeTx(tx *sql.Tx, platform string) error {
 	// Read the platform row through THIS transaction. Calling platformState
 	// here used c.db while the transaction already held the only pooled
 	// connection, and resume deadlocked outright.
@@ -979,7 +1019,7 @@ func (c *rolloutController) resume(platform string) error {
 	if err := tx.QueryRow(`SELECT generation FROM agent_rollout_platform WHERE platform = ?`,
 		platform).Scan(&generation); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return tx.Commit()
+			return nil // nothing rolled out on this platform yet
 		}
 		return err
 	}
@@ -1001,5 +1041,5 @@ func (c *rolloutController) resume(platform string) error {
 		rolloutActive, now.UnixMilli(), platform, generation); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return nil
 }

--- a/hub/agent_rollout.go
+++ b/hub/agent_rollout.go
@@ -119,6 +119,9 @@ type rolloutEvidence struct {
 	// metrics frame. Hub receipt time throughout: an agent's own timestamp is
 	// its claim about itself, and a stalled one keeps asserting freshness.
 	lastMetrics time.Time
+	// touched is the last time this record was written, used only to bound how
+	// many records one machine may accumulate.
+	touched time.Time
 }
 
 type rolloutController struct {
@@ -126,50 +129,41 @@ type rolloutController struct {
 	now func() time.Time
 
 	mu sync.Mutex
-	// evidence is keyed platform + "\x00" + machineID. Empty at construction.
-	evidence map[string]*rolloutEvidence
+	// evidence is keyed platform + "\x00" + machineID, then by the CONNECTION
+	// that produced it. Per-connection keys are what make writes safe without
+	// an ownership check: a socket can only write into its own record, so no
+	// interleaving lets one clobber another's. Empty at construction.
+	evidence map[string]map[*ConnectedAgent]*rolloutEvidence
 	// sending claims a (platform, generation, machine, attempt) for one
 	// goroutine, so concurrent recovery triggers cannot both resend.
 	sending map[string]bool
 
-	// owns reports whether a connection is the one the registry currently
-	// holds for a machine. This is THE ownership boundary for evidence.
-	//
-	// Pointer inequality alone is not it. A displaced old socket can still be
-	// readable for a while, and letting any different pointer replace the
-	// record would let those late frames wipe out the current connection's
-	// valid proof — a denial of progress driven by the very socket that lost
-	// the machine. The registry is the authority on who owns it now.
-	owns func(machineID string, conn *ConnectedAgent) bool
+	// current returns the connection the registry currently holds for a
+	// machine. It is called ONLY from dwellSatisfied, and never while c.mu is
+	// held, so the evidence lock and the registry lock have exactly one
+	// ordering and cannot deadlock against each other.
+	current func(machineID string) *ConnectedAgent
+	// currentMu guards `current` alone, so reading it does not require c.mu
+	// and cannot be part of any ordering with the registry.
+	currentMu sync.RWMutex
 }
 
 // attachRegistry points the controller at the live agent registry.
-func (c *rolloutController) attachRegistry(owns func(string, *ConnectedAgent) bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.owns = owns
+func (c *rolloutController) attachRegistry(current func(string) *ConnectedAgent) {
+	c.currentMu.Lock()
+	defer c.currentMu.Unlock()
+	c.current = current
 }
 
-// ownsConnection defaults to true only when no registry is attached, which is
-// the case in unit tests that drive the controller directly.
-func (c *rolloutController) ownsConnection(machineID string, conn *ConnectedAgent) bool {
-	c.mu.Lock()
-	owns := c.owns
-	c.mu.Unlock()
-	if owns == nil {
-		return true
+// currentConnection asks the registry who owns a machine right now.
+func (c *rolloutController) currentConnection(machineID string) *ConnectedAgent {
+	c.currentMu.RLock()
+	lookup := c.current
+	c.currentMu.RUnlock()
+	if lookup == nil {
+		return nil
 	}
-	return owns(machineID, conn)
-}
-
-// ownsLocked is ownsConnection for a caller that already holds c.mu. The
-// registry callback takes the agent registry's own lock, never this one, so
-// calling it here does not invert a lock order.
-func (c *rolloutController) ownsLocked(machineID string, conn *ConnectedAgent) bool {
-	if c.owns == nil {
-		return true
-	}
-	return c.owns(machineID, conn)
+	return lookup(machineID)
 }
 
 func rolloutKey(platform, machineID string) string {
@@ -194,7 +188,8 @@ func newRolloutController(db *sql.DB, now func() time.Time) (*rolloutController,
 	if now == nil {
 		now = time.Now
 	}
-	c := &rolloutController{db: db, now: now, evidence: map[string]*rolloutEvidence{}}
+	c := &rolloutController{db: db, now: now,
+		evidence: map[string]map[*ConnectedAgent]*rolloutEvidence{}}
 	if err := c.reconcileAfterRestart(); err != nil {
 		return nil, err
 	}
@@ -540,29 +535,37 @@ func (c *rolloutController) failSlotTx(tx *sql.Tx, st rolloutPlatformState, mach
  * machine it no longer owns.
  * -------------------------------------------------------------------------- */
 
-// observeCandidateReport records that a machine reported the candidate SHA ON
-// THIS CONNECTION. Dwell starts here, at hub receipt time.
+// observeCandidateReport records that a machine reported a SHA on THIS
+// connection.
+//
+// No ownership check, and none is needed: evidence is filed under the
+// connection that produced it, so a socket can only ever write into its own
+// record. A displaced one writes into a record nobody reads.
+//
+// The previous shape checked ownership OUTSIDE the lock and then replaced the
+// machine's single record under it. A report from a socket that was still the
+// owner when it was checked, and had lost the machine by the time it took the
+// lock, would overwrite the winner's proof — and nothing about the check
+// prevented it, because the check had already passed.
 func (c *rolloutController) observeCandidateReport(platform, machineID string, conn *ConnectedAgent,
 	generation int64, running, candidate string) {
 	if conn == nil || candidate == "" {
 		return
 	}
-	if !c.ownsConnection(machineID, conn) {
-		return // a displaced socket cannot report on the machine's behalf
-	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	key := rolloutKey(platform, machineID)
-	ev := c.evidence[key]
-	if ev == nil || ev.conn != conn || ev.generation != generation || !strings.EqualFold(ev.candidate, candidate) {
-		// A different socket, a different generation, or different bytes:
-		// start from nothing rather than inherit somebody else's dwell.
-		ev = &rolloutEvidence{conn: conn, generation: generation, candidate: strings.ToLower(candidate)}
-		c.evidence[key] = ev
+	ev := c.evidenceFor(platform, machineID, conn)
+	if ev.generation != generation || !strings.EqualFold(ev.candidate, candidate) {
+		// Different bytes or a different generation: this connection has
+		// proven nothing about them yet.
+		ev.generation = generation
+		ev.candidate = strings.ToLower(candidate)
+		ev.sawCandidate = false
+		ev.dwellStart = time.Time{}
 	}
 	if !strings.EqualFold(running, candidate) {
-		// Reporting something else on this connection ends any dwell: the
-		// machine is not on the candidate now, whatever it said before.
+		// Reporting something else ends this connection's dwell: the machine
+		// is not on the candidate now, whatever it said before.
 		ev.sawCandidate = false
 		ev.dwellStart = time.Time{}
 		return
@@ -571,6 +574,7 @@ func (c *rolloutController) observeCandidateReport(platform, machineID string, c
 	// It does not advance the dwell, because being told a version is not the
 	// same as observing a machine work.
 	ev.sawCandidate = true
+	ev.touched = c.now()
 }
 
 // noteMetrics records a metrics frame and restarts the dwell if the connection
@@ -596,79 +600,111 @@ func (e *rolloutEvidence) noteMetrics(now time.Time) {
 	e.lastMetrics = now
 }
 
-// observeTelemetry records a hub-received frame on this connection.
+// observeTelemetry records a hub-received metrics frame on this connection.
 //
 // Hub receipt time, never an agent timestamp: a stalled agent can keep
-// asserting its own freshness, and a clock that is wrong makes the claim
-// meaningless either way.
+// asserting its own freshness, and a wrong clock makes the claim meaningless
+// either way.
 func (c *rolloutController) observeTelemetry(platform, machineID string, conn *ConnectedAgent) {
 	if conn == nil {
 		return
 	}
-	key := rolloutKey(platform, machineID)
-	if !c.ownsConnection(machineID, conn) {
-		// A displaced socket's frames are dropped outright. They must neither
-		// sustain a dwell nor destroy the current connection's evidence.
-		return
-	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	ev := c.evidence[key]
-	if ev == nil || ev.conn != conn {
-		// The ownership check above happened OUTSIDE this lock, so a
-		// registration could have changed in between and this frame could be
-		// the displaced one by the time it arrives here. Re-check under the
-		// lock before discarding: an existing record that belongs to the
-		// current owner is never replaced by a different connection, so a late
-		// frame from a losing socket cannot wipe out valid proof.
-		if ev != nil && c.ownsLocked(machineID, ev.conn) {
-			return
-		}
-		ev = &rolloutEvidence{conn: conn}
-		c.evidence[key] = ev
-	}
-	ev.noteMetrics(c.now())
+	c.evidenceFor(platform, machineID, conn).noteMetrics(c.now())
 }
 
-// forgetConnection drops evidence when a socket goes away.
+// evidenceFor returns this connection's own record, creating it if needed.
+// Caller holds c.mu.
+func (c *rolloutController) evidenceFor(platform, machineID string, conn *ConnectedAgent) *rolloutEvidence {
+	key := rolloutKey(platform, machineID)
+	byConn := c.evidence[key]
+	if byConn == nil {
+		byConn = map[*ConnectedAgent]*rolloutEvidence{}
+		c.evidence[key] = byConn
+	}
+	ev := byConn[conn]
+	if ev == nil {
+		ev = &rolloutEvidence{conn: conn, touched: c.now()}
+		byConn[conn] = ev
+		c.pruneLocked(key, byConn)
+	}
+	return ev
+}
+
+// rolloutMaxEvidencePerMachine bounds records kept for one machine. A machine
+// that reconnects repeatedly would otherwise accumulate one per socket; a
+// disconnect normally removes its own, and this covers the case where it does
+// not.
+const rolloutMaxEvidencePerMachine = 4
+
+func (c *rolloutController) pruneLocked(key string, byConn map[*ConnectedAgent]*rolloutEvidence) {
+	for len(byConn) > rolloutMaxEvidencePerMachine {
+		var oldest *ConnectedAgent
+		var oldestAt time.Time
+		for conn, ev := range byConn {
+			if oldest == nil || ev.touched.Before(oldestAt) {
+				oldest, oldestAt = conn, ev.touched
+			}
+		}
+		delete(byConn, oldest)
+	}
+}
+
+// forgetConnection drops a connection's evidence when its socket goes away.
 func (c *rolloutController) forgetConnection(platform, machineID string, conn *ConnectedAgent) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	key := rolloutKey(platform, machineID)
-	if ev := c.evidence[key]; ev != nil && (conn == nil || ev.conn == conn) {
+	byConn := c.evidence[key]
+	if byConn == nil {
+		return
+	}
+	if conn == nil {
+		delete(c.evidence, key)
+		return
+	}
+	delete(byConn, conn)
+	if len(byConn) == 0 {
 		delete(c.evidence, key)
 	}
 }
 
-// dwellSatisfied reports whether this machine has proven itself on the
+// dwellSatisfied reports whether the machine has proven itself on the
 // connection the registry currently owns for it.
-func (c *rolloutController) dwellSatisfied(s *Server, platform, machineID string,
+//
+// The registry is consulted ONCE, here, and outside c.mu — so no path ever
+// holds the evidence lock while reaching into the agent registry, and the lock
+// order between them cannot invert. Reads select the current owner's record;
+// writes only ever touch their own. Neither can clobber the other.
+func (c *rolloutController) dwellSatisfied(platform, machineID string,
 	generation int64, candidate string) (bool, string) {
+	current := c.currentConnection(machineID)
+	if current == nil {
+		return false, "machine is not connected"
+	}
+
 	c.mu.Lock()
-	ev := c.evidence[rolloutKey(platform, machineID)]
-	var conn *ConnectedAgent
+	var ev *rolloutEvidence
+	if byConn := c.evidence[rolloutKey(platform, machineID)]; byConn != nil {
+		ev = byConn[current]
+	}
 	var sawCandidate bool
 	var evGeneration int64
 	var evCandidate string
 	var dwellStart, lastMetrics time.Time
 	if ev != nil {
-		conn, sawCandidate, dwellStart, lastMetrics = ev.conn, ev.sawCandidate, ev.dwellStart, ev.lastMetrics
+		sawCandidate, dwellStart, lastMetrics = ev.sawCandidate, ev.dwellStart, ev.lastMetrics
 		evGeneration, evCandidate = ev.generation, ev.candidate
 	}
 	c.mu.Unlock()
 
-	if ev == nil || conn == nil {
-		return false, "no live connection evidence"
+	if ev == nil {
+		return false, "no evidence from the current connection"
 	}
 	if evGeneration != generation || !strings.EqualFold(evCandidate, candidate) {
 		return false, "evidence is for a different candidate"
 	}
-	// The registry decides who owns the machine right now. A displaced socket
-	// may still be readable and must not vouch for anything.
-	if !c.ownsConnection(machineID, conn) {
-		return false, "evidence belongs to a replaced connection"
-	}
-	_ = s
 	if !sawCandidate {
 		return false, "candidate not reported on this connection"
 	}
@@ -728,7 +764,7 @@ func (c *rolloutController) releaseSend(r *rolloutReservation) {
 
 // tick promotes validated slots, advances stages and expires attempts for one
 // platform. It takes no lock across socket I/O and performs none.
-func (c *rolloutController) tick(s *Server, platform string) error {
+func (c *rolloutController) tick(platform string) error {
 	st, err := c.platformState(platform)
 	if err != nil || st == nil || st.Status != rolloutActive {
 		return err
@@ -763,7 +799,7 @@ func (c *rolloutController) tick(s *Server, platform string) error {
 
 	now := c.now()
 	for _, l := range outstanding {
-		if ok, _ := c.dwellSatisfied(s, platform, l.machineID, st.Generation, st.Candidate); ok {
+		if ok, _ := c.dwellSatisfied(platform, l.machineID, st.Generation, st.Candidate); ok {
 			if _, err := c.db.Exec(`UPDATE agent_rollout_slot SET state = ?, reason = ''
 				WHERE platform = ? AND generation = ? AND machine_id = ?`,
 				rolloutHealthy, platform, st.Generation, l.machineID); err != nil {

--- a/hub/agent_rollout.go
+++ b/hub/agent_rollout.go
@@ -301,6 +301,16 @@ type rolloutReservation struct {
 	Resend bool
 }
 
+// rolloutUnconfirmedReason is what an expired RESERVED slot is told to say.
+//
+// Not "never accepted the update offer". Reserved is the explicitly AMBIGUOUS
+// state: the socket write may have landed and the process died before the
+// record of it, so the hub does not know whether the machine ever saw the
+// offer. Blaming the machine for refusing something it may have received —
+// and may be running — is a claim the hub cannot support, and it is the first
+// thing an operator reads when a platform halts.
+const rolloutUnconfirmedReason = "update was not confirmed within the attempt window"
+
 // reserve takes one slot for a machine, or reports why it did not.
 //
 // The capacity check, the stage read and the insert are ONE transaction, and
@@ -376,7 +386,7 @@ func (c *rolloutController) reserve(platform, machineID, candidate string, relea
 			// Expiry first: resending into an attempt that has already run
 			// out of time would restart the clock by the back door.
 			if now.UnixMilli() > deadline {
-				if err := c.failSlotTx(tx, st, machineID, "never accepted the update offer"); err != nil {
+				if err := c.failSlotTx(tx, st, machineID, rolloutUnconfirmedReason); err != nil {
 					return nil, "", err
 				}
 				return stop("attempt window expired")
@@ -823,7 +833,7 @@ func (c *rolloutController) tick(platform string) error {
 		if now.UnixMilli() > l.deadline {
 			reason := "did not prove a healthy connection within the attempt window"
 			if l.state == rolloutReserved {
-				reason = "never accepted the update offer"
+				reason = rolloutUnconfirmedReason
 			}
 			tx, err := c.db.Begin()
 			if err != nil {
@@ -915,13 +925,31 @@ type rolloutStatus struct {
 	// counted as updated the moment it failed — leaving "0 updated, 1 failed"
 	// for a machine demonstrably on the new build.
 	//
-	// It is a count for THIS generation's slots only. Machines that were
-	// already current, and so never needed one, are not represented here at
-	// all; MachinesTotal on the fleet endpoints is the denominator, not this.
+	// It is HISTORICAL and scoped to THIS generation's slots: ran_candidate is
+	// a latch, so a machine counted here may since have been rolled back,
+	// disconnected, or failed. It says "observed on this build in this
+	// rollout", never "is on this build now". Machines that were already
+	// current, and so never needed a slot, are not represented here at all;
+	// MachinesTotal on the fleet endpoints is the denominator, not this.
 	Updated int `json:"updated"`
 	// Validated is the subset that has completed its dwell.
 	Validated int `json:"validated"`
-	// Pending is reserved or offered: not yet known to be running it.
+	// Validating is running the candidate with its dwell still accruing.
+	//
+	// It has to be reported separately, because it is neither pending nor
+	// validated: without it a canary mid-dwell left every count at zero and
+	// the summary read "waiting for an eligible machine" while a machine was
+	// in fact actively proving the build.
+	Validating int `json:"validating"`
+	// Pending is reserved or offered: an attempt exists and has not resolved.
+	//
+	// It is shown as "pending attempts", not "offered" and not "pending
+	// offers". A reservation is taken before the write to the socket, so it
+	// includes attempts never sent — and resume can open a fresh validation
+	// attempt for a machine ALREADY running the candidate, which correctly
+	// receives no announcement at all. Either word would assert a send, or a
+	// rejection, that the hub cannot know about. The JSON field name stays
+	// `pending` for compatibility; only the wording changed.
 	Pending int `json:"pending"`
 	// Withheld machines are ineligible, with reasons. Not failures.
 	Withheld       int               `json:"withheld"`
@@ -959,6 +987,7 @@ func (c *rolloutController) status(platform string) (*rolloutStatus, error) {
 			out.Validated++
 		case rolloutObserved:
 			// Running the candidate, dwell still accruing.
+			out.Validating++
 		case rolloutReserved, rolloutOffered:
 			out.Pending++
 		case rolloutWithheld:
@@ -981,8 +1010,12 @@ func rolloutSummary(st *rolloutStatus) string {
 	switch {
 	case st.Status == rolloutHalted:
 		return "halted — needs an operator: " + st.HaltReason
-	case st.Pending > 0:
-		return fmt.Sprintf("updating: %d in flight, %d validated", st.Pending, st.Validated)
+	case st.Pending > 0 || st.Validating > 0:
+		// Validating machines are in flight too. Omitting them read as
+		// "waiting for an eligible machine" for the whole of a canary dwell,
+		// which is the one window where the rollout is most busy.
+		return fmt.Sprintf("updating: %d pending attempts, %d validating, %d validated",
+			st.Pending, st.Validating, st.Validated)
 	case st.Validated == 0 && st.Withheld > 0:
 		return fmt.Sprintf("waiting for an eligible machine: %d withheld", st.Withheld)
 	case st.Validated == 0:
@@ -990,9 +1023,12 @@ func rolloutSummary(st *rolloutStatus) string {
 	case st.Failed > 0:
 		return fmt.Sprintf("%d validated, %d failed", st.Validated, st.Failed)
 	default:
-		// Only about machines currently connected: an offline one is not
-		// evidence of anything, which is why this is never written down.
-		return fmt.Sprintf("caught up among eligible connected machines: %d validated", st.Validated)
+		// This counts SLOTS, and slots exist only for machines this
+		// generation reserved one for. A machine that never connected, or was
+		// already current, has no slot at all — so this cannot say the
+		// connected fleet is caught up, and it must not try. It says only
+		// that nothing tracked is still outstanding.
+		return fmt.Sprintf("no outstanding tracked attempts: %d validated", st.Validated)
 	}
 }
 

--- a/hub/agent_rollout_scheduler_test.go
+++ b/hub/agent_rollout_scheduler_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// A stuck socket must not stop the fleet.
+//
+// The scheduler is a single goroutine, and writeLockedTo takes an agent's write
+// lock with no deadline. If admission waited on that lock, one amd64 machine
+// wedged mid-write would freeze admission and expiry for arm64 and Windows
+// too — every platform stalled behind one bad connection, which is precisely
+// the blast radius staging exists to bound.
+func TestABlockedWriterDoesNotStallOtherPlatforms(t *testing.T) {
+	_, s := setupTestServer(t)
+
+	// An agent whose write lock is held and never released, as a socket
+	// blocked in a write would be.
+	stuck := &ConnectedAgent{MachineID: "stuck-amd64"}
+	stuck.WriteMu.Lock()
+	t.Cleanup(stuck.WriteMu.Unlock)
+	s.agentsMu.Lock()
+	s.agents["stuck-amd64"] = stuck
+	s.agentsMu.Unlock()
+
+	// One pass must COMPLETE despite it. A pass that blocks never returns, so
+	// the bound here is the test's own timeout on the channel below.
+	done := make(chan struct{})
+	go func() {
+		s.runRolloutPass()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a single blocked writer froze the scheduler; no other platform could be admitted or expired")
+	}
+
+	// And the blocked machine holds no reservation: skipping a busy writer
+	// must not leave capacity consumed by a send that never happened.
+	var slots int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_rollout_slot WHERE machine_id = ?`,
+		"stuck-amd64").Scan(&slots); err != nil {
+		t.Fatalf("count slots: %v", err)
+	}
+	if slots != 0 {
+		t.Fatalf("a skipped busy writer left %d reservation(s) holding capacity", slots)
+	}
+}
+
+// Resume is all-or-nothing: telling an operator "resumed" while the failed
+// attempts stay terminal means the halt looks cleared and nothing moves.
+func TestResumeIsAtomic(t *testing.T) {
+	_, s := setupTestServer(t)
+
+	// A platform with something to reset; otherwise resume has no work and
+	// nothing to fail at, and the test would pass without testing anything.
+	if _, _, err := s.rollout.reserve("linux/amd64", "m1",
+		"aaaa000000000000000000000000000000000000000000000000000000000001", 8); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if err := s.setOperatorRolloutPause(true); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	// Drop the table the slot reset needs, so the transaction must fail.
+	if _, err := s.db.Exec(`DROP TABLE agent_rollout_slot`); err != nil {
+		t.Fatalf("drop: %v", err)
+	}
+
+	if err := s.resumeRolloutAtomically(); err == nil {
+		t.Fatal("resume must fail when its slot resets cannot be applied")
+	}
+	// The pause must still be set: a partial resume is not a resume.
+	paused, _ := s.operatorRolloutPause()
+	if !paused {
+		t.Fatal("a failed resume cleared the operator pause anyway; the operator would be " +
+			"told updates resumed while every failed attempt stayed terminal")
+	}
+}
+
+// A permanently busy socket must cost a recovered reservation NOTHING.
+//
+// Reserving and only then discovering the writer is busy spends the automatic
+// resend budget without transmitting a byte, so a machine whose socket stays
+// wedged would exhaust recovery and halt its platform having never been sent
+// anything. The skip has to happen before any slot, counter or deadline is
+// touched.
+func TestABusyWriterNeverSpendsARecoveredReservation(t *testing.T) {
+	_, s := setupTestServer(t)
+	const machineID = "busy-writer"
+	sha := "aaaa000000000000000000000000000000000000000000000000000000000001"
+
+	agent := &ConnectedAgent{MachineID: machineID}
+	s.agentsMu.Lock()
+	s.agents[machineID] = agent
+	s.agentsMu.Unlock()
+
+	// A reservation that was never offered: the ambiguous crash state.
+	if _, _, err := s.rollout.reserve("linux/amd64", machineID, sha, 8); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	var state0 string
+	var attempt0, resends0 int
+	var deadline0 int64
+	read := func() (string, int, int, int64) {
+		var state string
+		var attempt, resends int
+		var deadline int64
+		if err := s.db.QueryRow(`SELECT state, attempt, resend_count, deadline_unix_ms
+			FROM agent_rollout_slot WHERE machine_id = ?`, machineID).
+			Scan(&state, &attempt, &resends, &deadline); err != nil {
+			t.Fatalf("read slot: %v", err)
+		}
+		return state, attempt, resends, deadline
+	}
+	state0, attempt0, resends0, deadline0 = read()
+
+	// Hold the writer across more passes than the automatic budget allows.
+	agent.WriteMu.Lock()
+	for i := 0; i < rolloutMaxResends+3; i++ {
+		s.runRolloutPass()
+	}
+	agent.WriteMu.Unlock()
+
+	state1, attempt1, resends1, deadline1 := read()
+	if state1 != state0 || attempt1 != attempt0 || resends1 != resends0 || deadline1 != deadline0 {
+		t.Fatalf("a busy writer consumed recovery state: state %s->%s attempt %d->%d "+
+			"resends %d->%d deadline %d->%d",
+			state0, state1, attempt0, attempt1, resends0, resends1, deadline0, deadline1)
+	}
+
+	st, err := s.rollout.platformState("linux/amd64")
+	if err != nil {
+		t.Fatalf("platform state: %v", err)
+	}
+	if st != nil && st.Status == rolloutHalted {
+		t.Fatalf("a busy writer halted the platform without anything being sent: %s", st.HaltReason)
+	}
+}
+
+// A pass queued behind a machine deletion must not insert an orphan slot.
+func TestAQueuedPassCannotCreateSlotsForADeletedMachine(t *testing.T) {
+	_, s := setupTestServer(t)
+	const machineID = "deleted-machine"
+	agent := &ConnectedAgent{MachineID: machineID}
+
+	// Never registered — exactly the state after a delete has taken the
+	// registry entry, which is what the ingestion barrier checks.
+	s.announceVersionToAgent(machineID, agent)
+
+	var slots int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_rollout_slot WHERE machine_id = ?`,
+		machineID).Scan(&slots); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if slots != 0 {
+		t.Fatalf("a pass created %d slot(s) for a machine the registry does not hold", slots)
+	}
+}

--- a/hub/agent_rollout_scheduler_test.go
+++ b/hub/agent_rollout_scheduler_test.go
@@ -77,9 +77,18 @@ func eligibleAgent(t *testing.T, s *Server, machineID, osName, arch string) (*Co
 // machine on it has something to be offered.
 func stagePlatformBinary(t *testing.T, osName, arch string) {
 	t.Helper()
+	stagePlatformBinaryContent(t, osName, arch, "staged "+osName+"/"+arch+" agent binary")
+}
+
+// stagePlatformBinaryContent is stagePlatformBinary with the bytes chosen by
+// the caller, so a test can replace what a platform serves with a DIFFERENT
+// build. The content decides the SHA, and the SHA is the candidate — staging
+// the same bytes twice changes nothing the rollout can see.
+func stagePlatformBinaryContent(t *testing.T, osName, arch, content string) {
+	t.Helper()
 	name := "bloxos-agent-" + osName + "-" + arch
 	path := filepath.Join(t.TempDir(), name)
-	if err := os.WriteFile(path, []byte("staged "+osName+"/"+arch+" agent binary"), 0o755); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 		t.Fatalf("write %s: %v", name, err)
 	}
 	useTestResolvedBinaryForArch(t, osName, arch, path)
@@ -606,5 +615,326 @@ func TestDisplacedSocketsCannotDisplaceTheWinnersProof(t *testing.T) {
 	f.c.forgetConnection(testPlatform, machineID, winner)
 	if ok, _ := f.c.dwellSatisfied(testPlatform, machineID, st.Generation, candidateA); ok {
 		t.Fatal("evidence survived the connection that produced it")
+	}
+}
+
+// slotRow reads one machine's slot, and says whether it has one at all.
+func slotRow(t *testing.T, s *Server, machineID string) (state string, resends, ranCandidate, rows int) {
+	t.Helper()
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_rollout_slot WHERE machine_id = ?`,
+		machineID).Scan(&rows); err != nil {
+		t.Fatalf("count slots for %s: %v", machineID, err)
+	}
+	if rows == 0 {
+		return "", 0, 0, 0
+	}
+	if err := s.db.QueryRow(`SELECT state, resend_count, ran_candidate FROM agent_rollout_slot
+		WHERE machine_id = ? ORDER BY generation DESC LIMIT 1`, machineID).
+		Scan(&state, &resends, &ranCandidate); err != nil {
+		t.Fatalf("read slot for %s: %v", machineID, err)
+	}
+	return state, resends, ranCandidate, rows
+}
+
+// The candidate can change while a send is queued, and the queued send must
+// not deliver the build it was holding.
+//
+// This is not hypothetical. The announce resolves the SHA and signature, takes
+// a durable reservation, marshals the frame, and only then writes — and one
+// scheduler pass walks the whole registry, each write carrying a ten-second
+// deadline. A `bloxos-update` landing anywhere in that span replaces the
+// served bytes underneath a frame already prepared from the old ones.
+// Delivering it would announce a build the hub no longer serves: the agent
+// fetches the SHA it was given, receives the new binary instead, and the hash
+// fails against the signature it was handed — an update that breaks for a
+// reason nothing logged.
+//
+// The reservation must also go back. A slot held by a send that never happened
+// occupies the canary and the next machine waits behind nothing.
+func TestACandidateChangeAtTheSendBoundaryCancelsTheSend(t *testing.T) {
+	_, s := setupTestServer(t)
+	stagePendingUpdate(t)
+	const machineID = "candidate-switch"
+	agent, client := eligibleAgent(t, s, machineID, "linux", archAMD64)
+
+	// CONTROL: the hook itself does not suppress anything. Without this the
+	// assertions below would hold for a send the hook merely broke.
+	reached := 0
+	announceSendBoundaryHook = func(string) { reached++ }
+	t.Cleanup(func() { announceSendBoundaryHook = nil })
+
+	s.announceVersionToAgent(machineID, agent)
+	if reached != 1 {
+		t.Fatalf("control: the send boundary was reached %d times, want 1", reached)
+	}
+	if !readsAFrame(t, client) {
+		t.Fatal("control: with nothing changing at the boundary, the machine must be sent to")
+	}
+	if state, _, _, _ := slotRow(t, s, machineID); state != rolloutOffered {
+		t.Fatalf("control: the slot should be offered, got %q", state)
+	}
+
+	// Back to nothing reserved, so the next announce takes a FRESH
+	// reservation — the case releaseBeforeSend is written for.
+	if _, err := s.db.Exec(`DELETE FROM agent_rollout_slot WHERE machine_id = ?`, machineID); err != nil {
+		t.Fatalf("clear slot: %v", err)
+	}
+
+	// Now the served binary changes in exactly the window the hook marks:
+	// after the SHA was resolved and the slot reserved, before the write.
+	announceSendBoundaryHook = func(string) {
+		stagePlatformBinaryContent(t, "linux", archAMD64, "a different linux/amd64 agent build")
+	}
+	s.announceVersionToAgent(machineID, agent)
+
+	if _, _, _, rows := slotRow(t, s, machineID); rows != 0 {
+		state, _, _, _ := slotRow(t, s, machineID)
+		t.Fatalf("a reservation that was never sent stayed behind holding capacity (state %q)", state)
+	}
+	// Read last: a timed-out read poisons this connection for anything after
+	// it, and there is nothing after it.
+	if readsAFrame(t, client) {
+		t.Fatal("the hub announced the old candidate after the served binary changed underneath it")
+	}
+}
+
+// The two crash windows are indistinguishable in the hub's own records, and
+// the machine is the only thing that can tell them apart.
+//
+// A process that dies between reserving a slot and marking it offered leaves
+// exactly the same row whether the write never happened or happened and was
+// never recorded. Guessing either way is wrong in one of the two cases: assume
+// it was sent and a machine that received nothing waits out its window and
+// fails; assume it was not and a machine already running the candidate is
+// resent a build it has, while its real progress reads as an outstanding
+// offer.
+//
+// So the hub asks. Both windows are reached by ABORTING the announce inside
+// them — before any socket write, and after a successful one — rather than by
+// rewriting a row afterwards. That distinction is the test: a row rewritten
+// after the fact proves only that reconciliation reads it, and would still
+// pass if the reservation were taken after the write or the offer recorded
+// before it. Here the durable state is whatever the real ordering actually
+// left behind.
+//
+// A panic is the abort. Its defers release the write lock and the in-process
+// send claim, which is what process death does to memory, and recovery over
+// the same database with a fresh controller is what a restart looks like.
+func TestBothCrashWindowsResolveFromWhatTheMachineReports(t *testing.T) {
+	_, s := setupTestServer(t)
+	stagePendingUpdate(t)
+	stagePlatformBinary(t, "linux", archARM64)
+	t.Cleanup(func() { announceSendBoundaryHook = nil; announcePostWriteHook = nil })
+
+	// A distinctive value, so the recover below cannot mistake an unrelated
+	// panic — a nil map, a closed channel — for the injected abort and report
+	// a passing test about a crash that never happened where we meant it to.
+	type injectedAbort struct{ where string }
+	abort := func(t *testing.T, where string, fn func()) {
+		t.Helper()
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatalf("the announce returned normally; the %s abort never fired", where)
+			}
+			got, ok := r.(injectedAbort)
+			if !ok || got.where != where {
+				panic(r) // not ours: let it crash the test properly
+			}
+		}()
+		fn()
+	}
+
+	// A hub restart: a new controller over the SAME database. Durable rows
+	// survive, in-memory evidence and send claims do not.
+	restart := func() {
+		t.Helper()
+		if err := s.initRollout(); err != nil {
+			t.Fatalf("rebuild the controller: %v", err)
+		}
+	}
+
+	// ---- Window one: the process died BEFORE the write. ----------------
+	const missed = "crash-before-write"
+	missedAgent, missedClient := eligibleAgent(t, s, missed, "linux", archAMD64)
+
+	announceSendBoundaryHook = func(string) { panic(injectedAbort{where: "pre-write"}) }
+	abort(t, "pre-write", func() { s.announceVersionToAgent(missed, missedAgent) })
+	announceSendBoundaryHook = nil
+
+	state, resendsAfterCrash, _, rows := slotRow(t, s, missed)
+	if rows == 0 || state != rolloutReserved {
+		t.Fatalf("a crash before the write must leave a reserved slot, got %q (%d rows)", state, rows)
+	}
+	if readsAFrame(t, missedClient) {
+		t.Fatal("control: the pre-write abort let an announcement reach the socket anyway")
+	}
+
+	// It comes back — a new socket, a new controller — still on the OLD
+	// build, because it never received anything.
+	restart()
+	missedAgent, missedClient = eligibleAgent(t, s, missed, "linux", archAMD64)
+	s.announceVersionToAgent(missed, missedAgent)
+
+	state, resendsNow, _, _ := slotRow(t, s, missed)
+	if state != rolloutOffered {
+		t.Fatalf("a machine that never received the offer was not re-offered: state %q", state)
+	}
+	if resendsNow != resendsAfterCrash+1 {
+		t.Fatalf("the resend was not recorded against the attempt: %d -> %d", resendsAfterCrash, resendsNow)
+	}
+	if !readsAFrame(t, missedClient) {
+		t.Fatal("a machine that never received the offer was never sent it again")
+	}
+
+	// ---- Window two: the write landed, the mark did not. ----------------
+	const applied = "crash-after-write"
+	appliedAgent, appliedClient := eligibleAgent(t, s, applied, "linux", archARM64)
+
+	announcePostWriteHook = func(string) { panic(injectedAbort{where: "post-write"}) }
+	abort(t, "post-write", func() { s.announceVersionToAgent(applied, appliedAgent) })
+	announcePostWriteHook = nil
+
+	state, appliedResends, _, rows := slotRow(t, s, applied)
+	if rows == 0 || state != rolloutReserved {
+		t.Fatalf("a crash after the write must still leave a reserved slot, got %q (%d rows)", state, rows)
+	}
+	// CONTROL: the offer really did reach the wire in this window. Without
+	// this the two cases would be indistinguishable in the test as well as in
+	// the database, and the assertions below would prove nothing.
+	if !readsAFrame(t, appliedClient) {
+		t.Fatal("control: the post-write abort fired before the announcement was written")
+	}
+
+	// It comes back running the candidate, on a new socket and a new
+	// controller. That report is the whole answer: nothing the hub kept
+	// distinguishes this slot from the one above.
+	restart()
+	candidate := announcedSHAForArch("linux", archARM64)
+	if candidate == "" {
+		t.Fatal("control: linux/arm64 must have a candidate to report against")
+	}
+	appliedAgent, appliedClient = eligibleAgent(t, s, applied, "linux", archARM64)
+	s.recordAgentRunningVersionOn(applied, appliedAgent, agentVersionReport{
+		RunningSHA: candidate, OS: "linux", Arch: archARM64,
+		UpdateProtocol: 1, TransportOK: true, KeyPinned: true,
+	})
+
+	state, resends, ranCandidate, _ := slotRow(t, s, applied)
+	if state != rolloutObserved {
+		t.Fatalf("a machine reporting the candidate was not recorded as running it: state %q", state)
+	}
+	if ranCandidate != 1 {
+		t.Fatal("the machine ran the candidate but the slot does not say so, so it would read as 0 updated")
+	}
+	if resends != appliedResends {
+		t.Fatalf("resolving the window from the machine's report spent a resend: %d -> %d",
+			appliedResends, resends)
+	}
+
+	// And it is NOT resent: the build it already applied must not be
+	// delivered again, nor its progress restarted.
+	s.runRolloutPass()
+	state, resendsNow, _, _ = slotRow(t, s, applied)
+	if state != rolloutObserved {
+		t.Fatalf("a machine already running the candidate left the observed state: %q", state)
+	}
+	if resendsNow != resends {
+		t.Fatalf("a machine already running the candidate was resent: resends %d -> %d", resends, resendsNow)
+	}
+	// Read last: a timed-out read poisons this connection for anything after.
+	if readsAFrame(t, appliedClient) {
+		t.Fatal("the hub re-announced a build the machine had already reported running")
+	}
+}
+
+// A machine that reconnects must prove itself on the connection it comes back
+// on, even when the socket it displaced had already finished proving itself.
+//
+// This is the trap: a completed dwell is evidence about a SOCKET, and the
+// machine-keyed bookkeeping outlives the socket. A machine that crash-loops —
+// come up, report, hold for a minute, drop, reconnect — would otherwise be
+// validated on the strength of a connection that is already gone, which is
+// exactly the failure staged rollout exists to catch. The displaced handler
+// has not even exited yet when the new socket registers, so the finished
+// dwell is sitting in memory, fresh, under the same machine and platform.
+func TestALateReconnectMustProveItselfOnTheNewConnection(t *testing.T) {
+	_, s := setupTestServer(t)
+	stagePendingUpdate(t)
+	const machineID = "late-reconnect"
+	const platform = "linux/amd64"
+
+	// A controllable clock. The dwell is a minute of continuous telemetry and
+	// the server builds its controller on time.Now; every durable timestamp
+	// below comes from this too, so the attempt window stays consistent.
+	now := time.Unix(1_700_000_000, 0).UTC()
+	s.rollout.now = func() time.Time { return now }
+	advance := func(d time.Duration) { now = now.Add(d) }
+
+	first, firstClient := eligibleAgent(t, s, machineID, "linux", archAMD64)
+	s.runRolloutPass()
+	if !readsAFrame(t, firstClient) {
+		t.Fatal("control: the machine must be offered the update before it can prove it")
+	}
+	st, err := s.rollout.platformState(platform)
+	if err != nil || st == nil {
+		t.Fatalf("platform state: %v", err)
+	}
+
+	// The report goes through the real path, so the slot records that this
+	// machine ran the candidate exactly as a live one would.
+	report := agentVersionReport{
+		RunningSHA: st.Candidate, OS: "linux", Arch: archAMD64,
+		UpdateProtocol: 1, TransportOK: true, KeyPinned: true,
+	}
+	// Metrics every 30s, inside the allowed gap, spanning the whole dwell.
+	// The dwell is measured BETWEEN frames, so the last must be at least a
+	// dwell after the first.
+	proveOn := func(conn *ConnectedAgent) {
+		t.Helper()
+		s.recordAgentRunningVersionOn(machineID, conn, report)
+		advance(30 * time.Second)
+		s.rollout.observeTelemetry(platform, machineID, conn)
+		for span := time.Duration(0); span < rolloutDwell; span += 30 * time.Second {
+			advance(30 * time.Second)
+			s.rollout.observeTelemetry(platform, machineID, conn)
+		}
+	}
+
+	// The first connection finishes its dwell in full.
+	proveOn(first)
+	if ok, why := s.rollout.dwellSatisfied(platform, machineID, st.Generation, st.Candidate); !ok {
+		t.Fatalf("control: the first connection must have completed its dwell: %s", why)
+	}
+
+	// Then it reconnects before that proof was ever spent. The old handler is
+	// still unwinding, so its finished dwell is in memory and is NOT stale —
+	// nothing but the connection identity separates it from a valid one.
+	second, _ := eligibleAgent(t, s, machineID, "linux", archAMD64)
+	if second == first {
+		t.Fatal("control: the reconnect must be a different connection")
+	}
+	s.rollout.mu.Lock()
+	records := len(s.rollout.evidence[rolloutKey(platform, machineID)])
+	s.rollout.mu.Unlock()
+	if records < 1 {
+		t.Fatal("control: the displaced connection's completed dwell must still be in memory")
+	}
+
+	// The live socket has proven nothing, so nothing is validated.
+	s.runRolloutPass()
+	if state, _, _, _ := slotRow(t, s, machineID); state == rolloutHealthy {
+		t.Fatal("a reconnect was validated on the dwell of the connection it displaced")
+	}
+
+	// The displaced handler finally exits, taking only its own record.
+	s.unregisterAgentConnection(machineID, first)
+
+	// Proving itself on the new socket is what validates it.
+	proveOn(second)
+	s.runRolloutPass()
+	if state, _, ranCandidate, _ := slotRow(t, s, machineID); state != rolloutHealthy || ranCandidate != 1 {
+		t.Fatalf("a machine that proved itself on its new connection was not validated: state %q ran_candidate %d",
+			state, ranCandidate)
 	}
 }

--- a/hub/agent_rollout_scheduler_test.go
+++ b/hub/agent_rollout_scheduler_test.go
@@ -1,9 +1,98 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
+
+// eligibleAgent wires a machine that the announce path will actually act on:
+// a served binary exists, the hub knows its OS and arch, and its reported
+// protocol, transport, key and release floor all pass announceDecision.
+//
+// This matters more than it looks. Without it the announce path returns at
+// sha=="" or an unknown OS LONG before it reserves a slot or reaches the
+// ingestion barrier, so a test naming either of those would pass against code
+// that had neither — which is exactly what the first versions of the tests
+// below did.
+func eligibleAgent(t *testing.T, s *Server, machineID, osName, arch string) (*ConnectedAgent, *websocket.Conn) {
+	t.Helper()
+	// A TLS deployment, so transport policy does not withhold. Protocol 1
+	// rather than 2 deliberately: the protocol-2 anti-rollback gate requires a
+	// served binary carrying a release number, and stagePendingUpdate writes
+	// an unnumbered fixture. Using 2 here would withhold on
+	// agent_release_missing and every test below would be asserting against a
+	// machine the hub was refusing for an unrelated reason.
+	t.Setenv("PUBLIC_URL", "https://hub.example.com")
+
+	connections := make(chan *websocket.Conn, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		if conn, err := upgrader.Upgrade(w, r, nil); err == nil {
+			connections <- conn
+		}
+	}))
+	t.Cleanup(server.Close)
+	client, _, err := websocket.DefaultDialer.Dial("ws"+server.URL[len("http"):], nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+	hubSide := <-connections
+	t.Cleanup(func() { hubSide.Close() })
+
+	agent := &ConnectedAgent{MachineID: machineID, Conn: hubSide}
+	s.agentsMu.Lock()
+	s.agents[machineID] = agent
+	s.agentsMu.Unlock()
+	t.Cleanup(func() {
+		s.agentsMu.Lock()
+		delete(s.agents, machineID)
+		s.agentsMu.Unlock()
+	})
+
+	agentRunningVersionsMu.Lock()
+	agentRunningVersions[machineID] = agentVersionInfo{
+		MachineID: machineID, OS: osName, Arch: arch, ArchReported: true,
+		RunningSHA: "0000000000000000000000000000000000000000000000000000000000000000",
+		ReportedAt: time.Now(), UpdateProtocol: 1,
+		UpdateTransportOK: true, UpdateKeyPinned: true,
+	}
+	agentRunningVersionsMu.Unlock()
+	t.Cleanup(func() {
+		agentRunningVersionsMu.Lock()
+		delete(agentRunningVersions, machineID)
+		agentRunningVersionsMu.Unlock()
+	})
+	return agent, client
+}
+
+// stagePlatformBinary serves a distinct fixture binary for one platform, so a
+// machine on it has something to be offered.
+func stagePlatformBinary(t *testing.T, osName, arch string) {
+	t.Helper()
+	name := "bloxos-agent-" + osName + "-" + arch
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("staged "+osName+"/"+arch+" agent binary"), 0o755); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	useTestResolvedBinaryForArch(t, osName, arch, path)
+	recomputeBinaryForPlatform(agentPlatform{OS: normalizeAgentOS(osName), Arch: arch})
+}
+
+// readsAFrame reports whether the agent side received anything promptly.
+func readsAFrame(t *testing.T, client *websocket.Conn) bool {
+	t.Helper()
+	_ = client.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	_, _, err := client.ReadMessage()
+	return err == nil
+}
 
 // A stuck socket must not stop the fleet.
 //
@@ -14,18 +103,24 @@ import (
 // the blast radius staging exists to bound.
 func TestABlockedWriterDoesNotStallOtherPlatforms(t *testing.T) {
 	_, s := setupTestServer(t)
+	stagePendingUpdate(t)
 
-	// An agent whose write lock is held and never released, as a socket
-	// blocked in a write would be.
-	stuck := &ConnectedAgent{MachineID: "stuck-amd64"}
+	// A real amd64 machine whose write lock is held and never released, as a
+	// socket blocked mid-write would be.
+	stuck, _ := eligibleAgent(t, s, "stuck-amd64", "linux", archAMD64)
 	stuck.WriteMu.Lock()
 	t.Cleanup(stuck.WriteMu.Unlock)
-	s.agentsMu.Lock()
-	s.agents["stuck-amd64"] = stuck
-	s.agentsMu.Unlock()
 
-	// One pass must COMPLETE despite it. A pass that blocks never returns, so
-	// the bound here is the test's own timeout on the channel below.
+	// Real machines on the OTHER platforms, each with its own served binary.
+	// Without these the test could pass with nothing else in the registry at
+	// all, proving only that an empty loop finishes — and without their
+	// binaries the announce path would withhold on sha=="" long before
+	// reaching anything this test names.
+	stagePlatformBinary(t, "linux", archARM64)
+	stagePlatformBinary(t, "windows", archAMD64)
+	_, armClient := eligibleAgent(t, s, "arm-machine", "linux", archARM64)
+	_, winClient := eligibleAgent(t, s, "win-machine", "windows", archAMD64)
+
 	done := make(chan struct{})
 	go func() {
 		s.runRolloutPass()
@@ -34,7 +129,21 @@ func TestABlockedWriterDoesNotStallOtherPlatforms(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("a single blocked writer froze the scheduler; no other platform could be admitted or expired")
+		t.Fatal("a single blocked writer froze the scheduler; no other platform could be admitted")
+	}
+
+	// The other platforms must have actually PROGRESSED, not merely not
+	// crashed: each is its own platform, so each gets its own canary.
+	progressed := 0
+	for name, client := range map[string]*websocket.Conn{"arm64": armClient, "windows": winClient} {
+		if readsAFrame(t, client) {
+			progressed++
+		} else {
+			t.Logf("%s received no announcement", name)
+		}
+	}
+	if progressed != 2 {
+		t.Fatalf("only %d of 2 other platforms were admitted behind a blocked amd64 writer", progressed)
 	}
 
 	// And the blocked machine holds no reservation: skipping a busy writer
@@ -88,21 +197,10 @@ func TestResumeIsAtomic(t *testing.T) {
 // touched.
 func TestABusyWriterNeverSpendsARecoveredReservation(t *testing.T) {
 	_, s := setupTestServer(t)
+	stagePendingUpdate(t)
 	const machineID = "busy-writer"
-	sha := "aaaa000000000000000000000000000000000000000000000000000000000001"
+	agent, client := eligibleAgent(t, s, machineID, "linux", archAMD64)
 
-	agent := &ConnectedAgent{MachineID: machineID}
-	s.agentsMu.Lock()
-	s.agents[machineID] = agent
-	s.agentsMu.Unlock()
-
-	// A reservation that was never offered: the ambiguous crash state.
-	if _, _, err := s.rollout.reserve("linux/amd64", machineID, sha, 8); err != nil {
-		t.Fatalf("reserve: %v", err)
-	}
-	var state0 string
-	var attempt0, resends0 int
-	var deadline0 int64
 	read := func() (string, int, int, int64) {
 		var state string
 		var attempt, resends int
@@ -114,9 +212,41 @@ func TestABusyWriterNeverSpendsARecoveredReservation(t *testing.T) {
 		}
 		return state, attempt, resends, deadline
 	}
-	state0, attempt0, resends0, deadline0 = read()
 
-	// Hold the writer across more passes than the automatic budget allows.
+	// CONTROL, writable: one pass must actually admit and SEND. Without this
+	// the held-lock phase below could pass on a machine the announce path was
+	// declining for some unrelated reason, long before any slot existed.
+	s.runRolloutPass()
+	if !readsAFrame(t, client) {
+		t.Fatal("control: an eligible machine must receive an announcement")
+	}
+	if state, _, _, _ := read(); state != rolloutOffered {
+		t.Fatalf("control: the slot should be offered, got %s", state)
+	}
+
+	// Put it back into the ambiguous never-offered state a crash leaves.
+	if _, err := s.db.Exec(`UPDATE agent_rollout_slot SET state = ?, offered_unix_ms = NULL
+		WHERE machine_id = ?`, rolloutReserved, machineID); err != nil {
+		t.Fatalf("reset to reserved: %v", err)
+	}
+
+	// CONTROL, writable again: recovery DOES spend the resend budget when it
+	// can actually send, so the assertion below is about the busy path and not
+	// about recovery being inert.
+	before := func() int { _, _, r, _ := read(); return r }()
+	s.runRolloutPass()
+	if after := func() int { _, _, r, _ := read(); return r }(); after != before+1 {
+		t.Fatalf("control: a writable resend must consume the budget, %d -> %d", before, after)
+	}
+	_ = readsAFrame(t, client)
+	if _, err := s.db.Exec(`UPDATE agent_rollout_slot SET state = ?, offered_unix_ms = NULL
+		WHERE machine_id = ?`, rolloutReserved, machineID); err != nil {
+		t.Fatalf("reset to reserved: %v", err)
+	}
+
+	state0, attempt0, resends0, deadline0 := read()
+
+	// Now hold the writer across more passes than the budget allows.
 	agent.WriteMu.Lock()
 	for i := 0; i < rolloutMaxResends+3; i++ {
 		s.runRolloutPass()
@@ -129,7 +259,6 @@ func TestABusyWriterNeverSpendsARecoveredReservation(t *testing.T) {
 			"resends %d->%d deadline %d->%d",
 			state0, state1, attempt0, attempt1, resends0, resends1, deadline0, deadline1)
 	}
-
 	st, err := s.rollout.platformState("linux/amd64")
 	if err != nil {
 		t.Fatalf("platform state: %v", err)
@@ -137,24 +266,345 @@ func TestABusyWriterNeverSpendsARecoveredReservation(t *testing.T) {
 	if st != nil && st.Status == rolloutHalted {
 		t.Fatalf("a busy writer halted the platform without anything being sent: %s", st.HaltReason)
 	}
+
+	// And once writable again, it sends.
+	s.runRolloutPass()
+	if !readsAFrame(t, client) {
+		t.Fatal("the machine was never sent to after its writer freed up")
+	}
 }
 
 // A pass queued behind a machine deletion must not insert an orphan slot.
 func TestAQueuedPassCannotCreateSlotsForADeletedMachine(t *testing.T) {
 	_, s := setupTestServer(t)
+	stagePendingUpdate(t)
 	const machineID = "deleted-machine"
-	agent := &ConnectedAgent{MachineID: machineID}
+	agent, client := eligibleAgent(t, s, machineID, "linux", archAMD64)
 
-	// Never registered — exactly the state after a delete has taken the
-	// registry entry, which is what the ingestion barrier checks.
+	// CONTROL: while registered, this exact machine is admitted and sent to.
+	// Without it the assertion below would hold for a machine the announce
+	// path was rejecting long before the ingestion barrier.
+	s.announceVersionToAgent(machineID, agent)
+	if !readsAFrame(t, client) {
+		t.Fatal("control: a registered eligible machine must be sent to")
+	}
+	var created int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_rollout_slot WHERE machine_id = ?`,
+		machineID).Scan(&created); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if created != 1 {
+		t.Fatalf("control: the registered case must create a slot, got %d", created)
+	}
+
+	// Now what a delete does: take the registry entry and the durable rows.
+	// The platform row goes too, so the assertion below can tell "reserve was
+	// never reached" from "reserve ran and was cleaned up afterwards".
+	s.agentsMu.Lock()
+	delete(s.agents, machineID)
+	s.agentsMu.Unlock()
+	if _, err := s.db.Exec(`DELETE FROM agent_rollout_slot`); err != nil {
+		t.Fatalf("delete slots: %v", err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM agent_rollout_platform`); err != nil {
+		t.Fatalf("delete platforms: %v", err)
+	}
+
+	// A pass queued behind that delete must insert nothing.
 	s.announceVersionToAgent(machineID, agent)
 
 	var slots int
 	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_rollout_slot WHERE machine_id = ?`,
 		machineID).Scan(&slots); err != nil {
-		t.Fatalf("count: %v", err)
+		t.Fatalf("count slots: %v", err)
 	}
 	if slots != 0 {
 		t.Fatalf("a pass created %d slot(s) for a machine the registry does not hold", slots)
+	}
+
+	// And the reservation must never have been ATTEMPTED. Checking only that
+	// no slot survives cannot distinguish the barrier from the pre-send
+	// registry check cleaning up after itself — and that distinction is the
+	// whole point, because cleanup only happens if the process lives long
+	// enough to reach it. reserve() creates the platform row as its first act,
+	// so its absence proves reserve was never called.
+	var platforms int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_rollout_platform`).Scan(&platforms); err != nil {
+		t.Fatalf("count platforms: %v", err)
+	}
+	if platforms != 0 {
+		t.Fatal("the reservation ran for a deleted machine and was merely cleaned up afterwards; " +
+			"a crash between the two would have left an orphan slot holding capacity")
+	}
+}
+
+// A machine that took the update and then failed validation is still ON the
+// candidate. Deriving "updated" from the current state alone reported
+// "0 updated, 1 failed" for a machine demonstrably running the new build.
+func TestAFailedValidationStillCountsAsUpdated(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	st, _ := f.c.platformState(testPlatform)
+	if err := f.c.observeRunningCandidate(testPlatform, "m1", st.Generation); err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+
+	status, err := f.c.status(testPlatform)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Updated != 1 || status.Validated != 0 {
+		t.Fatalf("a machine running the candidate must be updated but not validated: %+v", status)
+	}
+
+	// Its dwell never completes and the attempt lapses.
+	f.advance(rolloutAttemptTimeout + rolloutRestartGrace + time.Minute)
+	if err := f.c.tick(testPlatform); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if state, _, _ := f.slot(testPlatform, "m1"); state != rolloutFailed {
+		t.Fatalf("the attempt should have failed, got %s", state)
+	}
+
+	status, err = f.c.status(testPlatform)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Failed != 1 {
+		t.Fatalf("the failure must be reported: %+v", status)
+	}
+	if status.Updated != 1 {
+		t.Fatalf("the machine is still running the candidate; reporting %d updated alongside "+
+			"%d failed tells an operator nothing shipped", status.Updated, status.Failed)
+	}
+}
+
+// A report that lands just after the served binary changed must not mark the
+// NEW generation's slot observed on the strength of the OLD bytes.
+func TestAReportForTheOldCandidateDoesNotObserveTheNewOne(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve A")
+	}
+	// The candidate changes; a new generation begins.
+	if _, _, err := f.c.reserve(testPlatform, "m2", candidateB, 9); err != nil {
+		t.Fatalf("reserve B: %v", err)
+	}
+	stB, _ := f.c.platformState(testPlatform)
+	if !strings.EqualFold(stB.Candidate, candidateB) {
+		t.Fatalf("the platform should be on B, got %s", stB.Candidate)
+	}
+
+	// m1 holds no slot in the new generation, so an attempt to observe it
+	// there must change nothing.
+	if err := f.c.observeRunningCandidate(testPlatform, "m1", stB.Generation); err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	status, err := f.c.status(testPlatform)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Updated != 0 {
+		t.Fatalf("a machine running the OLD candidate was counted as updated for the new one: %+v", status)
+	}
+}
+
+// A resume with no controller must fail, not clear the pause and report success.
+func TestResumeWithoutAControllerFails(t *testing.T) {
+	_, s := setupTestServer(t)
+	if err := s.setOperatorRolloutPause(true); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	controller := s.rollout
+	s.rollout = nil
+	t.Cleanup(func() { s.rollout = controller })
+
+	if err := s.resumeRolloutAtomically(); err == nil {
+		t.Fatal("resume must fail when no controller can retry the failed attempts")
+	}
+	if paused, _ := s.operatorRolloutPause(); !paused {
+		t.Fatal("a resume that could retry nothing cleared the pause anyway")
+	}
+}
+
+// The production path, not just the controller: an all-withheld first stage
+// followed by two machines becoming eligible must admit exactly ONE.
+//
+// The core test covers this through tick() alone. This one runs real passes,
+// because the hole it guards lived in the scheduler's completion wiring rather
+// than in the controller — a first stage with nothing outstanding completed
+// having proven nothing, and the next arrivals were treated as post-canary
+// work and both offered the untested build.
+func TestAllWithheldThenEligibleStillAdmitsOnlyACanary(t *testing.T) {
+	_, s := setupTestServer(t)
+	stagePendingUpdate(t)
+
+	// Two machines the announce path will refuse: protocol 1 with no usable
+	// transport is a real eligibility refusal, not a contrivance.
+	var clients []*websocket.Conn
+	for _, id := range []string{"w1", "w2"} {
+		_, client := eligibleAgent(t, s, id, "linux", archAMD64)
+		agentRunningVersionsMu.Lock()
+		v := agentRunningVersions[id]
+		v.UpdateTransportOK = false
+		agentRunningVersions[id] = v
+		agentRunningVersionsMu.Unlock()
+		clients = append(clients, client)
+	}
+	for i := 0; i < 3; i++ {
+		s.runRolloutPass()
+	}
+	// Assert the negative from durable state, not from the socket: a read that
+	// times out puts a gorilla connection into a permanent error state, so
+	// probing for silence would break the later positive check on the same
+	// client and the test would fail for a reason of its own making.
+	var attempts int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_rollout_slot WHERE state IN (?, ?, ?)`,
+		rolloutReserved, rolloutOffered, rolloutObserved).Scan(&attempts); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if attempts != 0 {
+		t.Fatalf("%d withheld machine(s) were admitted", attempts)
+	}
+
+	// Both become eligible at once.
+	agentRunningVersionsMu.Lock()
+	for _, id := range []string{"w1", "w2"} {
+		v := agentRunningVersions[id]
+		v.UpdateTransportOK = true
+		agentRunningVersions[id] = v
+	}
+	agentRunningVersionsMu.Unlock()
+
+	s.runRolloutPass()
+
+	offered := 0
+	for _, client := range clients {
+		if readsAFrame(t, client) {
+			offered++
+		}
+	}
+	if offered != 1 {
+		rows, _ := s.db.Query(`SELECT machine_id, state, reason FROM agent_rollout_slot`)
+		defer rows.Close()
+		for rows.Next() {
+			var id, state, reason string
+			_ = rows.Scan(&id, &state, &reason)
+			t.Logf("slot %s state=%s reason=%q", id, state, reason)
+		}
+		t.Fatalf("%d machines were offered the update with no canary ever validated; exactly one may be", offered)
+	}
+}
+
+// The same shape with nobody connected at all: an empty first stage must not
+// advance, so the first machine to appear is still a lone canary.
+func TestAnEmptyFirstStageThenTwoLateMachinesAdmitsOnlyACanary(t *testing.T) {
+	_, s := setupTestServer(t)
+	stagePendingUpdate(t)
+
+	for i := 0; i < 5; i++ {
+		s.runRolloutPass() // nothing connected
+	}
+
+	_, first := eligibleAgent(t, s, "late-1", "linux", archAMD64)
+	_, second := eligibleAgent(t, s, "late-2", "linux", archAMD64)
+	s.runRolloutPass()
+
+	offered := 0
+	for _, client := range []*websocket.Conn{first, second} {
+		if readsAFrame(t, client) {
+			offered++
+		}
+	}
+	if offered != 1 {
+		t.Fatalf("%d machines were offered after an empty first stage; the canary must still be one", offered)
+	}
+}
+
+// Disconnect must clear THAT connection's evidence, through the real
+// lifecycle path rather than by calling the cleanup directly — which is how
+// the cleanup came to have no callers at all while its comment claimed
+// disconnect handled it.
+func TestDisconnectClearsThatConnectionsEvidence(t *testing.T) {
+	_, s := setupTestServer(t)
+	stagePendingUpdate(t)
+	const machineID = "disconnecting"
+	agent, _ := eligibleAgent(t, s, machineID, "linux", archAMD64)
+	platform := "linux/amd64"
+
+	// Give it real evidence.
+	s.runRolloutPass()
+	st, err := s.rollout.platformState(platform)
+	if err != nil || st == nil {
+		t.Fatalf("platform state: %v", err)
+	}
+	s.rollout.observeCandidateReport(platform, machineID, agent, st.Generation,
+		st.Candidate, st.Candidate)
+	s.rollout.observeTelemetry(platform, machineID, agent)
+
+	s.rollout.mu.Lock()
+	before := len(s.rollout.evidence[rolloutKey(platform, machineID)])
+	s.rollout.mu.Unlock()
+	if before == 0 {
+		t.Fatal("control: the connection must have evidence before it disconnects")
+	}
+
+	// The real path a closing socket takes.
+	s.unregisterAgentConnection(machineID, agent)
+
+	s.rollout.mu.Lock()
+	after := len(s.rollout.evidence[rolloutKey(platform, machineID)])
+	s.rollout.mu.Unlock()
+	if after != 0 {
+		t.Fatalf("evidence for a closed connection survived the disconnect (%d record(s))", after)
+	}
+}
+
+// A displaced socket's late evidence must never cost the winner its proof,
+// and each connection's record must go away with that connection.
+func TestDisplacedSocketsCannotDisplaceTheWinnersProof(t *testing.T) {
+	f := newRolloutFixture(t)
+	const machineID = "m1"
+	if r, _, _ := f.c.reserve(testPlatform, machineID, candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	st, _ := f.c.platformState(testPlatform)
+
+	// The winner establishes real proof FIRST.
+	winner := conn(machineID)
+	f.register(machineID, winner)
+	f.prove(testPlatform, machineID, candidateA, winner)
+	if ok, why := f.c.dwellSatisfied(testPlatform, machineID, st.Generation, candidateA); !ok {
+		t.Fatalf("control: the winner must be validated first: %s", why)
+	}
+
+	// Then more displaced sockets than any backstop would have kept deliver
+	// late evidence. Each writes only into its own record.
+	displaced := make([]*ConnectedAgent, 0, 8)
+	for i := 0; i < 8; i++ {
+		f.advance(time.Second)
+		other := conn(machineID)
+		displaced = append(displaced, other)
+		f.c.observeCandidateReport(testPlatform, machineID, other, st.Generation, candidateA, candidateA)
+		f.c.observeTelemetry(testPlatform, machineID, other)
+	}
+	if ok, why := f.c.dwellSatisfied(testPlatform, machineID, st.Generation, candidateA); !ok {
+		t.Fatalf("late evidence from displaced sockets destroyed the winner's proof: %s", why)
+	}
+
+	// Each exiting connection removes only its own record.
+	for _, other := range displaced {
+		f.c.forgetConnection(testPlatform, machineID, other)
+	}
+	if ok, why := f.c.dwellSatisfied(testPlatform, machineID, st.Generation, candidateA); !ok {
+		t.Fatalf("a displaced socket's cleanup took the winner's proof: %s", why)
+	}
+
+	// And when the winner itself exits, its record goes.
+	f.c.forgetConnection(testPlatform, machineID, winner)
+	if ok, _ := f.c.dwellSatisfied(testPlatform, machineID, st.Generation, candidateA); ok {
+		t.Fatal("evidence survived the connection that produced it")
 	}
 }

--- a/hub/agent_rollout_startup_test.go
+++ b/hub/agent_rollout_startup_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// The rollout controller reads its own tables, and newServer runs BEFORE
+// migrations. Building the controller there meant every fresh install and
+// every upgrade constructed it against a schema without agent_rollout_slot,
+// retained that error, and withheld agent updates forever — on a database the
+// very next statement fixed.
+//
+// Unit fixtures migrate first and then build a server, so they cannot see
+// this. This test goes through the production order: open, construct, migrate,
+// then initialise.
+func TestTheRolloutControllerIsBuiltAfterMigrations(t *testing.T) {
+	db, err := sql.Open("sqlite", databaseDSN(filepath.Join(t.TempDir(), "fresh.db")))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	// Exactly main()'s order, on a database with no schema at all.
+	s := newServer(db)
+	t.Cleanup(func() { s.Shutdown(2) })
+
+	if s.rollout != nil {
+		t.Fatal("newServer must not build the controller: its tables do not exist yet")
+	}
+	// Until it is built, updates are WITHHELD — never waved through to the
+	// unrestricted legacy announce.
+	if s.rollout == nil && s.rolloutErr != nil {
+		t.Fatalf("newServer must not record a controller error either: %v", s.rolloutErr)
+	}
+
+	if err := s.initDB(); err != nil {
+		t.Fatalf("initDB: %v", err)
+	}
+	if err := s.initRollout(); err != nil {
+		t.Fatalf("the controller must be usable once migrations have run: %v", err)
+	}
+	if s.rollout == nil {
+		t.Fatal("initRollout reported success but left no controller")
+	}
+	if s.rolloutErr != nil {
+		t.Fatalf("a usable controller must clear the retained error: %v", s.rolloutErr)
+	}
+
+	// And it actually works against the migrated schema.
+	if r, _, err := s.rollout.reserve("linux/amd64", "m1",
+		"aaaa000000000000000000000000000000000000000000000000000000000001", 8); err != nil {
+		t.Fatalf("reserve on the migrated schema: %v", err)
+	} else if r == nil {
+		t.Fatal("the first machine must be admitted as the canary")
+	}
+}
+
+// A controller that could not be built must withhold, not fall through.
+func TestAMissingControllerWithholdsRatherThanAnnouncing(t *testing.T) {
+	db, err := sql.Open("sqlite", databaseDSN(filepath.Join(t.TempDir(), "broken.db")))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s := newServer(db)
+	t.Cleanup(func() { s.Shutdown(2) })
+
+	// No migrations: initRollout must fail and say so.
+	if err := s.initRollout(); err == nil {
+		t.Fatal("building the controller against an unmigrated database must fail")
+	}
+	if s.rollout != nil {
+		t.Fatal("a failed initialisation must leave no controller")
+	}
+	if s.rolloutErr == nil {
+		t.Fatal("the failure must be retained so announcements can refuse")
+	}
+}

--- a/hub/agent_rollout_test.go
+++ b/hub/agent_rollout_test.go
@@ -19,8 +19,8 @@ type rolloutFixture struct {
 	t   *testing.T
 
 	// registry mirrors the hub's: which connection currently owns a machine.
-	// Tests drive it explicitly rather than passing a nil Server, because the
-	// ownership boundary IS the behaviour under test in several of them.
+	// Tests drive it explicitly, because the ownership boundary IS the
+	// behaviour under test in several of them.
 	registryMu sync.Mutex
 	registry   map[string]*ConnectedAgent
 }
@@ -34,14 +34,13 @@ func (f *rolloutFixture) register(machineID string, c *ConnectedAgent) {
 	f.registry[machineID] = c
 }
 
-func (f *rolloutFixture) owns(machineID string, c *ConnectedAgent) bool {
+// currentConn answers "who owns this machine now". A machine with no recorded
+// registration defaults to whatever connection was last seen writing evidence,
+// which keeps the simpler unit tests from having to model the registry.
+func (f *rolloutFixture) currentConn(machineID string) *ConnectedAgent {
 	f.registryMu.Lock()
 	defer f.registryMu.Unlock()
-	current, ok := f.registry[machineID]
-	if !ok {
-		return true // no registration recorded: unit tests that do not model it
-	}
-	return current == c
+	return f.registry[machineID]
 }
 
 // newRolloutDB is an in-memory database with migrations applied. MaxOpenConns
@@ -69,7 +68,7 @@ func newRolloutFixture(t *testing.T) *rolloutFixture {
 	if err != nil {
 		t.Fatalf("controller: %v", err)
 	}
-	c.attachRegistry(f.owns)
+	c.attachRegistry(f.currentConn)
 	f.c = c
 	return f
 }
@@ -84,7 +83,7 @@ func (f *rolloutFixture) restart() {
 	if err != nil {
 		f.t.Fatalf("restart: %v", err)
 	}
-	c.attachRegistry(f.owns)
+	c.attachRegistry(f.currentConn)
 	f.c = c
 }
 
@@ -172,7 +171,7 @@ func TestTwoDistinctMachinesRaceForTheFinalSlot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("controller: %v", err)
 	}
-	controller.attachRegistry(f.owns)
+	controller.attachRegistry(f.currentConn)
 	f.c = controller
 	// Take the canary and validate it so the stage advances to a batch of two.
 	canary, _, _ := f.c.reserve(testPlatform, "canary", candidateA, 8)
@@ -181,7 +180,7 @@ func TestTwoDistinctMachinesRaceForTheFinalSlot(t *testing.T) {
 	}
 	c0 := conn("canary")
 	f.prove(testPlatform, "canary", candidateA, c0)
-	if err := f.c.tick(nil, testPlatform); err != nil {
+	if err := f.c.tick(testPlatform); err != nil {
 		t.Fatalf("tick: %v", err)
 	}
 
@@ -377,13 +376,14 @@ func TestDwellRequiresContinuousTelemetryOnOneConnection(t *testing.T) {
 	}
 	st, _ := f.c.platformState(testPlatform)
 	c1 := conn("m1")
+	f.register("m1", c1)
 
 	f.c.observeCandidateReport(testPlatform, "m1", c1, st.Generation, candidateA, candidateA)
 	// One report, then silence past the allowed gap, then a frame at the far
 	// end of the dwell. The endpoints look right; the middle proves nothing.
 	f.advance(rolloutDwell + time.Second)
 	f.c.observeTelemetry(testPlatform, "m1", c1)
-	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); ok {
+	if ok, why := f.c.dwellSatisfied(testPlatform, "m1", st.Generation, candidateA); ok {
 		t.Fatal("a gap in the middle of the dwell must restart it, not be ignored")
 	} else if why == "" {
 		t.Fatal("a refusal must say why")
@@ -391,48 +391,8 @@ func TestDwellRequiresContinuousTelemetryOnOneConnection(t *testing.T) {
 
 	// Continuous frames do satisfy it.
 	f.prove(testPlatform, "m1", candidateA, c1)
-	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); !ok {
+	if ok, why := f.c.dwellSatisfied(testPlatform, "m1", st.Generation, candidateA); !ok {
 		t.Fatalf("continuous telemetry across the dwell must satisfy it: %s", why)
-	}
-}
-
-// agentRunningVersions is keyed by machine and survives a socket replacement.
-// A new connection must not inherit the previous one's proof.
-func TestAReplacedConnectionInheritsNoEvidence(t *testing.T) {
-	f := newRolloutFixture(t)
-	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
-		t.Fatal("reserve")
-	}
-	st, _ := f.c.platformState(testPlatform)
-
-	old := conn("m1")
-	f.prove(testPlatform, "m1", candidateA, old)
-	if ok, _ := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); !ok {
-		t.Fatal("control: the first connection must satisfy the dwell")
-	}
-
-	// The socket is replaced, and the REGISTRY is what says so.
-	fresh := conn("m1")
-	f.register("m1", fresh)
-	f.c.observeTelemetry(testPlatform, "m1", fresh)
-	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); ok {
-		t.Fatal("a replaced connection inherited the previous connection's dwell")
-	} else if why == "" {
-		t.Fatal("a refusal must say why")
-	}
-
-	// The displaced socket may still be readable. Its late frames must neither
-	// sustain its own dead dwell nor destroy the new connection's evidence.
-	f.c.observeCandidateReport(testPlatform, "m1", old, st.Generation, candidateA, candidateA)
-	f.c.observeTelemetry(testPlatform, "m1", old)
-	if ok, _ := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); ok {
-		t.Fatal("a displaced socket vouched for the machine it no longer owns")
-	}
-
-	// The new connection can then prove itself normally.
-	f.prove(testPlatform, "m1", candidateA, fresh)
-	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); !ok {
-		t.Fatalf("the current connection must be able to prove itself: %s", why)
 	}
 }
 
@@ -451,7 +411,7 @@ func TestVersionReportsAloneNeverValidate(t *testing.T) {
 		f.c.observeCandidateReport(testPlatform, "m1", c1, st.Generation, candidateA, candidateA)
 		f.advance(20 * time.Second)
 	}
-	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); ok {
+	if ok, why := f.c.dwellSatisfied(testPlatform, "m1", st.Generation, candidateA); ok {
 		t.Fatal("repeated version reports with no metrics satisfied the dwell")
 	} else if why == "" {
 		t.Fatal("a refusal must say why")
@@ -474,7 +434,7 @@ func TestTheDwellEndpointMustBeARealMetricsFrame(t *testing.T) {
 
 	// The clock passes the dwell, but no further frame has arrived.
 	f.advance(rolloutDwell + time.Second)
-	if ok, _ := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); ok {
+	if ok, _ := f.c.dwellSatisfied(testPlatform, "m1", st.Generation, candidateA); ok {
 		t.Fatal("the dwell completed on a timer, with no metrics at its endpoint")
 	}
 }
@@ -487,8 +447,9 @@ func TestEvidenceForOneCandidateDoesNotValidateAnother(t *testing.T) {
 	}
 	st, _ := f.c.platformState(testPlatform)
 	c1 := conn("m1")
+	f.register("m1", c1)
 	f.prove(testPlatform, "m1", candidateA, c1)
-	if ok, _ := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); !ok {
+	if ok, _ := f.c.dwellSatisfied(testPlatform, "m1", st.Generation, candidateA); !ok {
 		t.Fatal("control: A must be satisfied")
 	}
 
@@ -501,7 +462,7 @@ func TestEvidenceForOneCandidateDoesNotValidateAnother(t *testing.T) {
 	if stB.Generation == st.Generation {
 		t.Fatal("a changed candidate must start a new generation")
 	}
-	if ok, _ := f.c.dwellSatisfied(nil, testPlatform, "m1", stB.Generation, candidateB); ok {
+	if ok, _ := f.c.dwellSatisfied(testPlatform, "m1", stB.Generation, candidateB); ok {
 		t.Fatal("A's dwell was accepted as proof for B")
 	}
 }
@@ -513,8 +474,9 @@ func TestRestartClearsInFlightEvidenceButKeepsValidatedProgress(t *testing.T) {
 	}
 	st, _ := f.c.platformState(testPlatform)
 	c1 := conn("m1")
+	f.register("m1", c1)
 	f.prove(testPlatform, "m1", candidateA, c1)
-	if err := f.c.tick(nil, testPlatform); err != nil {
+	if err := f.c.tick(testPlatform); err != nil {
 		t.Fatalf("tick: %v", err)
 	}
 	if state, _, _ := f.slot(testPlatform, "m1"); state != rolloutHealthy {
@@ -526,6 +488,7 @@ func TestRestartClearsInFlightEvidenceButKeepsValidatedProgress(t *testing.T) {
 		t.Fatal("the batch stage must admit m2")
 	}
 	c2 := conn("m2")
+	f.register("m2", c2)
 	f.c.observeCandidateReport(testPlatform, "m2", c2, st.Generation, candidateA, candidateA)
 	f.advance(30 * time.Second)
 	f.c.observeTelemetry(testPlatform, "m2", c2)
@@ -538,7 +501,7 @@ func TestRestartClearsInFlightEvidenceButKeepsValidatedProgress(t *testing.T) {
 	}
 	// ...and in-flight health evidence is not: downtime cannot accrue as dwell.
 	f.advance(rolloutDwell)
-	if ok, _ := f.c.dwellSatisfied(nil, testPlatform, "m2", st.Generation, candidateA); ok {
+	if ok, _ := f.c.dwellSatisfied(testPlatform, "m2", st.Generation, candidateA); ok {
 		t.Fatal("a dwell in progress at restart was allowed to complete across the gap")
 	}
 }
@@ -558,7 +521,7 @@ func TestAnEmptyPlatformNeverAdvancesPastTheCanary(t *testing.T) {
 		t.Fatalf("clear: %v", err)
 	}
 	for i := 0; i < 10; i++ {
-		if err := f.c.tick(nil, testPlatform); err != nil {
+		if err := f.c.tick(testPlatform); err != nil {
 			t.Fatalf("tick: %v", err)
 		}
 		f.advance(time.Minute)
@@ -588,7 +551,7 @@ func TestAReservationArrivingDuringATickIsNotStrandedByAnAdvance(t *testing.T) {
 		t.Fatal("canary")
 	}
 	f.prove(testPlatform, "canary", candidateA, conn("canary"))
-	if err := f.c.tick(nil, testPlatform); err != nil {
+	if err := f.c.tick(testPlatform); err != nil {
 		t.Fatalf("tick: %v", err)
 	}
 	before, _ := f.c.platformState(testPlatform)
@@ -603,7 +566,7 @@ func TestAReservationArrivingDuringATickIsNotStrandedByAnAdvance(t *testing.T) {
 		t.Fatalf("a reservation must not itself move the stage: %d -> %d", before.Stage, during.Stage)
 	}
 
-	if err := f.c.tick(nil, testPlatform); err != nil {
+	if err := f.c.tick(testPlatform); err != nil {
 		t.Fatalf("tick: %v", err)
 	}
 	after, _ := f.c.platformState(testPlatform)
@@ -621,7 +584,7 @@ func TestAStageOfWithheldMachinesDoesNotAdvance(t *testing.T) {
 		t.Fatalf("withhold: %v", err)
 	}
 	for i := 0; i < 5; i++ {
-		if err := f.c.tick(nil, testPlatform); err != nil {
+		if err := f.c.tick(testPlatform); err != nil {
 			t.Fatalf("tick: %v", err)
 		}
 		f.advance(time.Minute)
@@ -632,10 +595,17 @@ func TestAStageOfWithheldMachinesDoesNotAdvance(t *testing.T) {
 	}
 }
 
-// The ownership check happens outside the evidence lock, so a registration can
-// change in between. A frame from the losing socket must not discard the
-// winner's proof on its way past.
-func TestALateFrameFromADisplacedSocketCannotDiscardCurrentProof(t *testing.T) {
+// The interleaving that the old design could not survive: a report from a
+// socket that was STILL the owner when its ownership was checked, and had lost
+// the machine by the time it wrote.
+//
+// The previous code checked ownership outside the evidence lock and then
+// replaced the machine's single record under it, so that report destroyed the
+// winner's proof — and the check could not prevent it, because the check had
+// already passed. A test that simply sends a late frame after the registry
+// changed does not reach this: the early check rejects it. This one holds the
+// old writer between its check and its write.
+func TestAReportInFlightAcrossAReplacementCannotDiscardFreshProof(t *testing.T) {
 	f := newRolloutFixture(t)
 	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
 		t.Fatal("reserve")
@@ -644,21 +614,58 @@ func TestALateFrameFromADisplacedSocketCannotDiscardCurrentProof(t *testing.T) {
 
 	old := conn("m1")
 	fresh := conn("m1")
+	f.register("m1", old)
 
-	// The new connection wins the machine and proves itself.
+	// The old connection begins reporting; hold it before it writes.
+	released := make(chan struct{})
+	wrote := make(chan struct{})
+	go func() {
+		<-released
+		// Both ingestion paths, because both are writers.
+		f.c.observeCandidateReport(testPlatform, "m1", old, st.Generation, candidateA, candidateA)
+		f.c.observeTelemetry(testPlatform, "m1", old)
+		close(wrote)
+	}()
+
+	// While it is held, the machine is taken over and the new connection
+	// completes a full dwell.
 	f.register("m1", fresh)
 	f.prove(testPlatform, "m1", candidateA, fresh)
-	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); !ok {
-		t.Fatalf("control: the current connection must be validated: %s", why)
+	if ok, why := f.c.dwellSatisfied(testPlatform, "m1", st.Generation, candidateA); !ok {
+		t.Fatalf("control: the current connection must be validated first: %s", why)
 	}
 
-	// A frame from the displaced socket arrives afterwards. Letting it replace
-	// the record would reset a completed dwell and stall the rollout.
-	f.c.observeTelemetry(testPlatform, "m1", old)
-	f.c.observeCandidateReport(testPlatform, "m1", old, st.Generation, candidateA, candidateA)
+	close(released)
+	<-wrote
 
-	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); !ok {
-		t.Fatalf("a displaced socket's late frame destroyed valid proof: %s", why)
+	if ok, why := f.c.dwellSatisfied(testPlatform, "m1", st.Generation, candidateA); !ok {
+		t.Fatalf("a report in flight across the replacement destroyed valid proof: %s", why)
+	}
+}
+
+// The displaced socket's own record must also never be READ as the machine's
+// health once the registry has moved on.
+func TestADisplacedSocketsProofIsNeverRead(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	st, _ := f.c.platformState(testPlatform)
+
+	old := conn("m1")
+	f.register("m1", old)
+	f.prove(testPlatform, "m1", candidateA, old)
+	if ok, _ := f.c.dwellSatisfied(testPlatform, "m1", st.Generation, candidateA); !ok {
+		t.Fatal("control: the first connection must be validated")
+	}
+
+	// The machine is taken over by a socket that has proven nothing.
+	fresh := conn("m1")
+	f.register("m1", fresh)
+	if ok, why := f.c.dwellSatisfied(testPlatform, "m1", st.Generation, candidateA); ok {
+		t.Fatal("the displaced socket's completed dwell was read as the machine's health")
+	} else if why == "" {
+		t.Fatal("a refusal must say why")
 	}
 }
 
@@ -693,7 +700,7 @@ func TestProgressionNeedsNoOperatorAction(t *testing.T) {
 				f.prove(testPlatform, id, candidateA, conn(id))
 			}
 		}
-		if err := f.c.tick(nil, testPlatform); err != nil {
+		if err := f.c.tick(testPlatform); err != nil {
 			t.Fatalf("tick: %v", err)
 		}
 		for _, id := range machines {
@@ -726,7 +733,7 @@ func TestALateMachineReopensACompletedPlatform(t *testing.T) {
 		t.Fatal("reserve")
 	}
 	f.prove(testPlatform, "m1", candidateA, conn("m1"))
-	if err := f.c.tick(nil, testPlatform); err != nil {
+	if err := f.c.tick(testPlatform); err != nil {
 		t.Fatalf("tick: %v", err)
 	}
 	if err := f.c.markComplete(testPlatform); err != nil {
@@ -791,7 +798,7 @@ func TestResumeRetriesFailedAttempts(t *testing.T) {
 		t.Fatal("reserve")
 	}
 	f.advance(rolloutAttemptTimeout + rolloutRestartGrace + time.Minute)
-	if err := f.c.tick(nil, testPlatform); err != nil {
+	if err := f.c.tick(testPlatform); err != nil {
 		t.Fatalf("tick: %v", err)
 	}
 	if state, _, _ := f.slot(testPlatform, "m1"); state != rolloutFailed {
@@ -854,7 +861,7 @@ func TestPlatformsProgressIndependently(t *testing.T) {
 
 	// Fail amd64 outright.
 	f.advance(rolloutAttemptTimeout + rolloutRestartGrace + time.Minute)
-	if err := f.c.tick(nil, testPlatform); err != nil {
+	if err := f.c.tick(testPlatform); err != nil {
 		t.Fatalf("tick: %v", err)
 	}
 	amd, _ := f.c.platformState(testPlatform)

--- a/hub/agent_rollout_test.go
+++ b/hub/agent_rollout_test.go
@@ -725,19 +725,60 @@ func TestProgressionNeedsNoOperatorAction(t *testing.T) {
 	}
 }
 
-// "Complete" means caught up now, not closed forever.
-func TestALateMachineReopensACompletedPlatform(t *testing.T) {
+// A machine that was offline for the whole rollout must still be offered the
+// update when it appears — and must NOT skip the canary if none ever passed.
+//
+// There is no durable "complete" state to reopen. The stage is the only
+// authority: a late machine enters whatever stage the platform is actually in.
+// That is what closes the hole the completion state created, where an
+// all-withheld first stage finished having proven nothing and the next
+// arrivals were treated as post-canary work.
+func TestALateMachineEntersTheStageThePlatformIsActuallyIn(t *testing.T) {
 	f := newRolloutFixture(t)
-	r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8)
-	if r == nil {
-		t.Fatal("reserve")
+
+	// Nobody eligible yet: every machine is withheld.
+	for _, id := range []string{"w1", "w2"} {
+		if err := f.c.withhold(testPlatform, id, candidateA, 8, "no pinned update key"); err != nil {
+			t.Fatalf("withhold: %v", err)
+		}
 	}
-	f.prove(testPlatform, "m1", candidateA, conn("m1"))
+	for i := 0; i < 3; i++ {
+		if err := f.c.tick(testPlatform); err != nil {
+			t.Fatalf("tick: %v", err)
+		}
+	}
+
+	// Two machines become eligible at once. Exactly ONE may be admitted,
+	// because no canary has ever passed on this platform.
+	admitted := 0
+	for _, id := range []string{"late-1", "late-2"} {
+		r, _, err := f.c.reserve(testPlatform, id, candidateA, 8)
+		if err != nil {
+			t.Fatalf("reserve %s: %v", id, err)
+		}
+		if r != nil {
+			admitted++
+			if r.Stage != 0 {
+				t.Fatalf("%s was admitted at stage %d without a validated canary", id, r.Stage)
+			}
+		}
+	}
+	if admitted != 1 {
+		t.Fatalf("%d machines were admitted with no canary ever validated; exactly one may be", admitted)
+	}
+}
+
+// And once a canary HAS passed, a late arrival joins the batch stage rather
+// than being run through the canary again.
+func TestALateMachineJoinsTheBatchOnceACanaryPassed(t *testing.T) {
+	f := newRolloutFixture(t)
+	canary, _, _ := f.c.reserve(testPlatform, "canary", candidateA, 8)
+	if canary == nil {
+		t.Fatal("canary")
+	}
+	f.prove(testPlatform, "canary", candidateA, conn("canary"))
 	if err := f.c.tick(testPlatform); err != nil {
 		t.Fatalf("tick: %v", err)
-	}
-	if err := f.c.markComplete(testPlatform); err != nil {
-		t.Fatalf("markComplete: %v", err)
 	}
 
 	late, _, err := f.c.reserve(testPlatform, "late", candidateA, 8)
@@ -745,17 +786,13 @@ func TestALateMachineReopensACompletedPlatform(t *testing.T) {
 		t.Fatalf("reserve: %v", err)
 	}
 	if late == nil {
-		t.Fatal("a machine that was offline for the whole rollout must still be offered the update")
+		t.Fatal("a machine that appeared after the canary must still be offered the update")
 	}
 	if late.Stage == 0 {
-		t.Fatal("a late arrival must not be run through the canary again")
+		t.Fatal("a late arrival was run through the canary again despite one having passed")
 	}
-	st, _ := f.c.platformState(testPlatform)
-	if st.Status != rolloutActive {
-		t.Fatalf("the platform should have reopened, status=%s", st.Status)
-	}
-	// The machine that already passed is not re-validated.
-	if again, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); again != nil {
+	// The already-validated machine is not re-admitted.
+	if again, _, _ := f.c.reserve(testPlatform, "canary", candidateA, 8); again != nil {
 		t.Fatal("a validated machine must not be reserved again")
 	}
 }
@@ -831,8 +868,11 @@ func TestStatusCountsRunningCandidatesNotOnlyValidatedOnes(t *testing.T) {
 	if r == nil {
 		t.Fatal("reserve")
 	}
-	if _, err := f.db.Exec(`UPDATE agent_rollout_slot SET state = ? WHERE machine_id = ?`,
-		rolloutObserved, "m1"); err != nil {
+	// Through the real transition rather than direct SQL: the durable
+	// ran_candidate marker is what makes "updated" survive a later failure,
+	// and hand-writing the state would skip it.
+	st, _ := f.c.platformState(testPlatform)
+	if err := f.c.observeRunningCandidate(testPlatform, "m1", st.Generation); err != nil {
 		t.Fatalf("observe: %v", err)
 	}
 	status, err := f.c.status(testPlatform)
@@ -950,5 +990,53 @@ func TestLaterMachinesAreAdmittedWithoutAnyFurtherTrigger(t *testing.T) {
 	if r == nil {
 		t.Fatalf("%s was never admitted after the batch ahead of it passed (%q); "+
 			"a rollout that needs a trigger to continue looks exactly like one that is working", last, why)
+	}
+}
+
+// A later eligibility refusal must not release an attempt already under way.
+//
+// Fresh ineligibility is caught before a machine ever reserves, so a reserved
+// or offered row means an attempt is in flight — quite possibly one whose
+// write landed and whose mark was lost. Converting it to withheld would free
+// capacity for an offer that may be live, and let a second machine become
+// canary alongside it.
+func TestALaterRefusalCannotReleaseAnAttemptInFlight(t *testing.T) {
+	f := newRolloutFixture(t)
+	r, _, err := f.c.reserve(testPlatform, "m1", candidateA, 8)
+	if err != nil || r == nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	// Simulate the write-before-mark window: the slot still says reserved.
+	if state, _, _ := f.slot(testPlatform, "m1"); state != rolloutReserved {
+		t.Fatalf("expected reserved, got %s", state)
+	}
+
+	// Its signature material disappears and the hub now refuses it.
+	if err := f.c.withhold(testPlatform, "m1", candidateA, 8, "no pinned update key"); err != nil {
+		t.Fatalf("withhold: %v", err)
+	}
+	state, _, _ := f.slot(testPlatform, "m1")
+	if state != rolloutReserved {
+		t.Fatalf("an in-flight attempt was converted to %s; its offer may already have landed", state)
+	}
+
+	// And the canary slot is still occupied, so nobody else takes it.
+	if other, _, _ := f.c.reserve(testPlatform, "m2", candidateA, 8); other != nil {
+		t.Fatal("a second machine became canary while an ambiguous attempt was still outstanding")
+	}
+}
+
+// A machine with no slot at all is withheld normally.
+func TestAnIneligibleMachineWithNoSlotIsStillWithheld(t *testing.T) {
+	f := newRolloutFixture(t)
+	if err := f.c.withhold(testPlatform, "fresh", candidateA, 8, "no usable transport"); err != nil {
+		t.Fatalf("withhold: %v", err)
+	}
+	status, err := f.c.status(testPlatform)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Withheld != 1 || status.WithheldReason["fresh"] == "" {
+		t.Fatalf("a fresh ineligible machine must be withheld with its reason: %+v", status)
 	}
 }

--- a/hub/agent_rollout_test.go
+++ b/hub/agent_rollout_test.go
@@ -1,0 +1,868 @@
+package main
+
+import (
+	"database/sql"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// rolloutFixture is a controller over a real migrated database with an
+// injected clock. Time is never real here: a dwell that depended on wall-clock
+// sleep would make the suite slow and flaky, and would test the scheduler
+// rather than the rule.
+type rolloutFixture struct {
+	c   *rolloutController
+	db  *sql.DB
+	now time.Time
+	t   *testing.T
+
+	// registry mirrors the hub's: which connection currently owns a machine.
+	// Tests drive it explicitly rather than passing a nil Server, because the
+	// ownership boundary IS the behaviour under test in several of them.
+	registryMu sync.Mutex
+	registry   map[string]*ConnectedAgent
+}
+
+func (f *rolloutFixture) register(machineID string, c *ConnectedAgent) {
+	f.registryMu.Lock()
+	defer f.registryMu.Unlock()
+	if f.registry == nil {
+		f.registry = map[string]*ConnectedAgent{}
+	}
+	f.registry[machineID] = c
+}
+
+func (f *rolloutFixture) owns(machineID string, c *ConnectedAgent) bool {
+	f.registryMu.Lock()
+	defer f.registryMu.Unlock()
+	current, ok := f.registry[machineID]
+	if !ok {
+		return true // no registration recorded: unit tests that do not model it
+	}
+	return current == c
+}
+
+// newRolloutDB is an in-memory database with migrations applied. MaxOpenConns
+// stays at 1, matching the other suites: ":memory:" gives each connection its
+// OWN database, so a pool would hand different statements different schemas.
+func newRolloutDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open rollout test db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+	return db
+}
+
+func newRolloutFixture(t *testing.T) *rolloutFixture {
+	t.Helper()
+	db := newRolloutDB(t)
+	f := &rolloutFixture{db: db, now: time.Unix(1_700_000_000, 0).UTC(), t: t}
+	c, err := newRolloutController(db, func() time.Time { return f.now })
+	if err != nil {
+		t.Fatalf("controller: %v", err)
+	}
+	c.attachRegistry(f.owns)
+	f.c = c
+	return f
+}
+
+func (f *rolloutFixture) advance(d time.Duration) { f.now = f.now.Add(d) }
+
+// restart rebuilds the controller over the SAME database, which is what a hub
+// restart looks like: durable rows survive, in-memory evidence does not.
+func (f *rolloutFixture) restart() {
+	f.t.Helper()
+	c, err := newRolloutController(f.db, func() time.Time { return f.now })
+	if err != nil {
+		f.t.Fatalf("restart: %v", err)
+	}
+	c.attachRegistry(f.owns)
+	f.c = c
+}
+
+func (f *rolloutFixture) slot(platform, machineID string) (state string, attempt int, deadline int64) {
+	state, attempt, _, deadline = f.slotFull(platform, machineID)
+	return
+}
+
+func (f *rolloutFixture) slotFull(platform, machineID string) (state string, attempt, resends int, deadline int64) {
+	f.t.Helper()
+	err := f.db.QueryRow(`SELECT state, attempt, resend_count, deadline_unix_ms FROM agent_rollout_slot
+		WHERE platform = ? AND machine_id = ? ORDER BY generation DESC LIMIT 1`,
+		platform, machineID).Scan(&state, &attempt, &resends, &deadline)
+	if err != nil {
+		f.t.Fatalf("slot %s/%s: %v", platform, machineID, err)
+	}
+	return
+}
+
+// prove drives a machine all the way to validated on one connection.
+func (f *rolloutFixture) prove(platform, machineID, candidate string, conn *ConnectedAgent) {
+	f.t.Helper()
+	st, err := f.c.platformState(platform)
+	if err != nil || st == nil {
+		f.t.Fatalf("platform state: %v", err)
+	}
+	f.register(machineID, conn)
+	f.c.observeCandidateReport(platform, machineID, conn, st.Generation, candidate, candidate)
+	// Metrics every 30s, inside the allowed gap, spanning the whole dwell.
+	// The dwell is measured BETWEEN metrics frames, so the loop has to run
+	// until the last frame is at least a dwell after the first.
+	f.advance(30 * time.Second)
+	f.c.observeTelemetry(platform, machineID, conn)
+	for span := time.Duration(0); span < rolloutDwell; span += 30 * time.Second {
+		f.advance(30 * time.Second)
+		f.c.observeTelemetry(platform, machineID, conn)
+	}
+}
+
+const testPlatform = "linux/amd64"
+const candidateA = "aaaa000000000000000000000000000000000000000000000000000000000001"
+const candidateB = "bbbb000000000000000000000000000000000000000000000000000000000002"
+
+func conn(id string) *ConnectedAgent { return &ConnectedAgent{MachineID: id} }
+
+// ---------------------------------------------------------------- reservation
+
+func TestCanaryAdmitsExactlyOneMachine(t *testing.T) {
+	f := newRolloutFixture(t)
+	first, _, err := f.c.reserve(testPlatform, "m1", candidateA, 8)
+	if err != nil || first == nil {
+		t.Fatalf("first machine must be admitted as the canary: %v", err)
+	}
+	second, _, err := f.c.reserve(testPlatform, "m2", candidateA, 8)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if second != nil {
+		t.Fatal("a second machine must wait: the canary stage admits exactly one")
+	}
+}
+
+// The case a unique key on (machine, candidate) does NOT cover: it deduplicates
+// repeat calls for one machine, and would have let two DIFFERENT machines both
+// insert for the final slot.
+//
+// This one runs on a FILE database with the production DSN and a real
+// connection pool. The in-memory fixture pins MaxOpenConns to 1, so its
+// transactions serialise in the pool before SQLite is ever involved — the test
+// would pass without _txlock=immediate doing anything, and would deadlock
+// rather than race. The claim under test is about SQLite's write lock, so the
+// test has to reach it.
+func TestTwoDistinctMachinesRaceForTheFinalSlot(t *testing.T) {
+	db, err := sql.Open("sqlite", databaseDSN(filepath.Join(t.TempDir(), "rollout.db")))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	db.SetMaxOpenConns(4) // a real pool: the goroutines must actually overlap
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+	f := &rolloutFixture{db: db, now: time.Unix(1_700_000_000, 0).UTC(), t: t}
+	controller, err := newRolloutController(db, func() time.Time { return f.now })
+	if err != nil {
+		t.Fatalf("controller: %v", err)
+	}
+	controller.attachRegistry(f.owns)
+	f.c = controller
+	// Take the canary and validate it so the stage advances to a batch of two.
+	canary, _, _ := f.c.reserve(testPlatform, "canary", candidateA, 8)
+	if canary == nil {
+		t.Fatal("canary must reserve")
+	}
+	c0 := conn("canary")
+	f.prove(testPlatform, "canary", candidateA, c0)
+	if err := f.c.tick(nil, testPlatform); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	// Fill one of the two batch slots, leaving exactly one.
+	if r, _, _ := f.c.reserve(testPlatform, "filler", candidateA, 8); r == nil {
+		t.Fatal("the first batch slot must be available")
+	}
+
+	// Two distinct machines race for the last one.
+	var wg sync.WaitGroup
+	results := make([]*rolloutReservation, 2)
+	for i, id := range []string{"racer-a", "racer-b"} {
+		wg.Add(1)
+		go func(i int, id string) {
+			defer wg.Done()
+			r, _, err := f.c.reserve(testPlatform, id, candidateA, 8)
+			if err != nil {
+				t.Errorf("reserve %s: %v", id, err)
+			}
+			results[i] = r
+		}(i, id)
+	}
+	wg.Wait()
+
+	won := 0
+	for _, r := range results {
+		if r != nil {
+			won++
+		}
+	}
+	if won != 1 {
+		t.Fatalf("exactly one machine may take the final slot, %d did", won)
+	}
+}
+
+func TestARepeatedTriggerForOneMachineNeitherResendsNorExtends(t *testing.T) {
+	f := newRolloutFixture(t)
+	r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8)
+	if r == nil {
+		t.Fatal("reserve")
+	}
+	if err := f.c.markOffered(r); err != nil {
+		t.Fatalf("markOffered: %v", err)
+	}
+	_, _, deadlineBefore := f.slot(testPlatform, "m1")
+
+	f.advance(time.Minute)
+	again, _, err := f.c.reserve(testPlatform, "m1", candidateA, 8)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if again != nil {
+		t.Fatal("an offered slot must not be re-reserved by a duplicate trigger")
+	}
+	state, attempt, deadlineAfter := f.slot(testPlatform, "m1")
+	if state != rolloutOffered || attempt != 1 || deadlineAfter != deadlineBefore {
+		t.Fatalf("duplicate trigger changed the slot: state=%s attempt=%d deadline moved=%v",
+			state, attempt, deadlineAfter != deadlineBefore)
+	}
+}
+
+// ------------------------------------------------------------------- recovery
+
+// Crash after reserving, before the socket write: the agent was never offered
+// anything, so a bounded resend must be allowed — within the ORIGINAL window.
+func TestRecoveryResendPreservesTheAttemptWindow(t *testing.T) {
+	f := newRolloutFixture(t)
+	r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8)
+	if r == nil {
+		t.Fatal("reserve")
+	}
+	_, _, deadlineBefore := f.slot(testPlatform, "m1")
+
+	f.advance(2 * time.Minute) // crash, restart, machine reconnects
+	f.restart()
+
+	// The baseline is the deadline AFTER the restart grace has been applied.
+	// Comparing against the pre-restart value left room for the bug: the old
+	// code set a fresh now+10m window, which at t=2m lands at t=12m and sits
+	// comfortably inside "original plus five minutes of grace". The resend
+	// must not move the deadline AT ALL.
+	_, _, deadlineAfterRestart := f.slot(testPlatform, "m1")
+	if deadlineAfterRestart < deadlineBefore {
+		t.Fatal("the restart grace shortened the attempt window")
+	}
+
+	again, _, err := f.c.reserve(testPlatform, "m1", candidateA, 8)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if again == nil || !again.Resend {
+		t.Fatal("a reservation that never reached a socket must be resendable")
+	}
+	_, attempt, resends, deadlineAfterResend := f.slotFull(testPlatform, "m1")
+	// An automatic resend spends the RESEND budget, not an operator attempt:
+	// the two are separate so that exhausting recovery cannot make Resume inert.
+	if resends != 1 {
+		t.Fatalf("resend must consume the automatic resend budget, got %d", resends)
+	}
+	if attempt != 1 {
+		t.Fatalf("automatic recovery must not consume an operator attempt, got %d", attempt)
+	}
+	if deadlineAfterResend != deadlineAfterRestart {
+		t.Fatalf("the resend granted itself a new window: %d -> %d (%v added)",
+			deadlineAfterRestart, deadlineAfterResend,
+			time.Duration(deadlineAfterResend-deadlineAfterRestart)*time.Millisecond)
+	}
+}
+
+func TestRestartGraceIsGrantedOnceNotPerRestart(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	_, _, original := f.slot(testPlatform, "m1")
+
+	f.restart()
+	_, _, afterFirst := f.slot(testPlatform, "m1")
+	for i := 0; i < 5; i++ {
+		f.advance(10 * time.Second)
+		f.restart()
+	}
+	_, _, afterMany := f.slot(testPlatform, "m1")
+
+	if afterFirst < original {
+		t.Fatal("the grace shortened the attempt window")
+	}
+	if afterMany != afterFirst {
+		t.Fatalf("a crash loop kept extending the deadline: %d -> %d", afterFirst, afterMany)
+	}
+}
+
+// Exhausting the AUTOMATIC resend budget must not make the operator's Resume
+// inert: bounding both with one counter cleared the halt and moved nothing.
+func TestResumeWorksAfterTheAutomaticResendBudgetIsSpent(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	for i := 0; i < rolloutMaxResends+2; i++ {
+		if _, _, err := f.c.reserve(testPlatform, "m1", candidateA, 8); err != nil {
+			t.Fatalf("reserve: %v", err)
+		}
+	}
+	if state, _, _ := f.slot(testPlatform, "m1"); state != rolloutFailed {
+		t.Fatalf("the automatic budget should be spent, state=%s", state)
+	}
+
+	if err := f.c.resume(testPlatform); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	// Not merely status=active: the machine must actually become sendable.
+	r, why, err := f.c.reserve(testPlatform, "m1", candidateA, 8)
+	if err != nil {
+		t.Fatalf("reserve after resume: %v", err)
+	}
+	if r == nil {
+		t.Fatalf("resume left the machine unsendable (%q); the halt cleared but nothing moved", why)
+	}
+}
+
+func TestExhaustedResendAttemptsHaltDurably(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	for i := 0; i < rolloutMaxResends+2; i++ {
+		if _, _, err := f.c.reserve(testPlatform, "m1", candidateA, 8); err != nil {
+			t.Fatalf("reserve: %v", err)
+		}
+	}
+	// Reload from the database: a halt that lives only in the aborted
+	// transaction is not a halt.
+	f.restart()
+	st, err := f.c.platformState(testPlatform)
+	if err != nil || st == nil {
+		t.Fatalf("platform state: %v", err)
+	}
+	if st.Status != rolloutHalted {
+		t.Fatalf("exhausting attempts must halt the platform durably, status=%s", st.Status)
+	}
+	if st.HaltReason == "" {
+		t.Fatal("a halt must carry a reason an operator can read")
+	}
+}
+
+// ------------------------------------------------------------------- evidence
+
+func TestDwellRequiresContinuousTelemetryOnOneConnection(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	st, _ := f.c.platformState(testPlatform)
+	c1 := conn("m1")
+
+	f.c.observeCandidateReport(testPlatform, "m1", c1, st.Generation, candidateA, candidateA)
+	// One report, then silence past the allowed gap, then a frame at the far
+	// end of the dwell. The endpoints look right; the middle proves nothing.
+	f.advance(rolloutDwell + time.Second)
+	f.c.observeTelemetry(testPlatform, "m1", c1)
+	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); ok {
+		t.Fatal("a gap in the middle of the dwell must restart it, not be ignored")
+	} else if why == "" {
+		t.Fatal("a refusal must say why")
+	}
+
+	// Continuous frames do satisfy it.
+	f.prove(testPlatform, "m1", candidateA, c1)
+	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); !ok {
+		t.Fatalf("continuous telemetry across the dwell must satisfy it: %s", why)
+	}
+}
+
+// agentRunningVersions is keyed by machine and survives a socket replacement.
+// A new connection must not inherit the previous one's proof.
+func TestAReplacedConnectionInheritsNoEvidence(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	st, _ := f.c.platformState(testPlatform)
+
+	old := conn("m1")
+	f.prove(testPlatform, "m1", candidateA, old)
+	if ok, _ := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); !ok {
+		t.Fatal("control: the first connection must satisfy the dwell")
+	}
+
+	// The socket is replaced, and the REGISTRY is what says so.
+	fresh := conn("m1")
+	f.register("m1", fresh)
+	f.c.observeTelemetry(testPlatform, "m1", fresh)
+	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); ok {
+		t.Fatal("a replaced connection inherited the previous connection's dwell")
+	} else if why == "" {
+		t.Fatal("a refusal must say why")
+	}
+
+	// The displaced socket may still be readable. Its late frames must neither
+	// sustain its own dead dwell nor destroy the new connection's evidence.
+	f.c.observeCandidateReport(testPlatform, "m1", old, st.Generation, candidateA, candidateA)
+	f.c.observeTelemetry(testPlatform, "m1", old)
+	if ok, _ := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); ok {
+		t.Fatal("a displaced socket vouched for the machine it no longer owns")
+	}
+
+	// The new connection can then prove itself normally.
+	f.prove(testPlatform, "m1", candidateA, fresh)
+	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); !ok {
+		t.Fatalf("the current connection must be able to prove itself: %s", why)
+	}
+}
+
+// A version report says which bytes are running. It says nothing about the
+// machine being monitored, so repeating it must never satisfy a dwell.
+func TestVersionReportsAloneNeverValidate(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	st, _ := f.c.platformState(testPlatform)
+	c1 := conn("m1")
+	f.register("m1", c1)
+
+	for i := 0; i < 10; i++ {
+		f.c.observeCandidateReport(testPlatform, "m1", c1, st.Generation, candidateA, candidateA)
+		f.advance(20 * time.Second)
+	}
+	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); ok {
+		t.Fatal("repeated version reports with no metrics satisfied the dwell")
+	} else if why == "" {
+		t.Fatal("a refusal must say why")
+	}
+}
+
+// The dwell endpoint must be an observation, not a timer expiring.
+func TestTheDwellEndpointMustBeARealMetricsFrame(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	st, _ := f.c.platformState(testPlatform)
+	c1 := conn("m1")
+	f.register("m1", c1)
+
+	f.c.observeCandidateReport(testPlatform, "m1", c1, st.Generation, candidateA, candidateA)
+	f.advance(30 * time.Second)
+	f.c.observeTelemetry(testPlatform, "m1", c1) // dwell starts here
+
+	// The clock passes the dwell, but no further frame has arrived.
+	f.advance(rolloutDwell + time.Second)
+	if ok, _ := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); ok {
+		t.Fatal("the dwell completed on a timer, with no metrics at its endpoint")
+	}
+}
+
+// One connection proving candidate A must not hand that dwell to candidate B.
+func TestEvidenceForOneCandidateDoesNotValidateAnother(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	st, _ := f.c.platformState(testPlatform)
+	c1 := conn("m1")
+	f.prove(testPlatform, "m1", candidateA, c1)
+	if ok, _ := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); !ok {
+		t.Fatal("control: A must be satisfied")
+	}
+
+	// The candidate changes. The machine is still running A, on the same
+	// socket, and nothing about B has been observed.
+	if _, _, err := f.c.reserve(testPlatform, "m2", candidateB, 9); err != nil {
+		t.Fatalf("reserve B: %v", err)
+	}
+	stB, _ := f.c.platformState(testPlatform)
+	if stB.Generation == st.Generation {
+		t.Fatal("a changed candidate must start a new generation")
+	}
+	if ok, _ := f.c.dwellSatisfied(nil, testPlatform, "m1", stB.Generation, candidateB); ok {
+		t.Fatal("A's dwell was accepted as proof for B")
+	}
+}
+
+func TestRestartClearsInFlightEvidenceButKeepsValidatedProgress(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	st, _ := f.c.platformState(testPlatform)
+	c1 := conn("m1")
+	f.prove(testPlatform, "m1", candidateA, c1)
+	if err := f.c.tick(nil, testPlatform); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if state, _, _ := f.slot(testPlatform, "m1"); state != rolloutHealthy {
+		t.Fatalf("the canary should be validated, got %s", state)
+	}
+
+	// A second machine is mid-dwell when the hub restarts.
+	if r, _, _ := f.c.reserve(testPlatform, "m2", candidateA, 8); r == nil {
+		t.Fatal("the batch stage must admit m2")
+	}
+	c2 := conn("m2")
+	f.c.observeCandidateReport(testPlatform, "m2", c2, st.Generation, candidateA, candidateA)
+	f.advance(30 * time.Second)
+	f.c.observeTelemetry(testPlatform, "m2", c2)
+
+	f.restart()
+
+	// Validated progress is durable...
+	if state, _, _ := f.slot(testPlatform, "m1"); state != rolloutHealthy {
+		t.Fatalf("validated progress must survive a restart, got %s", state)
+	}
+	// ...and in-flight health evidence is not: downtime cannot accrue as dwell.
+	f.advance(rolloutDwell)
+	if ok, _ := f.c.dwellSatisfied(nil, testPlatform, "m2", st.Generation, candidateA); ok {
+		t.Fatal("a dwell in progress at restart was allowed to complete across the gap")
+	}
+}
+
+// -------------------------------------------------------------- progression
+
+// Before any eligible machine connects there are no slots at all. Advancing on
+// "nothing outstanding" would run the platform up to batch size before its
+// first machine ever arrived, and the canary would never happen.
+func TestAnEmptyPlatformNeverAdvancesPastTheCanary(t *testing.T) {
+	f := newRolloutFixture(t)
+	if _, _, err := f.c.reserve(testPlatform, "m1", candidateA, 8); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	// Drop the slot so the platform exists with no targets at all.
+	if _, err := f.db.Exec(`DELETE FROM agent_rollout_slot`); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if err := f.c.tick(nil, testPlatform); err != nil {
+			t.Fatalf("tick: %v", err)
+		}
+		f.advance(time.Minute)
+	}
+	st, _ := f.c.platformState(testPlatform)
+	if st.Stage != 0 {
+		t.Fatalf("an empty platform advanced to stage %d; the first machine would skip the canary", st.Stage)
+	}
+
+	// The first machine to arrive is still a lone canary.
+	if r, _, _ := f.c.reserve(testPlatform, "late", candidateA, 8); r == nil {
+		t.Fatal("the late machine must reserve")
+	}
+	if r, _, _ := f.c.reserve(testPlatform, "late2", candidateA, 8); r != nil {
+		t.Fatal("the second late machine must wait: the canary is still one machine")
+	}
+}
+
+// A reservation admitted after tick's preliminary look must not be stepped
+// over. Comparing on the stage does not catch this: the new reservation does
+// not change the stage, so a read-then-write advance still fires and leaves a
+// machine holding a slot in a stage the platform has already left.
+func TestAReservationArrivingDuringATickIsNotStrandedByAnAdvance(t *testing.T) {
+	f := newRolloutFixture(t)
+	// Validate the canary so the platform is eligible to advance.
+	if r, _, _ := f.c.reserve(testPlatform, "canary", candidateA, 8); r == nil {
+		t.Fatal("canary")
+	}
+	f.prove(testPlatform, "canary", candidateA, conn("canary"))
+	if err := f.c.tick(nil, testPlatform); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	before, _ := f.c.platformState(testPlatform)
+
+	// A machine is admitted into the CURRENT stage, exactly as one would be
+	// between a count and an update.
+	if r, _, _ := f.c.reserve(testPlatform, "arriving", candidateA, 8); r == nil {
+		t.Fatal("the new stage must admit a machine")
+	}
+	during, _ := f.c.platformState(testPlatform)
+	if during.Stage != before.Stage {
+		t.Fatalf("a reservation must not itself move the stage: %d -> %d", before.Stage, during.Stage)
+	}
+
+	if err := f.c.tick(nil, testPlatform); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	after, _ := f.c.platformState(testPlatform)
+	if after.Stage != during.Stage {
+		t.Fatalf("the stage advanced past outstanding work: %d -> %d", during.Stage, after.Stage)
+	}
+}
+
+// A stage in which every candidate was withheld has nothing outstanding and
+// has proven nothing. Advancing on "nothing in flight" alone would walk the
+// platform up through the batch sizes without ever testing the build.
+func TestAStageOfWithheldMachinesDoesNotAdvance(t *testing.T) {
+	f := newRolloutFixture(t)
+	if err := f.c.withhold(testPlatform, "m1", candidateA, 8, "no pinned update key"); err != nil {
+		t.Fatalf("withhold: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if err := f.c.tick(nil, testPlatform); err != nil {
+			t.Fatalf("tick: %v", err)
+		}
+		f.advance(time.Minute)
+	}
+	st, _ := f.c.platformState(testPlatform)
+	if st.Stage != 0 {
+		t.Fatalf("a stage that proved nothing advanced to %d", st.Stage)
+	}
+}
+
+// The ownership check happens outside the evidence lock, so a registration can
+// change in between. A frame from the losing socket must not discard the
+// winner's proof on its way past.
+func TestALateFrameFromADisplacedSocketCannotDiscardCurrentProof(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	st, _ := f.c.platformState(testPlatform)
+
+	old := conn("m1")
+	fresh := conn("m1")
+
+	// The new connection wins the machine and proves itself.
+	f.register("m1", fresh)
+	f.prove(testPlatform, "m1", candidateA, fresh)
+	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); !ok {
+		t.Fatalf("control: the current connection must be validated: %s", why)
+	}
+
+	// A frame from the displaced socket arrives afterwards. Letting it replace
+	// the record would reset a completed dwell and stall the rollout.
+	f.c.observeTelemetry(testPlatform, "m1", old)
+	f.c.observeCandidateReport(testPlatform, "m1", old, st.Generation, candidateA, candidateA)
+
+	if ok, why := f.c.dwellSatisfied(nil, testPlatform, "m1", st.Generation, candidateA); !ok {
+		t.Fatalf("a displaced socket's late frame destroyed valid proof: %s", why)
+	}
+}
+
+func TestProgressionNeedsNoOperatorAction(t *testing.T) {
+	f := newRolloutFixture(t)
+	machines := []string{"m1", "m2", "m3", "m4", "m5"}
+	validated := map[string]bool{}
+
+	for round := 0; round < 12 && len(validated) < len(machines); round++ {
+		for _, id := range machines {
+			if validated[id] {
+				continue
+			}
+			if r, _, err := f.c.reserve(testPlatform, id, candidateA, 8); err != nil {
+				t.Fatalf("reserve: %v", err)
+			} else if r != nil {
+				_ = f.c.markOffered(r)
+			}
+		}
+		for _, id := range machines {
+			if validated[id] {
+				continue
+			}
+			var state string
+			err := f.db.QueryRow(`SELECT state FROM agent_rollout_slot WHERE machine_id = ?`, id).Scan(&state)
+			if err == sql.ErrNoRows {
+				continue
+			} else if err != nil {
+				t.Fatalf("state: %v", err)
+			}
+			if state == rolloutOffered {
+				f.prove(testPlatform, id, candidateA, conn(id))
+			}
+		}
+		if err := f.c.tick(nil, testPlatform); err != nil {
+			t.Fatalf("tick: %v", err)
+		}
+		for _, id := range machines {
+			var state string
+			if err := f.db.QueryRow(`SELECT state FROM agent_rollout_slot WHERE machine_id = ?`, id).
+				Scan(&state); err == nil && state == rolloutHealthy {
+				validated[id] = true
+			}
+		}
+	}
+
+	if len(validated) != len(machines) {
+		t.Fatalf("only %d of %d machines progressed without operator action: %v",
+			len(validated), len(machines), validated)
+	}
+	st, _ := f.c.platformState(testPlatform)
+	if st.Status == rolloutHalted {
+		t.Fatalf("a healthy rollout halted: %s", st.HaltReason)
+	}
+	if st.Stage < 2 {
+		t.Fatalf("five machines at one canary plus batches of two should reach stage >= 2, got %d", st.Stage)
+	}
+}
+
+// "Complete" means caught up now, not closed forever.
+func TestALateMachineReopensACompletedPlatform(t *testing.T) {
+	f := newRolloutFixture(t)
+	r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8)
+	if r == nil {
+		t.Fatal("reserve")
+	}
+	f.prove(testPlatform, "m1", candidateA, conn("m1"))
+	if err := f.c.tick(nil, testPlatform); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if err := f.c.markComplete(testPlatform); err != nil {
+		t.Fatalf("markComplete: %v", err)
+	}
+
+	late, _, err := f.c.reserve(testPlatform, "late", candidateA, 8)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if late == nil {
+		t.Fatal("a machine that was offline for the whole rollout must still be offered the update")
+	}
+	if late.Stage == 0 {
+		t.Fatal("a late arrival must not be run through the canary again")
+	}
+	st, _ := f.c.platformState(testPlatform)
+	if st.Status != rolloutActive {
+		t.Fatalf("the platform should have reopened, status=%s", st.Status)
+	}
+	// The machine that already passed is not re-validated.
+	if again, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); again != nil {
+		t.Fatal("a validated machine must not be reserved again")
+	}
+}
+
+// --------------------------------------------------------- withheld / resume
+
+func TestAWithheldMachineDoesNotHaltAndResumesAutomatically(t *testing.T) {
+	f := newRolloutFixture(t)
+	if err := f.c.withhold(testPlatform, "m1", candidateA, 8, "no pinned update key"); err != nil {
+		t.Fatalf("withhold: %v", err)
+	}
+	st, _ := f.c.platformState(testPlatform)
+	if st.Status != rolloutActive {
+		t.Fatalf("an ineligible machine is not a failure; status=%s", st.Status)
+	}
+	status, err := f.c.status(testPlatform)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Withheld != 1 || status.Failed != 0 {
+		t.Fatalf("expected one withheld and no failures, got %+v", status)
+	}
+	if status.WithheldReason["m1"] == "" {
+		t.Fatal("a withheld machine must carry its reason")
+	}
+
+	// Eligibility is fixed: the machine must be picked up with no operator step.
+	r, _, err := f.c.reserve(testPlatform, "m1", candidateA, 8)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if r == nil {
+		t.Fatal("a machine whose eligibility recovered must be reserved without operator action")
+	}
+}
+
+func TestResumeRetriesFailedAttempts(t *testing.T) {
+	f := newRolloutFixture(t)
+	if r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8); r == nil {
+		t.Fatal("reserve")
+	}
+	f.advance(rolloutAttemptTimeout + rolloutRestartGrace + time.Minute)
+	if err := f.c.tick(nil, testPlatform); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if state, _, _ := f.slot(testPlatform, "m1"); state != rolloutFailed {
+		t.Fatalf("an expired attempt must fail, got %s", state)
+	}
+	st, _ := f.c.platformState(testPlatform)
+	if st.Status != rolloutHalted {
+		t.Fatal("a failed attempt must halt the platform")
+	}
+
+	if err := f.c.resume(testPlatform); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	state, attempt, _ := f.slot(testPlatform, "m1")
+	if state != rolloutReserved {
+		t.Fatalf("resume must give the failed slot a new attempt, state=%s", state)
+	}
+	if attempt < 2 {
+		t.Fatalf("resume must increment the attempt, got %d", attempt)
+	}
+	st, _ = f.c.platformState(testPlatform)
+	if st.Status != rolloutActive {
+		t.Fatalf("resume must clear the halt, status=%s", st.Status)
+	}
+}
+
+func TestStatusCountsRunningCandidatesNotOnlyValidatedOnes(t *testing.T) {
+	f := newRolloutFixture(t)
+	r, _, _ := f.c.reserve(testPlatform, "m1", candidateA, 8)
+	if r == nil {
+		t.Fatal("reserve")
+	}
+	if _, err := f.db.Exec(`UPDATE agent_rollout_slot SET state = ? WHERE machine_id = ?`,
+		rolloutObserved, "m1"); err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	status, err := f.c.status(testPlatform)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	// The machine IS running the candidate; only its dwell is unfinished.
+	// Reporting it as not updated reads as a stalled rollout.
+	if status.Updated != 1 {
+		t.Fatalf("a machine running the candidate must count as updated, got %d", status.Updated)
+	}
+	if status.Validated != 0 {
+		t.Fatalf("it is not validated yet, got %d", status.Validated)
+	}
+}
+
+func TestPlatformsProgressIndependently(t *testing.T) {
+	f := newRolloutFixture(t)
+	other := "linux/arm64"
+	if r, _, _ := f.c.reserve(testPlatform, "amd", candidateA, 8); r == nil {
+		t.Fatal("amd64 canary")
+	}
+	if r, _, _ := f.c.reserve(other, "arm", candidateB, 8); r == nil {
+		t.Fatal("arm64 canary")
+	}
+
+	// Fail amd64 outright.
+	f.advance(rolloutAttemptTimeout + rolloutRestartGrace + time.Minute)
+	if err := f.c.tick(nil, testPlatform); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	amd, _ := f.c.platformState(testPlatform)
+	if amd.Status != rolloutHalted {
+		t.Fatal("amd64 should have halted")
+	}
+	arm, _ := f.c.platformState(other)
+	if arm.Status != rolloutActive {
+		t.Fatalf("one platform halting must not halt another, arm64 status=%s", arm.Status)
+	}
+}

--- a/hub/agent_rollout_test.go
+++ b/hub/agent_rollout_test.go
@@ -873,3 +873,82 @@ func TestPlatformsProgressIndependently(t *testing.T) {
 		t.Fatalf("one platform halting must not halt another, arm64 status=%s", arm.Status)
 	}
 }
+
+// Admission must not depend on a trigger.
+//
+// A machine held back because the batch was full has no reason to send another
+// version report and no reason to reconnect — it is already reporting the OLD
+// build, happily, forever. If it is only ever considered when something pokes
+// the hub, a rollout stalls after the canary and looks identical to one that
+// is simply taking its time. So: admit the canary, prove it healthy, and then
+// require the waiting machines to be picked up on CAPACITY alone.
+func TestLaterMachinesAreAdmittedWithoutAnyFurtherTrigger(t *testing.T) {
+	f := newRolloutFixture(t)
+	candidate := candidateA
+
+	// The canary is admitted and validated.
+	canary, _, err := f.c.reserve(testPlatform, "canary", candidate, 8)
+	if err != nil || canary == nil {
+		t.Fatalf("canary must be admitted: %v", err)
+	}
+	if err := f.c.markOffered(canary); err != nil {
+		t.Fatalf("markOffered: %v", err)
+	}
+	f.prove(testPlatform, "canary", candidate, conn("canary"))
+	if err := f.c.tick(testPlatform); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if state, _, _ := f.slot(testPlatform, "canary"); state != rolloutHealthy {
+		t.Fatalf("the canary should be validated, got %s", state)
+	}
+
+	// Two machines that were connected the whole time and have reported
+	// nothing new. Exactly one pass of the scheduler's admission step — no
+	// version change, no reconnect, no resume.
+	waiting := []string{"waiter-1", "waiter-2", "waiter-3"}
+	admitted := map[string]bool{}
+	for _, id := range waiting {
+		r, _, err := f.c.reserve(testPlatform, id, candidate, 8)
+		if err != nil {
+			t.Fatalf("reserve %s: %v", id, err)
+		}
+		if r != nil {
+			admitted[id] = true
+			if err := f.c.markOffered(r); err != nil {
+				t.Fatalf("markOffered %s: %v", id, err)
+			}
+		}
+	}
+
+	if len(admitted) != rolloutBatchCapacity {
+		t.Fatalf("the batch after the canary admits %d machines, got %d (%v)",
+			rolloutBatchCapacity, len(admitted), admitted)
+	}
+	// And the third waits, rather than the batch quietly growing.
+	if admitted["waiter-3"] && admitted["waiter-1"] && admitted["waiter-2"] {
+		t.Fatal("all three were admitted; the batch bound did not hold")
+	}
+
+	// Those two prove themselves, and the next pass admits the last one —
+	// again with nothing having happened on any agent's side.
+	for id := range admitted {
+		f.prove(testPlatform, id, candidate, conn(id))
+	}
+	if err := f.c.tick(testPlatform); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	last := ""
+	for _, id := range waiting {
+		if !admitted[id] {
+			last = id
+		}
+	}
+	r, why, err := f.c.reserve(testPlatform, last, candidate, 8)
+	if err != nil {
+		t.Fatalf("reserve %s: %v", last, err)
+	}
+	if r == nil {
+		t.Fatalf("%s was never admitted after the batch ahead of it passed (%q); "+
+			"a rollout that needs a trigger to continue looks exactly like one that is working", last, why)
+	}
+}

--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -377,6 +377,16 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 	}
 	data, _ := json.Marshal(msg)
 
+	// announceSendBoundaryHook lets a test stop a goroutine exactly here — a
+	// reservation taken, the write lock held, nothing sent — so the recheck
+	// below can be exercised against a pause that arrives in that window. A
+	// sleep cannot do this: with TryLock a busy socket is skipped instantly,
+	// so there is no queue to race and the test would pass without ever
+	// reaching the boundary it names.
+	if announceSendBoundaryHook != nil {
+		announceSendBoundaryHook(machineID)
+	}
+
 	// The write lock is already held (taken before any slot state was
 	// touched). Recheck durable intent now, immediately before the write.
 	s.operatorRolloutMu.RLock()
@@ -453,6 +463,10 @@ func (s *Server) noteRolloutMetrics(machineID string, conn *ConnectedAgent) {
 	agentRunningVersionsMu.RUnlock()
 	s.rollout.observeTelemetry(rolloutPlatformKey(osName, arch), machineID, conn)
 }
+
+// announceSendBoundaryHook, when set by a test, runs after a reservation is
+// held and immediately before the pause/generation/ownership recheck.
+var announceSendBoundaryHook func(machineID string)
 
 // rolloutPlatformKey names a rollout target. Empty arch means the default,
 // matching what an arch-less download serves.
@@ -817,7 +831,12 @@ func (s *Server) recordAgentRunningVersionOn(machineID string, conn *ConnectedAg
 	// like an offer that never left.
 	if s.rollout != nil && conn != nil && expectedSHA != "" && runningSHA == expectedSHA {
 		platform := rolloutPlatformKey(osName, arch)
-		if st, err := s.rollout.platformState(platform); err == nil && st != nil {
+		if st, err := s.rollout.platformState(platform); err == nil && st != nil &&
+			strings.EqualFold(st.Candidate, expectedSHA) {
+			// The platform's candidate must BE the SHA this report matched.
+			// Read independently, a report that arrives just after the served
+			// binary changed would mark the NEW generation's slot observed on
+			// the strength of the machine running the OLD bytes.
 			if err := s.rollout.observeRunningCandidate(platform, machineID, st.Generation); err != nil {
 				log.Printf("rollout: could not record %s as running the candidate: %v", machineID, err)
 			}
@@ -949,7 +968,13 @@ func (s *Server) handleListVersions(c echo.Context) error {
 		for _, platform := range supportedAgentPlatforms {
 			status, err := s.rollout.status(platform.String())
 			if err != nil {
+				// Omitting the platform would read as "nothing is rolling out
+				// here", which is the one thing we do not know.
 				log.Printf("rollout: could not read status for %s: %v", platform, err)
+				rollout[platform.String()] = map[string]string{
+					"status": "unavailable",
+					"reason": err.Error(),
+				}
 				continue
 			}
 			if status == nil {
@@ -1022,14 +1047,22 @@ func (s *Server) resumeRolloutAtomically() error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	// Without a controller there is nothing to retry, and clearing the pause
+	// would tell an operator updates resumed while every failed attempt stayed
+	// terminal and nothing could ever be announced anyway.
+	if s.rollout == nil {
+		reason := "agent rollout controller unavailable"
+		if s.rolloutErr != nil {
+			reason = s.rolloutErr.Error()
+		}
+		return fmt.Errorf("cannot resume: %s", reason)
+	}
 	if err := setOperatorRolloutPauseTx(tx, false); err != nil {
 		return err
 	}
-	if s.rollout != nil {
-		for _, platform := range supportedAgentPlatforms {
-			if err := s.rollout.resumeTx(tx, platform.String()); err != nil {
-				return err
-			}
+	for _, platform := range supportedAgentPlatforms {
+		if err := s.rollout.resumeTx(tx, platform.String()); err != nil {
+			return err
 		}
 	}
 	return tx.Commit()

--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -25,8 +25,10 @@ import (
  *   1. Compute and cache the SHA-256 of the agent binary we serve at
  *      /download/agent (recomputed when mtime changes).
  *   2. Track each connected agent's running version (per-machine).
- *   3. Circuit breaker — pauses the rollout after consecutive failed
- *      reconnects so a bad build doesn't take out the whole fleet.
+ *   3. Route announcements through the staged rollout controller, so a bad
+ *      build reaches a canary rather than the whole fleet. There is no
+ *      automatic fleet-wide breaker any more: a failed attempt halts ONE
+ *      platform, durably, until an operator retries.
  *
  * Public surface:
  *   - initAgentVersionTracking()      — start the recompute + reconnect loops
@@ -289,11 +291,11 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 	}
 
 	// If we already know the agent's running SHA matches what we'd
-	// announce, skip both the message AND the reconnect-expectation
-	// timer. The agent's handleAgentVersion would silently no-op the
-	// announce (matching SHAs), so arming a 90s reconnect timer for a
-	// reconnect that will never come just trips the rollout circuit
-	// breaker on healthy fleets every time the hub restarts.
+	// announce, send nothing. The agent's handleAgentVersion compares SHAs
+	// and returns, so the frame is pure noise — and reserving a slot for it
+	// would spend a stage's capacity on a machine that is already there,
+	// leaving the machines that actually need the build waiting behind an
+	// attempt that can never produce anything to validate.
 	if hadVersion && v.RunningSHA == sha {
 		return
 	}
@@ -427,6 +429,14 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 		return
 	}
 
+	// announcePostWriteHook lets a test stop a goroutine in the OTHER crash
+	// window: the offer is on the wire, and the record of it is not yet
+	// durable. That window cannot be reached by rewriting a row afterwards —
+	// the whole point is that the process does not survive to write one.
+	if announcePostWriteHook != nil {
+		announcePostWriteHook(machineID)
+	}
+
 	if err := s.rollout.markOffered(reservation); err != nil {
 		log.Printf("rollout: could not mark the offer to %s: %v", machineID, err)
 	}
@@ -467,6 +477,10 @@ func (s *Server) noteRolloutMetrics(machineID string, conn *ConnectedAgent) {
 // announceSendBoundaryHook, when set by a test, runs after a reservation is
 // held and immediately before the pause/generation/ownership recheck.
 var announceSendBoundaryHook func(machineID string)
+
+// announcePostWriteHook, when set by a test, runs after the announcement has
+// been written to the socket and before the offer is recorded.
+var announcePostWriteHook func(machineID string)
 
 // rolloutPlatformKey names a rollout target. Empty arch means the default,
 // matching what an arch-less download serves.
@@ -573,12 +587,11 @@ func announceDecision(report *agentVersionInfo, osName, sha string) (sig string,
 	//
 	// A signature-capable agent computed the answer itself at connect time
 	// from its actual BLOXOS_HUB and reported it. Announcing to one that
-	// says no achieves nothing except arming a reconnect expectation for a
-	// reconnect that never comes — which expires into a rollout failure and,
-	// at two machines, pauses the whole fleet, with rolloutPauseReason
+	// says no achieves nothing: it will decline the download, so the slot
+	// runs out its attempt window and FAILS — halting the platform and
 	// blaming agent health for a refusal the hub provoked. The rule is
-	// already stated twenty lines up for the matching-SHA case: never arm
-	// the timer for an update you can predict won't produce a reconnect.
+	// already stated twenty lines up for the matching-SHA case: never spend
+	// an attempt on an update you can predict will not be taken.
 	//
 	// A pre-signature agent has no transport gate and cannot verify what we
 	// send it either, so the reason there is security rather than futility:
@@ -596,8 +609,10 @@ func announceDecision(report *agentVersionInfo, osName, sha string) (sig string,
 		// has ever pinned a key — so on every fleet that existed before this
 		// gate, this is the *default* state immediately after the hub picks
 		// up a signature-capable build, not an edge case. Announcing to it
-		// anyway arms the same 90s reconnect expectation for the same
-		// reconnect that will never come. agent_key_not_pinned is a
+		// anyway spends a stage's capacity on a download it will decline. It
+		// is WITHHELD instead — visible, with a reason, re-evaluated the
+		// moment it becomes eligible, and never a halt.
+		// agent_key_not_pinned is a
 		// distinct reason (not folded into the plaintext-transport message
 		// above) so an operator watching the rollout can tell "waiting on
 		// an installer re-run" apart from "agent is unhealthy" — the two
@@ -613,9 +628,9 @@ func announceDecision(report *agentVersionInfo, osName, sha string) (sig string,
 
 	// The agent refuses any announcement it cannot authenticate against the
 	// key its installer pinned. If we cannot produce a signature there is no
-	// update to be had — announcing anyway would only arm the 90s
-	// reconnect-expectation timer for a reconnect that never comes, and trip
-	// the rollout circuit breaker on a healthy fleet.
+	// update to be had — announcing anyway would spend a stage's capacity on
+	// an attempt that can only expire, and halt the platform over a hub-side
+	// signing problem that says nothing about the build or the fleet.
 	sig = announcedSignatureForArch(osName, arch, sha)
 	if sig == "" {
 		if enabled, reason := updateSigningStatus(); !enabled {
@@ -847,11 +862,12 @@ func (s *Server) recordAgentRunningVersionOn(machineID string, conn *ConnectedAg
 	// was suppressed because OS was unknown at WS-upgrade time. Trigger
 	// one now — but only when there's an actual pending update. Announcing
 	// to an already-up-to-date agent makes it silently no-op (the agent's
-	// handleAgentVersion compares SHAs and returns when they match), but
-	// announceVersionToAgent unconditionally arms a 90s reconnect-expectation
-	// timer that then fires a false-positive "rollout failure" log and
-	// counts toward the circuit breaker. Skip the announce when the agent
-	// is already on the announced SHA.
+	// handleAgentVersion compares SHAs and returns when they match), while
+	// the announce path would reserve a rollout slot for it — spending a
+	// stage's capacity on a machine that is already on the build, and
+	// leaving the machines that need it waiting behind an attempt with
+	// nothing to validate. Skip the announce when the agent is already on
+	// the announced SHA.
 	//
 	// The capability, transport, and key-pinned fields are part of the same
 	// story: at WS-upgrade time this frame had not arrived, so

--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -339,11 +339,53 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 	if hadVersion {
 		report = &v
 	}
+	platform := rolloutPlatformKey(osName, v.Arch)
+	release := currentAgentBinaryStateFor(osName, v.Arch).Release
+
+	// A missing or broken controller WITHHOLDS. Falling through to the
+	// unrestricted legacy announce would send a build to the entire fleet at
+	// exactly the moment the mechanism that bounds exposure is unavailable.
+	if s.rollout == nil {
+		reason := "agent rollout controller unavailable"
+		if s.rolloutErr != nil {
+			reason = s.rolloutErr.Error()
+		}
+		log.Printf("rollout: withholding update for %s — %s", machineID, reason)
+		return
+	}
+
 	sig, blocked := announceDecision(report, osName, sha)
 	if blocked != "" {
+		// Ineligible is not a rollout FAILURE. Recording it as one would halt
+		// the platform over a machine with no pinned key or an unusable
+		// transport, which says nothing about the build. It is withheld
+		// visibly instead, and re-evaluated as soon as it becomes eligible.
+		if err := s.rollout.withhold(platform, machineID, sha, release, blocked); err != nil {
+			log.Printf("rollout: could not record withheld machine %s: %v", machineID, err)
+		}
 		log.Printf("rollout: not announcing to %s — %s", machineID, blocked)
 		return
 	}
+
+	// Take a durable slot BEFORE anything is written to a socket. Racing
+	// triggers — a connect, a version report and a resume fan-out can all fire
+	// at once — collapse to one reservation, so repeats cannot reset a
+	// deadline or push a batch past its size.
+	reservation, why, err := s.rollout.reserve(platform, machineID, sha, release)
+	if err != nil {
+		log.Printf("rollout: could not reserve a slot for %s: %v", machineID, err)
+		return
+	}
+	if reservation == nil {
+		if why != "" {
+			log.Printf("rollout: holding %s — %s", machineID, why)
+		}
+		return
+	}
+	if !s.rollout.claimSend(reservation) {
+		return // another goroutine already owns this attempt
+	}
+	defer s.rollout.releaseSend(reservation)
 
 	msg := map[string]interface{}{
 		"type":      "agent_version",
@@ -360,24 +402,87 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 	// Do not hold the operator gate while waiting behind unrelated socket
 	// writes. Recheck durable intent after acquiring the agent's write lock.
 	s.operatorRolloutMu.RLock()
-	if paused, _ := s.operatorRolloutPause(); paused || announcedSHAForArch(osName, v.Arch) != sha {
+	// The registry check belongs HERE, at the actual send boundary, not only
+	// where the announcement was decided. This goroutine can queue behind
+	// unrelated socket writes, and in that window the machine may be deleted
+	// or taken over by a new connection — a stale connect callback must not
+	// announce down a displaced socket, nor record an outcome that resurrects
+	// rows for a machine that no longer exists.
+	if paused, _ := s.operatorRolloutPause(); paused || announcedSHAForArch(osName, v.Arch) != sha ||
+		!s.isRegisteredConnection(machineID, agent) ||
+		!s.rolloutGenerationUnchanged(platform, reservation) {
 		s.operatorRolloutMu.RUnlock()
 		agent.WriteMu.Unlock()
+		// Give the slot back rather than leaving capacity held by something
+		// that was never offered, and so the machine stays eligible once the
+		// operator resumes. Conditioned on our own generation and attempt, so
+		// it can only remove the row this call created.
+		if err := s.rollout.releaseBeforeSend(reservation); err != nil {
+			log.Printf("rollout: could not release the slot for %s: %v", machineID, err)
+		}
 		return
 	}
 	// Bound the only network I/O inside the pause barrier, matching the
 	// existing power-history ACK writer's deadline discipline.
 	_ = agent.Conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-	err := agent.Conn.WriteMessage(websocket.TextMessage, data)
+	writeErr := agent.Conn.WriteMessage(websocket.TextMessage, data)
 	_ = agent.Conn.SetWriteDeadline(time.Time{})
 	s.operatorRolloutMu.RUnlock()
 	agent.WriteMu.Unlock()
-	if err != nil {
-		log.Printf("rollout: failed to announce version to %s: %v", machineID, err)
+	if writeErr != nil {
+		log.Printf("rollout: failed to announce version to %s: %v", machineID, writeErr)
+		// The write failed, but it may have been partially delivered. The slot
+		// stays RESERVED rather than offered, which is the ambiguous state
+		// recovery is built to resolve: on reconnect the machine's reported
+		// SHA decides whether this landed.
 		return
 	}
 
-	s.armReconnectIfRegistered(machineID, agent)
+	if err := s.rollout.markOffered(reservation); err != nil {
+		log.Printf("rollout: could not mark the offer to %s: %v", machineID, err)
+	}
+}
+
+// noteRolloutMetrics feeds a metrics frame to the rollout controller as dwell
+// evidence for the connection it arrived on.
+func (s *Server) noteRolloutMetrics(machineID string, conn *ConnectedAgent) {
+	if s.rollout == nil || conn == nil || machineID == "" {
+		return
+	}
+	osName := s.lookupAgentOS(machineID)
+	if osName == "" {
+		return
+	}
+	agentRunningVersionsMu.RLock()
+	arch := agentRunningVersions[machineID].Arch
+	agentRunningVersionsMu.RUnlock()
+	s.rollout.observeTelemetry(rolloutPlatformKey(osName, arch), machineID, conn)
+}
+
+// rolloutPlatformKey names a rollout target. Empty arch means the default,
+// matching what an arch-less download serves.
+func rolloutPlatformKey(osName, arch string) string {
+	if arch == "" {
+		arch = defaultAgentArch
+	}
+	return normalizeAgentOS(osName) + "/" + arch
+}
+
+// rolloutGenerationUnchanged reports whether the candidate is still the one
+// this reservation was taken for.
+//
+// Checked INSIDE the pause barrier, immediately before the write. A candidate
+// that changed while this goroutine queued behind unrelated socket writes
+// would otherwise announce bytes the rollout has already moved on from.
+func (s *Server) rolloutGenerationUnchanged(platform string, reservation *rolloutReservation) bool {
+	if s.rollout == nil || reservation == nil {
+		return true
+	}
+	st, err := s.rollout.platformState(platform)
+	if err != nil || st == nil {
+		return false
+	}
+	return st.Generation == reservation.Generation && st.Status == rolloutActive
 }
 
 // armReconnectIfRegistered arms the reconnect expectation for an announced
@@ -662,6 +767,17 @@ func clearReconnectExpectation(machineID string) {
 // The report carries the agent's capability level and its own answer on
 // whether its transport permits self-update. See announceDecision.
 func (s *Server) recordAgentRunningVersion(machineID string, report agentVersionReport) {
+	s.recordAgentRunningVersionOn(machineID, nil, report)
+}
+
+// recordAgentRunningVersionOn is recordAgentRunningVersion with the connection
+// the report arrived on.
+//
+// The connection matters and the machine-keyed map cannot supply it:
+// agentRunningVersions survives a socket replacement, so a fresh connection
+// would inherit the previous one's matching SHA as if it had reported it. The
+// map stays for the UI; health is established per connection.
+func (s *Server) recordAgentRunningVersionOn(machineID string, conn *ConnectedAgent, report agentVersionReport) {
 	runningSHA, osName := report.RunningSHA, report.OS
 	// Resolve the per-OS expected SHA. If we don't yet know the agent's
 	// OS, lookupAgentOS will check the DB metrics for it. New-on-this-hub
@@ -682,6 +798,17 @@ func (s *Server) recordAgentRunningVersion(machineID string, report agentVersion
 		arch = s.lookupAgentArch(machineID)
 	}
 	expectedSHA := announcedSHAForArch(osName, arch)
+
+	// Health evidence is per connection. This is what stops a fresh socket
+	// inheriting the previous one's matching SHA from the machine-keyed map
+	// below, which survives a replacement and cannot establish health alone.
+	if s.rollout != nil && conn != nil && expectedSHA != "" {
+		platform := rolloutPlatformKey(osName, arch)
+		if st, err := s.rollout.platformState(platform); err == nil && st != nil {
+			s.rollout.observeCandidateReport(platform, machineID, conn,
+				st.Generation, runningSHA, expectedSHA)
+		}
+	}
 
 	hostname := s.lookupVersionHostname(machineID)
 

--- a/hub/agent_versions.go
+++ b/hub/agent_versions.go
@@ -127,23 +127,9 @@ type agentVersionReport struct {
 	ReleaseFloorOK  bool
 }
 
-type rolloutFailure struct {
-	machineID string
-	at        time.Time
-}
-
 var (
 	agentRunningVersions   = make(map[string]agentVersionInfo)
 	agentRunningVersionsMu sync.RWMutex
-
-	rolloutFailures    []rolloutFailure
-	rolloutFailuresMu  sync.Mutex
-	rolloutPaused      bool
-	rolloutPauseReason string
-	rolloutPausedMu    sync.RWMutex
-
-	pendingReconnects   = make(map[string]time.Time)
-	pendingReconnectsMu sync.Mutex
 )
 
 // initAgentVersionTracking is called from main() at hub startup.
@@ -152,38 +138,12 @@ func initAgentVersionTracking() {
 	// download, API read, or agent connection sees the same resolved paths.
 	recomputeAgentBinarySHA()
 	goSafelyForever("versionRefreshLoop", versionRefreshLoop)
-	goSafelyForever("reconnectMonitorLoop", reconnectMonitorLoop)
 }
 
 func versionRefreshLoop() {
 	for {
 		recomputeAgentBinarySHA()
 		time.Sleep(10 * time.Second)
-	}
-}
-
-func reconnectMonitorLoop() {
-	for {
-		time.Sleep(15 * time.Second)
-		now := time.Now()
-
-		pendingReconnectsMu.Lock()
-		expired := []string{}
-		for machineID, deadline := range pendingReconnects {
-			if now.After(deadline) {
-				expired = append(expired, machineID)
-			}
-		}
-		for _, mid := range expired {
-			log.Printf("rollout: %s did not reconnect within %s, marking as failure",
-				mid, reconnectExpectation)
-			delete(pendingReconnects, mid)
-		}
-		pendingReconnectsMu.Unlock()
-
-		for _, mid := range expired {
-			recordRolloutFailure(mid)
-		}
 	}
 }
 
@@ -261,15 +221,11 @@ func recomputeBinaryForPlatform(platform agentPlatform) {
 	if previous.SHA != "" && previous.SHA != sha {
 		log.Printf("version: %s agent binary changed (%s -> %s), update will propagate",
 			platform, versionShortSHA(previous.SHA), versionShortSHA(sha))
-		// Reset only the automatic failure breaker. The operator's durable
-		// pause lives in hub_settings and must survive a served-SHA change.
-		rolloutFailuresMu.Lock()
-		rolloutFailures = nil
-		rolloutFailuresMu.Unlock()
-		rolloutPausedMu.Lock()
-		rolloutPaused = false
-		rolloutPauseReason = ""
-		rolloutPausedMu.Unlock()
+		// A changed SHA is a new candidate, and reserve() starts a new
+		// generation for it — which is what clears prior progress and any
+		// halt. The old in-memory breaker had to be reset by hand here; the
+		// durable state does it as a consequence of the candidate changing.
+		// The operator's pause lives in hub_settings and is untouched.
 	}
 }
 
@@ -303,13 +259,20 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 		log.Printf("rollout: not announcing version to %s: %s", machineID, reason)
 		return
 	}
-	rolloutPausedMu.RLock()
-	paused := rolloutPaused
-	rolloutPausedMu.RUnlock()
-	if paused {
-		log.Printf("rollout: paused, not announcing version to %s", machineID)
+	// TryLock BEFORE anything touches a slot. This runs on the ONE scheduler
+	// goroutine and writeLockedTo has no deadline, so waiting here would
+	// freeze admission and expiry for every platform behind one stuck socket.
+	//
+	// It has to come first, not merely before the write: reserving and then
+	// discovering the socket is busy spends a recovered reservation's
+	// automatic resend budget without sending anything, so a permanently
+	// busy writer would exhaust recovery and halt the platform having never
+	// transmitted a byte. A busy socket is skipped with no slot, no counter
+	// and no deadline touched.
+	if agent == nil || !agent.WriteMu.TryLock() {
 		return
 	}
+	defer agent.WriteMu.Unlock()
 
 	// One read of the map, reused for the arch, the already-up-to-date
 	// check and the policy below. announceDecision takes no locks by
@@ -360,9 +323,17 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 		// the platform over a machine with no pinned key or an unusable
 		// transport, which says nothing about the build. It is withheld
 		// visibly instead, and re-evaluated as soon as it becomes eligible.
-		if err := s.rollout.withhold(platform, machineID, sha, release, blocked); err != nil {
-			log.Printf("rollout: could not record withheld machine %s: %v", machineID, err)
-		}
+		// Inside the ingestion barrier, which rechecks registry ownership and
+		// holds its read side across the commit. Machine deletion takes the
+		// write side around its own delete transaction, so a pass queued
+		// behind a delete cannot insert a row for a machine that is gone —
+		// a final pre-send check would only help if the process survived to
+		// reach it.
+		s.ingestFrame(machineID, agent, true, func() {
+			if err := s.rollout.withhold(platform, machineID, sha, release, blocked); err != nil {
+				log.Printf("rollout: could not record withheld machine %s: %v", machineID, err)
+			}
+		})
 		log.Printf("rollout: not announcing to %s — %s", machineID, blocked)
 		return
 	}
@@ -371,9 +342,17 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 	// triggers — a connect, a version report and a resume fan-out can all fire
 	// at once — collapse to one reservation, so repeats cannot reset a
 	// deadline or push a batch past its size.
-	reservation, why, err := s.rollout.reserve(platform, machineID, sha, release)
-	if err != nil {
-		log.Printf("rollout: could not reserve a slot for %s: %v", machineID, err)
+	var reservation *rolloutReservation
+	var why string
+	var reserveErr error
+	// Same barrier: the reservation INSERT must not outlive a deletion.
+	if !s.ingestFrame(machineID, agent, true, func() {
+		reservation, why, reserveErr = s.rollout.reserve(platform, machineID, sha, release)
+	}) {
+		return // the registry no longer holds this machine for this connection
+	}
+	if reserveErr != nil {
+		log.Printf("rollout: could not reserve a slot for %s: %v", machineID, reserveErr)
 		return
 	}
 	if reservation == nil {
@@ -398,9 +377,8 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 	}
 	data, _ := json.Marshal(msg)
 
-	agent.WriteMu.Lock()
-	// Do not hold the operator gate while waiting behind unrelated socket
-	// writes. Recheck durable intent after acquiring the agent's write lock.
+	// The write lock is already held (taken before any slot state was
+	// touched). Recheck durable intent now, immediately before the write.
 	s.operatorRolloutMu.RLock()
 	// The registry check belongs HERE, at the actual send boundary, not only
 	// where the announcement was decided. This goroutine can queue behind
@@ -412,13 +390,15 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 		!s.isRegisteredConnection(machineID, agent) ||
 		!s.rolloutGenerationUnchanged(platform, reservation) {
 		s.operatorRolloutMu.RUnlock()
-		agent.WriteMu.Unlock()
-		// Give the slot back rather than leaving capacity held by something
-		// that was never offered, and so the machine stays eligible once the
-		// operator resumes. Conditioned on our own generation and attempt, so
-		// it can only remove the row this call created.
-		if err := s.rollout.releaseBeforeSend(reservation); err != nil {
-			log.Printf("rollout: could not release the slot for %s: %v", machineID, err)
+		// A FRESH reservation is given back, so capacity is not held by
+		// something never offered and the machine stays eligible once the
+		// operator resumes. A RESEND is left alone: its slot is the ambiguous
+		// crash state, and discarding it to skip a send would throw away the
+		// record recovery depends on.
+		if !reservation.Resend {
+			if err := s.rollout.releaseBeforeSend(reservation); err != nil {
+				log.Printf("rollout: could not release the slot for %s: %v", machineID, err)
+			}
 		}
 		return
 	}
@@ -428,7 +408,6 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 	writeErr := agent.Conn.WriteMessage(websocket.TextMessage, data)
 	_ = agent.Conn.SetWriteDeadline(time.Time{})
 	s.operatorRolloutMu.RUnlock()
-	agent.WriteMu.Unlock()
 	if writeErr != nil {
 		log.Printf("rollout: failed to announce version to %s: %v", machineID, writeErr)
 		// The write failed, but it may have been partially delivered. The slot
@@ -441,6 +420,22 @@ func (s *Server) announceVersionToAgent(machineID string, agent *ConnectedAgent)
 	if err := s.rollout.markOffered(reservation); err != nil {
 		log.Printf("rollout: could not mark the offer to %s: %v", machineID, err)
 	}
+}
+
+// forgetRolloutMachine drops a deleted machine's in-memory dwell evidence and
+// wakes the scheduler.
+//
+// Call it AFTER the delete commits. The durable slots go inside that
+// transaction, with every other table, so a delete that fails and rolls back
+// leaves the machine's rollout state exactly as it was rather than having
+// freed capacity for a machine that still exists.
+func (s *Server) forgetRolloutMachine(machineID string) {
+	if s.rollout == nil || machineID == "" {
+		return
+	}
+	s.rollout.forgetEvidence(machineID)
+	// Freeing capacity is a reason to look again.
+	s.wakeRollout()
 }
 
 // noteRolloutMetrics feeds a metrics frame to the rollout controller as dwell
@@ -483,15 +478,6 @@ func (s *Server) rolloutGenerationUnchanged(platform string, reservation *rollou
 		return false
 	}
 	return st.Generation == reservation.Generation && st.Status == rolloutActive
-}
-
-// armReconnectIfRegistered arms the reconnect expectation for an announced
-// update only while agent still owns the registry entry, under the ingestion
-// barrier. The announce runs on its own goroutine, so without this a delete
-// that already cleared the expectation could be followed by a late arm and a
-// phantom rollout failure for a machine that no longer exists.
-func (s *Server) armReconnectIfRegistered(machineID string, agent *ConnectedAgent) bool {
-	return s.ingestFrame(machineID, agent, true, func() { expectReconnect(machineID) })
 }
 
 // announceDecision is the single place that decides whether an update may be
@@ -738,12 +724,6 @@ func (s *Server) lookupMetricsOS(machineID string) string {
 	return osStr
 }
 
-func expectReconnect(machineID string) {
-	pendingReconnectsMu.Lock()
-	defer pendingReconnectsMu.Unlock()
-	pendingReconnects[machineID] = time.Now().Add(reconnectExpectation)
-}
-
 // forgetAgentVersion drops the last-reported version for a machine that no
 // longer exists, so /api/versions stops listing it and no later reconnect
 // expectation can record a phantom rollout failure for it.
@@ -751,12 +731,6 @@ func forgetAgentVersion(machineID string) {
 	agentRunningVersionsMu.Lock()
 	delete(agentRunningVersions, machineID)
 	agentRunningVersionsMu.Unlock()
-}
-
-func clearReconnectExpectation(machineID string) {
-	pendingReconnectsMu.Lock()
-	defer pendingReconnectsMu.Unlock()
-	delete(pendingReconnects, machineID)
 }
 
 // recordAgentRunningVersion is called when the agent sends its SHA on connect.
@@ -836,9 +810,18 @@ func (s *Server) recordAgentRunningVersionOn(machineID string, conn *ConnectedAg
 		versionShortSHA(runningSHA), versionShortSHA(expectedSHA), osName, arch, report.UpdateProtocol,
 		expectedSHA != "" && runningSHA != expectedSHA, machineID)
 
-	if expectedSHA != "" && runningSHA == expectedSHA {
-		clearReconnectExpectation(machineID)
-		recordRolloutSuccess(machineID)
+	// The machine is RUNNING the candidate. Record that durably, so an
+	// operator sees it as updated while its dwell is still accruing rather
+	// than as nothing having happened — and so a crash between the socket
+	// write and the mark resolves explicitly on reconnect instead of looking
+	// like an offer that never left.
+	if s.rollout != nil && conn != nil && expectedSHA != "" && runningSHA == expectedSHA {
+		platform := rolloutPlatformKey(osName, arch)
+		if st, err := s.rollout.platformState(platform); err == nil && st != nil {
+			if err := s.rollout.observeRunningCandidate(platform, machineID, st.Generation); err != nil {
+				log.Printf("rollout: could not record %s as running the candidate: %v", machineID, err)
+			}
+		}
 	}
 
 	// If we just learned (or relearned) the OS, the first-connect announce
@@ -865,56 +848,10 @@ func (s *Server) recordAgentRunningVersionOn(machineID string, conn *ConnectedAg
 		!strings.EqualFold(prev.ReleaseFloorSHA, report.ReleaseFloorSHA) ||
 		prev.ReleaseFloorOK != report.ReleaseFloorOK) &&
 		expectedSHA != "" && runningSHA != expectedSHA {
-		s.agentsMu.RLock()
-		agent, online := s.agents[machineID]
-		s.agentsMu.RUnlock()
-		if online {
-			s.goTracked(func() { s.announceVersionToAgent(machineID, agent) })
-		}
+		// A changed report is a reason to LOOK, not a licence to send. The
+		// scheduler decides whether this machine gets capacity.
+		s.wakeRollout()
 	}
-}
-
-func recordRolloutFailure(machineID string) {
-	rolloutFailuresMu.Lock()
-	now := time.Now()
-	cutoff := now.Add(-rolloutFailureWindow)
-
-	fresh := rolloutFailures[:0]
-	for _, f := range rolloutFailures {
-		if f.at.After(cutoff) {
-			fresh = append(fresh, f)
-		}
-	}
-	fresh = append(fresh, rolloutFailure{machineID: machineID, at: now})
-	rolloutFailures = fresh
-	failureCount := len(fresh)
-	rolloutFailuresMu.Unlock()
-
-	log.Printf("rollout: failure recorded for %s (%d in window)", machineID, failureCount)
-
-	if failureCount >= rolloutFailureThreshold {
-		rolloutPausedMu.Lock()
-		if !rolloutPaused {
-			rolloutPaused = true
-			rolloutPauseReason = fmt.Sprintf(
-				"circuit breaker: %d agents failed to reconnect within %s",
-				failureCount, rolloutFailureWindow)
-			log.Printf("rollout: PAUSED — %s", rolloutPauseReason)
-		}
-		rolloutPausedMu.Unlock()
-	}
-}
-
-func recordRolloutSuccess(machineID string) {
-	rolloutFailuresMu.Lock()
-	defer rolloutFailuresMu.Unlock()
-	fresh := rolloutFailures[:0]
-	for _, f := range rolloutFailures {
-		if f.machineID != machineID {
-			fresh = append(fresh, f)
-		}
-	}
-	rolloutFailures = fresh
 }
 
 func (s *Server) lookupVersionHostname(machineID string) string {
@@ -967,10 +904,10 @@ func (s *Server) handleListVersions(c echo.Context) error {
 		}
 	}
 
-	rolloutPausedMu.RLock()
-	paused := rolloutPaused
-	pauseReason := rolloutPauseReason
-	rolloutPausedMu.RUnlock()
+	// The automatic breaker is gone: a platform halt replaces it, and is
+	// reported per platform in agent_rollout below rather than as a fleet-wide
+	// boolean that said nothing about which platform stopped or why.
+	paused, pauseReason := false, ""
 	if operatorPaused, reason := s.operatorRolloutPause(); operatorPaused {
 		paused, pauseReason = true, reason
 	}
@@ -996,7 +933,34 @@ func (s *Server) handleListVersions(c echo.Context) error {
 	// policy is in force.
 	delivery, deliveryErr := agentDeliveryStatus()
 
+	// Rollout state per platform, so a held or halted rollout is VISIBLE
+	// rather than only logged. Without this the dashboard shows update_pending
+	// on every agent indefinitely and an operator cannot tell a rollout in
+	// progress from one that stopped — which is the same failure the
+	// update_blocked_reason field exists to prevent, one level up.
+	rollout := map[string]interface{}{}
+	if s.rollout == nil {
+		reason := "agent rollout controller unavailable; updates are withheld"
+		if s.rolloutErr != nil {
+			reason = s.rolloutErr.Error()
+		}
+		rollout["unavailable"] = reason
+	} else {
+		for _, platform := range supportedAgentPlatforms {
+			status, err := s.rollout.status(platform.String())
+			if err != nil {
+				log.Printf("rollout: could not read status for %s: %v", platform, err)
+				continue
+			}
+			if status == nil {
+				continue // nothing has been rolled out for this platform yet
+			}
+			rollout[platform.String()] = status
+		}
+	}
+
 	return c.JSON(http.StatusOK, map[string]interface{}{
+		"agent_rollout":           rollout,
 		"agent_delivery":          delivery,
 		"agent_delivery_error":    deliveryErr,
 		"signing_enabled":         signingEnabled,
@@ -1031,39 +995,44 @@ func (s *Server) handlePauseRollout(c echo.Context) error {
 
 func (s *Server) handleResumeRollout(c echo.Context) error {
 	s.operatorRolloutMu.Lock()
-	if err := s.setOperatorRolloutPause(false); err != nil {
-		s.operatorRolloutMu.Unlock()
-		log.Printf("rollout: could not persist operator resume: %v", err)
+	// Clearing the pause and retrying the failed attempts are ONE transaction.
+	// Split, a failure halfway leaves the pause cleared and every failed slot
+	// still terminal — the operator is told "resumed", the halt looks gone,
+	// and nothing moves. Reporting partial success as success is worse than
+	// reporting failure.
+	err := s.resumeRolloutAtomically()
+	s.operatorRolloutMu.Unlock()
+	if err != nil {
+		log.Printf("rollout: could not resume: %v", err)
 		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "Could not save rollout resume. Rollout state was not changed; check hub database health and retry."})
 	}
-	rolloutPausedMu.Lock()
-	rolloutPaused = false
-	rolloutPauseReason = ""
-	rolloutPausedMu.Unlock()
-
-	rolloutFailuresMu.Lock()
-	rolloutFailures = nil
-	rolloutFailuresMu.Unlock()
-	s.operatorRolloutMu.Unlock()
 
 	log.Printf("rollout: RESUMED by operator")
-
-	// Re-announce to all currently connected agents.
-	s.agentsMu.RLock()
-	conns := make([]*ConnectedAgent, 0, len(s.agents))
-	ids := make([]string, 0, len(s.agents))
-	for id, a := range s.agents {
-		ids = append(ids, id)
-		conns = append(conns, a)
-	}
-	s.agentsMu.RUnlock()
-
-	for i := range conns {
-		mid, conn := ids[i], conns[i]
-		s.goTracked(func() { s.announceVersionToAgent(mid, conn) })
-	}
+	s.wakeRollout()
 
 	return c.JSON(http.StatusOK, map[string]string{"status": "resumed"})
+}
+
+// resumeRolloutAtomically clears the operator pause and gives every failed slot
+// a new attempt, in one transaction. All of it, or none.
+func (s *Server) resumeRolloutAtomically() error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := setOperatorRolloutPauseTx(tx, false); err != nil {
+		return err
+	}
+	if s.rollout != nil {
+		for _, platform := range supportedAgentPlatforms {
+			if err := s.rollout.resumeTx(tx, platform.String()); err != nil {
+				return err
+			}
+		}
+	}
+	return tx.Commit()
 }
 
 func versionShortSHA(sha string) string {

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -1284,6 +1284,12 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 
 				s.upsertMachine(m)
 				s.storeMetrics(m)
+				// A metrics frame is the hub OBSERVING the machine work, which
+				// is what a rollout dwell is made of. Bound to this connection
+				// and stamped with hub receipt time: an agent's own timestamp
+				// is its claim about itself, and a stalled one keeps asserting
+				// freshness.
+				s.noteRolloutMetrics(machineID, agent)
 
 				// Enrich the metrics broadcast with latency.
 				machineLatencyMu.RLock()
@@ -1441,7 +1447,7 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 					continue
 				}
 				if !s.ingestFrame(machineID, agent, registered, func() {
-					s.recordAgentRunningVersion(machineID, report)
+					s.recordAgentRunningVersionOn(machineID, agent, report)
 				}) {
 					return nil
 				}
@@ -1550,7 +1556,7 @@ func (s *Server) handleAgentWS(c echo.Context) error {
 				if pendingVersionReport != nil {
 					held := *pendingVersionReport
 					pendingVersionReport = nil
-					if !s.ingestFrame(machineID, agent, registered, func() { s.recordAgentRunningVersion(machineID, held) }) {
+					if !s.ingestFrame(machineID, agent, registered, func() { s.recordAgentRunningVersionOn(machineID, agent, held) }) {
 						return nil
 					}
 				}

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -110,7 +110,9 @@ func (s *Server) registerAgentConnection(machineID string, agent *ConnectedAgent
 		log.Printf("agent %s reconnected; closing displaced connection", machineID)
 		_ = displaced.Conn.Close()
 	}
-	s.goTracked(func() { s.announceVersionToAgent(machineID, agent) })
+	// Wake the scheduler rather than announcing here. It is the only sender,
+	// so a connect cannot race a version report or a resume for the same slot.
+	s.wakeRollout()
 	s.goTracked(func() { s.sendAISessionsConfig(machineID, agent) })
 }
 

--- a/hub/agentws.go
+++ b/hub/agentws.go
@@ -134,6 +134,19 @@ func (s *Server) unregisterAgentConnection(machineID string, agent *ConnectedAge
 		delete(s.agents, machineID)
 	}
 	s.agentsMu.Unlock()
+
+	// Drop THIS connection's rollout evidence, after the registry lock is
+	// released. Every exiting connection, including a displaced one: each owns
+	// only its own record, so this can never take the winner's proof. Without
+	// it a disconnect left dwell evidence behind for a socket that no longer
+	// exists, and the only thing bounding growth was a prune that could evict
+	// the wrong record.
+	if s.rollout != nil {
+		for _, platform := range supportedAgentPlatforms {
+			s.rollout.forgetConnection(platform.String(), machineID, agent)
+		}
+	}
+
 	if stillOurs {
 		s.markOffline(machineID)
 		// Live sessions only: a machine that is no longer connected has no

--- a/hub/lifecycle_safety_test.go
+++ b/hub/lifecycle_safety_test.go
@@ -94,9 +94,12 @@ func TestDeleteConnectedMachineClosesSocketAndDoesNotResurrect(t *testing.T) {
 	agentRunningVersionsMu.Lock()
 	agentRunningVersions["machine-A"] = agentVersionInfo{MachineID: "machine-A", RunningSHA: "deadbeef", OS: "linux", ReportedAt: time.Now()}
 	agentRunningVersionsMu.Unlock()
-	pendingReconnectsMu.Lock()
-	pendingReconnects["machine-A"] = time.Now()
-	pendingReconnectsMu.Unlock()
+	// A rollout slot, which is what now holds batch capacity. The old
+	// pendingReconnects map it replaces had the same hazard: state keyed by
+	// machine id that nothing expires on its own.
+	if _, _, err := s.rollout.reserve("linux/amd64", "machine-A", "deadbeef", 0); err != nil {
+		t.Fatalf("reserve a slot for the machine under test: %v", err)
+	}
 
 	events, unsubscribe := subscribeBroadcast(t)
 	defer unsubscribe()
@@ -119,11 +122,16 @@ func TestDeleteConnectedMachineClosesSocketAndDoesNotResurrect(t *testing.T) {
 	agentRunningVersionsMu.RLock()
 	_, versionKept := agentRunningVersions["machine-A"]
 	agentRunningVersionsMu.RUnlock()
-	pendingReconnectsMu.Lock()
-	_, reconnectKept := pendingReconnects["machine-A"]
-	pendingReconnectsMu.Unlock()
-	if versionKept || reconnectKept {
-		t.Fatalf("rollout state leaked: version=%v reconnect=%v", versionKept, reconnectKept)
+	var slotsKept int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_rollout_slot WHERE machine_id = ?`,
+		"machine-A").Scan(&slotsKept); err != nil {
+		t.Fatalf("count slots: %v", err)
+	}
+	if versionKept || slotsKept != 0 {
+		// A leaked slot is worse than untidy: reserved and offered slots hold
+		// batch capacity, and nothing would ever release it for a machine that
+		// no longer exists, so the platform stalls behind a ghost.
+		t.Fatalf("rollout state leaked: version=%v slots=%d", versionKept, slotsKept)
 	}
 
 	// A late frame on the dead socket must not bring the machine back.
@@ -786,46 +794,43 @@ collect:
 	}
 }
 
-// TestAnnounceCannotRearmReconnectAfterDelete: the update announce runs on
-// its own goroutine; its reconnect expectation must arm only while the
-// agent still owns the registry entry, so a delete cannot be followed by a
-// late arm and a phantom rollout failure.
-func TestAnnounceCannotRearmReconnectAfterDelete(t *testing.T) {
+// TestAnnounceCannotActOnADeletedMachine: the announce runs on its own
+// goroutine, so a delete can land while it is queued. The ownership check that
+// used to guard arming a reconnect expectation now guards the SEND itself,
+// which is strictly stronger — the old code still wrote to the socket and only
+// declined to arm afterwards.
+func TestAnnounceCannotActOnADeletedMachine(t *testing.T) {
 	_, s := setupTestServer(t)
 	agent := &ConnectedAgent{MachineID: "machine-A"}
 	s.agentsMu.Lock()
 	s.agents["machine-A"] = agent
 	s.agentsMu.Unlock()
-	defer func() {
-		pendingReconnectsMu.Lock()
-		delete(pendingReconnects, "machine-A")
-		pendingReconnectsMu.Unlock()
-	}()
 
-	if !s.armReconnectIfRegistered("machine-A", agent) {
-		t.Fatal("registered agent must be able to arm its reconnect expectation")
-	}
-	pendingReconnectsMu.Lock()
-	_, armed := pendingReconnects["machine-A"]
-	pendingReconnectsMu.Unlock()
-	if !armed {
-		t.Fatal("expectation not armed for registered agent")
+	if !s.isRegisteredConnection("machine-A", agent) {
+		t.Fatal("control: a registered agent must be recognised as the owner")
 	}
 
-	// What delete does: take the entry, clear the expectation.
+	// What delete does: take the registry entry and drop the rollout state.
 	s.agentsMu.Lock()
 	delete(s.agents, "machine-A")
 	s.agentsMu.Unlock()
-	clearReconnectExpectation("machine-A")
+	s.forgetRolloutMachine("machine-A")
 
-	if s.armReconnectIfRegistered("machine-A", agent) {
-		t.Fatal("late announce armed a reconnect expectation for a deleted machine")
+	if s.isRegisteredConnection("machine-A", agent) {
+		t.Fatal("a deleted machine's connection is still treated as its owner")
 	}
-	pendingReconnectsMu.Lock()
-	_, armed = pendingReconnects["machine-A"]
-	pendingReconnectsMu.Unlock()
-	if armed {
-		t.Fatal("reconnect expectation re-armed after delete")
+
+	// A late announce must neither write nor leave durable state behind. It is
+	// safe to call with a nil Conn precisely because it must never reach one.
+	s.announceVersionToAgent("machine-A", agent)
+
+	var slots int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_rollout_slot WHERE machine_id = ?`,
+		"machine-A").Scan(&slots); err != nil {
+		t.Fatalf("count slots: %v", err)
+	}
+	if slots != 0 {
+		t.Fatalf("a late announce resurrected %d slot(s) for a deleted machine", slots)
 	}
 }
 

--- a/hub/main.go
+++ b/hub/main.go
@@ -181,6 +181,13 @@ func main() {
 	}
 	log.Println("database initialized")
 
+	// After migrations, because the controller reads its own tables. Before
+	// anything can announce, because a nil controller withholds updates.
+	if err := s.initRollout(); err != nil {
+		log.Fatalf("failed to init agent rollout: %v", err)
+	}
+	s.startRolloutScheduler()
+
 	// Seed default alert rules.
 	s.seedAlertRules()
 

--- a/hub/main.go
+++ b/hub/main.go
@@ -866,11 +866,6 @@ func (s *Server) handleDeleteMachine(c echo.Context) error {
 	if live != nil && live.Conn != nil {
 		_ = live.Conn.Close()
 	}
-	// Rollout bookkeeping is keyed by machine id and never expires on its own:
-	// an armed reconnect expectation would record a phantom rollout failure
-	// for a machine that no longer exists, and the version list would show
-	// it forever.
-	clearReconnectExpectation(id)
 	forgetAgentVersion(id)
 
 	// Delete all related data in a transaction
@@ -880,7 +875,14 @@ func (s *Server) handleDeleteMachine(c echo.Context) error {
 	}
 	defer tx.Rollback()
 
-	tables := []string{"metrics", "gpu_metrics", "services", "containers", "alerts", "terminal_sessions", "agent_credentials", "power_history_records", "power_history_stream_state", "power_history_gaps"}
+	// agent_rollout_slot is deleted INSIDE this transaction, with everything
+	// else. Rollout state is keyed by machine id and nothing expires it: a
+	// reserved or offered slot holds batch capacity that nothing would ever
+	// release for a machine that no longer exists, so the platform stalls
+	// behind a ghost. Deleting it before the transaction would be worse than
+	// leaving it — a delete that then failed and rolled back would have freed
+	// the slot for a machine that still exists.
+	tables := []string{"metrics", "gpu_metrics", "services", "containers", "alerts", "terminal_sessions", "agent_credentials", "power_history_records", "power_history_stream_state", "power_history_gaps", "agent_rollout_slot"}
 	for _, table := range tables {
 		if _, err := tx.Exec("DELETE FROM "+table+" WHERE machine_id = ?", id); err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to delete " + table})
@@ -892,6 +894,10 @@ func (s *Server) handleDeleteMachine(c echo.Context) error {
 	if err := tx.Commit(); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to commit"})
 	}
+
+	// Only after the commit: the durable rows are gone, so the in-memory dwell
+	// evidence should follow, and the freed capacity is a reason to look again.
+	s.forgetRolloutMachine(id)
 
 	machineLatencyMu.Lock()
 	delete(machineLatency, id)

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -154,6 +154,14 @@ func setupTestServer(t *testing.T) (*echo.Echo, *Server) {
 	}
 
 	s := newServer(db)
+	// Migrations have run, so the rollout controller can be built — the same
+	// explicit step main() performs after initDB. Tests set it up rather than
+	// the production path tolerating a missing controller: without one, every
+	// announcement is WITHHELD, which is the fail-closed behaviour and must
+	// not be softened to keep a test green.
+	if err := s.initRollout(); err != nil {
+		t.Fatalf("init rollout controller: %v", err)
+	}
 	// Isolate bootstrap-CA discovery from the host's real Caddy roots. Without
 	// this, a developer or CI machine that happens to have a local Caddy CA at
 	// ~/.local/share/caddy (or /var/lib/caddy, /root) leaks that cert into the

--- a/hub/main_test.go
+++ b/hub/main_test.go
@@ -162,6 +162,10 @@ func setupTestServer(t *testing.T) (*echo.Echo, *Server) {
 	if err := s.initRollout(); err != nil {
 		t.Fatalf("init rollout controller: %v", err)
 	}
+	// The scheduler is the only thing that SENDS, so tests that expect an
+	// announcement need it running — the same order main() uses. Shutdown
+	// stops it before waiting, so it cannot outlive the database.
+	s.startRolloutScheduler()
 	// Isolate bootstrap-CA discovery from the host's real Caddy roots. Without
 	// this, a developer or CI machine that happens to have a local Caddy CA at
 	// ~/.local/share/caddy (or /var/lib/caddy, /root) leaks that cert into the

--- a/hub/migrations.go
+++ b/hub/migrations.go
@@ -545,6 +545,73 @@ var migrations = []migration{
 			return nil
 		},
 	},
+	{
+		description: "durable staged agent rollout state",
+		apply: func(tx *sql.Tx) error {
+			// Two tables, appended. The rollout used to be all-at-once with
+			// its failure state held only in memory, so a hub restart erased
+			// every in-flight expectation.
+			//
+			// `generation` is what makes candidate changes safe. A rollout to
+			// B, then back to A, must not revive A's earlier completed stages,
+			// so the candidate's identity is a monotonic generation rather
+			// than its SHA alone, and every slot is keyed by it. A callback
+			// naming an older generation is ignored, not applied.
+			//
+			// Health evidence is deliberately ABSENT from these tables. It is
+			// tied to a live connection, so persisting it would let a hub
+			// restart resurrect proof that a socket which no longer exists was
+			// healthy. Reservations, stage and completed outcomes are durable;
+			// in-flight dwell lives only in memory.
+			for _, statement := range []string{
+				`CREATE TABLE IF NOT EXISTS agent_rollout_platform (
+					platform           TEXT PRIMARY KEY,
+					generation         INTEGER NOT NULL,
+					candidate_sha      TEXT NOT NULL,
+					candidate_release  INTEGER NOT NULL DEFAULT 0,
+					stage              INTEGER NOT NULL DEFAULT 0,
+					status             TEXT NOT NULL DEFAULT 'active',
+					halt_reason        TEXT NOT NULL DEFAULT '',
+					updated_unix_ms    INTEGER NOT NULL
+				)`,
+				`CREATE TABLE IF NOT EXISTS agent_rollout_slot (
+					platform          TEXT NOT NULL,
+					generation        INTEGER NOT NULL,
+					machine_id        TEXT NOT NULL,
+					stage             INTEGER NOT NULL,
+					attempt           INTEGER NOT NULL DEFAULT 1,
+					state             TEXT NOT NULL,
+					reserved_unix_ms  INTEGER NOT NULL,
+					offered_unix_ms   INTEGER,
+					deadline_unix_ms  INTEGER NOT NULL,
+					reason            TEXT NOT NULL DEFAULT '',
+					-- Whether this ATTEMPT has already consumed its one
+					-- restart grace. Extending every live deadline on every
+					-- construction would give a crash loop unlimited time,
+					-- so the grace is bounded per attempt and reset only when
+					-- a new attempt begins.
+					grace_used        INTEGER NOT NULL DEFAULT 0,
+					-- Automatic crash-recovery sends used WITHIN the current
+					-- attempt. Separate from the attempt column, which is
+					-- the operator's: bounding operator retries by the same
+					-- counter made Resume permanently inert once automatic
+					-- recovery had exhausted it.
+					resend_count      INTEGER NOT NULL DEFAULT 0,
+					PRIMARY KEY (platform, generation, machine_id)
+				)`,
+				// The capacity query counts unvalidated slots for one
+				// (platform, generation); it runs inside the reservation's
+				// write transaction, so it is on the hot path of every send.
+				`CREATE INDEX IF NOT EXISTS idx_agent_rollout_slot_state
+					ON agent_rollout_slot (platform, generation, state)`,
+			} {
+				if _, err := tx.Exec(statement); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	},
 }
 
 // isDuplicateColumnErr returns true when SQLite rejects an ALTER TABLE ADD

--- a/hub/migrations.go
+++ b/hub/migrations.go
@@ -597,6 +597,13 @@ var migrations = []migration{
 					-- counter made Resume permanently inert once automatic
 					-- recovery had exhausted it.
 					resend_count      INTEGER NOT NULL DEFAULT 0,
+					-- Whether this machine was ever OBSERVED running the
+					-- candidate, independent of whether its dwell then
+					-- succeeded. Without it, a machine whose validation later
+					-- failed stops being counted as updated even though it is
+					-- demonstrably on the new build, and an operator reading
+					-- "0 updated, 1 failed" concludes nothing shipped.
+					ran_candidate     INTEGER NOT NULL DEFAULT 0,
 					PRIMARY KEY (platform, generation, machine_id)
 				)`,
 				// The capacity query counts unvalidated slots for one

--- a/hub/release_policy_test.go
+++ b/hub/release_policy_test.go
@@ -103,11 +103,10 @@ func TestReleaseWithholdingDoesNotArmReconnectAndIsVisible(t *testing.T) {
 		agentRunningVersionsMu.Lock()
 		delete(agentRunningVersions, id)
 		agentRunningVersionsMu.Unlock()
-		clearReconnectExpectation(id)
 	})
 	// A nil connection is deliberate: the policy must return before any write.
 	s.announceVersionToAgent(id, &ConnectedAgent{})
-	assertNoReconnectExpectation(t, id)
+	assertNoPendingRolloutAttempt(t, s, id)
 	rec := httptest.NewRecorder()
 	if err := s.handleListVersions(e.NewContext(httptest.NewRequest(http.MethodGet, "/api/versions", nil), rec)); err != nil {
 		t.Fatal(err)
@@ -151,7 +150,7 @@ func TestReleaseReportOverWebSocket(t *testing.T) {
 				if len(frames) != 0 {
 					t.Fatalf("refused update announced: %v", frames)
 				}
-				assertNoReconnectExpectation(t, id)
+				assertNoPendingRolloutAttempt(t, s, id)
 				return
 			}
 			if len(frames) != 1 {

--- a/hub/rollout_pause.go
+++ b/hub/rollout_pause.go
@@ -39,6 +39,21 @@ func (s *Server) operatorRolloutPause() (bool, string) {
 // automatic-breaker reset. Announcements hold its read side through enqueue,
 // so a successful pause response is a barrier for new announcements. It cannot
 // cancel an update frame already queued or an agent update already in flight.
+// setOperatorRolloutPauseTx is setOperatorRolloutPause inside a caller's
+// transaction, so clearing the pause can be committed together with the slot
+// resets that make a resume mean anything.
+func setOperatorRolloutPauseTx(tx *sql.Tx, paused bool) error {
+	value := "0"
+	if paused {
+		value = "1"
+	}
+	_, err := tx.Exec(`INSERT INTO hub_settings (key, value, updated_at)
+		VALUES (?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP`,
+		operatorRolloutPauseKey, value)
+	return err
+}
+
 func (s *Server) setOperatorRolloutPause(paused bool) error {
 	value := "0"
 	if paused {

--- a/hub/rollout_pause_test.go
+++ b/hub/rollout_pause_test.go
@@ -235,7 +235,20 @@ func TestOperatorPauseSurvivesSHAChangeAndSuppressesAnnouncements(t *testing.T) 
 	defer client.Close()
 	conn := <-connections
 	defer conn.Close()
-	agent := &ConnectedAgent{Conn: conn}
+	agent := &ConnectedAgent{MachineID: "pause-regression", Conn: conn}
+	// Register it, as a real connection is. The send boundary now verifies
+	// the registry still owns the machine before writing, so an announcement
+	// that queued behind unrelated socket writes cannot go down a socket that
+	// has since been displaced or deleted. An unregistered connection is
+	// correctly refused, which production never produces.
+	s.agentsMu.Lock()
+	s.agents["pause-regression"] = agent
+	s.agentsMu.Unlock()
+	t.Cleanup(func() {
+		s.agentsMu.Lock()
+		delete(s.agents, "pause-regression")
+		s.agentsMu.Unlock()
+	})
 	frames := make(chan []byte, 1)
 	go func() {
 		_, data, err := client.ReadMessage()

--- a/hub/rollout_pause_test.go
+++ b/hub/rollout_pause_test.go
@@ -25,7 +25,14 @@ func openPauseTestServer(t *testing.T, path string) *Server {
 	if err := runMigrations(db); err != nil {
 		t.Fatal(err)
 	}
-	return newServer(db)
+	s := newServer(db)
+	// Migrations have run, so build the controller — the explicit step main()
+	// performs after initDB. Without it a resume correctly refuses: there is
+	// no controller to retry the failed attempts with.
+	if err := s.initRollout(); err != nil {
+		t.Fatalf("init rollout controller: %v", err)
+	}
+	return s
 }
 
 func requestOperatorPause(t *testing.T, s *Server, pause bool) *httptest.ResponseRecorder {
@@ -300,12 +307,44 @@ func TestOperatorPauseSurvivesSHAChangeAndSuppressesAnnouncements(t *testing.T) 
 		t.Fatal("explicit resume did not allow announcement")
 	}
 
-	// A different socket writer must not hold Pause hostage. The announcement
-	// waiting behind it must recheck the pause before sending anything.
-	agent.WriteMu.Lock()
+	// An unrelated socket writer must not hold Pause hostage, and a pause that
+	// is ACKNOWLEDGED must stop an announcement that has already reserved its
+	// slot but not yet written.
+	//
+	// The old version slept 50ms and relied on the announcement queueing
+	// behind a held WriteMu. That is no longer what happens: the scheduler
+	// TryLocks, so a busy socket is skipped instantly and there is nothing
+	// queued to race. The test would have passed while exercising none of the
+	// boundary it names. This one stops the goroutine AT the boundary instead.
+	atBoundary := make(chan struct{})
+	release := make(chan struct{})
+	announceSendBoundaryHook = func(id string) {
+		if id != "pause-regression" {
+			return
+		}
+		close(atBoundary)
+		<-release
+	}
+	t.Cleanup(func() { announceSendBoundaryHook = nil })
+
+	// Clear the slot so this announcement is a fresh admission rather than a
+	// duplicate trigger, which would return before reaching the boundary.
+	if _, err := s.db.Exec(`DELETE FROM agent_rollout_slot WHERE machine_id = ?`,
+		"pause-regression"); err != nil {
+		t.Fatalf("clear slot: %v", err)
+	}
+
 	announceDone := make(chan struct{})
 	go func() { s.announceVersionToAgent("pause-regression", agent); close(announceDone) }()
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-atBoundary:
+	case <-time.After(2 * time.Second):
+		close(release)
+		t.Fatal("the announcement never reached its send boundary")
+	}
+
+	// Pause must not wait behind the in-flight announcement, which is holding
+	// this agent's write lock.
 	pauseDone := make(chan int, 1)
 	go func() {
 		r := httptest.NewRecorder()
@@ -319,22 +358,25 @@ func TestOperatorPauseSurvivesSHAChangeAndSuppressesAnnouncements(t *testing.T) 
 	select {
 	case status := <-pauseDone:
 		if status != 200 {
-			agent.WriteMu.Unlock()
-			t.Fatal(status)
+			close(release)
+			t.Fatalf("pause returned %d", status)
 		}
-	case <-time.After(time.Second):
-		agent.WriteMu.Unlock()
-		t.Fatal("Pause waited behind an unrelated agent socket writer")
+	case <-time.After(2 * time.Second):
+		close(release)
+		t.Fatal("Pause waited behind an in-flight announcement")
 	}
-	agent.WriteMu.Unlock()
+
+	// The pause is acknowledged. Only now is the announcement allowed to
+	// continue, and nothing may escape.
+	close(release)
 	select {
 	case <-announceDone:
-	case <-time.After(time.Second):
-		t.Fatal("queued announcement did not drain")
+	case <-time.After(2 * time.Second):
+		t.Fatal("the announcement did not drain")
 	}
-	_ = client.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	_ = client.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
 	if _, data, err := client.ReadMessage(); err == nil {
-		t.Fatalf("queued announcement escaped pause: %s", data)
+		t.Fatalf("an announcement escaped an acknowledged pause: %s", data)
 	}
 }
 

--- a/hub/rollout_pause_test.go
+++ b/hub/rollout_pause_test.go
@@ -44,25 +44,14 @@ func requestOperatorPause(t *testing.T, s *Server, pause bool) *httptest.Respons
 	return r
 }
 
-func isolateAutomaticPause(t *testing.T) {
-	t.Helper()
-	rolloutPausedMu.Lock()
-	old, reason := rolloutPaused, rolloutPauseReason
-	rolloutPaused, rolloutPauseReason = false, ""
-	rolloutPausedMu.Unlock()
-	rolloutFailuresMu.Lock()
-	failures := append([]rolloutFailure(nil), rolloutFailures...)
-	rolloutFailures = nil
-	rolloutFailuresMu.Unlock()
-	t.Cleanup(func() {
-		rolloutPausedMu.Lock()
-		rolloutPaused, rolloutPauseReason = old, reason
-		rolloutPausedMu.Unlock()
-		rolloutFailuresMu.Lock()
-		rolloutFailures = failures
-		rolloutFailuresMu.Unlock()
-	})
-}
+// isolateAutomaticPause used to save and restore the process-wide automatic
+// breaker. That breaker is gone: a platform halt replaces it, and halts live in
+// the database each Server owns, so there is no shared state to isolate.
+//
+// Kept as a no-op rather than deleted from every call site, so the tests below
+// keep reading as "this one is about the operator pause, not the automatic
+// one" — which is the distinction they exist to police.
+func isolateAutomaticPause(t *testing.T) { t.Helper() }
 
 func TestOperatorPauseSurvivesDatabaseReopen(t *testing.T) {
 	isolateAutomaticPause(t)
@@ -199,22 +188,44 @@ func TestOperatorPauseSurvivesSHAChangeAndSuppressesAnnouncements(t *testing.T) 
 	if r := requestOperatorPause(t, s, true); r.Code != 200 {
 		t.Fatal(r.Code)
 	}
-	rolloutPausedMu.Lock()
-	rolloutPaused, rolloutPauseReason = true, "automatic breaker"
-	rolloutPausedMu.Unlock()
+	// Halt the platform, as a failed attempt would.
+	if err := haltPlatformForTest(t, s, "linux/amd64", before); err != nil {
+		t.Fatalf("halt: %v", err)
+	}
+
 	if err := os.WriteFile(binary, []byte("changed binary fixture"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	recomputeBinaryFor("linux")
-	if currentAgentBinaryState("linux").SHA == before {
+	after := currentAgentBinaryState("linux").SHA
+	if after == before {
 		t.Fatal("test did not change served SHA")
 	}
-	rolloutPausedMu.RLock()
-	autoPaused := rolloutPaused
-	rolloutPausedMu.RUnlock()
-	if autoPaused {
-		t.Fatal("new build did not reset automatic breaker")
+
+	// A new build must clear the halt. It no longer does so by resetting a
+	// global: the changed candidate starts a new GENERATION, so the halt
+	// belongs to a rollout that is over. Asserting the observable outcome
+	// rather than the mechanism is the point — the old test asserted a boolean
+	// that no longer exists, while this behaviour still has to hold.
+	if _, _, err := s.rollout.reserve("linux/amd64", "halt-reset-probe", after, 0); err != nil {
+		t.Fatalf("reserve after the candidate changed: %v", err)
 	}
+	st, err := s.rollout.platformState("linux/amd64")
+	if err != nil || st == nil {
+		t.Fatalf("platform state: %v", err)
+	}
+	if st.Status == rolloutHalted {
+		t.Fatalf("a new build did not clear the halt: %s", st.HaltReason)
+	}
+	// The probe took the canary slot. Release it, and the halted fixture's
+	// slot with it, so the machine this test is actually about can be admitted
+	// — otherwise the assertion below would fail on capacity rather than on
+	// the pause behaviour it exists to check.
+	if _, err := s.db.Exec(`DELETE FROM agent_rollout_slot WHERE machine_id IN (?, ?)`,
+		"halt-reset-probe", "halt-victim"); err != nil {
+		t.Fatalf("clear fixture slots: %v", err)
+	}
+
 	if paused, _ := s.operatorRolloutPause(); !paused {
 		t.Fatal("SHA change cleared operator pause")
 	}
@@ -325,4 +336,28 @@ func TestOperatorPauseSurvivesSHAChangeAndSuppressesAnnouncements(t *testing.T) 
 	if _, data, err := client.ReadMessage(); err == nil {
 		t.Fatalf("queued announcement escaped pause: %s", data)
 	}
+}
+
+// haltPlatformForTest drives a platform into a halt the way a failed attempt
+// does: reserve a slot, let its window lapse, and tick.
+func haltPlatformForTest(t *testing.T, s *Server, platform, candidate string) error {
+	t.Helper()
+	if _, _, err := s.rollout.reserve(platform, "halt-victim", candidate, 0); err != nil {
+		return err
+	}
+	if _, err := s.db.Exec(`UPDATE agent_rollout_slot SET deadline_unix_ms = 0
+		WHERE platform = ? AND machine_id = ?`, platform, "halt-victim"); err != nil {
+		return err
+	}
+	if err := s.rollout.tick(platform); err != nil {
+		return err
+	}
+	st, err := s.rollout.platformState(platform)
+	if err != nil {
+		return err
+	}
+	if st == nil || st.Status != rolloutHalted {
+		t.Fatalf("fixture did not halt the platform: %+v", st)
+	}
+	return nil
 }

--- a/hub/server.go
+++ b/hub/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -23,6 +24,17 @@ type Server struct {
 	// Serializes durable operator pause/resume with queuing update announcements.
 	// The persisted row is authoritative; there is no restart-sensitive cache.
 	operatorRolloutMu sync.RWMutex
+
+	// rollout is the single policy every announcement path goes through. When
+	// it cannot be built, rolloutErr is set and every announcement is withheld
+	// — never allowed to fall through to the unrestricted legacy path, which
+	// would send a bad build to the whole fleet precisely when the thing that
+	// bounds exposure is broken.
+	rollout    *rolloutController
+	rolloutErr error
+	// rolloutStop cancels the single scheduler this server owns.
+	rolloutStop chan struct{}
+	rolloutOnce sync.Once
 
 	// Alert evaluations are serialized; pending duration state is bounded by
 	// currently observable enabled rule/machine pairs and resets on restart.
@@ -73,10 +85,77 @@ type Server struct {
 // newServer returns a Server backed by db with an empty agent registry.
 func newServer(db *sql.DB) *Server {
 	return &Server{
-		db:         db,
-		agents:     make(map[string]*ConnectedAgent),
-		aiSessions: newAISessionStore(),
+		db:          db,
+		agents:      make(map[string]*ConnectedAgent),
+		aiSessions:  newAISessionStore(),
+		rolloutStop: make(chan struct{}),
+		// The rollout controller is NOT built here. newServer runs before
+		// initDB, so its tables may not exist yet — see initRollout.
 	}
+}
+
+// initRollout builds the rollout controller. Call it AFTER migrations.
+//
+// This cannot live in newServer. main() constructs the server and only then
+// calls initDB, so on every fresh install and every upgrade the controller
+// would query its own tables before the migration that creates them. The
+// resulting error is retained by design, so a hub would withhold every agent
+// update forever — on a schema that the very next statement fixes. Unit
+// fixtures that migrate before constructing a server hide this completely.
+//
+// Until this succeeds s.rollout stays nil, and announceVersionToAgent
+// withholds rather than falling through to the unrestricted legacy path.
+func (s *Server) initRollout() error {
+	controller, err := newRolloutController(s.db, time.Now)
+	if err != nil {
+		s.rolloutErr = fmt.Errorf("agent rollout controller unavailable: %w", err)
+		log.Printf("WARNING: %v; agent updates will be withheld", s.rolloutErr)
+		return s.rolloutErr
+	}
+	controller.attachRegistry(s.currentAgentConnection)
+	s.rolloutErr = nil
+	s.rollout = controller
+	return nil
+}
+
+// currentAgentConnection is the registry's answer to who owns a machine now.
+// Takes agentsMu only; the rollout controller never holds its own lock across
+// this call, so the two can never deadlock against each other.
+func (s *Server) currentAgentConnection(machineID string) *ConnectedAgent {
+	s.agentsMu.RLock()
+	defer s.agentsMu.RUnlock()
+	return s.agents[machineID]
+}
+
+// startRolloutScheduler runs exactly one advancement loop for this server.
+//
+// The loop owns STAGE ADVANCEMENT and attempt expiry. Reservation itself still
+// happens on the trigger's own goroutine, which is safe because reserve() is a
+// single serialized transaction and claimSend gives one attempt one owner —
+// but it is not yet the "triggers merely wake the scheduler" shape, and this
+// comment does not claim otherwise.
+func (s *Server) startRolloutScheduler() {
+	s.rolloutOnce.Do(func() {
+		if s.rollout == nil {
+			return
+		}
+		s.goTracked(func() {
+			ticker := time.NewTicker(rolloutTickInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-s.rolloutStop:
+					return
+				case <-ticker.C:
+					for _, platform := range supportedAgentPlatforms {
+						if err := s.rollout.tick(platform.String()); err != nil {
+							log.Printf("rollout: tick for %s: %v", platform, err)
+						}
+					}
+				}
+			}
+		})
+	})
 }
 
 // goTracked runs fn in a goroutine registered against this server's WaitGroup.
@@ -118,6 +197,15 @@ func (s *Server) Shutdown(timeout time.Duration) bool {
 	s.lifecycleMu.Lock()
 	s.closing = true
 	s.lifecycleMu.Unlock()
+
+	// Stop the scheduler BEFORE waiting. A polling loop that outlived the wait
+	// would keep touching the database a test is about to close.
+	s.rolloutOnce.Do(func() {}) // ensure a later start cannot begin after this
+	select {
+	case <-s.rolloutStop:
+	default:
+		close(s.rolloutStop)
+	}
 
 	done := make(chan struct{})
 	go func() {

--- a/hub/server.go
+++ b/hub/server.go
@@ -32,8 +32,10 @@ type Server struct {
 	// bounds exposure is broken.
 	rollout    *rolloutController
 	rolloutErr error
-	// rolloutStop cancels the single scheduler this server owns.
+	// rolloutStop cancels the single scheduler this server owns; rolloutWake
+	// is how a trigger asks it to look again.
 	rolloutStop chan struct{}
+	rolloutWake chan struct{}
 	rolloutOnce sync.Once
 
 	// Alert evaluations are serialized; pending duration state is bounded by
@@ -89,6 +91,10 @@ func newServer(db *sql.DB) *Server {
 		agents:      make(map[string]*ConnectedAgent),
 		aiSessions:  newAISessionStore(),
 		rolloutStop: make(chan struct{}),
+		// Depth one: a wake is "look again", not a queue of work. Several
+		// triggers firing at once collapse into a single pass, which is the
+		// point — each of them would otherwise race to reserve and send.
+		rolloutWake: make(chan struct{}, 1),
 		// The rollout controller is NOT built here. newServer runs before
 		// initDB, so its tables may not exist yet — see initRollout.
 	}
@@ -129,11 +135,17 @@ func (s *Server) currentAgentConnection(machineID string) *ConnectedAgent {
 
 // startRolloutScheduler runs exactly one advancement loop for this server.
 //
-// The loop owns STAGE ADVANCEMENT and attempt expiry. Reservation itself still
-// happens on the trigger's own goroutine, which is safe because reserve() is a
-// single serialized transaction and claimSend gives one attempt one owner —
-// but it is not yet the "triggers merely wake the scheduler" shape, and this
-// comment does not claim otherwise.
+// THE SCHEDULER IS THE ONLY THING THAT SENDS. Triggers — a WebSocket connect, a
+// changed version report, an operator resume — call wakeRollout and return;
+// none of them reserves or writes. That is what makes progression single-owner:
+// several triggers arriving together collapse into one pass rather than each
+// racing to claim a slot.
+//
+// It also means admission does not depend on a trigger. A machine held back
+// because the batch was full is picked up by a later pass on capacity alone,
+// with no further version change and no reconnect. Requiring a trigger looks
+// identical to working, right up until a fleet stops updating because nothing
+// happened to poke it.
 func (s *Server) startRolloutScheduler() {
 	s.rolloutOnce.Do(func() {
 		if s.rollout == nil {
@@ -146,16 +158,61 @@ func (s *Server) startRolloutScheduler() {
 				select {
 				case <-s.rolloutStop:
 					return
+				case <-s.rolloutWake:
 				case <-ticker.C:
-					for _, platform := range supportedAgentPlatforms {
-						if err := s.rollout.tick(platform.String()); err != nil {
-							log.Printf("rollout: tick for %s: %v", platform, err)
-						}
-					}
 				}
+				s.runRolloutPass()
 			}
 		})
 	})
+}
+
+// wakeRollout asks the scheduler to look again. Never blocks: a pending wake
+// already covers whatever this caller observed.
+func (s *Server) wakeRollout() {
+	if s.rolloutWake == nil {
+		return
+	}
+	select {
+	case s.rolloutWake <- struct{}{}:
+	default:
+	}
+}
+
+// runRolloutPass advances state, then offers a slot to every connected agent.
+func (s *Server) runRolloutPass() {
+	if s.rollout == nil {
+		return
+	}
+	for _, platform := range supportedAgentPlatforms {
+		if err := s.rollout.tick(platform.String()); err != nil {
+			log.Printf("rollout: tick for %s: %v", platform, err)
+		}
+	}
+
+	// Snapshot the registry, then release it: announcing holds an agent's
+	// write lock and performs bounded network I/O, and holding agentsMu across
+	// that would stall every connect and disconnect behind one slow socket.
+	s.agentsMu.RLock()
+	ids := make([]string, 0, len(s.agents))
+	conns := make([]*ConnectedAgent, 0, len(s.agents))
+	for id, agent := range s.agents {
+		ids = append(ids, id)
+		conns = append(conns, agent)
+	}
+	s.agentsMu.RUnlock()
+
+	for i := range ids {
+		select {
+		case <-s.rolloutStop:
+			return
+		default:
+		}
+		// Most of these return immediately: the batch is full, the machine is
+		// already validated, or it holds no slot. Only machines that actually
+		// win capacity reach a socket.
+		s.announceVersionToAgent(ids[i], conns[i])
+	}
 }
 
 // goTracked runs fn in a goroutine registered against this server's WaitGroup.

--- a/hub/update_signing.go
+++ b/hub/update_signing.go
@@ -309,9 +309,9 @@ const minSignatureCapableProtocol = 1
 // receives, so the unverifiable migration hop must not happen anywhere an
 // off-host attacker can reach it. For a signature-capable agent the reason is
 // that it will refuse the download itself (agent/update_transport.go), so
-// announcing achieves nothing except arming a 90s reconnect-expectation timer
-// for a reconnect that will never come — which expires into a rollout failure
-// and, at two machines, trips the circuit breaker and pauses the whole fleet.
+// announcing achieves nothing except spending a rollout attempt on a download
+// the recipient will refuse — which expires into a failed slot and halts that
+// platform until an operator retries it.
 // Announcing an update the recipient is designed to decline is not a
 // no-op; it is a self-inflicted outage. Credit to Codex for catching it.
 //

--- a/hub/update_signing_test.go
+++ b/hub/update_signing_test.go
@@ -764,25 +764,43 @@ func (s *Server) collectAnnounceFrames(t *testing.T, e *echo.Echo, p announcePro
 	return frames
 }
 
-// assertNoReconnectExpectation is the assertion that actually matters when an
-// announce is withheld. An armed reconnect expectation for an update the agent
-// will never take expires into a rollout failure; two of those trip the
-// process-wide circuit breaker and pause updates for the whole fleet, with
-// rolloutPauseReason blaming agent health for a refusal the hub provoked.
-func assertNoReconnectExpectation(t *testing.T, machineID string) {
+// assertNoPendingRolloutAttempt is the assertion that actually matters when an
+// announce is withheld: the refusal must leave NO durable attempt behind.
+//
+// The hazard is unchanged from the reconnect-expectation era it replaces. A
+// slot reserved for an update the agent will never be offered expires into a
+// failure, and a failure halts the platform — blaming agent health for a
+// refusal the hub itself provoked, and stopping updates for every other
+// machine on that platform.
+func assertNoPendingRolloutAttempt(t *testing.T, s *Server, machineID string) {
 	t.Helper()
-	pendingReconnectsMu.Lock()
-	_, armed := pendingReconnects[machineID]
-	pendingReconnectsMu.Unlock()
-	if armed {
-		t.Fatalf("a reconnect expectation was armed for %s despite no announce being sent — "+
-			"it will expire into a false rollout failure and can trip the circuit breaker", machineID)
+	if s.rollout == nil {
+		return
 	}
-	rolloutPausedMu.RLock()
-	paused, reason := rolloutPaused, rolloutPauseReason
-	rolloutPausedMu.RUnlock()
-	if paused {
-		t.Fatalf("rollout is paused: %s", reason)
+	rows, err := s.db.Query(`SELECT platform, state, reason FROM agent_rollout_slot
+		WHERE machine_id = ? AND state IN (?, ?, ?)`,
+		machineID, rolloutReserved, rolloutOffered, rolloutObserved)
+	if err != nil {
+		t.Fatalf("query rollout slots: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var platform, state, reason string
+		if err := rows.Scan(&platform, &state, &reason); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		t.Fatalf("a %s attempt was left pending for %s on %s despite no announce being sent (%s) — "+
+			"it will expire into a false failure and halt the platform", state, machineID, platform, reason)
+	}
+
+	for _, platform := range supportedAgentPlatforms {
+		st, err := s.rollout.platformState(platform.String())
+		if err != nil {
+			t.Fatalf("platform state: %v", err)
+		}
+		if st != nil && st.Status == rolloutHalted {
+			t.Fatalf("rollout halted on %s: %s", platform, st.HaltReason)
+		}
 	}
 }
 
@@ -812,7 +830,7 @@ func TestLegacyAgentGetsNoAnnounceOverPlaintext(t *testing.T) {
 	if len(frames) != 0 {
 		t.Fatalf("hub announced an update to a pre-signature agent over plaintext: %q", frames)
 	}
-	assertNoReconnectExpectation(t, machineID)
+	assertNoPendingRolloutAttempt(t, s, machineID)
 }
 
 // Same agent, TLS deployment: the one migration hop is allowed, because an
@@ -846,7 +864,7 @@ func TestNoAnnounceWhenAgentReportsPlaintextTransport(t *testing.T) {
 	if len(frames) != 0 {
 		t.Fatalf("hub announced an update the agent had already said it would refuse: %q", frames)
 	}
-	assertNoReconnectExpectation(t, machineID)
+	assertNoPendingRolloutAttempt(t, s, machineID)
 }
 
 // And the same agent reporting a usable transport and a pinned key is
@@ -894,7 +912,7 @@ func TestNoAnnounceWhenAgentKeyNotPinned(t *testing.T) {
 	if len(frames) != 0 {
 		t.Fatalf("hub announced an update to an agent with no pinned key: %q", frames)
 	}
-	assertNoReconnectExpectation(t, machineID)
+	assertNoPendingRolloutAttempt(t, s, machineID)
 
 	agentRunningVersionsMu.RLock()
 	info, ok := agentRunningVersions[machineID]
@@ -926,7 +944,7 @@ func TestNoAnnounceWhenAgentOmitsKeyPinnedField(t *testing.T) {
 	if len(frames) != 0 {
 		t.Fatalf("hub announced an update to an agent that never reported update_key_pinned: %q", frames)
 	}
-	assertNoReconnectExpectation(t, machineID)
+	assertNoPendingRolloutAttempt(t, s, machineID)
 }
 
 // TestNoSignatureMeansNoAnnounceOnTheWire is the end-to-end form of the claim
@@ -945,7 +963,7 @@ func TestNoSignatureMeansNoAnnounceOnTheWire(t *testing.T) {
 	if len(frames) != 0 {
 		t.Fatalf("hub announced an update it could not sign: %q", frames)
 	}
-	assertNoReconnectExpectation(t, machineID)
+	assertNoPendingRolloutAttempt(t, s, machineID)
 }
 
 /* ----------------------------------------------------------------------------
@@ -1015,7 +1033,7 @@ func TestArm64AgentOnAmd64OnlyHubGetsNoAnnounce(t *testing.T) {
 	if len(frames) != 0 {
 		t.Fatalf("hub announced to an arm64 agent with no arm64 build: %q", frames)
 	}
-	assertNoReconnectExpectation(t, machineID)
+	assertNoPendingRolloutAttempt(t, s, machineID)
 
 	s.markCredentialsRotated(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/versions", nil)
@@ -1142,7 +1160,7 @@ func TestLegacyAgentOnArm64HostIsWithheld(t *testing.T) {
 	if len(frames) != 0 {
 		t.Fatalf("hub announced to a legacy agent on an arm64 host: %q", frames)
 	}
-	assertNoReconnectExpectation(t, machineID)
+	assertNoPendingRolloutAttempt(t, s, machineID)
 
 	agentRunningVersionsMu.RLock()
 	info := agentRunningVersions[machineID]


### PR DESCRIPTION
Draft, stacked on #233 (PR2a, frozen at `d8a3eca`). Not approved, not merged, not tagged, not deployed.

## Before

The hub announced a new agent build to **every connected agent at once**, driven by whatever happened to trigger it — a WebSocket connect, a version report, a restart. Nothing was written down. If the hub restarted mid-rollout it had no idea what it had already offered; if a build was bad, the fleet had already taken it. A fleet-wide circuit breaker paused *everything* after a couple of failed reconnects — one bad machine stopped every platform, and recovery was a manual reset of in-memory state that no restart preserved.

## After

One scheduler goroutine owns sending. Triggers only call `wakeRollout()`; none of them reserves or writes. Admission happens on **capacity alone**, so a machine held back because the batch was full is picked up by a later pass with no further trigger — requiring one looks identical to working right up until a fleet stops updating because nothing poked it.

**Stages.** Per platform (`linux/amd64`, `linux/arm64`, `windows/amd64`), independently: one canary, then batches of two. A stage advances only when nothing in it is still outstanding **and** at least one machine in it validated — without the second condition, a stage whose every candidate was withheld would advance having learned nothing about the build.

**Durable reservations.** A slot is taken in SQLite *before* anything reaches a socket. The capacity check, the stage read and the insert are one transaction under `_txlock=immediate`, which is what bounds concurrency between *different* machines — a unique key on (machine, candidate) only deduplicates repeat calls for the same machine, and two machines racing for the final slot would both have inserted.

**Generations.** A changed candidate bumps the platform's generation; every slot, reservation and piece of evidence is scoped to one. A report that arrives just after the served binary changed cannot mark the new generation's slot observed on the strength of the machine running the old bytes.

## Crash semantics: at-least-once, and honest about it

A process that dies between reserving a slot and recording the offer leaves **the same row** whether the write landed or not. The hub does not guess. Recovery is a bounded resend under the same slot identity — the deadline and grace are *preserved*, because refreshing them would let a crash loop buy unlimited time — and the ambiguity is resolved by **what the machine reports when it comes back**. If it reports the candidate, the slot becomes observed; if it reports the old build, it is resent.

Delivery is at-least-once and is not claimed otherwise. Accordingly, an expired reservation reports *"update was not confirmed within the attempt window"* rather than accusing the machine of refusing an offer it may be running.

## Health

**A matching SHA is not health.** Version reports establish which bytes; metrics establish that the thing is alive. A machine is validated by 60 seconds of continuous telemetry with inter-frame gaps bounded at 45s, and the dwell endpoint must be a real frame — comparing the clock would complete a dwell during silence.

**Evidence belongs to a connection, not a machine.** `agentRunningVersions` survives socket replacement, so a fresh connection would otherwise inherit the previous one's matching SHA. Records are keyed by `*ConnectedAgent`, held in memory only, and dropped as each handler exits. A reconnect proves itself again.

This is a liveness check. It does not prove any feature still works, and the docs say so in those words.

## Operator controls

The operator pause and a platform halt are **different things**, and the page now says which is which:

| | Operator pause | Platform halt |
|---|---|---|
| Set by | a person | the hub, on a failed attempt |
| Scope | fleet | one platform |
| Survives restart | yes | yes |

`rollout_paused` means only that someone pressed pause. **Retry halted rollouts** appears whenever any platform is halted — previously the only recovery control appeared when the pause was *on*, so a halted platform with the pause off offered a Pause button and nothing else. It is the existing `POST /api/versions/resume`, which clears the pause and gives every halted platform a fresh attempt in one transaction; the wording states that fleet-wide scope because there is no per-platform retry.

The pause is honoured **at the send boundary**, not only where the announcement was decided, and so is registry ownership: a goroutine can queue behind unrelated socket writes, and in that window the machine may be deleted or taken over by a new connection.

**Deletion.** `agent_rollout_slot` is deleted inside the machine's own delete transaction, so a rollback keeps its rollout state. An ingestion barrier held across the commit stops a queued pass inserting a slot for a machine that is gone.

## What the UI claims

Counts are rendered through a pure, separately tested module. Each platform row names the candidate SHA its counts describe — the hub only picks up a new candidate when a reservation runs, so with the pause on it can serve one build while the rollout still describes the previous one.

- *"N observed on this build"* — the underlying flag is a latch; the machine may since have failed or rolled back.
- *"N pending attempts"* — reservation precedes the socket write, and a resume opens an attempt for machines already on the build, which are never announced to.
- *"no outstanding tracked attempts"* — it counts slots, which exist only for machines this generation reserved one for, so it cannot speak for the connected fleet.
- An unrecognised or missing status renders **Unavailable**, never a healthy zero.

## Validation

Full hub suite exit 0 (118.6s), hub vet 0. Dashboard `tsc` 0, lint 0 at the 3-warning baseline, 209 node tests. The reviewer independently ran the three send tests under `-race` (7.7s) and verified the page in a browser: clicking Retry with the pause off sends exactly `POST /api/versions/resume`; the unavailable sentinel renders Unavailable with its reason and no retry offered; 1440/1280/390 in both themes, no errors or overflow.

Crash-window coverage is **fault injection**: the announce is aborted after the durable reserve and before any write, and after a successful write and before the offer is marked; the controller is then rebuilt over the same database and the machine reconnects on a new socket.

## Limitations

- Delivery is at-least-once, not exactly-once.
- Validation is liveness only.
- Health evidence is in-memory, so a restart resets dwells that were **in flight**. Slots already validated stay validated — they are durable.
- Full publish-retry idempotency is **not** addressed here and is not claimed — that is PR2c, which is required before any release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX
