### PR TITLE
fix(release): deterministic assets and a publish retry that reuses what it verified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,11 @@ jobs:
       # This form proves the gate is wired and reachable. It does NOT verify
       # the release build sets the marker — the flag is supplied here. The
       # image-built hub is covered by the Compose smoke job.
-      - name: Test release identity gate and history
+      - name: Test release identity gate, history and workflow wiring
         run: |
           python3 ../scripts/test_release_identity.py
           python3 ../scripts/test_release_history.py
+          python3 ../scripts/test_release_workflow.py
 
       - name: Hub delivery boot gate (source build)
         run: sudo -E env "PATH=$PATH" BLOXOS_BOOT_SMOKE_REQUIRE_ROOT=1 python3 ../scripts/test_hub_bundle_boot.py

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -166,8 +166,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     outputs:
-      hub_digest: ${{ steps.hub.outputs.digest }}
-      dashboard_digest: ${{ steps.dashboard.outputs.digest }}
+      # The RESOLVED pair, which on a retry comes from the record a previous
+      # attempt published rather than from a rebuild. Everything downstream
+      # reads these, so a skipped build cannot leave a dangling reference.
+      hub_ref: ${{ steps.refs.outputs.hub }}
+      dashboard_ref: ${{ steps.refs.outputs.dashboard }}
     permissions:
       # contents: write is needed to persist the verified agent catalog to the
       # draft release BEFORE the Docker tags are promoted.
@@ -186,8 +189,23 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Nothing guarantees a rebuild lands on the same index digest. When it
+      # does not, a retry promotes tags the already-published catalog
+      # disagrees with — and that catalog is never overwritten, so the release
+      # can never be completed. A previous attempt's verified pair is reused
+      # instead. Absence is the only outcome that means "build": a failed
+      # lookup exits non-zero here.
+      - name: Look up a verified image pair from a previous attempt
+        id: intent
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/release_history.py lookup-build --repo "$GITHUB_REPOSITORY" \
+            --tag "${{ github.ref_name }}" --version "${{ github.ref_name }}" \
+            --revision "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
       - name: Push hub image by digest
         id: hub
+        if: steps.intent.outputs.reuse != 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -203,6 +221,7 @@ jobs:
           cache-from: type=gha,scope=hub
       - name: Push dashboard image by digest
         id: dashboard
+        if: steps.intent.outputs.reuse != 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -216,17 +235,55 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha,scope=dashboard
+      # The single place a build digest is read. Everything after this uses
+      # the resolved refs, so a skipped build leaves nothing dangling.
+      - name: Resolve the image pair for this run
+        id: refs
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.intent.outputs.reuse }}" == "true" ]]; then
+            hub="${{ steps.intent.outputs.hub }}"
+            dashboard="${{ steps.intent.outputs.dashboard }}"
+          else
+            hub="$HUB_IMAGE@${{ steps.hub.outputs.digest }}"
+            dashboard="$DASHBOARD_IMAGE@${{ steps.dashboard.outputs.digest }}"
+          fi
+          for ref in "$hub" "$dashboard"; do
+            [[ "$ref" =~ ^ghcr\.io/bokiko/bloxos-(hub|dashboard)@sha256:[0-9a-f]{64}$ ]] \
+              || { echo "not a canonical digest-pinned ref: $ref" >&2; exit 1; }
+          done
+          echo "hub=$hub" >> "$GITHUB_OUTPUT"
+          echo "dashboard=$dashboard" >> "$GITHUB_OUTPUT"
+
       # ==== Release identity gate ====
       #
       # Everything below runs BEFORE promotion, and the ordering is the point.
       # Once Docker tags move, the bytes are live and any ambiguity about what
       # this release number means is permanent.
+
+      # BOTH images, BOTH architectures, before anything is recorded or moved.
+      # The export path checks the dashboard image too, but only after
+      # promotion — and a reused record matching this run's sha is evidence
+      # about the RECORD, not about the images it points at. Same function the
+      # export uses; this is a reuse, not a second validation framework.
+      - name: Validate the platform and source of both images on both architectures
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          for image in "${{ steps.refs.outputs.hub }}" "${{ steps.refs.outputs.dashboard }}"; do
+            for platform in linux/amd64 linux/arm64; do
+              python3 scripts/image_platform.py --image "$image" --platform "$platform" \
+                --revision "$SOURCE_SHA"
+            done
+          done
+
       - name: Extract the canonical agent bundle from the published hub image
         env:
-          HUB_DIGEST: ${{ steps.hub.outputs.digest }}
+          HUB_REF: ${{ steps.refs.outputs.hub }}
           SOURCE_SHA: ${{ github.sha }}
           RELEASE_TAG: ${{ github.ref_name }}
-        run: bash scripts/export-agent-bundle.sh "$HUB_IMAGE@$HUB_DIGEST" "$SOURCE_SHA" "$RELEASE_TAG" "$RUNNER_TEMP/native-agents"
+        run: bash scripts/export-agent-bundle.sh "$HUB_REF" "$SOURCE_SHA" "$RELEASE_TAG" "$RUNNER_TEMP/native-agents"
 
       # A containerised arm64 hub serves the agents built into its OWN image,
       # and the two images are built separately from build args that could
@@ -234,7 +291,7 @@ jobs:
       # so both are read directly and compared to the canonical bundle.
       - name: Extract and validate the agent bundle from each hub image platform
         env:
-          HUB_DIGEST: ${{ steps.hub.outputs.digest }}
+          HUB_REF: ${{ steps.refs.outputs.hub }}
         run: |
           set -euo pipefail
           for platform in linux/amd64 linux/arm64; do
@@ -242,7 +299,7 @@ jobs:
             # Resolve the index to that platform's immutable child digest. A
             # bare `docker pull --platform` can hand back a different image
             # from a classic store, so the shared helper picks the exact child.
-            ref=$(python3 scripts/image_platform.py --image "$HUB_IMAGE@$HUB_DIGEST" --platform "$platform")
+            ref=$(python3 scripts/image_platform.py --image "$HUB_REF" --platform "$platform")
             docker pull --platform "$platform" "$ref"
             actual=$(docker image inspect --format '{{.Os}}/{{.Architecture}}' "$ref")
             test "$actual" = "$platform" || { echo "resolved $ref is $actual, wanted $platform" >&2; exit 1; }
@@ -284,6 +341,27 @@ jobs:
             --image-catalog "linux/amd64=$RUNNER_TEMP/image-catalog-amd64.json" \
             --image-catalog "linux/arm64=$RUNNER_TEMP/image-catalog-arm64.json"
 
+      # Record the pair AFTER it has been validated and BEFORE the catalog or
+      # any tag moves. A crash after this leaves a record of a verified but
+      # unpromoted pair — exactly what a retry needs, and harmless if the
+      # release is abandoned. A crash before it leaves nothing, and the retry
+      # simply builds again.
+      - name: Persist the verified image pair before the catalog and promotion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          python3 scripts/release_history.py record-build \
+            --version "$RELEASE_TAG" --revision "$GITHUB_SHA" \
+            --hub "${{ steps.refs.outputs.hub }}" --dashboard "${{ steps.refs.outputs.dashboard }}" \
+            --output "$RUNNER_TEMP/release-build.json"
+          python3 scripts/release_history.py ensure-draft --repo "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" \
+            --notes "Release verification in progress. Agent identity verified; assets pending."
+          python3 scripts/release_history.py persist-build --repo "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" --build "$RUNNER_TEMP/release-build.json"
+
       # Persist the VERIFIED catalog before the tags move. If a run dies after
       # promotion, the images are live; without this the next run would find no
       # record of what agent bytes they carry and would have nothing to check
@@ -295,21 +373,14 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            prerelease_flags=()
-            if [[ "$RELEASE_TAG" == *-* ]]; then prerelease_flags=(--prerelease); fi
-            gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --verify-tag --draft \
-              "${prerelease_flags[@]}" --title "BloxOS $RELEASE_TAG" \
-              --notes "Release verification in progress. Agent identity verified; assets pending."
-          fi
           python3 scripts/release_history.py persist --repo "$GITHUB_REPOSITORY" \
             --tag "$RELEASE_TAG" --catalog "$RUNNER_TEMP/native-agents/agent-manifest.json"
 
       - name: Promote both images to the version and latest tags
         env:
           VERSION: ${{ github.ref_name }}
-          HUB_DIGEST: ${{ steps.hub.outputs.digest }}
-          DASHBOARD_DIGEST: ${{ steps.dashboard.outputs.digest }}
+          HUB_REF: ${{ steps.refs.outputs.hub }}
+          DASHBOARD_REF: ${{ steps.refs.outputs.dashboard }}
         run: |
           set -euo pipefail
           version="${VERSION#v}"
@@ -319,8 +390,8 @@ jobs:
             hub_tags+=(-t "$HUB_IMAGE:latest")
             dashboard_tags+=(-t "$DASHBOARD_IMAGE:latest")
           fi
-          docker buildx imagetools create "${hub_tags[@]}" "$HUB_IMAGE@$HUB_DIGEST"
-          docker buildx imagetools create "${dashboard_tags[@]}" "$DASHBOARD_IMAGE@$DASHBOARD_DIGEST"
+          docker buildx imagetools create "${hub_tags[@]}" "$HUB_REF"
+          docker buildx imagetools create "${dashboard_tags[@]}" "$DASHBOARD_REF"
 
   native-bundle:
     name: Package native agents and server updater
@@ -339,10 +410,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract and check the exact published agent bytes
         env:
-          HUB_DIGEST: ${{ needs.publish.outputs.hub_digest }}
+          HUB_REF: ${{ needs.publish.outputs.hub_ref }}
           SOURCE_SHA: ${{ github.sha }}
           RELEASE_TAG: ${{ github.ref_name }}
-        run: bash scripts/export-agent-bundle.sh "$HUB_IMAGE@$HUB_DIGEST" "$SOURCE_SHA" "$RELEASE_TAG" "$RUNNER_TEMP/native-agents"
+        run: bash scripts/export-agent-bundle.sh "$HUB_REF" "$SOURCE_SHA" "$RELEASE_TAG" "$RUNNER_TEMP/native-agents"
       - name: Extract the exact published server pair
         # Server archives are the exact published image contents, not separate
         # source rebuilds. They now also carry the agent payloads, so upgrading
@@ -350,13 +421,13 @@ jobs:
         # SAME directory whose files are attached as standalone assets below,
         # and the script asserts byte equality rather than rebuilding.
         env:
-          HUB_DIGEST: ${{ needs.publish.outputs.hub_digest }}
-          DASHBOARD_DIGEST: ${{ needs.publish.outputs.dashboard_digest }}
+          HUB_REF: ${{ needs.publish.outputs.hub_ref }}
+          DASHBOARD_REF: ${{ needs.publish.outputs.dashboard_ref }}
           SOURCE_SHA: ${{ github.sha }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           python3 scripts/export-server-bundle.py \
-            --hub "$HUB_IMAGE@$HUB_DIGEST" --dashboard "$DASHBOARD_IMAGE@$DASHBOARD_DIGEST" \
+            --hub "$HUB_REF" --dashboard "$DASHBOARD_REF" \
             --revision "$SOURCE_SHA" --version "$RELEASE_TAG" --output "$RUNNER_TEMP/server-bundle" \
             --agents "$RUNNER_TEMP/native-agents"
       - name: Attach server and agent assets to a draft release
@@ -366,14 +437,13 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if gh release view "$RELEASE_TAG" --json isDraft >/dev/null 2>&1; then
-            test "$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)" = true
-          else
-            prerelease_flags=()
-            if [[ "$RELEASE_TAG" == *-* ]]; then prerelease_flags=(--prerelease); fi
-            gh release create "$RELEASE_TAG" --verify-tag --draft "${prerelease_flags[@]}" --title "BloxOS $RELEASE_TAG" \
-              --notes "Release verification passed. Native payloads are extracted from the published image; operator review and final release notes are pending. Fleet signatures are installation-specific and are not included."
-          fi
+          # One listing, which either loads or fails. `gh release view || create`
+          # read ANY failure as "no release exists", so an expired token or a
+          # rate limit would take the create branch on a release that is
+          # already published — and skip the check that it is still a draft.
+          python3 scripts/release_history.py ensure-draft --repo "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" \
+            --notes "Release verification passed. Native payloads are extracted from the published image; operator review and final release notes are pending. Fleet signatures are installation-specific and are not included."
           # agent-manifest.json was already persisted before promotion. Verify
           # the bytes agree rather than uploading again: a published catalog is
           # evidence of what the release carries and is never overwritten.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,7 @@ on:
       - "scripts/image_platform.py"
       - "scripts/test_release_identity.py"
       - "scripts/test_release_history.py"
+      - "scripts/test_release_workflow.py"
       - "scripts/test_server_bundle_agents.py"
       - "scripts/test_hub_bundle_boot.py"
       - "scripts/updater/**"

--- a/scripts/export-server-bundle.py
+++ b/scripts/export-server-bundle.py
@@ -1,21 +1,76 @@
 #!/usr/bin/env python3
 """Package the exact published server images and updater into release assets."""
 import argparse
+import gzip
 import hashlib
+import io
 import json
 from pathlib import Path
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tarfile
 import tempfile
-import zipapp
+import zipfile
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import agent_bundle  # noqa: E402  (same directory; the canonical payload checker)
 
 AGENT_DIR = "agents"
+
+# Release assets must be a function of their CONTENT, not of when or where they
+# were built.
+#
+# Two builds of the same revision produced different bytes, and every one of
+# the causes was metadata:
+#
+#   - the gzip header carries the compression time AND the output filename, so
+#     the same tar compressed a second later, or written to a differently named
+#     temporary path, differed in its first sixteen bytes;
+#   - tar members carry mtime, uid/gid and uname/gname, so the staging
+#     directory's creation time and the build account leaked into the archive.
+#     `stage_agents` writes its files fresh, so those mtimes were always "now";
+#   - zipapp entries carry each source file's mtime and mode.
+#
+# Nothing here changes what the archives CONTAIN. It fixes the metadata at the
+# serialisation boundary, which is also why the staging tree's own timestamps
+# and path stop mattering: they are normalised on the way out rather than
+# controlled on the way in.
+ARCHIVE_EPOCH = 1577836800  # 2020-01-01T00:00:00Z, fixed and arbitrary
+# Zip cannot represent a date before 1980, so it gets its own constant rather
+# than a conversion that would silently clamp.
+ZIP_DATE = (2020, 1, 1, 0, 0, 0)
+
+
+def normalized_member(member, size_source=None):
+    """Strip build-environment identity from one tar member.
+
+    Mode keeps only the distinction that matters — whether the file is
+    executable — because the rest of it is the build account's umask. Ownership
+    is dropped entirely: an archive that records `runner:docker` is describing
+    the machine that built it, not the release.
+
+    mtime is set to an INTEGER. A float mtime makes tarfile emit a pax header
+    to carry the fraction, so the member's encoded length would depend on the
+    filesystem's timestamp resolution.
+    """
+    member.mtime = ARCHIVE_EPOCH
+    member.uid = 0
+    member.gid = 0
+    member.uname = ""
+    member.gname = ""
+    member.pax_headers = {}
+    if member.isdir():
+        member.mode = 0o755
+    elif member.issym():
+        member.mode = 0o777
+    else:
+        member.mode = 0o755 if member.mode & 0o111 else 0o644
+    if size_source is not None:
+        member.size = size_source
+    return member
 
 
 def run(args):
@@ -182,23 +237,82 @@ def pack_tree(tree, archive):
     for entry in tree.rglob("*"):
         if entry.is_symlink() and not entry.resolve().is_relative_to(root):
             raise ValueError("Bundle symlink escapes exported server tree")
+    def safe_member(member):
+        size = None
+        if member.islnk():
+            member.type = tarfile.REGTYPE
+            member.linkname = ""
+            size = (tree / member.name).stat().st_size
+        if member.issym():
+            if Path(member.linkname).is_absolute():
+                raise ValueError("Bundle contains an absolute symlink")
+        elif not (member.isfile() or member.isdir()):
+            raise ValueError("Bundle contains a non-regular filesystem entry")
+        return normalized_member(member, size)
+
+    # The gzip stream is built explicitly rather than through "w:gz".
+    #
+    # tarfile's convenience mode hands the OUTPUT PATH to gzip, which writes
+    # both the current time and that filename into the gzip header — so the
+    # same tar bytes, compressed a second later or staged under a different
+    # temporary directory, produced a different asset. mtime=0 is the format's
+    # own "no timestamp", and an empty filename omits the FNAME field entirely.
+    #
+    # Member ORDER needs no intervention: tarfile.add walks each directory in
+    # sorted order, so the sequence follows the tree rather than the
+    # filesystem's readdir.
+    #
     # Node resolves modules from their REAL path. Dereferencing pnpm links
     # changes that path and breaks dependency lookup. Preserve validated local
     # relative links, including links to packages pruned by Next's tracer.
-    with tarfile.open(archive, "w:gz", dereference=False) as target:
-        def safe_member(member):
-            if member.islnk():
-                member.type = tarfile.REGTYPE
-                member.linkname = ""
-                member.size = (tree / member.name).stat().st_size
-            if member.issym():
-                if Path(member.linkname).is_absolute():
-                    raise ValueError("Bundle contains an absolute symlink")
-            elif not (member.isfile() or member.isdir()):
-                raise ValueError("Bundle contains a non-regular filesystem entry")
-            return member
-        for directory in ("hub", "dashboard"):
-            target.add(tree / directory, arcname=directory, filter=safe_member)
+    with open(archive, "wb") as raw:
+        with gzip.GzipFile(filename="", mode="wb", compresslevel=9,
+                           fileobj=raw, mtime=0) as compressed:
+            with tarfile.open(fileobj=compressed, mode="w",
+                              format=tarfile.PAX_FORMAT, dereference=False) as target:
+                for directory in ("hub", "dashboard"):
+                    target.add(tree / directory, arcname=directory, filter=safe_member)
+
+
+def pack_zipapp(source, target, interpreter, main_spec):
+    """Build the updater zipapp with fixed entry metadata.
+
+    zipapp.create_archive is otherwise exactly right — it already walks the
+    source in sorted order — but it writes each entry with the SOURCE FILE's
+    mtime and mode, both of which come from `shutil.copyfile` into a temporary
+    directory moments earlier. Two builds therefore differed in every local
+    header.
+
+    The layout is the one zipapp produces and the interpreter line is written
+    the same way, so this changes the asset's metadata and nothing else.
+    Entries are stored uncompressed, as zipapp does by default, which also
+    means the bytes do not depend on the zlib build.
+    """
+    module, _, function = main_spec.partition(":")
+    main_py = "# -*- coding: utf-8 -*-\nimport {}\n{}.{}()\n".format(module, module, function)
+
+    def entry(name, data, mode):
+        info = zipfile.ZipInfo(name, date_time=ZIP_DATE)
+        info.compress_type = zipfile.ZIP_STORED
+        info.external_attr = (mode & 0xFFFF) << 16
+        info.create_system = 3  # Unix, so the mode above is meaningful
+        return info, data
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_STORED) as archive:
+        for child in sorted(source.rglob("*")):
+            if child.is_dir():
+                continue
+            if not child.is_file() or child.is_symlink():
+                raise ValueError("Updater package contains a non-regular file: " + str(child))
+            name = child.relative_to(source).as_posix()
+            info, data = entry(name, child.read_bytes(), 0o644)
+            archive.writestr(info, data)
+        info, data = entry("__main__.py", main_py.encode("utf-8"), 0o644)
+        archive.writestr(info, data)
+
+    target.write_bytes(b"#!" + interpreter.encode("utf-8") + b"\n" + buffer.getvalue())
+    target.chmod(target.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def main():
@@ -248,7 +362,8 @@ def main():
         package.mkdir()
         for source in (Path(__file__).parent / "updater").glob("*.py"):
             shutil.copyfile(source, package / source.name)
-        zipapp.create_archive(directory, args.output / "bloxos-update", interpreter="/usr/bin/python3", main="updater.cli:entrypoint")
+        pack_zipapp(Path(directory), args.output / "bloxos-update",
+                    "/usr/bin/python3", "updater.cli:entrypoint")
     subprocess.run(["python3", str(args.output / "bloxos-update"), "--help"], check=True)
 
 

--- a/scripts/export-server-bundle.py
+++ b/scripts/export-server-bundle.py
@@ -93,15 +93,39 @@ def platform_image(image, platform):
     return image.split("@", 1)[0] + "@" + matches[0]
 
 
-def export(image, platform, source, destination, revision):
-    image = platform_image(image, platform)
-    subprocess.run(["docker", "pull", "--platform", platform, image], check=True)
-    actual_platform = run(["docker", "image", "inspect", "--format", '{{.Os}}/{{.Architecture}}', image])
+def verify_image_identity(image, platform, revision):
+    """Resolve an index to one platform's child and prove what that child is.
+
+    Two independent checks, neither implying the other. The platform check
+    catches a classic-store collision handing back a different image than the
+    index entry names. The revision label is the only thing tying published
+    bytes to the source a release claims — a recorded image pair that matches
+    this run's tag and sha says nothing about what the image it REFERENCES was
+    built from, so that has to be read off the image itself.
+
+    Returns the immutable per-platform ref, so callers operate on the child
+    they verified rather than re-resolving the index.
+    """
+    ref = platform_image(image, platform)
+    # `docker pull` writes progress to STDOUT. This function's callers include
+    # a CLI whose stdout is captured into a shell variable, so inheriting it
+    # would splice download progress into the resolved reference. The progress
+    # is still shown — on stderr, where it belongs.
+    progress = subprocess.run(["docker", "pull", "--platform", platform, ref],
+                              check=True, stdout=subprocess.PIPE, text=True)
+    sys.stderr.write(progress.stdout)
+    actual_platform = run(["docker", "image", "inspect", "--format", '{{.Os}}/{{.Architecture}}', ref])
     if actual_platform != platform:
-        raise ValueError("Published image platform does not match requested platform")
-    actual = run(["docker", "image", "inspect", "--format", '{{index .Config.Labels "org.opencontainers.image.revision"}}', image])
+        raise ValueError(f"Published image {ref} is {actual_platform}, expected {platform}")
+    actual = run(["docker", "image", "inspect", "--format", '{{index .Config.Labels "org.opencontainers.image.revision"}}', ref])
     if actual != revision:
-        raise ValueError("Published image revision does not match release")
+        raise ValueError(f"Published image {ref} was built from {actual or 'no recorded revision'}, "
+                         f"expected {revision}")
+    return ref
+
+
+def export(image, platform, source, destination, revision):
+    image = verify_image_identity(image, platform, revision)
     container = run(["docker", "create", "--platform", platform, "--network", "none", image])
     if not re.fullmatch(r"[0-9a-f]{64}", container):
         raise ValueError("Invalid export container ID")

--- a/scripts/image_platform.py
+++ b/scripts/image_platform.py
@@ -2,9 +2,15 @@
 """Resolve a multi-platform image index to one platform's immutable child digest.
 
 A thin wrapper so the workflow does not re-implement the resolution. The logic
-lives in export-server-bundle.py's platform_image, which already handles the
-classic-store collision where `docker pull --platform` can hand back a
-different image than the index entry for that platform.
+lives in export-server-bundle.py, which already handles the classic-store
+collision where `docker pull --platform` can hand back a different image than
+the index entry for that platform.
+
+With --revision it also proves the resolved child's platform and source label,
+using the SAME function the export path uses. The release workflow needs that
+before it records or promotes anything: the export checks the dashboard image's
+revision, but only after promotion, and a reused image-pair record matching this
+run's sha is not evidence about the images it points at.
 """
 import argparse
 import importlib.util
@@ -20,8 +26,13 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--image", required=True)
     parser.add_argument("--platform", required=True)
+    parser.add_argument("--revision",
+                        help="also verify the resolved child's platform and source revision")
     args = parser.parse_args()
-    print(_module.platform_image(args.image, args.platform))
+    if args.revision:
+        print(_module.verify_image_identity(args.image, args.platform, args.revision))
+    else:
+        print(_module.platform_image(args.image, args.platform))
 
 
 if __name__ == "__main__":

--- a/scripts/release_history.py
+++ b/scripts/release_history.py
@@ -34,10 +34,27 @@ and evidence does not get replaced because a later run disagreed with it.
 import argparse
 import json
 from pathlib import Path
+import re
 import subprocess
 import sys
 
 CATALOG_ASSET = "agent-manifest.json"
+
+# The published image pair this release was built from.
+#
+# A publish retry rebuilds both images, and nothing guarantees a rebuild lands
+# on the same index digest — it MAY differ, which is enough. When it does, the
+# retry promotes tags pointing at a new digest while the catalog persisted by
+# the first attempt describes the old one, and every downstream check that ties
+# a bundle to its image fails permanently, with no way to finish the release
+# because a published catalog is never overwritten. So a retry reuses the pair
+# the first attempt verified rather than depending on a rebuild matching it.
+#
+# This is a CI-only record. The updater's manifest schema is untouched; no
+# worker reads this file and none needs to.
+BUILD_ASSET = "release-build.json"
+BUILD_SCHEMA = 1
+IMAGE_REF = re.compile(r"ghcr\.io/bokiko/bloxos-(hub|dashboard)@sha256:[0-9a-f]{64}\Z")
 
 
 class HistoryError(Exception):
@@ -205,6 +222,134 @@ def persist(repo, tag, catalog_path, releases=None, fetch=None):
     return f"{CATALOG_ASSET} persisted for {tag} before promotion"
 
 
+def build_record(version, revision, hub, dashboard):
+    """The intent document, validated on the way in as well as on the way out.
+
+    Refs must be canonical and digest-pinned. A tag is a moving target, and the
+    entire point of recording the pair is that a retry lands on exactly the
+    bytes the first attempt verified.
+
+    Every field is type-checked before it is matched. This parses a file that
+    may have been hand-edited or truncated, so a non-string where a string
+    belongs has to become a HistoryError the caller already handles, not a
+    TypeError out of `re`.
+    """
+    for label, value in (("version", version), ("revision", revision),
+                         ("hub image", hub), ("dashboard image", dashboard)):
+        if not isinstance(value, str):
+            raise HistoryError(f"{label} must be a string, got {type(value).__name__}: {value!r}")
+    if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?", version):
+        raise HistoryError(f"not a release tag: {version!r}")
+    if not re.fullmatch(r"[0-9a-f]{40}", revision):
+        raise HistoryError(f"not a full revision: {revision!r}")
+    for name, ref in (("hub", hub), ("dashboard", dashboard)):
+        if not IMAGE_REF.fullmatch(ref) or not ref.startswith(f"ghcr.io/bokiko/bloxos-{name}@"):
+            raise HistoryError(f"{name} image must be a canonical digest-pinned BloxOS ref: {ref!r}")
+    return {"schema": BUILD_SCHEMA, "version": version, "revision": revision,
+            "images": {"hub": hub, "dashboard": dashboard}}
+
+
+def parse_build_record(raw, tag):
+    try:
+        record = json.loads(raw)
+    except ValueError as error:
+        raise HistoryError(f"release {tag!r} has an unreadable {BUILD_ASSET}: {error}")
+    if not isinstance(record, dict):
+        raise HistoryError(f"release {tag!r} has a malformed {BUILD_ASSET}")
+    schema = record.get("schema")
+    # `True == 1` in Python, so a bare equality check accepts "schema": true.
+    if not isinstance(schema, int) or isinstance(schema, bool) or schema != BUILD_SCHEMA:
+        raise HistoryError(f"release {tag!r} has {BUILD_ASSET} schema {schema!r}, "
+                           f"expected {BUILD_SCHEMA}. Refusing to guess what it means.")
+    images = record.get("images")
+    if not isinstance(images, dict):
+        raise HistoryError(f"release {tag!r} has {BUILD_ASSET} with no image pair")
+    # Revalidate through the same constructor, so a hand-edited or truncated
+    # asset cannot supply a tag-shaped ref that a later step would resolve.
+    return build_record(record.get("version"), record.get("revision"),
+                        images.get("hub"), images.get("dashboard"))
+
+
+def lookup_build(repo, tag, version, revision, releases=None, fetch=None):
+    """The verified image pair for this tag, or None only when positively absent.
+
+    Absence is the ONLY outcome that means "build". A listing failure, a
+    download failure, an unreadable asset or a record describing a different
+    source all raise: treating any of them as absence would rebuild the images
+    and promote tags that disagree with a catalog already published under this
+    release, which is precisely the state that cannot be recovered from.
+    """
+    listing = list_releases(repo) if releases is None else releases
+    current = next((release for release in listing if release.get("tag") == tag), None)
+    if current is None:
+        return None  # no release for this tag at all: nothing has been built
+    raw = raw_asset_of(repo, current, BUILD_ASSET, fetch=fetch)
+    if raw is None:
+        return None  # confirmed absent
+    record = parse_build_record(raw, tag)
+    mismatched = {key: (record[key], want)
+                  for key, want in (("version", version), ("revision", revision))
+                  if want is not None and record[key] != want}
+    if mismatched:
+        raise HistoryError(
+            f"{tag} already has a {BUILD_ASSET} describing a DIFFERENT build: "
+            + "; ".join(f"{key} is {got!r}, this run is {want!r}"
+                        for key, (got, want) in sorted(mismatched.items()))
+            + ". A release number means one set of bytes; these belong under a new release.")
+    return record
+
+
+def ensure_draft(repo, tag, prerelease, notes, releases=None, create=None):
+    """Make sure a DRAFT release exists for this tag, without guessing.
+
+    Both callers previously did `gh release view ... || gh release create ...`,
+    which reads ANY failure as "no release exists". An expired token, a rate
+    limit or a network blip would then try to create a release that is already
+    published — and on a retry, the branch that was supposed to assert the
+    release is still a draft would instead silently take the create path.
+
+    The listing either loads or raises, and only a listing that positively does
+    not contain this tag is treated as absence.
+    """
+    listing = list_releases(repo) if releases is None else releases
+    current = next((release for release in listing if release.get("tag") == tag), None)
+    if current is not None:
+        if not current.get("draft"):
+            raise HistoryError(
+                f"{tag} is already PUBLISHED. Release assets are attached to drafts and a "
+                f"published release is never modified by the pipeline.")
+        return f"{tag} draft already exists"
+    flags = ["--prerelease"] if prerelease else []
+    (create or gh)("release", "create", tag, "--repo", repo, "--verify-tag", "--draft",
+                   *flags, "--title", f"BloxOS {tag}", "--notes", notes)
+    return f"{tag} draft created"
+
+
+def persist_build(repo, tag, build_path, releases=None, fetch=None):
+    """Attach the verified image pair, idempotently and never destructively.
+
+    Called AFTER identity validation and BEFORE the agent catalog is persisted
+    or any tag is promoted. A run that dies after this leaves a record of a pair
+    that was verified but not promoted — which is exactly what the retry needs,
+    and is harmless if the release is abandoned. Dying BEFORE it leaves nothing,
+    and the retry simply builds again.
+    """
+    candidate = Path(build_path).read_bytes()
+    parse_build_record(candidate, tag)  # never publish something we could not read back
+    listing = list_releases(repo) if releases is None else releases
+    current = next((release for release in listing if release.get("tag") == tag), None)
+    if current is not None:
+        existing = raw_asset_of(repo, current, BUILD_ASSET, fetch=fetch)
+        if existing is not None:
+            if existing == candidate:
+                return f"{BUILD_ASSET} already published for {tag} and matches; nothing to do"
+            raise HistoryError(
+                f"{tag} already has a DIFFERENT {BUILD_ASSET} attached (byte comparison). "
+                f"The image pair a release was built from is never rewritten.")
+    gh("release", "upload", tag, str(build_path), "--repo", repo)
+    return f"{BUILD_ASSET} persisted for {tag} before the catalog and before promotion"
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -224,6 +369,32 @@ def main():
     u.add_argument("--tag", required=True)
     u.add_argument("files", nargs="+", type=Path)
 
+    l = commands.add_parser("lookup-build",
+                            help="resolve the verified image pair for a retry, or report absence")
+    l.add_argument("--repo", required=True)
+    l.add_argument("--tag", required=True)
+    l.add_argument("--version", required=True)
+    l.add_argument("--revision", required=True)
+    l.add_argument("--output", type=Path,
+                   help="where to write the recovered record, when one exists")
+
+    pb = commands.add_parser("persist-build", help="attach the verified image pair immutably")
+    pb.add_argument("--repo", required=True)
+    pb.add_argument("--tag", required=True)
+    pb.add_argument("--build", required=True, type=Path)
+
+    d = commands.add_parser("ensure-draft", help="create the draft release only if it is truly absent")
+    d.add_argument("--repo", required=True)
+    d.add_argument("--tag", required=True)
+    d.add_argument("--notes", required=True)
+
+    rb = commands.add_parser("record-build", help="write the image-pair intent document")
+    rb.add_argument("--version", required=True)
+    rb.add_argument("--revision", required=True)
+    rb.add_argument("--hub", required=True)
+    rb.add_argument("--dashboard", required=True)
+    rb.add_argument("--output", required=True, type=Path)
+
     args = parser.parse_args()
     try:
         if args.command == "gather":
@@ -232,6 +403,27 @@ def main():
             print(f"gathered {len(history)} agent release(s) from published and draft releases")
         elif args.command == "persist":
             print(persist(args.repo, args.tag, args.catalog))
+        elif args.command == "ensure-draft":
+            print(ensure_draft(args.repo, args.tag, "-" in args.tag, args.notes))
+        elif args.command == "record-build":
+            record = build_record(args.version, args.revision, args.hub, args.dashboard)
+            args.output.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+            print(f"recorded the image pair for {args.version}")
+        elif args.command == "persist-build":
+            print(persist_build(args.repo, args.tag, args.build))
+        elif args.command == "lookup-build":
+            record = lookup_build(args.repo, args.tag, args.version, args.revision)
+            # key=value on stdout, for >> "$GITHUB_OUTPUT". Absence is reported
+            # as a value, never as a non-zero exit: only a FAILED lookup exits
+            # non-zero, so the workflow cannot confuse the two.
+            if record is None:
+                print("reuse=false")
+            else:
+                if args.output is not None:
+                    args.output.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+                print("reuse=true")
+                print("hub=" + record["images"]["hub"])
+                print("dashboard=" + record["images"]["dashboard"])
         else:
             for line in upload(args.repo, args.tag, args.files):
                 print(line)

--- a/scripts/test_release_history.py
+++ b/scripts/test_release_history.py
@@ -5,10 +5,12 @@ from pathlib import Path
 import sys
 import tempfile
 import unittest
+import unittest.mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from release_history import CATALOG_ASSET, HistoryError, catalog_of, gather, persist, upload
+from release_history import (BUILD_ASSET, CATALOG_ASSET, HistoryError, build_record, catalog_of,
+                             gather, lookup_build, persist, persist_build, upload)
 
 PLATFORMS = ("linux/amd64", "linux/arm64", "windows/amd64")
 
@@ -207,6 +209,163 @@ class BinaryAssetTests(unittest.TestCase):
         self.assertNotEqual(reformatted, body)
         with self.assertRaises(HistoryError):
             persist("owner/repo", "v2.0.0", path, releases, fetcher_bytes({1: reformatted}))
+
+
+
+# ---------------------------------------------------------------- build intent
+#
+# A publish retry rebuilds both images, and an image build is not reproducible:
+# the rebuild lands on a different index digest. Without a record of the pair
+# the first attempt verified, a retry promotes tags that disagree with the
+# catalog already published under the same release — a state nothing can
+# recover from, because a published catalog is never overwritten.
+
+REVISION = "f" * 40
+HUB_REF = "ghcr.io/bokiko/bloxos-hub@sha256:" + "a" * 64
+DASHBOARD_REF = "ghcr.io/bokiko/bloxos-dashboard@sha256:" + "b" * 64
+OTHER_HUB_REF = "ghcr.io/bokiko/bloxos-hub@sha256:" + "c" * 64
+
+
+def build_asset(asset_id, extra=None):
+    assets = [{"name": BUILD_ASSET, "id": asset_id}]
+    if extra:
+        assets.extend(extra)
+    return {"tag": "v1.2.3", "draft": True, "assets": assets}
+
+
+def recorded(version="v1.2.3", revision=REVISION, hub=HUB_REF, dashboard=DASHBOARD_REF):
+    return build_record(version, revision, hub, dashboard)
+
+
+def raw(record):
+    return (json.dumps(record, indent=2, sort_keys=True) + "\n").encode()
+
+
+class BuildIntentTests(unittest.TestCase):
+    def test_a_fresh_release_reports_absence_so_the_images_are_built(self):
+        # No release at all, and a release with other assets but no record.
+        self.assertIsNone(lookup_build("owner/repo", "v1.2.3", "v1.2.3", REVISION, [], fetcher_bytes({})))
+        listing = [{"tag": "v1.2.3", "draft": True, "assets": [{"name": CATALOG_ASSET, "id": 5}]}]
+        self.assertIsNone(lookup_build("owner/repo", "v1.2.3", "v1.2.3", REVISION,
+                                       listing, fetcher_bytes({})))
+
+    def test_a_matching_record_is_reused_and_keeps_both_refs(self):
+        record = recorded()
+        found = lookup_build("owner/repo", "v1.2.3", "v1.2.3", REVISION,
+                             [build_asset(11, [{"name": "bloxos-update", "id": 9}])],
+                             fetcher_bytes({11: raw(record)}))
+        self.assertIsNotNone(found)
+        # BOTH refs are retained. Recovering only the hub would leave the
+        # dashboard to be rebuilt, and the pair would no longer be the pair
+        # anything was verified against.
+        self.assertEqual(found["images"]["hub"], HUB_REF)
+        self.assertEqual(found["images"]["dashboard"], DASHBOARD_REF)
+
+    def test_a_record_from_a_different_source_fails_closed(self):
+        for field, record in (("revision", recorded(revision="1" * 40)),
+                              ("version", recorded(version="v1.2.4"))):
+            with self.subTest(field=field):
+                with self.assertRaises(HistoryError) as caught:
+                    lookup_build("owner/repo", "v1.2.3", "v1.2.3", REVISION,
+                                 [build_asset(11)], fetcher_bytes({11: raw(record)}))
+                self.assertIn("DIFFERENT", str(caught.exception))
+
+    def test_a_fetch_failure_is_never_read_as_absence(self):
+        # The dangerous misreading: a transient download error would rebuild
+        # the images and promote a digest the published catalog disagrees with.
+        with self.assertRaises(HistoryError):
+            lookup_build("owner/repo", "v1.2.3", "v1.2.3", REVISION,
+                         [build_asset(11)], fetcher_bytes({}))
+
+    def test_an_unreadable_or_wrong_schema_record_fails_closed(self):
+        cases = {
+            "truncated": b'{"schema": 1, "version"',
+            "not an object": b'[]',
+            "future schema": raw({"schema": 2, "version": "v1.2.3", "revision": REVISION,
+                                  "images": {"hub": HUB_REF, "dashboard": DASHBOARD_REF}}),
+            "no images": raw({"schema": 1, "version": "v1.2.3", "revision": REVISION}),
+            # True == 1 in Python, so a bare equality check accepts this.
+            "boolean schema": raw({"schema": True, "version": "v1.2.3", "revision": REVISION,
+                                   "images": {"hub": HUB_REF, "dashboard": DASHBOARD_REF}}),
+            # A non-string where a string belongs must not reach `re`.
+            "numeric revision": raw({"schema": 1, "version": "v1.2.3", "revision": 12345,
+                                     "images": {"hub": HUB_REF, "dashboard": DASHBOARD_REF}}),
+            "null version": raw({"schema": 1, "version": None, "revision": REVISION,
+                                 "images": {"hub": HUB_REF, "dashboard": DASHBOARD_REF}}),
+            "list ref": raw({"schema": 1, "version": "v1.2.3", "revision": REVISION,
+                             "images": {"hub": [HUB_REF], "dashboard": DASHBOARD_REF}}),
+            # A tag-shaped ref is the one that would silently resolve later.
+            "moving ref": raw({"schema": 1, "version": "v1.2.3", "revision": REVISION,
+                               "images": {"hub": "ghcr.io/bokiko/bloxos-hub:1.2.3",
+                                          "dashboard": DASHBOARD_REF}}),
+        }
+        for label, body in cases.items():
+            with self.subTest(case=label):
+                with self.assertRaises(HistoryError):
+                    lookup_build("owner/repo", "v1.2.3", "v1.2.3", REVISION,
+                                 [build_asset(11)], fetcher_bytes({11: body}))
+
+    def test_a_record_is_never_overwritten(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / BUILD_ASSET
+            path.write_bytes(raw(recorded()))
+            # Identical: a no-op, and nothing is uploaded.
+            message = persist_build("owner/repo", "v1.2.3", path,
+                                    [build_asset(11)], fetcher_bytes({11: raw(recorded())}))
+            self.assertIn("nothing to do", message)
+            # Conflicting: an error, never a replacement.
+            with self.assertRaises(HistoryError):
+                persist_build("owner/repo", "v1.2.3", path, [build_asset(11)],
+                              fetcher_bytes({11: raw(recorded(hub=OTHER_HUB_REF))}))
+
+    def test_a_crash_between_the_record_and_the_catalog_is_recoverable(self):
+        """The window the record exists for.
+
+        The first attempt persisted the image pair and died before the catalog.
+        The retry must find that pair, skip the builds, and then be free to
+        persist the catalog — which is still absent.
+        """
+        listing = [build_asset(11)]  # record present, no catalog
+        found = lookup_build("owner/repo", "v1.2.3", "v1.2.3", REVISION,
+                             listing, fetcher_bytes({11: raw(recorded())}))
+        self.assertEqual(found["images"]["hub"], HUB_REF)
+        with tempfile.TemporaryDirectory() as directory:
+            catalog_path = Path(directory) / CATALOG_ASSET
+            catalog_path.write_bytes(json.dumps(catalog(9, 0xaa)).encode())
+            with unittest.mock.patch("release_history.gh") as upload_call:
+                message = persist("owner/repo", "v1.2.3", catalog_path,
+                                  listing, fetcher_bytes({11: raw(recorded())}))
+            self.assertIn("persisted", message)
+            upload_call.assert_called_once()
+
+    def test_a_crash_after_promotion_still_reuses_the_same_pair(self):
+        """Images already live. The retry must not build a second pair.
+
+        This is the unrecoverable case if absence were guessed: the promoted
+        tags point at the first pair, and a rebuild would promote a different
+        one over a catalog that can never be rewritten to match.
+        """
+        listing = [build_asset(11, [{"name": CATALOG_ASSET, "id": 12}])]
+        bodies = {11: raw(recorded()), 12: json.dumps(catalog(9, 0xaa)).encode()}
+        found = lookup_build("owner/repo", "v1.2.3", "v1.2.3", REVISION, listing,
+                             fetcher_bytes(bodies))
+        self.assertEqual(found["images"], {"hub": HUB_REF, "dashboard": DASHBOARD_REF})
+        # And the identical catalog is recognised, so the retry uploads nothing.
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / CATALOG_ASSET
+            path.write_bytes(bodies[12])
+            with unittest.mock.patch("release_history.gh") as upload_call:
+                message = persist("owner/repo", "v1.2.3", path, listing, fetcher_bytes(bodies))
+            self.assertIn("matches", message)
+            upload_call.assert_not_called()
+
+    def test_the_record_itself_refuses_a_ref_that_could_move(self):
+        for hub in ("ghcr.io/bokiko/bloxos-hub:latest",
+                    "ghcr.io/bokiko/bloxos-dashboard@sha256:" + "a" * 64,
+                    "ghcr.io/someone/bloxos-hub@sha256:" + "a" * 64, ""):
+            with self.subTest(hub=hub):
+                with self.assertRaises(HistoryError):
+                    build_record("v1.2.3", REVISION, hub, DASHBOARD_REF)
 
 
 if __name__ == "__main__":

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -62,6 +62,32 @@ def shell_block(body):
     raise AssertionError("step has no run block")
 
 
+def mapping_block(body, key, indent):
+    """A `key:` block of NAME: value pairs, as written, preserving expressions.
+
+    Used for a step's `env:` and a job's `outputs:`. Reading these rather than
+    restating them is the point: a harness that hardcodes the mapping would
+    pass with HUB_REF and DASHBOARD_REF swapped in the workflow.
+    """
+    lines = body.splitlines()
+    found, collecting = {}, False
+    for line in lines:
+        if line.strip() == f"{key}:":
+            collecting = True
+            continue
+        if collecting:
+            if line.strip().startswith("#"):
+                continue
+            if line.strip() and not line.startswith(" " * indent):
+                break
+            if ":" in line:
+                name, _, value = line.strip().partition(":")
+                found[name.strip()] = value.strip()
+    if not found:
+        raise AssertionError(f"no {key!r} block found; the parser or the workflow has moved")
+    return found
+
+
 def substitute(block, values):
     """Replace Actions expressions with fixture values, failing on any unknown one.
 
@@ -116,13 +142,12 @@ class ReleaseWorkflowWiringTests(unittest.TestCase):
         self.assertNotIn("outputs.digest", self.native,
                          "the native bundle job must consume the resolved refs, not build outputs")
         # The job's own outputs block sits before the first step, so the scan
-        # above cannot see it — and it is what native-bundle consumes.
-        declared = self.publish.split("steps:", 1)[0]
-        self.assertIn("outputs:", declared)
-        self.assertNotIn("steps.hub.outputs.digest", declared)
-        self.assertNotIn("steps.dashboard.outputs.digest", declared)
-        self.assertIn("steps.refs.outputs.hub", declared)
-        self.assertIn("steps.refs.outputs.dashboard", declared)
+        # above cannot see it — and it is what native-bundle consumes. The
+        # exact expression is asserted, not its presence: a hub_ref wired to
+        # the dashboard would satisfy any "both strings appear" check.
+        declared = mapping_block(self.publish.split("steps:", 1)[0], "outputs", 6)
+        self.assertEqual(declared.get("hub_ref"), "${{ steps.refs.outputs.hub }}")
+        self.assertEqual(declared.get("dashboard_ref"), "${{ steps.refs.outputs.dashboard }}")
 
     def test_both_builds_are_skipped_when_a_verified_pair_is_reused(self):
         for image in ("Push hub image", "Push dashboard image"):
@@ -200,7 +225,9 @@ class ReleaseRetryExecutionTests(unittest.TestCase):
         publish = steps(jobs(text)["publish"])
         by_name = {name: body for name, body in publish}
         cls.resolve = shell_block(next(b for n, b in by_name.items() if "Resolve the image pair" in n))
-        cls.promote = shell_block(next(b for n, b in by_name.items() if "Promote both images" in n))
+        promote_body = next(b for n, b in by_name.items() if "Promote both images" in n)
+        cls.promote = shell_block(promote_body)
+        cls.promote_env = mapping_block(promote_body, "env", 10)
 
     def setUp(self):
         self.work = Path(tempfile.mkdtemp())
@@ -257,8 +284,16 @@ class ReleaseRetryExecutionTests(unittest.TestCase):
                 "steps.dashboard.outputs.digest": BUILT_DASHBOARD}
 
     def promote_with(self, hub, dashboard, version="v1.2.3", fail_on=None):
-        return self.run_block(self.promote, {}, fail_on=fail_on,
-                              env={"VERSION": version, "HUB_REF": hub, "DASHBOARD_REF": dashboard})
+        # The step's OWN env mapping, read from the workflow and then resolved.
+        # Hardcoding {HUB_REF: hub, DASHBOARD_REF: dashboard} here would let a
+        # swap of the two in docker.yml pass: both strings would still be
+        # present, and both tests would still see two plausible promotions.
+        values = {"github.ref_name": version,
+                  "steps.refs.outputs.hub": hub,
+                  "steps.refs.outputs.dashboard": dashboard}
+        env = {name: substitute(expression, values)
+               for name, expression in self.promote_env.items()}
+        return self.run_block(self.promote, {}, fail_on=fail_on, env=env)
 
     def test_a_fresh_run_resolves_and_promotes_the_freshly_built_pair(self):
         result, emitted = self.run_block(self.resolve, self.resolve_values(reuse=False))

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Wiring checks for the release workflow. No network, no Docker, no YAML library.
+
+Unit-testing the intent document proves it round-trips. It does NOT prove the
+workflow uses it: a reuse path that resolves the recorded pair and then promotes
+`steps.hub.outputs.digest` anyway is inert on the happy path and catastrophic on
+the one run that matters, because a skipped build's output is the empty string.
+
+These assertions are deliberately textual. The properties are textual — which
+expression a step references, and what order the steps are in — and a YAML
+library is not installed everywhere this runs.
+"""
+from pathlib import Path
+import re
+import sys
+import unittest
+
+WORKFLOW = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "docker.yml"
+
+
+def jobs(text):
+    """Split the workflow into {job name: body}, by indentation."""
+    found, name, start = {}, None, None
+    lines = text.splitlines(keepends=True)
+    offset = 0
+    for line in lines:
+        match = re.fullmatch(r"  ([A-Za-z][\w-]*):\n", line)
+        if match:
+            if name is not None:
+                found[name] = text[start:offset]
+            name, start = match.group(1), offset
+        offset += len(line)
+    if name is not None:
+        found[name] = text[start:]
+    return found
+
+
+def steps(job):
+    """Split one job's body into its steps, in order, as (name, body)."""
+    pieces = re.split(r"\n      - ", "\n" + job)
+    out = []
+    for piece in pieces[1:]:
+        match = re.search(r"name: (.+)", piece)
+        out.append(((match.group(1).strip() if match else piece.splitlines()[0].strip()), piece))
+    return out
+
+
+class ReleaseWorkflowWiringTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = WORKFLOW.read_text()
+        cls.publish = jobs(cls.text)["publish"]
+        cls.native = jobs(cls.text)["native-bundle"]
+        cls.publish_steps = steps(cls.publish)
+
+    def index_of(self, fragment, where=None):
+        for position, (name, _) in enumerate(where or self.publish_steps):
+            if fragment.lower() in name.lower():
+                return position
+        self.fail(f"no step matching {fragment!r}; the parser or the workflow has moved")
+
+    def body_of(self, fragment):
+        return self.publish_steps[self.index_of(fragment)][1]
+
+    # CONTROL: if this parser silently found nothing, every assertion below
+    # would pass vacuously.
+    def test_the_parser_actually_sees_the_publish_job(self):
+        self.assertGreater(len(self.publish_steps), 8,
+                           "the publish job was not parsed into steps")
+        for required in ("Look up a verified image pair", "Push hub image",
+                         "Push dashboard image", "Resolve the image pair", "Promote both images"):
+            self.index_of(required)
+
+    def test_only_the_resolve_step_reads_a_build_digest(self):
+        """A skipped build's output is the empty string.
+
+        Any surviving reference would resolve to `ghcr.io/...@` on a retry —
+        an invalid reference at best, and at worst a tag promoted to something
+        nothing verified.
+        """
+        offenders = [name for name, body in self.publish_steps
+                     if "outputs.digest" in body and "Resolve the image pair" not in name]
+        self.assertEqual(offenders, [],
+                         f"these steps still read a build digest directly: {offenders}")
+        self.assertNotIn("outputs.digest", self.native,
+                         "the native bundle job must consume the resolved refs, not build outputs")
+
+    def test_both_builds_are_skipped_when_a_verified_pair_is_reused(self):
+        for image in ("Push hub image", "Push dashboard image"):
+            with self.subTest(image=image):
+                self.assertIn("if: steps.intent.outputs.reuse != 'true'", self.body_of(image),
+                              f"{image} would rebuild over a pair that was already verified")
+
+    def test_the_lookup_happens_before_anything_is_built(self):
+        lookup = self.index_of("Look up a verified image pair")
+        self.assertLess(lookup, self.index_of("Push hub image"))
+        self.assertLess(lookup, self.index_of("Push dashboard image"))
+
+    def test_both_refs_flow_through_promotion_and_native_extraction(self):
+        promote = self.body_of("Promote both images")
+        self.assertIn("steps.refs.outputs.hub", promote)
+        self.assertIn("steps.refs.outputs.dashboard", promote)
+        # Recovering only the hub would leave the dashboard to be rebuilt, and
+        # the pair would no longer be the pair anything was verified against.
+        self.assertIn("needs.publish.outputs.hub_ref", self.native)
+        self.assertIn("needs.publish.outputs.dashboard_ref", self.native)
+
+    def test_both_images_are_validated_on_both_architectures_before_anything_moves(self):
+        validate = self.index_of("Validate the platform and source of both images")
+        body = self.publish_steps[validate][1]
+        self.assertIn("steps.refs.outputs.hub", body)
+        self.assertIn("steps.refs.outputs.dashboard", body)
+        self.assertIn("linux/amd64 linux/arm64", body)
+        self.assertIn("--revision", body)
+        # A reused record matching this run's sha is evidence about the record,
+        # not about the images it names — so this must precede recording it.
+        self.assertLess(validate, self.index_of("Persist the verified image pair"))
+        self.assertLess(validate, self.index_of("Promote both images"))
+
+    def test_the_pair_is_recorded_after_verification_and_before_the_catalog(self):
+        record = self.index_of("Persist the verified image pair")
+        self.assertLess(self.index_of("Verify release identity"), record)
+        self.assertLess(record, self.index_of("Persist the verified agent catalog"))
+        self.assertLess(record, self.index_of("Promote both images"))
+
+    def test_no_step_treats_a_failed_release_lookup_as_absence(self):
+        """`gh release view ... || gh release create ...` reads ANY failure as
+        "no release exists" — an expired token would create a release that is
+        already published, and skip the assertion that it is still a draft."""
+        for job in ("publish", "native-bundle"):
+            with self.subTest(job=job):
+                body = jobs(self.text)[job]
+                self.assertNotIn("gh release view", re.sub(r"^\s*#.*$", "", body, flags=re.M),
+                                 f"{job} still branches on a failed release lookup")
+                self.assertIn("release_history.py ensure-draft", body)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -10,9 +10,12 @@ These assertions are deliberately textual. The properties are textual — which
 expression a step references, and what order the steps are in — and a YAML
 library is not installed everywhere this runs.
 """
+import os
 from pathlib import Path
 import re
-import sys
+import shutil
+import subprocess
+import tempfile
 import unittest
 
 WORKFLOW = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "docker.yml"
@@ -43,6 +46,34 @@ def steps(job):
         match = re.search(r"name: (.+)", piece)
         out.append(((match.group(1).strip() if match else piece.splitlines()[0].strip()), piece))
     return out
+
+
+def shell_block(body):
+    """The `run: |` script of one step, dedented, exactly as the workflow has it."""
+    lines = body.splitlines()
+    for position, line in enumerate(lines):
+        if line.strip() == "run: |":
+            block = []
+            for rest in lines[position + 1:]:
+                if rest.strip() and not rest.startswith(" " * 10):
+                    break
+                block.append(rest[10:])
+            return "\n".join(block).rstrip() + "\n"
+    raise AssertionError("step has no run block")
+
+
+def substitute(block, values):
+    """Replace Actions expressions with fixture values, failing on any unknown one.
+
+    Unknown expressions are an error rather than a blank: a new one appearing
+    in these blocks is precisely when this harness must stop being trusted.
+    """
+    def replace(match):
+        key = match.group(1).strip()
+        if key not in values:
+            raise AssertionError(f"unmapped workflow expression {key!r}; the harness is stale")
+        return values[key]
+    return re.sub(r"\$\{\{([^}]+?)\}\}", replace, block)
 
 
 class ReleaseWorkflowWiringTests(unittest.TestCase):
@@ -84,6 +115,14 @@ class ReleaseWorkflowWiringTests(unittest.TestCase):
                          f"these steps still read a build digest directly: {offenders}")
         self.assertNotIn("outputs.digest", self.native,
                          "the native bundle job must consume the resolved refs, not build outputs")
+        # The job's own outputs block sits before the first step, so the scan
+        # above cannot see it — and it is what native-bundle consumes.
+        declared = self.publish.split("steps:", 1)[0]
+        self.assertIn("outputs:", declared)
+        self.assertNotIn("steps.hub.outputs.digest", declared)
+        self.assertNotIn("steps.dashboard.outputs.digest", declared)
+        self.assertIn("steps.refs.outputs.hub", declared)
+        self.assertIn("steps.refs.outputs.dashboard", declared)
 
     def test_both_builds_are_skipped_when_a_verified_pair_is_reused(self):
         for image in ("Push hub image", "Push dashboard image"):
@@ -133,6 +172,161 @@ class ReleaseWorkflowWiringTests(unittest.TestCase):
                 self.assertNotIn("gh release view", re.sub(r"^\s*#.*$", "", body, flags=re.M),
                                  f"{job} still branches on a failed release lookup")
                 self.assertIn("release_history.py ensure-draft", body)
+
+
+
+HUB_IMAGE = "ghcr.io/bokiko/bloxos-hub"
+DASHBOARD_IMAGE = "ghcr.io/bokiko/bloxos-dashboard"
+BUILT_HUB = "sha256:" + "1" * 64
+BUILT_DASHBOARD = "sha256:" + "2" * 64
+# Deliberately different from the built pair, so a block that silently falls
+# back to a rebuild cannot produce these by accident.
+RECORDED_HUB = f"{HUB_IMAGE}@sha256:" + "a" * 64
+RECORDED_DASHBOARD = f"{DASHBOARD_IMAGE}@sha256:" + "b" * 64
+
+
+class ReleaseRetryExecutionTests(unittest.TestCase):
+    """Run the ACTUAL resolve and promote shell, with a fake docker.
+
+    The structural guards prove no step *mentions* a build digest. They cannot
+    prove the reuse path produces the recorded pair and promotes exactly it —
+    and that is the path that only ever runs on a retry, where a skipped
+    build's output is the empty string.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        text = WORKFLOW.read_text()
+        publish = steps(jobs(text)["publish"])
+        by_name = {name: body for name, body in publish}
+        cls.resolve = shell_block(next(b for n, b in by_name.items() if "Resolve the image pair" in n))
+        cls.promote = shell_block(next(b for n, b in by_name.items() if "Promote both images" in n))
+
+    def setUp(self):
+        self.work = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.work, True)
+        self.log = self.work / "docker.log"
+        binaries = self.work / "bin"
+        binaries.mkdir()
+        fake = binaries / "docker"
+        fake.write_text(
+            "#!/bin/sh\n"
+            f'printf "%s\\n" "$*" >> {self.log}\n'
+            'if [ -n "$FAIL_ON" ]; then case "$*" in *"$FAIL_ON"*) exit 1;; esac; fi\n'
+            "exit 0\n")
+        fake.chmod(0o755)
+        self.path = str(binaries) + os.pathsep + os.environ["PATH"]
+
+    def run_block(self, block, values, fail_on=None, env=None):
+        script = substitute(block, values)
+        output = self.work / f"output-{len(list(self.work.glob('output-*')))}"
+        output.write_text("")
+        environment = dict(os.environ, PATH=self.path, GITHUB_OUTPUT=str(output),
+                           HUB_IMAGE=HUB_IMAGE, DASHBOARD_IMAGE=DASHBOARD_IMAGE)
+        # The step's own `env:` block. The promotion script reads its refs from
+        # there rather than inline, which is exactly how the workflow has it.
+        environment.update(env or {})
+        if fail_on:
+            environment["FAIL_ON"] = fail_on
+        result = subprocess.run(["bash", "-c", script], text=True, capture_output=True,
+                                env=environment, cwd=str(self.work))
+        emitted = dict(line.split("=", 1) for line in output.read_text().splitlines() if "=" in line)
+        return result, emitted
+
+    def docker_calls(self):
+        return self.log.read_text().splitlines() if self.log.exists() else []
+
+    def image_builds(self):
+        """Actual image builds, not `buildx imagetools`, which only moves tags."""
+        return [call for call in self.docker_calls()
+                if call.startswith("build ") or call.startswith("buildx build")]
+
+    def resolve_values(self, reuse):
+        """A reuse run has NO build outputs: the steps were skipped, so Actions
+        substitutes the empty string. That is the whole hazard."""
+        if reuse:
+            return {"steps.intent.outputs.reuse": "true",
+                    "steps.intent.outputs.hub": RECORDED_HUB,
+                    "steps.intent.outputs.dashboard": RECORDED_DASHBOARD,
+                    "steps.hub.outputs.digest": "",
+                    "steps.dashboard.outputs.digest": ""}
+        return {"steps.intent.outputs.reuse": "false",
+                "steps.intent.outputs.hub": "",
+                "steps.intent.outputs.dashboard": "",
+                "steps.hub.outputs.digest": BUILT_HUB,
+                "steps.dashboard.outputs.digest": BUILT_DASHBOARD}
+
+    def promote_with(self, hub, dashboard, version="v1.2.3", fail_on=None):
+        return self.run_block(self.promote, {}, fail_on=fail_on,
+                              env={"VERSION": version, "HUB_REF": hub, "DASHBOARD_REF": dashboard})
+
+    def test_a_fresh_run_resolves_and_promotes_the_freshly_built_pair(self):
+        result, emitted = self.run_block(self.resolve, self.resolve_values(reuse=False))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(emitted["hub"], f"{HUB_IMAGE}@{BUILT_HUB}")
+        self.assertEqual(emitted["dashboard"], f"{DASHBOARD_IMAGE}@{BUILT_DASHBOARD}")
+
+        result, _ = self.promote_with(emitted["hub"], emitted["dashboard"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        created = [call for call in self.docker_calls() if "imagetools create" in call]
+        self.assertEqual(len(created), 2, created)
+        self.assertTrue(created[0].endswith(f"{HUB_IMAGE}@{BUILT_HUB}"), created[0])
+        self.assertTrue(created[1].endswith(f"{DASHBOARD_IMAGE}@{BUILT_DASHBOARD}"), created[1])
+
+    def test_a_reuse_run_promotes_exactly_the_recorded_pair(self):
+        result, emitted = self.run_block(self.resolve, self.resolve_values(reuse=True))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        # Not "@" with nothing after it, and not the built pair: exactly the
+        # refs the earlier attempt verified.
+        self.assertEqual(emitted["hub"], RECORDED_HUB)
+        self.assertEqual(emitted["dashboard"], RECORDED_DASHBOARD)
+
+        result, _ = self.promote_with(emitted["hub"], emitted["dashboard"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        created = [call for call in self.docker_calls() if "imagetools create" in call]
+        self.assertEqual(len(created), 2, created)
+        self.assertTrue(created[0].endswith(RECORDED_HUB), created[0])
+        self.assertTrue(created[1].endswith(RECORDED_DASHBOARD), created[1])
+        # And nothing was built: the fake docker was never asked to.
+        self.assertEqual(self.image_builds(), [])
+
+    def test_a_crash_after_the_first_promotion_retries_onto_the_same_pair(self):
+        """The unrecoverable case if the pair were not recorded.
+
+        The hub tag is already live when the run dies. A retry that rebuilt
+        would promote a second, different pair over a catalog that can never be
+        rewritten to match.
+        """
+        first_resolve, first = self.run_block(self.resolve, self.resolve_values(reuse=True))
+        self.assertEqual(first_resolve.returncode, 0, first_resolve.stderr)
+        crashed, _ = self.promote_with(first["hub"], first["dashboard"],
+                                       fail_on=DASHBOARD_IMAGE + "@")
+        self.assertNotEqual(crashed.returncode, 0, "the injected failure did not fire")
+        promoted_before = [c for c in self.docker_calls() if "imagetools create" in c]
+        self.assertTrue(any(RECORDED_HUB in c for c in promoted_before),
+                        "the hub tag should already be live when the retry starts")
+
+        # The retry: same saved record, same resolution, same promotion.
+        self.log.unlink()
+        retry_resolve, second = self.run_block(self.resolve, self.resolve_values(reuse=True))
+        self.assertEqual(retry_resolve.returncode, 0, retry_resolve.stderr)
+        self.assertEqual((second["hub"], second["dashboard"]), (first["hub"], first["dashboard"]))
+        result, _ = self.promote_with(second["hub"], second["dashboard"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        created = [c for c in self.docker_calls() if "imagetools create" in c]
+        self.assertTrue(any(c.endswith(RECORDED_HUB) for c in created), created)
+        self.assertTrue(any(c.endswith(RECORDED_DASHBOARD) for c in created), created)
+        self.assertEqual(self.image_builds(), [])
+
+    def test_the_resolver_refuses_a_reference_that_lost_its_digest(self):
+        """CONTROL for the harness: an empty build output must be caught here,
+        not handed to docker."""
+        broken = self.resolve_values(reuse=False)
+        broken["steps.hub.outputs.digest"] = ""
+        result, emitted = self.run_block(self.resolve, broken)
+        self.assertNotEqual(result.returncode, 0,
+                            "a digest-less reference must not reach promotion")
+        self.assertNotIn("hub", emitted)
 
 
 if __name__ == "__main__":

--- a/scripts/test_server_bundle_agents.py
+++ b/scripts/test_server_bundle_agents.py
@@ -379,5 +379,67 @@ class ServerBundleAgentTests(unittest.TestCase):
         subprocess.run([sys.executable, str(built[0])], check=True)
 
 
+class ImageIdentityCliTests(unittest.TestCase):
+    """The helper is invoked as `ref=$(... --revision ...)`, so its STDOUT is a
+    reference. A return-value test cannot see that boundary: `docker pull`
+    writes progress to stdout, and inheriting it splices download chatter into
+    the variable the workflow then passes to docker.
+    """
+
+    INDEX = {"manifests": [
+        {"platform": {"os": "linux", "architecture": "amd64"}, "digest": "sha256:" + "1" * 64},
+        {"platform": {"os": "linux", "architecture": "arm64", "variant": "v8"},
+         "digest": "sha256:" + "2" * 64},
+    ]}
+    IMAGE = "ghcr.io/bokiko/bloxos-dashboard@sha256:" + "d" * 64
+    REVISION = "a" * 40
+
+    def fake_docker(self, revision):
+        """A docker that is deliberately NOISY on stdout, as the real one is."""
+        directory = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, directory, True)
+        script = directory / "docker"
+        script.write_text(f"""#!/usr/bin/env python3
+import sys
+argv = sys.argv[1:]
+if argv[0] == "manifest":
+    print({json.dumps(self.INDEX)!r}, end="")
+elif argv[0] == "pull":
+    # Real docker prints progress here, on STDOUT.
+    print("latest: Pulling from bokiko/bloxos-dashboard")
+    print("Digest: sha256:" + "9" * 64)
+elif argv[0] == "image":
+    fmt = argv[argv.index("--format") + 1]
+    print("linux/amd64" if ".Os" in fmt else {revision!r})
+""")
+        script.chmod(0o755)
+        return directory
+
+    def run_cli(self, revision, platform="linux/amd64"):
+        environment = dict(os.environ)
+        environment["PATH"] = str(self.fake_docker(revision)) + os.pathsep + environment["PATH"]
+        return subprocess.run(
+            [sys.executable, str(REPO / "scripts" / "image_platform.py"),
+             "--image", self.IMAGE, "--platform", platform, "--revision", self.REVISION],
+            text=True, capture_output=True, env=environment)
+
+    def test_stdout_is_exactly_the_resolved_reference(self):
+        result = self.run_cli(self.REVISION)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stdout.strip(),
+                         "ghcr.io/bokiko/bloxos-dashboard@sha256:" + "1" * 64,
+                         "stdout must carry the reference and nothing else; the workflow "
+                         "captures it into a shell variable it then passes to docker")
+        self.assertNotIn("Pulling from", result.stdout)
+        # The progress is not discarded, just moved.
+        self.assertIn("Pulling from", result.stderr)
+
+    def test_a_dashboard_image_from_another_revision_is_refused(self):
+        result = self.run_cli("b" * 40)
+        self.assertNotEqual(result.returncode, 0,
+                            "an image built from a different source must not validate")
+        self.assertIn("was built from", result.stderr)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/test_server_bundle_agents.py
+++ b/scripts/test_server_bundle_agents.py
@@ -33,6 +33,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 import unittest
 from unittest import mock
 
@@ -175,9 +176,12 @@ class ServerBundleAgentTests(unittest.TestCase):
     # skipped arm64. Both server architectures must carry all three agent
     # platforms — an arm64 hub that cannot serve a Windows machine is exactly
     # the kind of gap that only shows up on the one board nobody tested.
-    def test_main_packs_every_agent_into_both_server_archives(self):
-        output = self.root / "release-assets"
-        hub_image = HUB_IMAGE
+    def run_main(self, output):
+        """Drive the REAL entrypoint with Docker stubbed out.
+
+        Everything after extraction — staging, verification, packing, the
+        manifest and the zipapp — is the production code path.
+        """
         dashboard_image = "ghcr.io/bokiko/bloxos-dashboard@sha256:" + "c" * 64
 
         def fake_export(image, platform, source, destination, revision):
@@ -189,14 +193,17 @@ class ServerBundleAgentTests(unittest.TestCase):
             else:
                 shutil.copytree(self.tree / "dashboard", destination, dirs_exist_ok=True)
 
-        argv = ["export-server-bundle.py", "--hub", hub_image, "--dashboard", dashboard_image,
+        argv = ["export-server-bundle.py", "--hub", HUB_IMAGE, "--dashboard", dashboard_image,
                 "--revision", SOURCE_SHA, "--version", VERSION,
                 "--output", str(output), "--agents", str(self.agents)]
         with mock.patch.object(export_server_bundle, "export", fake_export), \
                 mock.patch.object(export_server_bundle.subprocess, "run"), \
-                mock.patch.object(export_server_bundle.zipapp, "create_archive"), \
                 mock.patch.object(sys, "argv", argv):
             export_server_bundle.main()
+        return output
+
+    def test_main_packs_every_agent_into_both_server_archives(self):
+        output = self.run_main(self.root / "release-assets")
 
         published = json.loads((output / "update-manifest.json").read_text())
         self.assertEqual(sorted(published["native"]), ["amd64", "arm64"])
@@ -272,6 +279,104 @@ class ServerBundleAgentTests(unittest.TestCase):
                     export_server_bundle.verify_packed_agents(archive, manifest)
                 for name, body in original.items():
                     (packed / name).write_bytes(body)
+
+
+    # A release asset must be a function of its CONTENT.
+    #
+    # Two builds of the same revision produced different bytes, and the causes
+    # were all metadata: the gzip header carries the compression time and the
+    # output filename; tar members carry mtime, uid/gid and uname/gname; zipapp
+    # entries carry each source file's mtime and mode. `stage_agents` writes its
+    # files fresh, so those mtimes were always "now" — which means the archives
+    # could never have been reproducible, and a publish retry could never have
+    # been proven to re-produce what it was retrying.
+    #
+    # This runs the REAL entrypoint twice, with everything that leaked
+    # deliberately made to differ: the clock, the staging tree's timestamps, the
+    # umask the files are created under, and every path involved (the staging
+    # tree is a fresh mkdtemp each time, and the outputs go to different
+    # directories). ALL output bytes must match — both archives, the updater
+    # zipapp and the manifest.
+    def test_two_exports_of_the_same_release_are_byte_identical(self):
+        real_pack = export_server_bundle.pack_tree
+        standalone = {p.name: p.read_bytes() for p in sorted(self.agents.iterdir())}
+
+        def export_at(name, clock, stamp, umask):
+            def stamping_pack(tree, archive):
+                # The staging tree's own timestamps, set to something different
+                # on each run. Deepest first, so stamping a directory is not
+                # undone by writing inside it afterwards.
+                for path in sorted(tree.rglob("*"), reverse=True):
+                    os.utime(path, (stamp, stamp), follow_symlinks=False)
+                os.utime(tree, (stamp, stamp))
+                return real_pack(tree, archive)
+
+            # The published inputs are stamped too: nothing the packer reads
+            # may reach the output as a timestamp.
+            for path in sorted(self.agents.rglob("*")) + sorted(self.tree.rglob("*")):
+                os.utime(path, (stamp, stamp), follow_symlinks=False)
+
+            previous = os.umask(umask)
+            try:
+                with mock.patch.object(export_server_bundle, "pack_tree", stamping_pack), \
+                        mock.patch.object(time, "time", lambda: clock):
+                    return self.run_main(self.root / name)
+            finally:
+                os.umask(previous)
+
+        first = export_at("assets-first", 1_600_000_000.0, 1_600_000_000, 0o022)
+        second = export_at("assets-second", 1_900_000_123.5, 1_900_000_123, 0o077)
+
+        names = sorted(p.name for p in first.iterdir())
+        self.assertEqual(names, sorted(p.name for p in second.iterdir()),
+                         "the two exports produced different sets of assets")
+        self.assertIn("bloxos-update", names)
+        self.assertIn("update-manifest.json", names)
+        for arch in ("amd64", "arm64"):
+            self.assertIn(f"bloxos-server-linux-{arch}.tar.gz", names)
+
+        for name in names:
+            self.assertEqual(
+                hashlib.sha256((first / name).read_bytes()).hexdigest(),
+                hashlib.sha256((second / name).read_bytes()).hexdigest(),
+                f"{name} is not reproducible: two exports of the same revision differ")
+
+        # The standalone agent assets are inputs, not outputs. Packing must not
+        # have touched the bytes that are published beside the archives.
+        self.assertEqual({p.name: p.read_bytes() for p in sorted(self.agents.iterdir())},
+                         standalone, "packing modified the published agent payloads")
+
+        # Determinism must not have been bought by breaking transport: the
+        # unchanged updater still has to carry the second run's archive.
+        destination = self.root / "extracted-deterministic"
+        engine.safe_extract_tar(str(second / "bloxos-server-linux-amd64.tar.gz"), str(destination))
+        packed = destination / "hub" / "agents"
+        for name in [bundle.MANIFEST, *bundle.FILES.values()]:
+            self.assertEqual((packed / name).read_bytes(), (self.agents / name).read_bytes(),
+                             f"{name} did not survive transport from a deterministic archive")
+        digest = (self.agents / "agent-manifest.sha256").read_text().split()[0]
+        self.assertEqual(bundle.check(packed, digest)["agent_release"], RELEASE)
+
+    # The zipapp is an asset too, and its entries carried source mtimes.
+    def test_the_updater_zipapp_is_reproducible_and_still_runs(self):
+        built = []
+        for index, stamp in enumerate((1_600_000_000, 1_900_000_123)):
+            source = self.root / f"zipapp-source-{index}"
+            (source / "updater").mkdir(parents=True)
+            for name, body in (("__init__.py", b""), ("cli.py", b"def entrypoint():\n    pass\n")):
+                path = source / "updater" / name
+                path.write_bytes(body)
+                os.utime(path, (stamp, stamp))
+            target = self.root / f"bloxos-update-{index}"
+            export_server_bundle.pack_zipapp(source, target, "/usr/bin/python3", "updater.cli:entrypoint")
+            built.append(target)
+
+        self.assertEqual(built[0].read_bytes(), built[1].read_bytes(),
+                         "the updater zipapp is not reproducible")
+        # CONTROL: it is still an executable zipapp, not merely identical bytes.
+        self.assertTrue(built[0].read_bytes().startswith(b"#!/usr/bin/python3\n"))
+        self.assertTrue(os.access(built[0], os.X_OK))
+        subprocess.run([sys.executable, str(built[0])], check=True)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_updater_package.py
+++ b/scripts/tests/test_updater_package.py
@@ -1,4 +1,5 @@
 import importlib.util
+import io
 import json
 from pathlib import Path
 import tarfile
@@ -36,21 +37,59 @@ class PackageTests(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     bundle.platform_image("ghcr.io/bokiko/bloxos-hub@sha256:" + "d" * 64, "linux/arm64")
 
+    @staticmethod
+    def pulled(stdout="latest: Pulling from bokiko/bloxos-hub\n"):
+        """What subprocess.run actually returns for the pull.
+
+        A bare MagicMock is not good enough any more: the pull's stdout is
+        captured and re-emitted on stderr, because `docker pull` writes
+        progress to STDOUT and the helper is invoked as `ref=$(...)` — so
+        inheriting it would splice progress into the resolved reference.
+        Mocking it as a MagicMock made that write a TypeError.
+        """
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout)
+
     def test_export_uses_child_for_pull_inspect_and_create(self):
         child = "ghcr.io/bokiko/bloxos-hub@sha256:" + "b" * 64
+        progress = "latest: Pulling from bokiko/bloxos-hub\nDigest: sha256:beef\n"
+        captured = io.StringIO()
         with patch.object(bundle, "platform_image", return_value=child), \
              patch.object(bundle, "run", side_effect=["linux/arm64", "revision", "c" * 64]) as run, \
-             patch.object(bundle.subprocess, "run") as command:
+             patch.object(bundle.sys, "stderr", captured), \
+             patch.object(bundle.subprocess, "run", return_value=self.pulled(progress)) as command:
             bundle.export("index", "linux/arm64", "/binary", Path("/out"), "revision")
             self.assertEqual(command.call_args_list[0].args[0], ["docker", "pull", "--platform", "linux/arm64", child])
+            # Captured, not inherited, and not discarded.
+            self.assertEqual(command.call_args_list[0].kwargs.get("stdout"), subprocess.PIPE)
+            self.assertEqual(captured.getvalue(), progress)
             self.assertEqual(run.call_args_list[-1].args[0], ["docker", "create", "--platform", "linux/arm64", "--network", "none", child])
 
     def test_wrong_child_platform_is_rejected_before_create(self):
         with patch.object(bundle, "platform_image", return_value="child"), \
              patch.object(bundle, "run", return_value="linux/amd64"), \
-             patch.object(bundle.subprocess, "run") as command:
-            with self.assertRaisesRegex(ValueError, "platform"):
+             patch.object(bundle.subprocess, "run", return_value=self.pulled()) as command:
+            with self.assertRaises(ValueError) as caught:
                 bundle.export("index", "linux/arm64", "/binary", Path("/out"), "revision")
+            # The message has to name what was found AND what was wanted: a
+            # bare "platform" regex passed for any wording and would pass for
+            # a message that named neither.
+            message = str(caught.exception)
+            self.assertIn("linux/amd64", message)
+            self.assertIn("linux/arm64", message)
+            self.assertIn("child", message)
+            # Only the pull ran. Nothing was created from the wrong image.
+            self.assertEqual(command.call_count, 1)
+
+    def test_a_wrong_revision_is_rejected_before_create(self):
+        """The same protection for the other half of image identity."""
+        with patch.object(bundle, "platform_image", return_value="child"), \
+             patch.object(bundle, "run", side_effect=["linux/arm64", "b" * 40]), \
+             patch.object(bundle.subprocess, "run", return_value=self.pulled()) as command:
+            with self.assertRaises(ValueError) as caught:
+                bundle.export("index", "linux/arm64", "/binary", Path("/out"), "a" * 40)
+            message = str(caught.exception)
+            self.assertIn("b" * 40, message)
+            self.assertIn("a" * 40, message)
             self.assertEqual(command.call_count, 1)
 
     @unittest.skipUnless(shutil.which("node"), "Node runtime required")


### PR DESCRIPTION
Draft, stacked on #234 (PR2b) which is stacked on #233 (PR2a, frozen). Not approved, not merged, not tagged, not deployed.

**Required before any release.** Both problems here are in the release pipeline itself, and both make a failed publish unrecoverable.

## 1. Release assets were not a function of their content

Two builds of the same revision produced different bytes, so "retry the publish" could never be proven to re-produce what it was retrying — which is the foundation the whole no-clobber policy stands on. Every cause was metadata:

| Source | Why it leaked | Fix |
|---|---|---|
| gzip header | `tarfile.open(path, "w:gz")` hands the **output path** to gzip, which writes it *and* the compression time into the header | build the stream explicitly, `mtime=0`, empty filename |
| tar members | mtime, uid/gid, uname/gname — an archive recording `runner:docker` describes the machine that built it | normalise at the serialisation boundary; mode reduced to "is it executable" |
| zipapp entries | each source file's mtime and mode, from a copy into a temp dir moments earlier | fixed entry metadata, same layout, stored uncompressed |

The mtime is an **integer** deliberately: a float makes `tarfile` emit a pax header to carry the fraction, so the member's encoded length would depend on the filesystem's timestamp resolution.

Member *order* needed no intervention — `tarfile.add` and `zipapp` both already walk sorted. Nothing about what the archives contain changed. Normalising on the way out is also why the staging tree's own timestamps and path stop mattering.

**Test:** the real entrypoint runs twice with the clock, the staging tree's timestamps, the umask and every path made to differ; all output bytes must match — both archives, the updater zipapp and the manifest. It also asserts the published standalone agent payloads were not touched, and that the unchanged updater still carries the result, so determinism cannot be bought by breaking transport.

## 2. A publish retry could not finish

A retry rebuilds both images, and nothing guarantees a rebuild lands on the same index digest. When it does not, the catalog derived from the new hub image differs from the one the first attempt already persisted — and a published catalog is never overwritten, so the retry **fails at that comparison and stops**.

The ordering from PR2a holds and does its job here: the catalog is persisted *before* promotion, so nothing mismatched ever reaches the Docker tags. The damage is narrower and still fatal — that release can no longer be completed by any number of retries. The no-clobber policy was rejecting its own recovery path.

`release-build.json` is a small immutable release asset — schema, version, revision, both canonical digest-pinned refs. Looked up **before** the builds:

- positively absent → build, as now
- present and matching → **skip both builds, reuse the refs**
- unreadable, wrong schema, different source, or a **failed lookup** → fail closed

Absence is the only outcome that means "build"; treating a rate limit or an expired token as absence would reintroduce exactly the divergence this prevents.

The record is persisted **after** identity validation and **before** the catalog or any tag moves. A crash after it leaves a verified-but-unpromoted pair, which is what the retry needs; a crash before it leaves nothing, so the retry simply builds. Reused images are revalidated exactly as freshly built ones — same extraction, same per-platform payload checks, same identity gate.

The updater's manifest schema is untouched. This is a CI-only record; no worker reads it.

## Also fixed

- **Both images are validated before anything is recorded or promoted**, on both architectures. The export path checked the dashboard image's revision only *after* promotion, and a record matching this run's sha is evidence about the record, not about the images it names. Uses the function the export already uses, lifted out and shared.
- **`docker pull` writes progress to stdout**, and the helper is invoked as `ref=$(... --revision ...)`, so progress was spliced into the reference handed back to docker. Now on stderr.
- **Two shell branches read `gh release view` failing as "no release exists"**, so an auth or network failure would try to create an already-published release and skip the assertion that it is still a draft. Both now go through one listing that either loads or raises.

## Validation

A reuse path that resolves the recorded pair and then promotes `steps.hub.outputs.digest` anyway is inert on the happy path and wrong on the one run that matters, because a skipped build's output is the empty string. So the wiring is tested two ways:

- **Structural** — no step outside the resolver reads a build digest; the job's `outputs:` block maps `hub_ref` → `steps.refs.outputs.hub` exactly; both builds carry the reuse guard; the ordering holds; neither job branches on a failed release lookup.
- **Behavioural** — the actual `run:` blocks *and* the actual `env:` mapping are lifted from the workflow, resolved against fixtures, and executed under bash with a fake docker that logs its argv. Fresh run, reuse run (build outputs empty, recorded refs deliberately different from the built ones), and a crash injected after the hub tag is live.

Every rejection test was run against the broken version and fails for its intended reason — including the two that motivated the harness: swapping `HUB_REF`/`DASHBOARD_REF` in the step env promotes hub tags to the dashboard digest, and a reuse branch that falls through to the build outputs yields `ghcr.io/bokiko/bloxos-hub@` with no digest.

## Suites

release-history 26, export 13, workflow 12, agent-bundle 32, release-identity 22 — all pass. `scripts/test_release_workflow.py` is registered in `ci.yml`.

## Limitations

The retry path is tested against the workflow's own shell with a fake docker. It has **not** been exercised against a real tagged release, and will not be until a release is authorised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXnJ9o77HWeBitLWKFCBX
